### PR TITLE
Move shared chrome into the root layout (nav-pages-scaffolding PR 1)

### DIFF
--- a/docs/plans/nav-pages-scaffolding.md
+++ b/docs/plans/nav-pages-scaffolding.md
@@ -1,0 +1,97 @@
+# Nav pages and scaffolding
+
+## Problem, from the user's point of view
+
+Everything a visitor can reach lives on the single landing page. The nav's
+four links scroll to sections, and Book Now points at the art section for
+lack of anywhere better. A parent who wants to book, check conditions, or
+read more than a teaser paragraph has no page to land on — and every future
+feature (booking, the conditions tool, program detail) has no place to grow.
+
+## Solution
+
+Hybrid IA: the landing page keeps its sections as teasers, and five routes
+carry full pages — `/art`, `/coop`, `/conditions`, `/community`, `/book`.
+All five are structural shells in the repo's labeled-placeholder pattern:
+the section's copy as the seed, placeholders where real content (schedule,
+pricing, photos, scheduler embed, conditions tool) lands in later passes.
+
+The nav converts from hash anchors to routed links, flipped one link per
+page slice so a routed link never points at a route that does not exist.
+
+## Implementation decisions
+
+- **Hybrid, not a migration.** Sections stay on `/`; pages are added
+  beside them, each teaser linking to its page. Rejected: stripping the
+  landing page down (destroys finished, verified work for no stated need);
+  keeping anchors and adding only `/book` and `/conditions` (leaves a nav
+  that is half anchors, and anchors only work from `/`).
+- **Shared chrome moves to the root layout.** `Nav` and `Footer` leave
+  `page.tsx` for `layout.tsx`, so every route gets them for free. `main`
+  stays per-page: each page owns its main landmark and the `flex-1`
+  spacer, and page tests keep asserting the landmark on the page itself.
+- **Routed nav from one links config.** The link list stays a single
+  array; entries flip from `#hash` to a route as that route's slice lands.
+  The routed-link machinery (`next/link`, active state via a client
+  component reading `usePathname`, `aria-current="page"` on the current
+  page's link) lands with the first slice that flips a link and is reused
+  by the rest. The Book Now pill points at `/book`. Rejected: flipping the
+  whole nav at once — every link 404s until the last page exists.
+- **Short slugs** matching the existing section ids (`#art` → `/art`,
+  etc.). Rejected: label-verbatim slugs (`/art-classes`, `/tuesday-co-op`)
+  — diverges from the id vocabulary already in the URLs.
+- **Per-page metadata** via the Metadata API; the layout gains a title
+  template so page titles read "Page — Wild Coast Kids".
+- **Structural shells only.** No booking provider is chosen (`/book` gets
+  a labeled placeholder slot, like the conditions embed slot); the
+  conditions tool remains its own future plan (`/conditions` carries the
+  same reserved slot the section has); no client copy exists yet.
+- **No content layer.** Rejected: extracting copy into shared data
+  modules so teasers and pages can share it — exactly one paragraph is
+  shared today, and structure for one string is the speculative
+  flexibility this repo's rules prohibit.
+- No new dependencies. No ADR: nothing here decides a dependency, data
+  format or threading contract; the IA decision is recorded in this file.
+
+## Test seams
+
+- **Layout wiring:** `layout.test.tsx` renders the root layout with a
+  sentinel child (`next/font/google` mocked — it throws outside the Next
+  compiler) and asserts the `navigation` and `contentinfo` landmarks plus
+  the child. This is the seam for "every route gets the chrome", and it
+  moves `layout.tsx` out of the deliberately-untested set — the coverage
+  floor rises to match, per the threshold comment's own rule.
+- **Each page:** its own test in the same commit, asserting by role and
+  accessible name (main landmark, heading, its placeholder slots) —
+  the established style from `src/app/page.test.tsx`.
+- **Nav flips:** `Nav.test.tsx` href assertions update in the same slice
+  as each flip; the active-state behavior is asserted with a mocked
+  `usePathname`.
+- **Gates:** `npm run gate` green at every commit.
+
+## Slices
+
+PR 1 — branch `layout-shared-chrome`:
+
+1. This plan.
+2. Move `Nav` and `Footer` into the root layout; `page.tsx` keeps only its
+   sections and `main`. Ships `layout.test.tsx`; coverage floor rises.
+
+PR 2 — branch cut from `main` after PR 1 merges (order mirrors the nav;
+each slice = route + shell + metadata + its nav flip + teaser link):
+
+3. `/book` — Book Now pill flips; routed-link machinery lands here.
+4. `/art` — first section link flips; active-state assertion lands here.
+5. `/coop`
+6. `/conditions`
+7. `/community`
+
+Per-slice issues are skipped deliberately: one person works these in
+sequence from this file, and splitting would buy nothing (CLAUDE.md §5).
+
+## Out of scope
+
+Real copy, images and logo, booking provider choice and its embed, the
+conditions tool itself, form backend, CMS, analytics, dark mode. Creating
+the `CONTEXT.md` that CLAUDE.md references but the repo lacks — its own
+slice if wanted.

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -1,0 +1,24 @@
+import { expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import RootLayout from "./layout";
+
+// next/font/google resolves font files inside the Next compiler and throws
+// when its loader runs anywhere else, so the test stubs it to its shape.
+vi.mock("next/font/google", () => ({
+  Montserrat: () => ({ variable: "--font-montserrat" }),
+}));
+
+test("the layout wraps every page in the shared nav and footer", () => {
+  render(
+    <RootLayout params={Promise.resolve({})}>
+      <main>page content</main>
+    </RootLayout>,
+  );
+
+  // The chrome must surround whatever page renders, so the seam asserts all
+  // three landmarks together: nav and footer from the layout, main from the
+  // page passed through as children.
+  expect(screen.getByRole("navigation")).toBeDefined();
+  expect(screen.getByRole("contentinfo")).toBeDefined();
+  expect(screen.getByRole("main")).toBeDefined();
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { Montserrat } from "next/font/google";
+import { Footer } from "@/components/Footer";
+import { Nav } from "@/components/Nav";
 import "./globals.css";
 
 // The whole page speaks one family; weight (400–900) and italics carry the
@@ -24,7 +26,9 @@ export default function RootLayout({ children }: LayoutProps<"/">) {
       className={`${montserrat.variable} h-full antialiased motion-safe:scroll-smooth`}
     >
       <body className="flex min-h-full flex-col overflow-x-hidden bg-cream font-sans text-dark">
+        <Nav />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,25 +1,19 @@
 import { CommunityForm } from "@/components/CommunityForm";
 import { Conditions } from "@/components/Conditions";
-import { Footer } from "@/components/Footer";
 import { GallerySection } from "@/components/GallerySection";
 import { HeroViewport } from "@/components/HeroViewport";
-import { Nav } from "@/components/Nav";
 import { ProgramCards } from "@/components/ProgramCards";
 import { QuoteStats } from "@/components/QuoteStats";
 
 export default function Home() {
   return (
-    <>
-      <Nav />
-      <main className="flex-1">
-        <HeroViewport />
-        <GallerySection />
-        <ProgramCards />
-        <QuoteStats />
-        <Conditions />
-        <CommunityForm />
-      </main>
-      <Footer />
-    </>
+    <main className="flex-1">
+      <HeroViewport />
+      <GallerySection />
+      <ProgramCards />
+      <QuoteStats />
+      <Conditions />
+      <CommunityForm />
+    </main>
   );
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -20,14 +20,13 @@ export default defineConfig({
       // denominator grew with deliberately-untested entry plumbing (see
       // docs/adr/0002), and the commit doing so must name the statements and
       // why they stay untested. Nothing is excluded to flatter the number:
-      // run-gates.mjs and run-vitest.mjs sit at 0% on purpose and layout.tsx
-      // is untested, and all three drag these figures down in plain sight
-      // rather than quietly.
+      // run-gates.mjs and run-vitest.mjs sit at 0% on purpose, and both drag
+      // these figures down in plain sight rather than quietly.
       thresholds: {
-        statements: 60.39,
+        statements: 63.36,
         branches: 73.52,
-        functions: 78.94,
-        lines: 62.63,
+        functions: 81.57,
+        lines: 65.93,
       },
     },
   },


### PR DESCRIPTION
## What and why

First of two PRs for [docs/plans/nav-pages-scaffolding.md](docs/plans/nav-pages-scaffolding.md): five placeholder-shell routes (`/art` `/coop` `/conditions` `/community` `/book`) behind a hybrid IA, with the nav flipping from hash anchors to routed links one page at a time.

Two commits, per the plan's slices:

1. **The plan itself** — problem, decisions with rejected alternatives, test seams, slice order. Produced by a grilling session; the plan file is the durable record.
2. **Nav and Footer move from `page.tsx` into the root layout**, so every future route gets the chrome for free. `main` stays per-page (each page owns its landmark and `flex-1` spacer). `layout.tsx` leaves the deliberately-untested set: new `layout.test.tsx` asserts the navigation/contentinfo/main landmark sandwich with `next/font/google` stubbed. Coverage floor raised to the new actuals (statements 60.39→63.36, functions 78.94→81.57, lines 62.63→65.93) per the threshold comment's own rule.

## Gate output

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
```

Coverage summary at the slice commit: Statements 63.36% (64/101), Branches 73.52% (25/34), Functions 81.57% (31/38), Lines 65.93% (60/91). All 38 tests pass.

## Not done here

- The five page routes, nav link flips, teaser links, and per-page metadata — PR 2, cut from `main` after this merges (the pages stand on this refactor).
- No per-slice issues, deliberately: solo sequential work from the plan file (CLAUDE.md §5).
- `TODO(verify)` items: none new; the booking URL TODO from the landing plan is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)