### PR TITLE
Normalize the gate cwd's drive-letter casing before spawning gates

### DIFF
--- a/docs/plans/gate-drive-casing.md
+++ b/docs/plans/gate-drive-casing.md
@@ -1,0 +1,85 @@
+# Gate hardening: normalize the cwd drive-letter casing (issue #4)
+
+Date: 2026-08-12.
+
+## Problem, from the user's point of view
+
+`npm run gate` sometimes fails on the test gate with every vitest suite dead at
+boot — zero tests run, and an error at `vitest.setup.ts:6` claiming `"vitest"
+is imported directly without running "vitest" command`. Re-running with an
+unchanged tree passes. A gate that fails for reasons unrelated to the tree
+teaches people to re-run until green, which is the end of the gate meaning
+anything.
+
+## Diagnosis (evidence, not theory)
+
+- 10/10 runs launched with a cwd of `c:\Projects\...` (lowercase drive) failed
+  with the exact symptom; 10/10 runs with `C:\Projects\...` passed. A
+  controlled experiment — same command, same tree, only the spawn `cwd`
+  differing in drive-letter case — reproduced fail/pass deterministically.
+- Coverage mode is not a factor: plain `vitest run` fails identically under a
+  lowercase-drive cwd.
+- Mechanism: Node's ESM loader keys its module cache by file URL.
+  `file:///c:/...` and `file:///C:/...` are different keys, so the worker loads
+  a second copy of `@vitest/runner`; the setup file's `afterEach` registers
+  against the copy that holds no suite state, which is precisely the error
+  vitest prints.
+- The "intermittency" is which terminal launched the gate. Some shells and
+  agent harnesses put a lowercase drive letter in `process.cwd()`; most put
+  uppercase. Nothing about the tree, timing, or cache was ever involved. The
+  ~14s "environment" figure in the failing output is vitest summing jsdom boot
+  across 12 files and was a red herring.
+
+## Decision
+
+Normalize the drive-letter casing of the cwd that `scripts/run-gates.mjs`
+passes to every gate subprocess:
+
+- `normalizeDriveCasing(path)` — pure, in `scripts/gates.mjs`, unit-tested.
+  Uppercases a leading `[a-z]:` and touches nothing else.
+- `run-gates.mjs` passes `cwd: normalizeDriveCasing(process.cwd())` in the
+  existing `spawn` options. This edits an existing statement rather than
+  adding new untested plumbing, so the deliberately-untested surface of
+  `run-gates.mjs` (ADR 0002) does not grow and the coverage floor is not
+  eroded by the fix.
+
+### Considered and rejected
+
+- **Normalize `root` in `vitest.config.mts`.** Tested; insufficient. The
+  config file and worker module URLs still derive from the process cwd — the
+  failure reproduces with `root` normalized.
+- **`fs.realpathSync.native(process.cwd())`** — canonicalizes the whole path,
+  covering casing drift beyond the drive letter. Rejected because gates.mjs is
+  the filesystem-free tested seam ("nothing in this file spawns a process or
+  touches the filesystem"), so realpath could only live untested in
+  run-gates.mjs. The observed failure class is the drive letter; the broader
+  class is noted in issue #5, not speculatively engineered here.
+- **A vitest wrapper script for all test npm scripts.** Fixes `npm run test`
+  from a lowercase shell too, but is new untested plumbing with a coverage
+  floor interaction. Split off as issue #5.
+
+## Test seams
+
+- `scripts/gates.test.mjs` unit-tests `normalizeDriveCasing`: lowercase drive
+  uppercased, uppercase left alone, POSIX paths left alone, non-drive path
+  segments untouched. These are the regression tests, at the seam the repo
+  already trusts for gate logic.
+- The end-to-end property — "the gate passes when launched from a
+  lowercase-drive shell" — has no cheap automated seam: it needs a subprocess
+  spawning the full gate suite (minutes) or a nested vitest-in-vitest run
+  (slow, fragile under coverage). Per ADR 0002 the subprocess layer stays
+  deliberately untested; the e2e verification is run manually and its output
+  pasted into the PR.
+
+## Out of scope
+
+- Direct `npm run test` / `test:watch` / `test:coverage` from a
+  lowercase-drive shell (issue #5).
+- Path-casing mismatches beyond the drive letter (noted in issue #5).
+- Reporting the underlying behavior upstream to vitest.
+
+## Slices
+
+1. This plan file.
+2. `normalizeDriveCasing` in gates.mjs + unit tests + use in run-gates.mjs
+   spawn options (one behavior change, tests in the same commit).

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -29,6 +29,22 @@ export const GATES = [
   { name: "build", command: "npm run build" },
 ];
 
+/**
+ * Uppercase a leading lowercase Windows drive letter, leaving everything else
+ * alone. Node's ESM loader keys its module cache by file URL, so a process
+ * whose cwd starts with `c:\` loads the same file twice under `file:///c:/`
+ * and `file:///C:/` — which makes every vitest suite fail at boot with
+ * "Vitest failed to find the current suite". Some shells and agent harnesses
+ * launch with a lowercase drive; the gate must not care which kind it was
+ * born in. See docs/plans/gate-drive-casing.md.
+ *
+ * @param {string} path
+ * @returns {string}
+ */
+export function normalizeDriveCasing(path) {
+  return path.replace(/^[a-z]:/, (drive) => drive.toUpperCase());
+}
+
 export const PASSED = "passed";
 export const FAILED = "failed";
 export const SKIPPED = "skipped";

--- a/scripts/gates.test.mjs
+++ b/scripts/gates.test.mjs
@@ -7,6 +7,7 @@ import {
   evaluate,
   formatRows,
   judge,
+  normalizeDriveCasing,
 } from "./gates.mjs";
 
 const gate = (overrides = {}) => ({
@@ -102,6 +103,33 @@ describe("formatRows", () => {
       "  FAIL  typecheck",
       "  SKIP  e2e        (needs a display)",
     ]);
+  });
+});
+
+// Regression tests for issue #4: a lowercase drive letter in the gate
+// runner's cwd made Node load @vitest/runner twice (file:///c:/ and
+// file:///C:/ are different ESM cache keys), so every suite failed at boot.
+describe("normalizeDriveCasing", () => {
+  test("uppercases a lowercase drive letter", () => {
+    expect(normalizeDriveCasing("c:\\Projects\\repo")).toBe(
+      "C:\\Projects\\repo",
+    );
+  });
+
+  test("leaves an already-uppercase drive letter alone", () => {
+    expect(normalizeDriveCasing("C:\\Projects\\repo")).toBe(
+      "C:\\Projects\\repo",
+    );
+  });
+
+  test("touches only the drive letter, not the rest of the path", () => {
+    expect(normalizeDriveCasing("d:\\lower\\MIXED\\path")).toBe(
+      "D:\\lower\\MIXED\\path",
+    );
+  });
+
+  test("leaves a POSIX path alone", () => {
+    expect(normalizeDriveCasing("/home/user/repo")).toBe("/home/user/repo");
   });
 });
 

--- a/scripts/run-gates.mjs
+++ b/scripts/run-gates.mjs
@@ -16,6 +16,7 @@ import {
   SKIPPED,
   evaluate,
   formatRows,
+  normalizeDriveCasing,
 } from "./gates.mjs";
 
 /**
@@ -25,8 +26,13 @@ import {
 function run(command) {
   return new Promise((resolve) => {
     // shell: true so `npm run x` resolves npm.cmd on Windows. The commands come
-    // from the table in this repo, never from user input.
-    const child = spawn(command, { shell: true });
+    // from the table in this repo, never from user input. cwd is normalized
+    // because a lowercase drive letter makes vitest load its runner twice and
+    // fail every suite at boot (issue #4).
+    const child = spawn(command, {
+      shell: true,
+      cwd: normalizeDriveCasing(process.cwd()),
+    });
     let output = "";
 
     child.stdout.on("data", (chunk) => (output += chunk));

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -20,10 +20,10 @@ export default defineConfig({
       // purpose (see docs/adr/0002) and layout.tsx is untested, and both drag
       // these figures down in plain sight rather than quietly.
       thresholds: {
-        statements: 62.76,
-        branches: 72.72,
-        functions: 77.77,
-        lines: 65.88,
+        statements: 63.54,
+        branches: 73.52,
+        functions: 78.94,
+        lines: 66.27,
       },
     },
   },


### PR DESCRIPTION
Closes #4

## What changed and why

The test gate intermittently failed with all 12 vitest suites dead at boot (`Vitest failed to find the current suite` at `vitest.setup.ts:6`), then passed on re-run. Diagnosis (evidence in `docs/plans/gate-drive-casing.md`): the trigger is the drive-letter casing of the launching shell's cwd. Node's ESM loader keys its module cache by file URL, so a cwd of `c:\...` loads `@vitest/runner` twice (`file:///c:/` vs `file:///C:/`) and the setup file's `afterEach` registers against the instance with no suite state. 10/10 runs failed with a lowercase-drive cwd, 10/10 passed with uppercase, and a controlled experiment (same command, same tree, only the spawn `cwd` casing differing) flipped fail/pass deterministically. Coverage mode was a red herring (plain `vitest run` fails identically), as was the ~14s environment figure (vitest sums jsdom boot across files).

Slices:
1. **Plan file** `docs/plans/gate-drive-casing.md` — diagnosis evidence, rejected alternatives (normalizing vitest `root` was tested and is insufficient), seam decision.
2. **Fix + regression tests** — pure `normalizeDriveCasing()` in `scripts/gates.mjs` (the tested seam; gates.mjs stays filesystem-free), applied in the existing `spawn` options in `scripts/run-gates.mjs` so the ADR-0002 deliberately-untested plumbing gains no new statements. Four unit tests in `scripts/gates.test.mjs`. Coverage floor raised to the new actuals (statements 62.76→63.54, branches 72.72→73.52, functions 77.77→78.94, lines 65.88→66.27) per the config's raise-when-it-rises rule.

## Gate output (run at each slice's commit)

Slice 2's gate, spawned end-to-end with `cwd: 'c:\Projects\lena-projects\wild-coast-kids'` (lowercase drive — the exact context that failed 10/10 before the fix):

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
```

(exit code 0; slice 1's gate was identical, run from an uppercase cwd since the fix wasn't in yet.)

Coverage summary from the fixed tree:

```
Statements   : 63.54% ( 61/96 )
Branches     : 73.52% ( 25/34 )
Functions    : 78.94% ( 30/38 )
Lines        : 66.27% ( 57/86 )
```

## What I did not do

- No automated e2e test that spawns the gate from a lowercase cwd: it would run the full gate suite (minutes) or nest vitest inside vitest under coverage (slow, fragile). Per ADR 0002 the subprocess layer stays deliberately untested; the e2e verification above is manual and its output pasted here. The unit tests lock down the normalization logic itself.
- `npm run test` / `test:watch` / `test:coverage` invoked directly from a lowercase-drive shell still fail — filed as #5 rather than growing this slice.
- No upstream vitest report yet (noted in #5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)