### PR TITLE
Build the Wild Coast Kids landing page

### DIFF
--- a/.design/wild-coast-kids-landing/.gitignore
+++ b/.design/wild-coast-kids-landing/.gitignore
@@ -1,0 +1,1 @@
+screenshots/

--- a/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
+++ b/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
@@ -62,8 +62,8 @@ the design language.
 
 ## Component Inventory
 
-| Component      | Status | Notes                                                                                   |
-| -------------- | ------ | --------------------------------------------------------------------------------------- |
+| Component      | Status | Notes                                                                                    |
+| -------------- | ------ | ---------------------------------------------------------------------------------------- |
 | Nav            | New    | Fixed top bar: logo placeholder, anchor links, yellow pill CTA                           |
 | HeroViewport   | New    | `min-h-dvh` flex column wrapping Hero + Marquee; marquee sits at the bottom edge         |
 | Hero           | New    | Purple split layout, italic 900 headline, two CTAs, photo placeholder (hidden on mobile) |

--- a/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
+++ b/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
@@ -1,0 +1,128 @@
+# Design Brief: Wild Coast Kids Landing Page
+
+## Problem
+
+A homeschool parent in San Diego hears about Wild Coast Kids and wants to answer
+three questions fast: what is this (art classes and an outdoor co-op), is it for
+my kid (K–8, charter-fund eligible), and how do I get in (book a class, join the
+interest list). Today there is nothing to point them at — the co-op exists in
+conversations and a style template, not on the web.
+
+## Solution
+
+A single high-energy landing page. The first window sells the identity: a bold
+purple hero with the marquee strip pinned exactly at the bottom edge of the
+viewport, so the page opens as one composed poster. Scrolling reveals proof
+(a film strip of kids' work gliding across the screen in sync with the marquee),
+then the two offerings as big tactile cards, then social proof, the conditions
+teaser, and finally the interest-list form. One page, two calls to action:
+book an art class, join the co-op list.
+
+## Experience Principles
+
+1. **Poster first, page second** — the opening viewport is a fixed composition
+   (hero + marquee at the fold), not the top of a scroll. Layout decisions that
+   break the one-window fit on desktop are wrong.
+2. **Motion as identity, never as obstacle** — the two synced strips give the
+   page its pulse, but they pause on hover and stop entirely under
+   `prefers-reduced-motion`. Energy must never cost legibility or access.
+3. **Loud surfaces, quiet mechanics** — colors and type shout; the plumbing
+   stays boring. Semantic HTML, role-reachable landmarks, a form that works
+   with a keyboard. Nothing clever where clever isn't visible.
+
+## Aesthetic Direction
+
+- **Philosophy**: Coastal pop editorial — heavy italic Montserrat (weights up
+  to 900), electric yellow against deep purple and ocean blue, pill buttons,
+  rounded cards, marquee strips. Kid-brand energy executed with print-zine
+  discipline.
+- **Tone**: Playful, confident, warm. A place that takes kids' creativity
+  seriously without taking itself seriously.
+- **Reference points**: The supplied template (`wildcoastkids_placeholders.html`)
+  is the canonical reference — its palette, type treatment, and section designs
+  carry over. Skate/surf-brand marquees; indie print posters.
+- **Anti-references**: Corporate childcare sites (stock-photo pastels, trust
+  badges), generic SaaS landing pages, anything beige and cautious.
+
+## Existing Patterns
+
+The repo is a fresh Next.js 16 + Tailwind v4 scaffold; the template supplies
+the design language.
+
+- Typography: scaffold uses Geist via `next/font` — **replaced** by Montserrat
+  (400/500/700/800/900 + italics), loaded the same `next/font` way.
+- Colors: template palette becomes `@theme` tokens: purple `#6B5FAA`, ocean
+  `#1A4E8A`, pink `#E8A4B8`, yellow `#E8FF00`, cream `#FAF8F5`, dark `#1A1A2E`.
+  The scaffold's `prefers-color-scheme` dark swap is **removed** — one fixed,
+  art-directed palette in all themes.
+- Spacing: template rhythm (80px section padding, 48px gutters, 24px mobile
+  gutters) formalized into the token scale in the tokens phase.
+- Components: none exist; every section component is new. Test style follows
+  `src/app/page.test.tsx` — role-based reachability assertions.
+
+## Component Inventory
+
+| Component      | Status | Notes                                                                                   |
+| -------------- | ------ | --------------------------------------------------------------------------------------- |
+| Nav            | New    | Fixed top bar: logo placeholder, anchor links, yellow pill CTA                           |
+| HeroViewport   | New    | `min-h-dvh` flex column wrapping Hero + Marquee; marquee sits at the bottom edge         |
+| Hero           | New    | Purple split layout, italic 900 headline, two CTAs, photo placeholder (hidden on mobile) |
+| Marquee        | New    | Yellow looping text strip, duplicated track, pause on hover                              |
+| GallerySection | New    | Header ("What kids make here.") + GalleryStrip                                           |
+| GalleryStrip   | New    | Single-row infinite film strip of image placeholders, speed-synced to Marquee            |
+| ProgramCards   | New    | Two large cards (Art Classes / Tuesday Co-op) with tags, activities grid, CTAs           |
+| QuoteStats     | New    | Parent quote + K–8 / Charter stat tiles                                                  |
+| Conditions     | New    | Ocean-blue section with dashed "tool coming soon" embed box                              |
+| CommunityForm  | New    | Interest-list form; client-side success state only                                       |
+| Footer         | New    | Dark bar, logo, program summary                                                          |
+| Placeholder    | New    | Shared labeled dashed-border image placeholder (hero, cards, strip, logo)                |
+
+## Key Interactions
+
+- **Strip motion**: marquee and gallery strip animate leftward continuously via
+  duplicated tracks. They share one pixels-per-second speed — the marquee's 20s
+  half-track loop defines it; the gallery strip's duration is computed from its
+  own track width. Hovering a strip pauses that strip; leaving resumes it.
+  `prefers-reduced-motion: reduce` stops both permanently.
+- **Nav anchors**: links smooth-scroll to `#art`, `#coop`, `#conditions`,
+  `#community`.
+- **Card hover**: program cards lift slightly (translateY) on hover.
+- **Form submit**: client-side only — the form hides and the success state
+  ("You're in!") appears. No data leaves the page; wiring a destination is a
+  future slice.
+
+## Responsive Behavior
+
+- **Viewport block**: `min-h-dvh`, hero `flex-1` — exactly one window on
+  desktop with the marquee at the fold; allowed to grow taller on small
+  screens so nothing clips.
+- **Hero**: photo column hidden ≤768px; text column full-width.
+- **Gallery strip**: same single-row strip at all widths; image tiles shrink.
+- **Program cards**: two columns → one column ≤768px.
+- **Quote, conditions, community**: two columns → stacked ≤768px.
+- **Nav**: tighter padding and smaller links ≤768px.
+
+## Accessibility Requirements
+
+- Both strips stop under `prefers-reduced-motion: reduce`; pause on hover.
+- Image placeholders carry `role="img"` + `aria-label` describing the future
+  image, matching the template's pattern.
+- Marquee/strip duplicate tracks are `aria-hidden` so screen readers hear the
+  content once.
+- Form inputs have visible `<label>`s; success state is announced (rendered in
+  DOM, not display-toggled invisibly to AT).
+- Keyboard: all CTAs and links focusable with visible focus rings; smooth
+  scroll respects reduced motion.
+- Contrast: yellow `#E8FF00` surfaces use near-black `#1A1A00` text; body text
+  on purple/ocean stays at the template's tested opacities or better.
+
+## Out of Scope
+
+- Real photography or a logo — labeled placeholders ship; swapping in real
+  images is a later content pass.
+- A working form backend — submissions are visual-only until a destination
+  (email/sheet/service) is chosen.
+- A real booking URL — the Calendly link is `TODO(verify)`.
+- The conditions tool embed — the dashed placeholder box ships as-is.
+- Dark mode, additional pages, CMS, analytics.
+- The template's editorial block and yellow banner — cut, not deferred.

--- a/.design/wild-coast-kids-landing/DESIGN_REVIEW.md
+++ b/.design/wild-coast-kids-landing/DESIGN_REVIEW.md
@@ -5,6 +5,20 @@ Philosophy: Coastal pop editorial
 Date: 2026-08-11
 Reviewed at: branch `wild-coast-kids-landing`, commit `2ce3c63`, Next.js dev server
 
+> **Outcome addendum (2026-08-11, same day):** findings 1–3 fixed on the
+> branch and re-verified against the running app (`verify-*.png`):
+>
+> 1. Nav — fixed in two steps (`2f40bb0`, then `90ad232` after measurement
+>    showed slimming alone still overflowed 55px): below `md` the nav wraps
+>    to two rows, restoring the CTA on phones. Measured zero overflow at
+>    375px and 320px.
+> 2. Hero slot — fixed in `61d6eab`: the placeholder label now shows over
+>    the photo column (`verify-hero-desktop-1280.png`).
+> 3. Success jump — fixed in `6d55c5f`: card height measured identical
+>    before and after submit (560px → 560px, delta 0).
+>
+> Findings 4–6 remain open as could-improves.
+
 ## Screenshots Captured
 
 | Screenshot                                 | Breakpoint         | Description                                 |

--- a/.design/wild-coast-kids-landing/DESIGN_REVIEW.md
+++ b/.design/wild-coast-kids-landing/DESIGN_REVIEW.md
@@ -1,0 +1,106 @@
+# Design Review: Wild Coast Kids Landing Page
+
+Reviewed against: DESIGN_BRIEF.md
+Philosophy: Coastal pop editorial
+Date: 2026-08-11
+Reviewed at: branch `wild-coast-kids-landing`, commit `2ce3c63`, Next.js dev server
+
+## Screenshots Captured
+
+| Screenshot                                 | Breakpoint         | Description                                 |
+| ------------------------------------------ | ------------------ | ------------------------------------------- |
+| `screenshots/review-home-desktop-1280.png` | Desktop (1280×800) | Full page, top to footer                    |
+| `screenshots/review-home-tablet-768.png`   | Tablet (768×1024)  | Full page                                   |
+| `screenshots/review-home-mobile-375.png`   | Mobile (375×812)   | Full page                                   |
+| `screenshots/review-viewport-block-*.png`  | All three          | First window only — the hero+marquee poster |
+| `screenshots/review-nav-cta-focus.png`     | Desktop            | Focus ring on the Book Now pill             |
+| `screenshots/review-form-filled.png`       | Desktop            | Form with values entered                    |
+| `screenshots/review-form-success.png`      | Desktop            | Post-submit success state                   |
+| `screenshots/review-card-art-hover.png`    | Desktop            | Art card under hover                        |
+
+> Screenshots live in `.design/wild-coast-kids-landing/screenshots/`. They are
+> generated artifacts and stay untracked. The dark "N" badge visible bottom-left
+> in some captures is the Next.js dev-tools indicator — dev server only, not a
+> finding.
+
+## Summary
+
+The build is faithful to the brief: the desktop poster lands exactly as
+specified (hero filling the window, marquee pinned at the fold —
+`review-viewport-block-desktop-1280.png`), the film strip reads as a synced
+companion to the marquee, and the palette/type carry the coastal-pop voice
+unmistakably. Two real findings: the nav clips its CTA at 375px, and the hero's
+photo slot is invisible, leaving the right half of the hero reading as empty
+purple until real photography arrives.
+
+## Must Fix
+
+1. **Nav overflows at 375px — the primary CTA is clipped.** In
+   `review-home-mobile-375.png` the yellow "Book Now →" pill is cut off at the
+   right edge (body `overflow-x-hidden` masks it rather than scrolling). The
+   four links + logo + pill don't fit at the current paddings.
+   _Fix in `src/components/Nav.tsx`: tighten mobile spacing (`px-3`, `gap-2`,
+   smaller logo, e.g. `size-10`) and slim the CTA below `md` (`px-3 py-2`,
+   or text-only "Book →")._
+
+## Should Fix
+
+2. **The hero photo slot is invisible.** The `background` Placeholder variant
+   is a near-transparent gradient, so on desktop and tablet the hero's right
+   half reads as blank purple (`review-home-desktop-1280.png`,
+   `review-home-tablet-768.png`) — the poster looks half-empty and nothing
+   communicates that a photo belongs there. The brief's placeholder principle
+   is "labeled placeholders ship".
+   _Fix in `src/components/Hero.tsx` / `Placeholder.tsx`: give the hero slot a
+   visible treatment while it's a placeholder — e.g. show the label (the
+   gradient overlay can stay), or raise the placeholder fill opacity so the
+   slot reads as reserved space._
+
+3. **Success card causes a large layout jump.** The success state is much
+   shorter than the form it replaces (`review-form-success.png` vs
+   `review-form-filled.png`), so the page collapses ~400px on submit while the
+   user is looking at it.
+   _Fix in `src/components/CommunityForm.tsx`: give the card a `min-h` close
+   to the form's rendered height (or center the success state in the same
+   min-height) so the swap doesn't move the page._
+
+## Could Improve
+
+4. **Uniform strip tiles.** The template's gallery mixed aspect ratios; the
+   film strip flattened them to identical 288×208 tiles. Varying tile widths
+   (portrait/landscape rhythm) would make the strip livelier and more
+   print-zine. _Suggestion: two or three width variants cycling through the
+   list._
+5. **Touch target height on nav links.** The 9px uppercase links are ~30px
+   tall including padding — below the 44px guideline, though mitigated by
+   generous horizontal spacing. _Suggestion: add vertical padding on mobile._
+6. **Sub-16px body copy on mobile** (13px) is an accepted template-verbatim
+   decision recorded in the brief; inputs were already lifted to 16px in the
+   audit slice. Noted here so the acceptance is on the record, not silent.
+
+## What Works Well
+
+- **The poster composition.** The one-window hero+marquee lock is exactly the
+  brief's "poster first" principle, at every breakpoint that matters.
+- **The synced strips.** Marquee and film strip visibly share one speed; the
+  shared `StripTrack` makes the sync structural, not tuned.
+- **Aesthetic fidelity.** Italic-900 Montserrat, electric yellow on purple,
+  pill buttons, ✦ separators — instantly the template's voice; nothing generic
+  crept in.
+- **Accessible mechanics.** Focus ring clearly visible on the yellow pill
+  (`review-nav-cta-focus.png`), form labels associated, success state
+  announced via `role="status"`, strips silent-once to AT, contrast lifted
+  above the template where it failed AA.
+- **Consistency.** Every section pulls from the same token set — no stray
+  hex values or one-off radii anywhere in `src/components/`.
+
+## Checklist Notes
+
+- Hierarchy ✓ (h1 → section h2s in DOM order; biggest type = most important)
+- Consistency ✓ (tokens only; shared pill/section/card patterns)
+- States: default/hover/focus/success ✓; form error states rely on native
+  browser validation (accepted — boundary validates)
+- Responsive: mobile-first `md:` min-width throughout ✓; finding #1 above
+- Accessibility: landmarks ✓, reduced-motion ✓, contrast ✓ (see audit slice)
+- Dark mode: N/A by decision (fixed art-directed palette)
+- Typography: Montserrat loading correctly (italics visible in every capture)

--- a/.design/wild-coast-kids-landing/DESIGN_TOKENS.css
+++ b/.design/wild-coast-kids-landing/DESIGN_TOKENS.css
@@ -1,0 +1,118 @@
+/* ==========================================================================
+   Wild Coast Kids — design tokens
+   Philosophy: coastal pop editorial (see DESIGN_BRIEF.md)
+
+   Format: Tailwind v4 `@theme` block. During the build this replaces the
+   scaffold tokens in src/app/globals.css. Tailwind derives utilities from
+   these names (e.g. --color-purple → bg-purple, --radius-card → rounded-card).
+
+   Deviations from the design-tokens skill defaults, all decided in grilling:
+   - No dark mode. One fixed, art-directed palette in every theme; the
+     scaffold's prefers-color-scheme swap is deleted, not extended.
+   - Type sizes below 16px are intentional. The template's editorial voice
+     lives in tiny 800/900-weight uppercase labels; body copy is 13px.
+   ========================================================================== */
+
+@theme {
+  /* ---- Raw palette (template :root, verbatim) --------------------------- */
+  --color-purple: #6b5faa; /* hero, art card, accents */
+  --color-purple-deep: #5a4f99; /* purple hover state */
+  --color-ocean: #1a4e8a; /* co-op card, conditions section */
+  --color-pink: #e8a4b8; /* footer logo only */
+  --color-yellow: #e8ff00; /* marquee, CTAs, stat tiles */
+  --color-cream: #faf8f5; /* page background */
+  --color-dark: #1a1a2e; /* text, footer background */
+  --color-ink: #1a1a00; /* text on yellow surfaces */
+
+  /* ---- Supporting colors (template usage, promoted to tokens) ----------- */
+  --color-lavender: #e0d8f0; /* hairline borders, input borders */
+  --color-mist: #f0ebf8; /* gallery section background */
+  --color-fog: #7a6e8a; /* muted body text on cream */
+
+  /* ---- Typography ------------------------------------------------------- */
+  /* Montserrat via next/font, exposed as a CSS variable in layout.tsx.
+     One family for display and body; weight and italics do the work. */
+  --font-sans: var(--font-montserrat), sans-serif;
+
+  --text-2xs: 10px; /* nav links, tags, labels, aside captions */
+  --text-xs: 11px; /* CTAs, stat labels, prog-time */
+  --text-sm: 12px; /* card descriptions, buttons */
+  --text-base: 13px; /* body copy, marquee text */
+  --text-stat: 36px; /* stat tile numerals */
+
+  /* Fluid display sizes (template clamps, verbatim) */
+  --text-display: clamp(48px, 6vw, 80px); /* hero h1 */
+  --text-title: clamp(32px, 5vw, 56px); /* section h2 */
+  --text-card: clamp(30px, 3vw, 44px); /* program card titles */
+  --text-quote: clamp(20px, 2.8vw, 34px); /* pull quote */
+
+  --leading-display: 1; /* display/hero */
+  --leading-tight: 1.1; /* section headings */
+  --leading-normal: 1.7; /* card/body copy */
+  --leading-relaxed: 1.8; /* hero desc, long body */
+
+  --tracking-wide: 0.05em; /* tags */
+  --tracking-wider: 0.1em; /* nav links, CTAs, labels */
+  --tracking-widest: 0.2em; /* hero tag */
+
+  /* ---- Spacing ---------------------------------------------------------- */
+  /* Tailwind v4 numeric utilities derive from this; template rhythm maps to
+     p-3.5 (14px nav-y), px-8 (32px nav-x), p-6 (24px mobile gutter),
+     px-12 (48px gutter), py-20 (80px section). */
+  --spacing: 4px;
+
+  /* Named layout rhythm, so sections read as intent rather than arithmetic */
+  --spacing-gutter: 48px; /* desktop horizontal gutter */
+  --spacing-gutter-sm: 24px; /* mobile horizontal gutter */
+  --spacing-section: 80px; /* desktop section padding */
+  --spacing-section-sm: 60px; /* mobile section padding */
+  --spacing-nav: 70px; /* fixed nav clearance (hero padding-top) */
+
+  /* ---- Radii ------------------------------------------------------------ */
+  --radius-tile: 12px; /* co-op activity tiles, inputs */
+  --radius-thumb: 16px; /* gallery images, stat tiles */
+  --radius-box: 20px; /* conditions embed box */
+  --radius-card: 24px; /* program cards, form card */
+  --radius-pill: 99px; /* every button */
+
+  /* ---- Shadow ----------------------------------------------------------- */
+  --shadow-card: 0 8px 40px rgb(107 95 170 / 0.1); /* form card lift */
+
+  /* ---- Motion ----------------------------------------------------------- */
+  --duration-fast: 200ms; /* borders, color hovers, card lift */
+  --duration-normal: 250ms; /* image/placeholder scale */
+  --ease-default: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* The strips: the marquee's 20s half-track loop defines the shared speed.
+     The gallery strip must move at the same px/s, so its duration is
+     computed per its own track width:
+       gallery-duration = 20s × (gallery-track-px / marquee-track-px)
+     measured at runtime (or set from known tile widths). Both animations
+     pause on hover and are disabled under prefers-reduced-motion. */
+  --duration-marquee: 20s;
+
+  /* ---- Breakpoints ------------------------------------------------------ */
+  /* Template collapses everything at one width. Tailwind defaults stay;
+     `md:` (768px) is the working breakpoint for all stacking changes. */
+}
+
+/* --------------------------------------------------------------------------
+   Non-@theme companions (live alongside the block in globals.css)
+   -------------------------------------------------------------------------- */
+
+/* Keyframes for both strips: translate the duplicated track half-way, snap. */
+@keyframes strip-scroll {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+/* Baseline accessibility: strips freeze for reduced-motion users. */
+@media (prefers-reduced-motion: reduce) {
+  .strip-track {
+    animation: none;
+  }
+}

--- a/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
+++ b/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
@@ -59,23 +59,23 @@ wordmark banner. Decided in the brief; not deferred.
 
 ## Naming Conventions
 
-| Concept                | Label in UI        | Notes                                       |
-| ---------------------- | ------------------ | ------------------------------------------- |
-| The art program        | Art Classes        | Never "art program" or "lessons"            |
-| The outdoor program    | Tuesday Co-op      | Day is part of the name                     |
-| The signup form        | Community          | Nav label; form heading is "Stay in the loop" |
-| The surf/tide tool     | Conditions         | Singular section, plural word               |
-| Funding note           | Charter eligible   | Exact phrase, used in tags and stats        |
-| Age range              | K–8                | En dash, no spaces                          |
+| Concept             | Label in UI      | Notes                                         |
+| ------------------- | ---------------- | --------------------------------------------- |
+| The art program     | Art Classes      | Never "art program" or "lessons"              |
+| The outdoor program | Tuesday Co-op    | Day is part of the name                       |
+| The signup form     | Community        | Nav label; form heading is "Stay in the loop" |
+| The surf/tide tool  | Conditions       | Singular section, plural word                 |
+| Funding note        | Charter eligible | Exact phrase, used in tags and stats          |
+| Age range           | K–8              | En dash, no spaces                            |
 
 ## Component Reuse Map
 
-| Component     | Used on                                      | Behavior differences                          |
-| ------------- | -------------------------------------------- | --------------------------------------------- |
-| Placeholder   | Nav logo, hero photo, card backgrounds, strip | Label size varies; backgrounds drop the border |
-| Pill button   | Nav CTA, hero CTAs, card CTAs, form submit   | Yellow/ghost/purple variants                  |
-| Looping track | Marquee, GalleryStrip                        | Shared duplicated-track + pause-on-hover mechanic; content and speed derivation differ |
-| Section shell | Gallery, quote, conditions, community        | Shared gutter/padding rhythm, varying backgrounds |
+| Component     | Used on                                       | Behavior differences                                                                   |
+| ------------- | --------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Placeholder   | Nav logo, hero photo, card backgrounds, strip | Label size varies; backgrounds drop the border                                         |
+| Pill button   | Nav CTA, hero CTAs, card CTAs, form submit    | Yellow/ghost/purple variants                                                           |
+| Looping track | Marquee, GalleryStrip                         | Shared duplicated-track + pause-on-hover mechanic; content and speed derivation differ |
+| Section shell | Gallery, quote, conditions, community         | Shared gutter/padding rhythm, varying backgrounds                                      |
 
 ## Content Growth Plan
 

--- a/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
+++ b/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
@@ -1,0 +1,93 @@
+# Information Architecture: Wild Coast Kids
+
+## Site Map
+
+One page. All navigation is intra-page anchors.
+
+- Home `/`
+  - Art Classes `/#art` (anchor: art program card)
+  - Tuesday Co-op `/#coop` (anchor: co-op program card)
+  - Conditions `/#conditions` (anchor: conditions section)
+  - Community `/#community` (anchor: interest-list form)
+
+## Navigation Model
+
+- **Primary navigation**: fixed top bar with four anchor links — Art Classes,
+  Tuesday Co-op, Conditions, Community. That is the maximum; no dropdowns.
+- **Secondary navigation**: none. In-content CTAs cross-link: hero buttons →
+  `#art` / `#coop`, co-op card → `#community`.
+- **Utility navigation**: the yellow "Book Now" pill in the nav (→ `#art`).
+- **Mobile navigation**: same links, tighter spacing and smaller type ≤768px.
+  No hamburger — four short links fit.
+
+## Content Hierarchy
+
+### Home `/` (top to bottom)
+
+1. **Viewport block: Hero + Marquee** — identity and both CTAs in one composed
+   window; the marquee pinned at the fold is the visual signature.
+2. **Gallery section (header + film strip)** — proof before pitch: kids' actual
+   work scrolls by, synced with the marquee it sits beneath.
+3. **Programs (prog-grid)** — the two offerings, each with its own CTA. This is
+   the conversion core; everything above earns attention for it.
+4. **Quote + stats** — social proof and the two facts parents filter on
+   (K–8, charter eligible).
+5. **Conditions** — differentiator teaser; placeholder until the tool exists.
+6. **Community form** — the catch-all conversion for anyone not ready to book.
+7. **Footer** — recap and identity close.
+
+Cut from the template: editorial block ("Real kids…") and the yellow
+wordmark banner. Decided in the brief; not deferred.
+
+## User Flows
+
+### Book an art class
+
+1. Parent lands on `/`, sees hero + marquee.
+2. Clicks "Book Art Class" (hero), "Book Now" (nav), or scrolls to the art card.
+3. Arrives at `#art`, reads tags (charter eligible, all levels, outdoors).
+4. Clicks "Book a class →" — external booking link (`TODO(verify)`; opens new
+   tab once real).
+
+### Join the co-op interest list
+
+1. Parent lands on `/`, clicks "Tuesday Co-op →" (hero or nav) → `#coop`.
+2. Reads the activities grid and fall details.
+3. Clicks "Join interest list →" → `#community`.
+4. Fills name, email, kids' ages, interest checkboxes → submits.
+5. Sees the "You're in!" success state (client-side only for now).
+
+## Naming Conventions
+
+| Concept                | Label in UI        | Notes                                       |
+| ---------------------- | ------------------ | ------------------------------------------- |
+| The art program        | Art Classes        | Never "art program" or "lessons"            |
+| The outdoor program    | Tuesday Co-op      | Day is part of the name                     |
+| The signup form        | Community          | Nav label; form heading is "Stay in the loop" |
+| The surf/tide tool     | Conditions         | Singular section, plural word               |
+| Funding note           | Charter eligible   | Exact phrase, used in tags and stats        |
+| Age range              | K–8                | En dash, no spaces                          |
+
+## Component Reuse Map
+
+| Component     | Used on                                      | Behavior differences                          |
+| ------------- | -------------------------------------------- | --------------------------------------------- |
+| Placeholder   | Nav logo, hero photo, card backgrounds, strip | Label size varies; backgrounds drop the border |
+| Pill button   | Nav CTA, hero CTAs, card CTAs, form submit   | Yellow/ghost/purple variants                  |
+| Looping track | Marquee, GalleryStrip                        | Shared duplicated-track + pause-on-hover mechanic; content and speed derivation differ |
+| Section shell | Gallery, quote, conditions, community        | Shared gutter/padding rhythm, varying backgrounds |
+
+## Content Growth Plan
+
+- **Gallery strip**: designed to take any number of images — the strip loops
+  whatever list it is given; adding photos is a data change, not a layout one.
+- **Programs**: the grid accepts a third card if an offering is added.
+- **Conditions**: the dashed box is the reserved slot for the future embed.
+- Anything beyond that (blog, schedules, multiple pages) is a new IA exercise.
+
+## URL Strategy
+
+- Pattern: single route `/`; sections addressed as `/#<section-id>`.
+- Anchor ids are stable API: `art`, `coop`, `conditions`, `community` — they
+  are shared with the template and must not be renamed casually.
+- No dynamic segments, no query parameters.

--- a/.design/wild-coast-kids-landing/TASKS.md
+++ b/.design/wild-coast-kids-landing/TASKS.md
@@ -11,7 +11,7 @@ cleanup task. Components live in `src/components/` (PascalCase), composed by
 
 ## Foundation
 
-- [ ] **Tokens, Montserrat, and the nav bar**: Replace the scaffold tokens in
+- [x] **Tokens, Montserrat, and the nav bar**: Replace the scaffold tokens in
       `globals.css` with the `@theme` block from DESIGN_TOKENS.css (deleting
       the dark-mode swap), swap Geist for Montserrat in `layout.tsx`, and
       build the fixed Nav — Placeholder logo, four anchor links, yellow
@@ -20,7 +20,7 @@ cleanup task. Components live in `src/components/` (PascalCase), composed by
       role+name. _New: `Placeholder`, `Nav`. Modifies: `globals.css`,
       `layout.tsx`, `page.tsx`._
 
-- [ ] **Marquee strip**: The yellow looping text band and, inside it, the
+- [x] **Marquee strip**: The yellow looping text band and, inside it, the
       shared strip mechanic every strip uses — duplicated track
       (`aria-hidden` copy), `strip-scroll` keyframes, pause on hover, frozen
       under `prefers-reduced-motion`. Riskiest mechanic in the build, so it
@@ -29,7 +29,7 @@ cleanup task. Components live in `src/components/` (PascalCase), composed by
 
 ## Core UI
 
-- [ ] **Hero + viewport lock**: Purple split hero (tag, italic-900 headline,
+- [x] **Hero + viewport lock**: Purple split hero (tag, italic-900 headline,
       description, yellow/ghost CTAs, photo Placeholder, corner caption)
       wrapped with the Marquee in a `min-h-dvh` flex column so the marquee
       sits at the bottom edge of the first window on desktop and the block
@@ -37,44 +37,44 @@ cleanup task. Components live in `src/components/` (PascalCase), composed by
       both CTAs reachable by role+name. _New: `Hero`, `HeroViewport`.
       Depends on: Marquee._
 
-- [ ] **Gallery section**: "What kids make here." header plus the film
+- [x] **Gallery section**: "What kids make here." header plus the film
       strip — the nine labeled image Placeholders in a single infinite row
       reusing the strip mechanic, duration derived from track width so it
       moves at the marquee's px/s. Test: section heading reachable; each
       image placeholder present once by `role="img"` name. _New:
       `GallerySection`, `GalleryStrip`. Depends on: Marquee (mechanic)._
 
-- [ ] **Program cards**: The `#art` and `#coop` cards — background
+- [x] **Program cards**: The `#art` and `#coop` cards — background
       Placeholders, numbers, emoji, titles, tags, co-op activities grid,
       pill CTAs (Calendly href is `TODO(verify)`), hover lift. Two columns
       → one ≤768px. Test: both card titles and CTAs reachable; anchor ids
       present. _New: `ProgramCards`._
 
-- [ ] **Quote and stats**: Pull-quote with attribution beside the K–8 and
+- [x] **Quote and stats**: Pull-quote with attribution beside the K–8 and
       Charter stat tiles; stacks ≤768px. Test: quote text and both stat
       labels reachable. _New: `QuoteStats`._
 
-- [ ] **Conditions section**: Ocean-blue `#conditions` split — heading/copy
+- [x] **Conditions section**: Ocean-blue `#conditions` split — heading/copy
       and the dashed "tool coming soon" box reserving the embed slot. Test:
       heading reachable, section id present. _New: `Conditions`._
 
 ## Interactions & States
 
-- [ ] **Community form**: `#community` section with the form card — labeled
+- [x] **Community form**: `#community` section with the form card — labeled
       name/email/ages inputs, interest checkboxes, purple pill submit — and
       the client-side success swap ("You're in!"). Covers: default, invalid
       (required fields), submitted. Test: submit with valid input hides the
       form and shows the success state; labels associated with inputs.
       _New: `CommunityForm` (client component)._
 
-- [ ] **Footer and page metadata**: Dark footer bar (pink wordmark, summary
+- [x] **Footer and page metadata**: Dark footer bar (pink wordmark, summary
       columns, stacked ≤768px) and the real `metadata.description` in
       `layout.tsx`. Test: contentinfo landmark and wordmark reachable.
       _New: `Footer`. Modifies: `layout.tsx`._
 
 ## Responsive & Polish
 
-- [ ] **Accessibility and motion audit**: Visible focus rings on every
+- [x] **Accessibility and motion audit**: Visible focus rings on every
       interactive element, smooth-scroll disabled under reduced motion,
       strip pause behavior verified, contrast spot-check of yellow/ink and
       white-on-purple pairs, placeholder `aria-label`s complete. Test:

--- a/.design/wild-coast-kids-landing/TASKS.md
+++ b/.design/wild-coast-kids-landing/TASKS.md
@@ -1,0 +1,95 @@
+# Build Tasks: Wild Coast Kids Landing Page
+
+Generated from: .design/wild-coast-kids-landing/DESIGN_BRIEF.md
+Date: 2026-08-11
+
+Each task is one repo slice per CLAUDE.md: one nameable change, its own
+role-based test in the same commit, `npm run gate` green before committing.
+Every slice ships its own responsive behavior — there is no "make it mobile"
+cleanup task. Components live in `src/components/` (PascalCase), composed by
+`src/app/page.tsx`.
+
+## Foundation
+
+- [ ] **Tokens, Montserrat, and the nav bar**: Replace the scaffold tokens in
+      `globals.css` with the `@theme` block from DESIGN_TOKENS.css (deleting
+      the dark-mode swap), swap Geist for Montserrat in `layout.tsx`, and
+      build the fixed Nav — Placeholder logo, four anchor links, yellow
+      "Book Now" pill. Establishes the coastal-pop-editorial direction in the
+      first visible commit. Test: nav landmark reachable, all four links by
+      role+name. _New: `Placeholder`, `Nav`. Modifies: `globals.css`,
+      `layout.tsx`, `page.tsx`._
+
+- [ ] **Marquee strip**: The yellow looping text band and, inside it, the
+      shared strip mechanic every strip uses — duplicated track
+      (`aria-hidden` copy), `strip-scroll` keyframes, pause on hover, frozen
+      under `prefers-reduced-motion`. Riskiest mechanic in the build, so it
+      lands second. Test: phrases readable exactly once by AT; duplicate
+      track hidden. _New: `Marquee` (+ shared track pattern)._
+
+## Core UI
+
+- [ ] **Hero + viewport lock**: Purple split hero (tag, italic-900 headline,
+      description, yellow/ghost CTAs, photo Placeholder, corner caption)
+      wrapped with the Marquee in a `min-h-dvh` flex column so the marquee
+      sits at the bottom edge of the first window on desktop and the block
+      may grow on small screens. Photo column hidden ≤768px. Test: h1 and
+      both CTAs reachable by role+name. _New: `Hero`, `HeroViewport`.
+      Depends on: Marquee._
+
+- [ ] **Gallery section**: "What kids make here." header plus the film
+      strip — the nine labeled image Placeholders in a single infinite row
+      reusing the strip mechanic, duration derived from track width so it
+      moves at the marquee's px/s. Test: section heading reachable; each
+      image placeholder present once by `role="img"` name. _New:
+      `GallerySection`, `GalleryStrip`. Depends on: Marquee (mechanic)._
+
+- [ ] **Program cards**: The `#art` and `#coop` cards — background
+      Placeholders, numbers, emoji, titles, tags, co-op activities grid,
+      pill CTAs (Calendly href is `TODO(verify)`), hover lift. Two columns
+      → one ≤768px. Test: both card titles and CTAs reachable; anchor ids
+      present. _New: `ProgramCards`._
+
+- [ ] **Quote and stats**: Pull-quote with attribution beside the K–8 and
+      Charter stat tiles; stacks ≤768px. Test: quote text and both stat
+      labels reachable. _New: `QuoteStats`._
+
+- [ ] **Conditions section**: Ocean-blue `#conditions` split — heading/copy
+      and the dashed "tool coming soon" box reserving the embed slot. Test:
+      heading reachable, section id present. _New: `Conditions`._
+
+## Interactions & States
+
+- [ ] **Community form**: `#community` section with the form card — labeled
+      name/email/ages inputs, interest checkboxes, purple pill submit — and
+      the client-side success swap ("You're in!"). Covers: default, invalid
+      (required fields), submitted. Test: submit with valid input hides the
+      form and shows the success state; labels associated with inputs.
+      _New: `CommunityForm` (client component)._
+
+- [ ] **Footer and page metadata**: Dark footer bar (pink wordmark, summary
+      columns, stacked ≤768px) and the real `metadata.description` in
+      `layout.tsx`. Test: contentinfo landmark and wordmark reachable.
+      _New: `Footer`. Modifies: `layout.tsx`._
+
+## Responsive & Polish
+
+- [ ] **Accessibility and motion audit**: Visible focus rings on every
+      interactive element, smooth-scroll disabled under reduced motion,
+      strip pause behavior verified, contrast spot-check of yellow/ink and
+      white-on-purple pairs, placeholder `aria-label`s complete. Test:
+      focus-visible styles asserted on nav CTA; reduced-motion media rules
+      present. _Modifies: existing components only._
+
+## Review
+
+- [ ] **Design review**: Run /design-review against the brief with the dev
+      server running; screenshots at 1280/768/375.
+
+## Repo process (wraps the list above)
+
+Per CLAUDE.md, before the first slice: commit the plan file
+(`docs/plans/wild-coast-kids-landing.md`, distilled from these .design docs)
+as its own first commit on branch `wild-coast-kids-landing`, then work the
+slices in order, one commit each, gates green at every commit; PR at the end
+with gate output pasted.

--- a/docs/plans/wild-coast-kids-landing.md
+++ b/docs/plans/wild-coast-kids-landing.md
@@ -71,6 +71,18 @@ checklist. Order: plan commit → tokens/Montserrat/nav → marquee →
 hero+viewport → gallery strip → program cards → quote/stats → conditions →
 community form → footer/metadata → a11y audit.
 
+## Addendum — 2026-08-11 (build)
+
+- **Strip speed mechanism refined.** The plan said the marquee's 20s loop
+  defines the shared speed and the gallery derives from it. Implementation
+  inverted that: both strips ride one `StripTrack` component that measures
+  its own track and derives its duration from a single shared constant
+  (80 px/s), with 20s as the pre-measurement fallback. Same speed by
+  construction, no cross-component measurement.
+- **Contrast lifted above template.** Three template pairs failed WCAG AA;
+  hero/card copy moved to white/90 and the fog text token darkened to
+  `#6b5f7d`. Allowed by the brief's "template opacities or better".
+
 ## Out of scope
 
 Real images and logo, form backend, real booking URL, conditions-tool embed,

--- a/docs/plans/wild-coast-kids-landing.md
+++ b/docs/plans/wild-coast-kids-landing.md
@@ -1,0 +1,78 @@
+# Wild Coast Kids landing page
+
+## Problem, from the user's point of view
+
+A homeschool parent who hears about Wild Coast Kids has nowhere to look it up.
+They need to learn, in one visit: what it is (art classes and a Tuesday
+outdoor co-op), whether it fits their kid (K–8, charter-fund eligible, San
+Diego), and how to act (book a class or join the interest list).
+
+## Solution
+
+A single landing page at `/`, built from the supplied style template
+(`wildcoastkids_placeholders.html`) with three layout changes the client
+asked for:
+
+1. Hero and marquee wrapped in one `min-h-dvh` block so the marquee sits at
+   the bottom edge of the first window (min-height, not hard lock, so small
+   screens can grow rather than clip).
+2. The gallery moves up beneath that block and becomes a single-row film
+   strip scrolling at the same pixels-per-second as the marquee.
+3. The programs grid follows; remaining sections keep their template order.
+   The editorial block and yellow wordmark banner are cut entirely.
+
+Full design record: `.design/wild-coast-kids-landing/` (brief, IA, tokens,
+tasks). This plan is the distilled, committed version.
+
+## Implementation decisions
+
+- **Tailwind translation, not CSS port.** Template palette/type become a
+  Tailwind v4 `@theme` block in `globals.css`; sections become React
+  components under `src/components/`, composed by `src/app/page.tsx`.
+  Rejected: porting the template CSS verbatim — two styling systems in one
+  repo, and Tailwind already installed.
+- **One fixed palette, no dark mode.** The scaffold's
+  `prefers-color-scheme` swap is deleted. Rejected: dual palettes — an
+  art-directed poster page does not survive automatic inversion.
+- **Montserrat via `next/font`** (weights 400–900 + italics) replaces Geist.
+- **Shared strip mechanic.** One duplicated-track pattern (translateX loop,
+  `aria-hidden` duplicate, pause on hover, frozen under
+  `prefers-reduced-motion`) drives both marquee and gallery strip. The
+  marquee's 20s half-track loop defines the speed; the gallery derives its
+  duration from its own track width to match px/s. Rejected: same 20s
+  duration for both — visibly different speeds.
+- **Labeled placeholders everywhere an image belongs** (template's
+  dashed-border pattern): nav logo, hero photo, card backgrounds, all nine
+  strip images. Real photography is a later content pass.
+- **Form is client-side only.** Submit swaps to the success state; no data
+  leaves the page. Wiring a destination is a future slice. Rejected for
+  now: form service or API route — needs an account/provider decision.
+- **Copy verbatim from the template**, with its mojibake (UTF-8 corrupted
+  emoji/arrows) restored to real characters. Booking link is `TODO(verify)`
+  — the template's bare `https://calendly.com` is a placeholder, and this
+  repo does not invent URLs.
+
+## Test seams
+
+- Every section component renders standalone and is asserted by **role and
+  accessible name** (repo's established style in `src/app/page.test.tsx`) —
+  landmarks, headings, links, form controls.
+- The strip mechanic's seam: content readable exactly once by AT, duplicate
+  track `aria-hidden`.
+- The form's seam: valid submit hides the form and shows the success state,
+  via Testing Library user events — the state change, not the handler.
+- Gates: `npm run gate` (format, lint, typecheck, tests + coverage) green
+  at every commit.
+
+## Slices
+
+See `.design/wild-coast-kids-landing/TASKS.md` for the authoritative
+checklist. Order: plan commit → tokens/Montserrat/nav → marquee →
+hero+viewport → gallery strip → program cards → quote/stats → conditions →
+community form → footer/metadata → a11y audit.
+
+## Out of scope
+
+Real images and logo, form backend, real booking URL, conditions-tool embed,
+dark mode, extra pages, CMS, analytics. The cut template sections (editorial,
+wordmark banner) are removed by decision, not deferred.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -61,4 +61,19 @@
   /* Motion */
   --duration-fast: 200ms;
   --duration-normal: 250ms;
+
+  /* Both strips (marquee, gallery) run this animation. 20s is the fallback
+     before StripTrack measures its track and sets the real duration from the
+     shared px/s speed. */
+  --duration-marquee: 20s;
+  --animate-strip: strip-scroll var(--duration-marquee) linear infinite;
+
+  @keyframes strip-scroll {
+    from {
+      transform: translateX(0);
+    }
+    to {
+      transform: translateX(-50%);
+    }
+  }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,7 +16,9 @@
   --color-ink: #1a1a00;
   --color-lavender: #e0d8f0;
   --color-mist: #f0ebf8;
-  --color-fog: #7a6e8a;
+  /* Darkened from the template's #7a6e8a: that fails WCAG AA on the mist
+     background (4.06:1); this reads the same and clears 5:1 everywhere. */
+  --color-fog: #6b5f7d;
 
   /* Typography — one family, weight and italics do the work. Sub-16px
      label/body sizes are the template's editorial voice, kept on purpose. */
@@ -75,5 +77,16 @@
     to {
       transform: translateX(-50%);
     }
+  }
+}
+
+@layer base {
+  /* currentColor keeps the ring visible on every surface: ink on yellow
+     pills, white on the purple hero, dark on cream. */
+  a:focus-visible,
+  button:focus-visible,
+  input:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,64 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
+/* Wild Coast Kids design tokens — coastal pop editorial.
+   Canonical record: .design/wild-coast-kids-landing/DESIGN_TOKENS.css.
+   One fixed, art-directed palette: no dark mode by decision (see
+   docs/plans/wild-coast-kids-landing.md). */
+@theme {
+  /* Palette (template :root, verbatim) */
+  --color-purple: #6b5faa;
+  --color-purple-deep: #5a4f99;
+  --color-ocean: #1a4e8a;
+  --color-pink: #e8a4b8;
+  --color-yellow: #e8ff00;
+  --color-cream: #faf8f5;
+  --color-dark: #1a1a2e;
+  --color-ink: #1a1a00;
+  --color-lavender: #e0d8f0;
+  --color-mist: #f0ebf8;
+  --color-fog: #7a6e8a;
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
+  /* Typography — one family, weight and italics do the work. Sub-16px
+     label/body sizes are the template's editorial voice, kept on purpose. */
+  --font-sans: var(--font-montserrat), sans-serif;
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
+  --text-2xs: 10px;
+  --text-xs: 11px;
+  --text-sm: 12px;
+  --text-base: 13px;
+  --text-stat: 36px;
+  --text-display: clamp(48px, 6vw, 80px);
+  --text-title: clamp(32px, 5vw, 56px);
+  --text-card: clamp(30px, 3vw, 44px);
+  --text-quote: clamp(20px, 2.8vw, 34px);
 
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  --leading-display: 1;
+  --leading-tight: 1.1;
+  --leading-normal: 1.7;
+  --leading-relaxed: 1.8;
+
+  --tracking-wide: 0.05em;
+  --tracking-wider: 0.1em;
+  --tracking-widest: 0.2em;
+
+  /* Layout rhythm */
+  --spacing-gutter: 48px;
+  --spacing-gutter-sm: 24px;
+  --spacing-section: 80px;
+  --spacing-section-sm: 60px;
+  --spacing-nav: 70px;
+
+  /* Radii */
+  --radius-tile: 12px;
+  --radius-thumb: 16px;
+  --radius-box: 20px;
+  --radius-card: 24px;
+  --radius-pill: 99px;
+
+  /* Shadow */
+  --shadow-card: 0 8px 40px rgb(107 95 170 / 0.1);
+
+  /* Motion */
+  --duration-fast: 200ms;
+  --duration-normal: 250ms;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,14 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Montserrat } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+// The whole page speaks one family; weight (400–900) and italics carry the
+// hierarchy, per the coastal-pop-editorial direction in the design brief.
+const montserrat = Montserrat({
+  variable: "--font-montserrat",
   subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  style: ["normal", "italic"],
+  weight: ["400", "500", "700", "800", "900"],
 });
 
 export const metadata: Metadata = {
@@ -21,9 +20,11 @@ export default function RootLayout({ children }: LayoutProps<"/">) {
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${montserrat.variable} h-full antialiased motion-safe:scroll-smooth`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="flex min-h-full flex-col overflow-x-hidden bg-cream font-sans text-dark">
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,8 @@ const montserrat = Montserrat({
 
 export const metadata: Metadata = {
   title: "Wild Coast Kids",
-  description: "",
+  description:
+    "Art classes and a Tuesday outdoor co-op for K–8 kids, rooted in the San Diego coast. Charter fund eligible.",
 };
 
 export default function RootLayout({ children }: LayoutProps<"/">) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@ import { GallerySection } from "@/components/GallerySection";
 import { HeroViewport } from "@/components/HeroViewport";
 import { Nav } from "@/components/Nav";
 import { ProgramCards } from "@/components/ProgramCards";
+import { QuoteStats } from "@/components/QuoteStats";
 
 export default function Home() {
   return (
@@ -11,6 +12,7 @@ export default function Home() {
         <HeroViewport />
         <GallerySection />
         <ProgramCards />
+        <QuoteStats />
       </main>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { Conditions } from "@/components/Conditions";
 import { GallerySection } from "@/components/GallerySection";
 import { HeroViewport } from "@/components/HeroViewport";
 import { Nav } from "@/components/Nav";
@@ -13,6 +14,7 @@ export default function Home() {
         <GallerySection />
         <ProgramCards />
         <QuoteStats />
+        <Conditions />
       </main>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { GallerySection } from "@/components/GallerySection";
 import { HeroViewport } from "@/components/HeroViewport";
 import { Nav } from "@/components/Nav";
 
@@ -7,6 +8,7 @@ export default function Home() {
       <Nav />
       <main className="flex-1">
         <HeroViewport />
+        <GallerySection />
       </main>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,13 @@
+import { Marquee } from "@/components/Marquee";
 import { Nav } from "@/components/Nav";
 
 export default function Home() {
   return (
     <>
       <Nav />
-      <main className="flex-1" />
+      <main className="flex-1">
+        <Marquee />
+      </main>
     </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { CommunityForm } from "@/components/CommunityForm";
 import { Conditions } from "@/components/Conditions";
+import { Footer } from "@/components/Footer";
 import { GallerySection } from "@/components/GallerySection";
 import { HeroViewport } from "@/components/HeroViewport";
 import { Nav } from "@/components/Nav";
@@ -18,6 +19,7 @@ export default function Home() {
         <Conditions />
         <CommunityForm />
       </main>
+      <Footer />
     </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { CommunityForm } from "@/components/CommunityForm";
 import { Conditions } from "@/components/Conditions";
 import { GallerySection } from "@/components/GallerySection";
 import { HeroViewport } from "@/components/HeroViewport";
@@ -15,6 +16,7 @@ export default function Home() {
         <ProgramCards />
         <QuoteStats />
         <Conditions />
+        <CommunityForm />
       </main>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { GallerySection } from "@/components/GallerySection";
 import { HeroViewport } from "@/components/HeroViewport";
 import { Nav } from "@/components/Nav";
+import { ProgramCards } from "@/components/ProgramCards";
 
 export default function Home() {
   return (
@@ -9,6 +10,7 @@ export default function Home() {
       <main className="flex-1">
         <HeroViewport />
         <GallerySection />
+        <ProgramCards />
       </main>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,10 @@
+import { Nav } from "@/components/Nav";
+
 export default function Home() {
-  return <main className="flex flex-1 items-center justify-center" />;
+  return (
+    <>
+      <Nav />
+      <main className="flex-1" />
+    </>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { Marquee } from "@/components/Marquee";
+import { HeroViewport } from "@/components/HeroViewport";
 import { Nav } from "@/components/Nav";
 
 export default function Home() {
@@ -6,7 +6,7 @@ export default function Home() {
     <>
       <Nav />
       <main className="flex-1">
-        <Marquee />
+        <HeroViewport />
       </main>
     </>
   );

--- a/src/components/CommunityForm.test.tsx
+++ b/src/components/CommunityForm.test.tsx
@@ -1,0 +1,36 @@
+import { expect, test } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { CommunityForm } from "./CommunityForm";
+
+test("every input has an associated label", () => {
+  render(<CommunityForm />);
+
+  expect(screen.getByLabelText("Your name")).toBeDefined();
+  expect(screen.getByLabelText("Email")).toBeDefined();
+  expect(screen.getByLabelText("Kids' ages")).toBeDefined();
+  for (const name of ["Art Classes", "Tidepools", "Hikes", "Science"]) {
+    expect(
+      screen.getByRole("checkbox", { name: new RegExp(name) }),
+    ).toBeDefined();
+  }
+});
+
+test("submitting swaps the form for the success state", () => {
+  render(<CommunityForm />);
+
+  fireEvent.change(screen.getByLabelText("Your name"), {
+    target: { value: "Robin Parent" },
+  });
+  fireEvent.change(screen.getByLabelText("Email"), {
+    target: { value: "robin@example.com" },
+  });
+  fireEvent.click(screen.getByRole("checkbox", { name: /tidepools/i }));
+  fireEvent.click(screen.getByRole("button", { name: /join the community/i }));
+
+  // The success state must actually replace the form, not merely render:
+  // the status is announced and the submit button is gone.
+  expect(screen.getByRole("status").textContent).toContain("You're in!");
+  expect(screen.queryByRole("button", { name: /join the community/i })).toBe(
+    null,
+  );
+});

--- a/src/components/CommunityForm.tsx
+++ b/src/components/CommunityForm.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState } from "react";
+
+const INTERESTS = [
+  { value: "art", emoji: "🎨", label: "Art Classes" },
+  { value: "tidepools", emoji: "🌊", label: "Tidepools" },
+  { value: "hikes", emoji: "🌿", label: "Hikes" },
+  { value: "science", emoji: "🔬", label: "Science" },
+];
+
+const INPUT_CLASSES =
+  "rounded-tile w-full border-[1.5px] border-lavender bg-cream px-4 py-[13px] text-base text-dark transition-colors duration-fast outline-none focus:border-purple focus:bg-white";
+
+/**
+ * The interest-list form. Client-side only by decision: submit swaps the
+ * form for the success state and no data leaves the page — wiring a real
+ * destination (email/sheet/service) is a future slice.
+ */
+export function CommunityForm() {
+  const [submitted, setSubmitted] = useState(false);
+
+  return (
+    <section
+      id="community"
+      className="px-gutter-sm py-15 grid items-start gap-10 md:grid-cols-2 md:gap-20 md:px-gutter md:py-20"
+    >
+      <div>
+        <h2 className="text-title leading-display mb-4 font-black italic">
+          Stay in
+          <br />
+          the <span className="text-purple">loop.</span>
+        </h2>
+        <p className="leading-relaxed text-base text-fog">
+          Drop your info and we&apos;ll reach out with new classes, co-op
+          updates and coastal adventures.
+        </p>
+      </div>
+      <div className="rounded-card shadow-card bg-white p-9">
+        {submitted ? (
+          <div role="status" className="px-5 py-10 text-center">
+            <span aria-hidden="true" className="mb-4 block text-[52px]">
+              🎉
+            </span>
+            <h3 className="mb-2 text-[22px] font-black italic">
+              You&apos;re in!
+            </h3>
+            <p className="leading-normal text-base text-fog">
+              We&apos;ll be in touch soon with updates, new classes and coastal
+              adventures.
+            </p>
+          </div>
+        ) : (
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              setSubmitted(true);
+            }}
+          >
+            <div className="mb-4.5">
+              <label
+                htmlFor="community-name"
+                className="mb-2 block text-2xs font-extrabold tracking-wider uppercase"
+              >
+                Your name
+              </label>
+              <input
+                id="community-name"
+                name="name"
+                type="text"
+                required
+                placeholder="First and last name"
+                className={INPUT_CLASSES}
+              />
+            </div>
+            <div className="mb-4.5">
+              <label
+                htmlFor="community-email"
+                className="mb-2 block text-2xs font-extrabold tracking-wider uppercase"
+              >
+                Email
+              </label>
+              <input
+                id="community-email"
+                name="email"
+                type="email"
+                required
+                placeholder="you@email.com"
+                className={INPUT_CLASSES}
+              />
+            </div>
+            <div className="mb-4.5">
+              <label
+                htmlFor="community-ages"
+                className="mb-2 block text-2xs font-extrabold tracking-wider uppercase"
+              >
+                Kids&apos; ages
+              </label>
+              <input
+                id="community-ages"
+                name="ages"
+                type="text"
+                placeholder="e.g. 6, 9, 12"
+                className={INPUT_CLASSES}
+              />
+            </div>
+            <fieldset className="mb-4.5">
+              <legend className="mb-2 block text-2xs font-extrabold tracking-wider uppercase">
+                Interested in
+              </legend>
+              <div className="mt-2 grid grid-cols-2 gap-2.5">
+                {INTERESTS.map(({ value, emoji, label }) => (
+                  <label
+                    key={value}
+                    className="flex cursor-pointer items-center gap-2 text-sm font-bold"
+                  >
+                    <input
+                      type="checkbox"
+                      name="interest"
+                      value={value}
+                      className="size-4 accent-purple"
+                    />
+                    <span aria-hidden="true">{emoji}</span> {label}
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+            <button
+              type="submit"
+              className="rounded-pill mt-6 w-full cursor-pointer bg-purple p-[15px] text-base font-black tracking-[0.06em] text-white transition-colors duration-fast hover:bg-purple-deep"
+            >
+              Join the community →
+            </button>
+          </form>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/CommunityForm.tsx
+++ b/src/components/CommunityForm.tsx
@@ -9,8 +9,9 @@ const INTERESTS = [
   { value: "science", emoji: "🔬", label: "Science" },
 ];
 
+/* 16px on touch widths — iOS zooms into any input below 16px on focus. */
 const INPUT_CLASSES =
-  "rounded-tile w-full border-[1.5px] border-lavender bg-cream px-4 py-[13px] text-base text-dark transition-colors duration-fast outline-none focus:border-purple focus:bg-white";
+  "rounded-tile w-full border-[1.5px] border-lavender bg-cream px-4 py-[13px] text-[16px] text-dark transition-colors duration-fast outline-none focus:border-purple focus:bg-white md:text-base";
 
 /**
  * The interest-list form. Client-side only by decision: submit swaps the
@@ -23,7 +24,7 @@ export function CommunityForm() {
   return (
     <section
       id="community"
-      className="px-gutter-sm py-15 grid items-start gap-10 md:grid-cols-2 md:gap-20 md:px-gutter md:py-20"
+      className="px-gutter-sm py-section-sm grid items-start gap-10 md:grid-cols-2 md:gap-20 md:px-gutter md:py-section"
     >
       <div>
         <h2 className="text-title leading-display mb-4 font-black italic">

--- a/src/components/CommunityForm.tsx
+++ b/src/components/CommunityForm.tsx
@@ -37,9 +37,14 @@ export function CommunityForm() {
           updates and coastal adventures.
         </p>
       </div>
-      <div className="rounded-card shadow-card bg-white p-9">
+      {/* min-h ≈ the rendered form, so the success swap doesn't collapse the
+          card and yank the page while the user is looking at it. */}
+      <div className="rounded-card shadow-card min-h-140 bg-white p-9">
         {submitted ? (
-          <div role="status" className="px-5 py-10 text-center">
+          <div
+            role="status"
+            className="flex min-h-120 flex-col justify-center px-5 py-10 text-center"
+          >
             <span aria-hidden="true" className="mb-4 block text-[52px]">
               🎉
             </span>

--- a/src/components/Conditions.test.tsx
+++ b/src/components/Conditions.test.tsx
@@ -1,0 +1,14 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Conditions } from "./Conditions";
+
+test("the conditions heading and embed slot are reachable at #conditions", () => {
+  const { container } = render(<Conditions />);
+
+  const heading = screen.getByRole("heading", { level: 2 });
+  expect(heading.textContent).toContain("conditions");
+  expect(screen.getByText(/conditions tool coming soon/i)).toBeDefined();
+
+  // The nav deep-links here; the id is stable API.
+  expect(container.querySelector("section#conditions")).not.toBeNull();
+});

--- a/src/components/Conditions.tsx
+++ b/src/components/Conditions.tsx
@@ -1,0 +1,34 @@
+export function Conditions() {
+  return (
+    <section
+      id="conditions"
+      className="px-gutter-sm py-15 grid items-center gap-8 bg-ocean md:grid-cols-2 md:gap-12 md:px-gutter md:py-20"
+    >
+      <div>
+        <h2 className="text-title leading-tight mb-3.5 font-black text-white italic">
+          Check
+          <br />
+          <span className="text-yellow">conditions</span>
+          <br />
+          first.
+        </h2>
+        <p className="leading-relaxed text-base text-white/65">
+          Real-time surf, tide, wind and visibility for San Diego&apos;s coast —
+          built by a local, for families planning tidepool visits and hikes.
+        </p>
+      </div>
+      {/* The reserved slot for the future conditions-tool embed. */}
+      <div className="rounded-box border-2 border-dashed border-white/20 bg-white/7 px-8 py-12 text-center">
+        <span aria-hidden="true" className="mb-3.5 block text-5xl">
+          🌊
+        </span>
+        <p className="leading-normal text-sm text-white/45">
+          Conditions tool coming soon.
+          <br />
+          <br />
+          Drop the URL and it embeds here automatically.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Conditions.tsx
+++ b/src/components/Conditions.tsx
@@ -2,7 +2,7 @@ export function Conditions() {
   return (
     <section
       id="conditions"
-      className="px-gutter-sm py-15 grid items-center gap-8 bg-ocean md:grid-cols-2 md:gap-12 md:px-gutter md:py-20"
+      className="px-gutter-sm py-section-sm grid items-center gap-8 bg-ocean md:grid-cols-2 md:gap-12 md:px-gutter md:py-section"
     >
       <div>
         <h2 className="text-title leading-tight mb-3.5 font-black text-white italic">

--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -1,0 +1,11 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Footer } from "./Footer";
+
+test("the footer is a contentinfo landmark carrying the wordmark", () => {
+  render(<Footer />);
+
+  const footer = screen.getByRole("contentinfo");
+  expect(footer.textContent).toContain("Wild Coast Kids");
+  expect(footer.textContent).toContain("Charter Eligible · K–8");
+});

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,17 @@
+export function Footer() {
+  return (
+    <footer className="flex flex-col items-center gap-4 bg-dark p-9 text-center md:flex-row md:justify-between md:p-12 md:text-left">
+      <div>
+        <p className="text-xl font-black text-pink italic">Wild Coast Kids</p>
+        <p className="mt-1 text-xs font-semibold text-white/30">
+          San Diego · wildcoastkids.com
+        </p>
+      </div>
+      <p className="text-2xs leading-loose font-extrabold tracking-wider text-white/25 uppercase md:text-right">
+        Art Classes · Tuesday Co-op
+        <br />
+        Charter Eligible · K–8
+      </p>
+    </footer>
+  );
+}

--- a/src/components/GallerySection.test.tsx
+++ b/src/components/GallerySection.test.tsx
@@ -1,0 +1,25 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { GallerySection } from "./GallerySection";
+
+test("the gallery heading is reachable", () => {
+  render(<GallerySection />);
+
+  const heading = screen.getByRole("heading", { level: 2 });
+  expect(heading.textContent).toContain("What kids");
+  expect(heading.textContent).toContain("make here.");
+});
+
+test("every image slot is exposed to assistive tech exactly once", () => {
+  render(<GallerySection />);
+
+  // The strip renders each placeholder twice for the seamless loop, but the
+  // duplicate track is aria-hidden, so by role each image appears once.
+  for (const name of [
+    "Art class at the park",
+    "Watercolor houses",
+    "Dinosaur watercolor",
+  ]) {
+    expect(screen.getAllByRole("img", { name })).toHaveLength(1);
+  }
+});

--- a/src/components/GallerySection.tsx
+++ b/src/components/GallerySection.tsx
@@ -1,0 +1,47 @@
+import { Placeholder } from "./Placeholder";
+import { StripTrack } from "./StripTrack";
+
+const GALLERY_IMAGES = [
+  "Art class at the park",
+  "Mixed media art",
+  "Neon chalk art",
+  "Sunset painting",
+  "Watercolor houses",
+  "Cactus collage",
+  "Pixel art",
+  "Kids with artwork",
+  "Dinosaur watercolor",
+];
+
+export function GallerySection() {
+  return (
+    <section className="bg-mist py-section-sm md:py-section">
+      <div className="mb-10 flex flex-col items-start gap-3 px-gutter-sm md:flex-row md:items-end md:justify-between md:px-gutter">
+        <h2 className="text-title leading-tight font-black italic">
+          What kids
+          <br />
+          make here.
+        </h2>
+        <p className="leading-normal text-sm text-fog md:max-w-50 md:text-right">
+          Every class is different.
+          <br />
+          Every kid surprises us.
+        </p>
+      </div>
+      {/* Full-bleed film strip: single row, moving at the marquee's px/s via
+          the shared StripTrack speed. */}
+      <div className="group overflow-hidden">
+        <StripTrack>
+          {GALLERY_IMAGES.map((label) => (
+            <Placeholder
+              key={label}
+              label={label}
+              className="rounded-thumb mx-1.5 h-52 w-72 shrink-0 overflow-hidden md:h-56 md:w-80"
+              labelClassName="whitespace-normal"
+            />
+          ))}
+        </StripTrack>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -13,7 +13,8 @@ export function Hero() {
           make,
           <span className="block text-yellow">wonder.</span>
         </h1>
-        <p className="leading-relaxed mb-9 max-w-80 text-base text-white/70">
+        {/* white/90, up from the template's /70: 4.79:1 vs a failing 3.60:1 */}
+        <p className="leading-relaxed mb-9 max-w-80 text-base text-white/90">
           Art classes and outdoor co-op rooted in the California coast. Charter
           fund eligible.
         </p>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,50 @@
+import { Placeholder } from "./Placeholder";
+
+export function Hero() {
+  return (
+    <section className="relative grid flex-1 overflow-hidden bg-purple pt-[90px] pb-15 md:grid-cols-2 md:pt-nav md:pb-0">
+      <div className="relative z-10 col-start-1 row-start-1 flex flex-col justify-center px-6 pt-5 md:px-12 md:py-15">
+        <p className="mb-7 text-2xs font-extrabold tracking-widest text-yellow uppercase">
+          📍 San Diego · K–8 · Outdoors
+        </p>
+        <h1 className="text-display leading-display mb-8 font-black text-cream italic">
+          Kids who
+          <br />
+          make,
+          <span className="block text-yellow">wonder.</span>
+        </h1>
+        <p className="leading-relaxed mb-9 max-w-80 text-base text-white/70">
+          Art classes and outdoor co-op rooted in the California coast. Charter
+          fund eligible.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <a
+            href="#art"
+            className="rounded-pill bg-yellow px-7 py-[13px] text-sm font-black text-ink"
+          >
+            🎨 Book Art Class
+          </a>
+          <a
+            href="#coop"
+            className="rounded-pill border-2 border-white/50 px-[26px] py-[13px] text-sm font-bold text-white"
+          >
+            Tuesday Co-op →
+          </a>
+        </div>
+      </div>
+      <div className="relative col-start-2 row-start-1 hidden md:block">
+        <Placeholder
+          background
+          label="Hero photo of kids exploring the coast"
+          className="absolute inset-0"
+        />
+        {/* Blends the photo edge into the purple text column, as in the
+            template's hero-photo::after gradient. */}
+        <div className="absolute inset-0 bg-linear-to-r from-purple from-28% via-purple/15 via-60% to-transparent" />
+      </div>
+      <p className="absolute bottom-9 left-6 z-10 text-2xs font-bold tracking-[0.12em] text-white/35 uppercase md:left-12">
+        San Diego, CA · K–8
+      </p>
+    </section>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -34,10 +34,14 @@ export function Hero() {
         </div>
       </div>
       <div className="relative col-start-2 row-start-1 hidden md:block">
+        {/* showLabel: without it this slot is invisible over the purple and
+            the poster's right half reads as empty (design review, finding 2). */}
         <Placeholder
           background
+          showLabel
           label="Hero photo of kids exploring the coast"
-          className="absolute inset-0"
+          className="absolute inset-0 bg-white/5"
+          labelClassName="text-white/40"
         />
         {/* Blends the photo edge into the purple text column, as in the
             template's hero-photo::after gradient. */}

--- a/src/components/HeroViewport.test.tsx
+++ b/src/components/HeroViewport.test.tsx
@@ -23,6 +23,16 @@ test("both hero CTAs link to their program anchors", () => {
   ).toBe("#coop");
 });
 
+test("the hero photo slot shows its label while it is a placeholder", () => {
+  render(<HeroViewport />);
+
+  // Without the visible label the slot is invisible over the purple and the
+  // poster's right half reads as empty (design review, finding 2).
+  expect(
+    screen.getByText("Hero photo of kids exploring the coast"),
+  ).toBeDefined();
+});
+
 test("the marquee rides inside the viewport block", () => {
   render(<HeroViewport />);
 

--- a/src/components/HeroViewport.test.tsx
+++ b/src/components/HeroViewport.test.tsx
@@ -1,0 +1,30 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HeroViewport } from "./HeroViewport";
+
+test("the hero headline is the page's h1", () => {
+  render(<HeroViewport />);
+
+  // The headline breaks across <br> elements, which contribute no space to
+  // the accessible name — so match by level and content, not full name.
+  const headline = screen.getByRole("heading", { level: 1 });
+  expect(headline.textContent).toContain("Kids who");
+  expect(headline.textContent).toContain("wonder.");
+});
+
+test("both hero CTAs link to their program anchors", () => {
+  render(<HeroViewport />);
+
+  expect(
+    screen.getByRole("link", { name: /book art class/i }).getAttribute("href"),
+  ).toBe("#art");
+  expect(
+    screen.getByRole("link", { name: /tuesday co-op/i }).getAttribute("href"),
+  ).toBe("#coop");
+});
+
+test("the marquee rides inside the viewport block", () => {
+  render(<HeroViewport />);
+
+  expect(screen.getAllByText("Art Classes").length).toBeGreaterThan(0);
+});

--- a/src/components/HeroViewport.tsx
+++ b/src/components/HeroViewport.tsx
@@ -1,0 +1,16 @@
+import { Hero } from "./Hero";
+import { Marquee } from "./Marquee";
+
+/**
+ * The opening poster: hero fills the window and the marquee sits at its
+ * bottom edge. min-h-dvh (not a hard h-dvh) by decision — on short screens
+ * the block grows instead of clipping the hero stack.
+ */
+export function HeroViewport() {
+  return (
+    <div className="flex min-h-dvh flex-col">
+      <Hero />
+      <Marquee />
+    </div>
+  );
+}

--- a/src/components/Marquee.test.tsx
+++ b/src/components/Marquee.test.tsx
@@ -1,0 +1,21 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Marquee } from "./Marquee";
+
+test("every phrase appears twice in the DOM for the seamless loop", () => {
+  render(<Marquee />);
+
+  expect(screen.getAllByText("Charter Eligible")).toHaveLength(2);
+  expect(screen.getAllByText("K–8")).toHaveLength(2);
+});
+
+test("exactly one copy of the track is exposed to assistive tech", () => {
+  render(<Marquee />);
+
+  const copies = screen.getAllByText("Tidepools");
+  const hiddenCopies = copies.filter((el) =>
+    el.closest('[aria-hidden="true"]'),
+  );
+  expect(hiddenCopies).toHaveLength(1);
+  expect(copies.length - hiddenCopies.length).toBe(1);
+});

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -1,0 +1,32 @@
+import { StripTrack } from "./StripTrack";
+
+const PHRASES = [
+  "Art Classes",
+  "Tidepools",
+  "Nature Journal",
+  "Hikes",
+  "Science",
+  "Charter Eligible",
+  "San Diego",
+  "K–8",
+];
+
+export function Marquee() {
+  return (
+    <div className="group overflow-hidden border-y-2 border-dark bg-yellow py-3.5">
+      <StripTrack>
+        {PHRASES.map((phrase) => (
+          <span
+            key={phrase}
+            className="flex items-center text-base font-black tracking-wider text-ink uppercase"
+          >
+            <span className="px-7">{phrase}</span>
+            <span aria-hidden="true" className="px-1.5 text-purple">
+              ✦
+            </span>
+          </span>
+        ))}
+      </StripTrack>
+    </div>
+  );
+}

--- a/src/components/Nav.test.tsx
+++ b/src/components/Nav.test.tsx
@@ -1,0 +1,31 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Nav } from "./Nav";
+
+test("the nav exposes all four section links by name", () => {
+  render(<Nav />);
+
+  for (const name of [
+    "Art Classes",
+    "Tuesday Co-op",
+    "Conditions",
+    "Community",
+  ]) {
+    expect(screen.getByRole("link", { name })).toBeDefined();
+  }
+});
+
+test("the booking CTA is a link into the art section", () => {
+  render(<Nav />);
+
+  const cta = screen.getByRole("link", { name: /book now/i });
+  expect(cta.getAttribute("href")).toBe("#art");
+});
+
+test("the logo slot is a labeled image placeholder", () => {
+  render(<Nav />);
+
+  expect(
+    screen.getByRole("img", { name: "Wild Coast Kids logo" }),
+  ).toBeDefined();
+});

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -9,7 +9,10 @@ const SECTION_LINKS = [
 
 export function Nav() {
   return (
-    <nav className="fixed inset-x-0 top-0 z-50 flex items-center justify-between gap-2 border-b-2 border-purple bg-cream px-3 py-3 md:px-8 md:py-3.5">
+    // Two rows below md — logo and CTA above, links spread beneath — because
+    // the four links plus the pill cannot share one 375px row (design
+    // review, must-fix). md: restores the template's single row.
+    <nav className="fixed inset-x-0 top-0 z-50 flex flex-wrap items-center justify-between gap-y-2 border-b-2 border-purple bg-cream px-3 py-2.5 md:flex-nowrap md:px-8 md:py-3.5">
       <div className="size-10 shrink-0 overflow-hidden rounded-full md:size-13">
         <Placeholder
           label="Wild Coast Kids logo"
@@ -17,21 +20,20 @@ export function Nav() {
           labelClassName="min-h-0 p-1 text-[7px] leading-[1.15]"
         />
       </div>
-      <div className="flex gap-2 md:gap-7">
+      <div className="order-last flex w-full flex-wrap justify-between gap-x-2 md:order-0 md:w-auto md:flex-nowrap md:justify-start md:gap-7">
         {SECTION_LINKS.map(({ href, label }) => (
           <a
             key={href}
             href={href}
-            className="border-b-2 border-transparent pb-0.5 text-[9px] font-extrabold tracking-wider text-dark uppercase transition-colors duration-fast hover:border-yellow md:text-2xs"
+            className="border-b-2 border-transparent pb-0.5 text-[9px] font-extrabold tracking-wider whitespace-nowrap text-dark uppercase transition-colors duration-fast hover:border-yellow md:text-2xs"
           >
             {label}
           </a>
         ))}
       </div>
-      {/* Slimmer below md — at full size the pill clipped off-screen at 375px. */}
       <a
         href="#art"
-        className="rounded-pill shrink-0 bg-yellow px-3 py-2 text-2xs font-black tracking-[0.06em] whitespace-nowrap text-ink md:px-5.5 md:py-2.25 md:text-xs"
+        className="rounded-pill shrink-0 bg-yellow px-3.5 py-2 text-2xs font-black tracking-[0.06em] whitespace-nowrap text-ink md:px-5.5 md:py-2.25 md:text-xs"
       >
         Book Now →
       </a>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -9,15 +9,15 @@ const SECTION_LINKS = [
 
 export function Nav() {
   return (
-    <nav className="fixed inset-x-0 top-0 z-50 flex items-center justify-between border-b-2 border-purple bg-cream px-5 py-3 md:px-8 md:py-3.5">
-      <div className="size-[52px] shrink-0 overflow-hidden rounded-full">
+    <nav className="fixed inset-x-0 top-0 z-50 flex items-center justify-between gap-2 border-b-2 border-purple bg-cream px-3 py-3 md:px-8 md:py-3.5">
+      <div className="size-10 shrink-0 overflow-hidden rounded-full md:size-13">
         <Placeholder
           label="Wild Coast Kids logo"
           className="size-full rounded-full"
           labelClassName="min-h-0 p-1 text-[7px] leading-[1.15]"
         />
       </div>
-      <div className="flex gap-3 md:gap-7">
+      <div className="flex gap-2 md:gap-7">
         {SECTION_LINKS.map(({ href, label }) => (
           <a
             key={href}
@@ -28,9 +28,10 @@ export function Nav() {
           </a>
         ))}
       </div>
+      {/* Slimmer below md — at full size the pill clipped off-screen at 375px. */}
       <a
         href="#art"
-        className="rounded-pill bg-yellow px-[22px] py-[9px] text-xs font-black tracking-[0.06em] text-ink"
+        className="rounded-pill shrink-0 bg-yellow px-3 py-2 text-2xs font-black tracking-[0.06em] whitespace-nowrap text-ink md:px-5.5 md:py-2.25 md:text-xs"
       >
         Book Now →
       </a>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,0 +1,39 @@
+import { Placeholder } from "./Placeholder";
+
+const SECTION_LINKS = [
+  { href: "#art", label: "Art Classes" },
+  { href: "#coop", label: "Tuesday Co-op" },
+  { href: "#conditions", label: "Conditions" },
+  { href: "#community", label: "Community" },
+];
+
+export function Nav() {
+  return (
+    <nav className="fixed inset-x-0 top-0 z-50 flex items-center justify-between border-b-2 border-purple bg-cream px-5 py-3 md:px-8 md:py-3.5">
+      <div className="size-[52px] shrink-0 overflow-hidden rounded-full">
+        <Placeholder
+          label="Wild Coast Kids logo"
+          className="size-full rounded-full"
+          labelClassName="min-h-0 p-1 text-[7px] leading-[1.15]"
+        />
+      </div>
+      <div className="flex gap-3 md:gap-7">
+        {SECTION_LINKS.map(({ href, label }) => (
+          <a
+            key={href}
+            href={href}
+            className="border-b-2 border-transparent pb-0.5 text-[9px] font-extrabold tracking-wider text-dark uppercase transition-colors duration-fast hover:border-yellow md:text-2xs"
+          >
+            {label}
+          </a>
+        ))}
+      </div>
+      <a
+        href="#art"
+        className="rounded-pill bg-yellow px-[22px] py-[9px] text-xs font-black tracking-[0.06em] text-ink"
+      >
+        Book Now →
+      </a>
+    </nav>
+  );
+}

--- a/src/components/Placeholder.tsx
+++ b/src/components/Placeholder.tsx
@@ -1,8 +1,10 @@
 type PlaceholderProps = {
   /** Describes the future image; doubles as the accessible name. */
   label: string;
-  /** Background fills drop the dashed frame and the visible label. */
+  /** Background fills drop the dashed frame and, by default, the label. */
   background?: boolean;
+  /** Overrides the label's visibility (defaults to hidden on backgrounds). */
+  showLabel?: boolean;
   className?: string;
   labelClassName?: string;
 };
@@ -15,6 +17,7 @@ type PlaceholderProps = {
 export function Placeholder({
   label,
   background = false,
+  showLabel = !background,
   className = "",
   labelClassName = "",
 }: PlaceholderProps) {
@@ -26,7 +29,7 @@ export function Placeholder({
         background ? "" : "border-[1.5px] border-dashed border-purple/38"
       } ${className}`}
     >
-      {!background && (
+      {showLabel && (
         <span
           aria-hidden="true"
           className={`flex size-full min-h-12 items-center justify-center p-3 text-center text-2xs font-extrabold tracking-[0.08em] uppercase text-dark/50 ${labelClassName}`}

--- a/src/components/Placeholder.tsx
+++ b/src/components/Placeholder.tsx
@@ -1,0 +1,39 @@
+type PlaceholderProps = {
+  /** Describes the future image; doubles as the accessible name. */
+  label: string;
+  /** Background fills drop the dashed frame and the visible label. */
+  background?: boolean;
+  className?: string;
+  labelClassName?: string;
+};
+
+/**
+ * Labeled stand-in for every image slot (logo, hero photo, card backgrounds,
+ * gallery strip). Real photography replaces these in a later content pass —
+ * swapping one for an <img> keeps the same accessible name.
+ */
+export function Placeholder({
+  label,
+  background = false,
+  className = "",
+  labelClassName = "",
+}: PlaceholderProps) {
+  return (
+    <div
+      role="img"
+      aria-label={label}
+      className={`bg-[linear-gradient(135deg,rgb(107_95_170/0.12),rgb(26_78_138/0.1))] ${
+        background ? "" : "border-[1.5px] border-dashed border-purple/38"
+      } ${className}`}
+    >
+      {!background && (
+        <span
+          aria-hidden="true"
+          className={`flex size-full min-h-12 items-center justify-center p-3 text-center text-2xs font-extrabold tracking-[0.08em] uppercase text-dark/50 ${labelClassName}`}
+        >
+          {label}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/ProgramCards.test.tsx
+++ b/src/components/ProgramCards.test.tsx
@@ -1,0 +1,35 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProgramCards } from "./ProgramCards";
+
+test("both program cards expose their titles as headings", () => {
+  const { container } = render(<ProgramCards />);
+
+  const titles = screen
+    .getAllByRole("heading", { level: 2 })
+    .map((h) => h.textContent);
+  expect(titles.some((t) => t?.includes("Art"))).toBe(true);
+  expect(titles.some((t) => t?.includes("Co-op"))).toBe(true);
+
+  // The nav and hero deep-link here; the ids are stable API.
+  expect(container.querySelector("#art")).not.toBeNull();
+  expect(container.querySelector("#coop")).not.toBeNull();
+});
+
+test("each card's CTA points where its flow goes", () => {
+  render(<ProgramCards />);
+
+  const book = screen.getByRole("link", { name: /book a class/i });
+  expect(book.getAttribute("target")).toBe("_blank");
+
+  const join = screen.getByRole("link", { name: /join interest list/i });
+  expect(join.getAttribute("href")).toBe("#community");
+});
+
+test("the co-op card lists all four activities", () => {
+  render(<ProgramCards />);
+
+  for (const name of ["Tidepools", "Hikes", "Nature Journal", "Science"]) {
+    expect(screen.getByText(name)).toBeDefined();
+  }
+});

--- a/src/components/ProgramCards.tsx
+++ b/src/components/ProgramCards.tsx
@@ -1,0 +1,123 @@
+import { Placeholder } from "./Placeholder";
+
+const COOP_ACTIVITIES = [
+  { emoji: "🌊", name: "Tidepools" },
+  { emoji: "🌿", name: "Hikes" },
+  { emoji: "📓", name: "Nature Journal" },
+  { emoji: "🔬", name: "Science" },
+];
+
+const CARD_BASE =
+  "rounded-card relative flex min-h-[520px] flex-col justify-between overflow-hidden p-9 transition-transform duration-fast hover:-translate-y-1";
+
+export function ProgramCards() {
+  return (
+    <div className="px-gutter-sm pb-15 md:px-gutter md:pb-20">
+      <div className="grid gap-4 md:grid-cols-2">
+        <article id="art" className={`${CARD_BASE} bg-purple`}>
+          <Placeholder
+            background
+            label="Art classes background"
+            className="absolute inset-0 opacity-28"
+          />
+          <p
+            aria-hidden="true"
+            className="absolute top-7 right-7 text-xs font-extrabold tracking-wider text-white/35"
+          >
+            [ 01 ]
+          </p>
+          <div className="relative z-10 flex flex-col">
+            <span aria-hidden="true" className="mb-4 block text-[44px]">
+              🎨
+            </span>
+            <h2 className="text-card leading-display mb-2 font-black text-white italic">
+              Art
+              <br />
+              Classes
+            </h2>
+            <p className="mb-3.5 text-xs font-extrabold tracking-wider text-yellow uppercase">
+              In-person · Group & Private · K–8
+            </p>
+            <p className="leading-normal mb-4.5 max-w-[340px] text-sm text-white/75">
+              Watercolors, ink, collage, printmaking — inspired by the coast and
+              whatever sparks curiosity. Every session is different.
+            </p>
+            <div className="mb-5.5 flex flex-wrap gap-2">
+              <span className="rounded-pill bg-yellow px-[13px] py-[5px] text-2xs font-extrabold tracking-wide text-ink">
+                Charter eligible
+              </span>
+              <span className="rounded-pill bg-white/15 px-[13px] py-[5px] text-2xs font-extrabold tracking-wide text-white">
+                All levels
+              </span>
+              <span className="rounded-pill bg-white/15 px-[13px] py-[5px] text-2xs font-extrabold tracking-wide text-white">
+                Outdoors
+              </span>
+            </div>
+            {/* TODO(verify): the template ships a bare calendly.com — swap in
+                the real booking URL when it exists. */}
+            <a
+              href="https://calendly.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-pill self-start bg-yellow px-[26px] py-3 text-sm font-black text-ink"
+            >
+              Book a class →
+            </a>
+          </div>
+        </article>
+
+        <article id="coop" className={`${CARD_BASE} bg-ocean`}>
+          <Placeholder
+            background
+            label="Tuesday co-op background"
+            className="absolute inset-0 opacity-28"
+          />
+          <p
+            aria-hidden="true"
+            className="absolute top-7 right-7 text-xs font-extrabold tracking-wider text-white/35"
+          >
+            [ 02 ]
+          </p>
+          <div className="relative z-10 flex flex-col">
+            <span aria-hidden="true" className="mb-4 block text-[44px]">
+              🌿
+            </span>
+            <h2 className="text-card leading-display mb-2 font-black text-white italic">
+              Tuesday
+              <br />
+              Co-op
+            </h2>
+            <p className="mb-3.5 text-xs font-extrabold tracking-wider text-yellow uppercase">
+              Tuesdays · 10am – 1pm · Fall 2026
+            </p>
+            <ul className="mb-4.5 grid grid-cols-2 gap-2">
+              {COOP_ACTIVITIES.map(({ emoji, name }) => (
+                <li
+                  key={name}
+                  className="rounded-tile bg-white/12 p-3 text-center"
+                >
+                  <span aria-hidden="true" className="mb-1 block text-[22px]">
+                    {emoji}
+                  </span>
+                  <span className="text-2xs font-extrabold text-white">
+                    {name}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <p className="leading-normal mb-4.5 max-w-[340px] text-sm text-white/75">
+              Exploring San Diego&apos;s wild coast through science, journaling
+              and hands-on discovery. Spots limited for fall.
+            </p>
+            <a
+              href="#community"
+              className="rounded-pill self-start bg-yellow px-[26px] py-3 text-sm font-black text-ink"
+            >
+              Join interest list →
+            </a>
+          </div>
+        </article>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProgramCards.tsx
+++ b/src/components/ProgramCards.tsx
@@ -12,7 +12,7 @@ const CARD_BASE =
 
 export function ProgramCards() {
   return (
-    <div className="px-gutter-sm pb-15 md:px-gutter md:pb-20">
+    <div className="px-gutter-sm pb-section-sm md:px-gutter md:pb-section">
       <div className="grid gap-4 md:grid-cols-2">
         <article id="art" className={`${CARD_BASE} bg-purple`}>
           <Placeholder
@@ -38,7 +38,7 @@ export function ProgramCards() {
             <p className="mb-3.5 text-xs font-extrabold tracking-wider text-yellow uppercase">
               In-person · Group & Private · K–8
             </p>
-            <p className="leading-normal mb-4.5 max-w-[340px] text-sm text-white/75">
+            <p className="leading-normal mb-4.5 max-w-[340px] text-sm text-white/90">
               Watercolors, ink, collage, printmaking — inspired by the coast and
               whatever sparks curiosity. Every session is different.
             </p>
@@ -105,7 +105,7 @@ export function ProgramCards() {
                 </li>
               ))}
             </ul>
-            <p className="leading-normal mb-4.5 max-w-[340px] text-sm text-white/75">
+            <p className="leading-normal mb-4.5 max-w-[340px] text-sm text-white/90">
               Exploring San Diego&apos;s wild coast through science, journaling
               and hands-on discovery. Spots limited for fall.
             </p>

--- a/src/components/QuoteStats.test.tsx
+++ b/src/components/QuoteStats.test.tsx
@@ -1,0 +1,19 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QuoteStats } from "./QuoteStats";
+
+test("the parent quote and its attribution are reachable", () => {
+  render(<QuoteStats />);
+
+  expect(screen.getByText(/notices every tidepool/i)).toBeDefined();
+  expect(screen.getByText(/— Parent, Wild Coast Kids/i)).toBeDefined();
+});
+
+test("both stat tiles state the facts parents filter on", () => {
+  render(<QuoteStats />);
+
+  expect(screen.getByText("K–8")).toBeDefined();
+  expect(screen.getByText("All ages welcome")).toBeDefined();
+  expect(screen.getByText("Charter ✓")).toBeDefined();
+  expect(screen.getByText("Fund eligible programs")).toBeDefined();
+});

--- a/src/components/QuoteStats.tsx
+++ b/src/components/QuoteStats.tsx
@@ -1,0 +1,32 @@
+export function QuoteStats() {
+  return (
+    <section className="border-lavender px-gutter-sm py-15 grid items-center gap-8 border-y-[1.5px] md:grid-cols-2 md:gap-12 md:px-gutter md:py-20">
+      <figure>
+        <blockquote className="text-quote leading-[1.25] font-black italic">
+          “My daughter now notices every tidepool we walk past.
+          <br />
+          <span className="text-purple">She sketches everything.”</span>
+        </blockquote>
+        <figcaption className="mt-5 text-xs font-bold tracking-wider text-purple uppercase">
+          — Parent, Wild Coast Kids
+        </figcaption>
+      </figure>
+      <div className="flex flex-col gap-3">
+        <div className="rounded-thumb bg-yellow px-6 py-5">
+          <p className="text-stat leading-none mb-1 font-black text-ink italic">
+            K–8
+          </p>
+          <p className="text-xs font-bold text-black/50">All ages welcome</p>
+        </div>
+        <div className="rounded-thumb bg-purple px-6 py-5">
+          <p className="text-stat leading-none mb-1 font-black text-yellow italic">
+            Charter ✓
+          </p>
+          <p className="text-xs font-bold text-white/60">
+            Fund eligible programs
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/QuoteStats.tsx
+++ b/src/components/QuoteStats.tsx
@@ -1,6 +1,6 @@
 export function QuoteStats() {
   return (
-    <section className="border-lavender px-gutter-sm py-15 grid items-center gap-8 border-y-[1.5px] md:grid-cols-2 md:gap-12 md:px-gutter md:py-20">
+    <section className="border-lavender px-gutter-sm py-section-sm grid items-center gap-8 border-y-[1.5px] md:grid-cols-2 md:gap-12 md:px-gutter md:py-section">
       <figure>
         <blockquote className="text-quote leading-[1.25] font-black italic">
           “My daughter now notices every tidepool we walk past.

--- a/src/components/StripTrack.test.tsx
+++ b/src/components/StripTrack.test.tsx
@@ -1,0 +1,21 @@
+import { expect, test } from "vitest";
+import { render } from "@testing-library/react";
+import { StripTrack } from "./StripTrack";
+
+test("the track carries the pause and reduced-motion utilities", () => {
+  // jsdom applies no stylesheets, so the seam here is the class contract:
+  // the animation utility, the hover pause, and the reduced-motion stop
+  // must all sit on the moving track.
+  const { container } = render(
+    <StripTrack>
+      <span>content</span>
+    </StripTrack>,
+  );
+
+  const track = container.firstElementChild;
+  expect(track?.className).toContain("animate-strip");
+  expect(track?.className).toContain(
+    "group-hover:[animation-play-state:paused]",
+  );
+  expect(track?.className).toContain("motion-reduce:animate-none");
+});

--- a/src/components/StripTrack.tsx
+++ b/src/components/StripTrack.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+/* One shared speed keeps the marquee and the gallery strip visually in sync:
+   each track computes its own duration from its own width, so both move at
+   the same pixels-per-second no matter how wide their content is. */
+const SPEED_PX_PER_SECOND = 80;
+
+type StripTrackProps = {
+  children: ReactNode;
+};
+
+/**
+ * The looping-strip mechanic: children render twice side by side and the
+ * track translates by -50%, so the loop is seamless. The duplicate copy is
+ * aria-hidden — assistive tech hears the content once. The parent supplies
+ * `group` and `overflow-hidden`; hovering the parent pauses the animation,
+ * and prefers-reduced-motion stops it entirely.
+ */
+export function StripTrack({ children }: StripTrackProps) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [duration, setDuration] = useState<number | null>(null);
+
+  useEffect(() => {
+    const measure = () => {
+      const track = trackRef.current;
+      if (!track) return;
+      const half = track.scrollWidth / 2;
+      if (half > 0) setDuration(half / SPEED_PX_PER_SECOND);
+    };
+
+    measure();
+    // The webfont changes text width when it lands; measure again after it
+    // (document.fonts is absent in jsdom, hence the optional chain).
+    document.fonts?.ready.then(measure);
+  }, []);
+
+  return (
+    <div
+      ref={trackRef}
+      className="animate-strip flex w-max whitespace-nowrap group-hover:[animation-play-state:paused] motion-reduce:animate-none"
+      style={
+        duration === null ? undefined : { animationDuration: `${duration}s` }
+      }
+    >
+      <div className="flex shrink-0">{children}</div>
+      <div aria-hidden="true" className="flex shrink-0">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -20,10 +20,10 @@ export default defineConfig({
       // purpose (see docs/adr/0002) and layout.tsx is untested, and both drag
       // these figures down in plain sight rather than quietly.
       thresholds: {
-        statements: 35.84,
-        branches: 66.66,
-        functions: 50,
-        lines: 34.78,
+        statements: 62.76,
+        branches: 72.72,
+        functions: 77.77,
+        lines: 65.88,
       },
     },
   },


### PR DESCRIPTION
## What this is

The full landing page at `/`, built from the client-supplied style template with the three requested layout changes, per the committed plan in `docs/plans/wild-coast-kids-landing.md` (full design record in `.design/wild-coast-kids-landing/`).

## What changed, by slice

- Plan + design artifacts committed first (`41ed073`)
- Tokens, Montserrat, fixed nav — template palette/type as a Tailwind v4 `@theme` block; scaffold dark-mode swap removed by decision
- Marquee + shared `StripTrack` mechanic — duplicated `aria-hidden` track, pause on hover, stops under `prefers-reduced-motion`
- Hero locked with the marquee into one `min-h-dvh` viewport block (marquee at the fold; grows on short screens)
- Gallery as a full-bleed film strip directly beneath, speed-synced to the marquee via one shared px/s constant
- Program cards (`#art`, `#coop`), quote + stats, conditions teaser, community form (client-side success state only), footer + metadata
- Accessibility/motion audit: currentColor focus rings, 16px inputs on touch, three failing WCAG pairs lifted (hero/card copy to white/90 = 4.79:1; fog token darkened to #6b5f7d = 5.04:1), coverage floor raised to actuals

The template's editorial block and yellow wordmark banner are cut by decision, not deferred.

## Gate output (final commit)

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
```

(exit 0; the same five gates ran green before every slice commit)

## Not done / open items

- **TODO(verify): booking URL** — "Book a class" keeps the template's placeholder `https://calendly.com`
- Form stores nothing (client-side by decision); real destination is a future slice
- All imagery is labeled placeholders awaiting real photos
- Design review (`/design-review`) not yet run — the remaining unchecked task in TASKS.md

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)