### PR TITLE
Check text files out as LF on every platform

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Check every text file out with LF, on every platform.
+#
+# Without this, core.autocrlf=true on Windows writes CRLF into the working tree
+# while the index stays LF. Prettier's endOfLine defaults to "lf", so the format
+# gate goes red on a fresh Windows clone and green in CI on Linux - the gate
+# would then depend on who ran it, which is exactly what one gate command
+# exists to prevent.
+#
+# text=auto still leaves binary files (favicon.ico) alone.
+* text=auto eol=lf


### PR DESCRIPTION
A one-slice bugfix. Found by running the gate on merged `main`.

## The bug

`npm run gate` went **red on Windows and green in CI on Linux** — the same
commit, two answers.

`core.autocrlf=true` writes CRLF into the working tree while the index stays
LF, and there was no `.gitattributes` to say otherwise. Prettier's `endOfLine`
defaults to `lf`, so `format:check` failed on 14 files that CI had passed
minutes earlier.

The consequence is worse than a noisy check: **anyone cloning this repo on
Windows got a red gate on a clean checkout**, with nothing wrong with their
code. A gate whose verdict depends on who ran it is the one thing a single gate
command exists to prevent.

## The fix

`.gitattributes` with `* text=auto eol=lf`, plus a renormalising checkout.
`text=auto` still leaves binaries (`favicon.ico`) alone.

Setting Prettier's `endOfLine` to `auto` was rejected: it hides the divergence
and lets mixed endings into the repo rather than removing the cause.

## Verification

Cloned the branch fresh on Windows and ran the documented setup end to end:

```
git clone --branch fix-line-endings …
npm ci
npm run gate

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
```

Exit code 0. `git ls-files --eol` in that clone reports `i/lf w/lf` with the
attribute applied, where it previously reported `w/crlf`. This also
incidentally confirms the `Setup: npm ci` line in CLAUDE.md takes a fresh clone
to a working state.

## No MUST FAIL row, deliberately

CLAUDE.md asks a bugfix to start with a failing regression test, committed as
MUST FAIL where the table supports it. It doesn't fit here: the failure is
platform-dependent and never reproduces on CI's Linux runner, so a row declared
MUST FAIL would fail CI immediately and permanently.

The regression evidence is `format:check` itself — red on Windows before this
commit, green after, with CI unchanged throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)