### PR TITLE
Add the five nav pages and flip the nav to routes (nav-pages-scaffolding PR 2)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,56 @@
+# Wild Coast Kids
+
+The site for an art-class and outdoor-co-op program for K–8 kids in San Diego.
+This file is the project's domain glossary: the words the code, the copy, the
+issues and the plans all use for the same things. When two words are in play
+for one concept, this file picks one and lists the rest under _Avoid_.
+
+## Language
+
+**Program**:
+One of the two things the site offers — art classes, and the Tuesday co-op.
+Each has a card on the landing page and a page of its own.
+_Avoid_: offering, service, class (a class is one session of the art program)
+
+**Teaser**:
+A landing-page section that summarises a topic and links to its full page. The
+teaser stays on `/` once the page exists; it is not a copy of the page.
+_Avoid_: preview, blurb, summary, excerpt
+
+**Interest list**:
+The list a parent joins to hear about new classes and co-op spots. Collected by
+the interest-list form, which appears on the landing page and on `/community`.
+Every CTA that points at it reads "Join the interest list".
+_Avoid_: email list, mailing list, the community, the loop
+
+**Reserved slot**:
+A labeled stand-in for content that has been decided on but not yet written or
+built — a schedule, a booking scheduler, the conditions tool. Renders as a
+dashed frame with an emoji and a "coming soon" line naming what lands there.
+_Avoid_: coming-soon box, empty state, placeholder (that word is taken, below)
+
+**Placeholder**:
+A labeled stand-in for a future _image_ — logo, hero photo, card background,
+gallery frame. Carries the accessible name the real image will inherit, so
+swapping in the photograph changes nothing for assistive tech.
+_Avoid_: stub, dummy image, reserved slot (that is for content, not images)
+
+**Strip**:
+A band of content that loops horizontally — the yellow marquee and the gallery
+film strip. Every strip moves at one shared pixels-per-second speed, whatever
+its width.
+_Avoid_: carousel, ticker, marquee (the marquee is one strip, not the concept)
+
+**Pill**:
+The site's call-to-action shape: a fully-rounded link. Five tones, and the list
+is closed — `yellow`, `purple`, `ocean`, `outline-light`, `outline-dark`. A
+pill is a link; the interest-list form's submit control is the site's only
+true button.
+_Avoid_: button, chip, badge (a badge is the smaller non-interactive pill on a
+program card)
+
+**Conditions**:
+The real-time surf, tide, wind and visibility tool for San Diego's coast, built
+separately and embedded here. Has a teaser on the landing page and a page of
+its own; both currently carry a reserved slot for it.
+_Avoid_: weather, forecast, surf report

--- a/docs/plans/nav-pages-scaffolding.md
+++ b/docs/plans/nav-pages-scaffolding.md
@@ -102,6 +102,30 @@ sequence from this file, and splitting would buy nothing (CLAUDE.md §5).
   rather than waiting for `/art`; the `/art` slice then only moved the
   nav's link row onto the existing machinery.
 
+## Addendum — 2026-08-12 (review)
+
+- **`/community` linked to itself.** The `/community` slice reused the
+  landing section wholesale, so the teaser's "Meet the community" CTA
+  rendered on the page it points at. Fixed by splitting `InterestListForm`
+  out of `CommunityForm`: the landing page composes teaser + form, and
+  `/community` renders the form alone under its own heading. A MUST FAIL
+  regression test went in first, as `test.fails` — the gate table's
+  `mustFail` flag judges a whole gate, and the test gate runs the whole
+  suite, so it cannot express one failing test inside a passing suite.
+- **`CONTEXT.md` landed here**, though this plan put it out of scope. The
+  split needed a name for the thing the form collects, and the repo had
+  four in use: "interest list" (program card, `/book`, `/coop`), "join the
+  community" (the form's own button), "stay in the loop" (its heading) and
+  "email list" (in conversation). The glossary picks **interest list**.
+- **Two inconsistencies are knowingly left open**, both deliberately out of
+  this PR's scope: the form's submit button still reads "Join the
+  community", and `CommunityForm` no longer contains a form. Both are
+  rename/copy slices, which this repo keeps separate from bugfixes.
+- **The "no content layer" rejection above is worth reopening**, but not
+  here. It was decided when exactly one paragraph was shared; the reserved
+  slot is now duplicated at six call sites. That is a structural
+  duplication rather than a copy one, and it gets its own plan.
+
 ## Out of scope
 
 Real copy, images and logo, booking provider choice and its embed, the

--- a/docs/plans/nav-pages-scaffolding.md
+++ b/docs/plans/nav-pages-scaffolding.md
@@ -89,6 +89,19 @@ each slice = route + shell + metadata + its nav flip + teaser link):
 Per-slice issues are skipped deliberately: one person works these in
 sequence from this file, and splitting would buy nothing (CLAUDE.md §5).
 
+## Addendum — 2026-08-12 (build)
+
+- **The /book slice flipped one more CTA than planned.** The art card's
+  "Book a class" link carried the template's placeholder calendly.com
+  behind a TODO(verify); pointing it at `/book` retires that TODO and
+  moves the provider decision behind the booking page. The hero CTAs
+  stay on their program anchors — their flow targets the cards, not
+  booking directly.
+- **The active-state assertion landed one slice early.** NavLink and its
+  aria-current tests shipped with `/book` (the component's own slice)
+  rather than waiting for `/art`; the `/art` slice then only moved the
+  nav's link row onto the existing machinery.
+
 ## Out of scope
 
 Real copy, images and logo, booking provider choice and its embed, the

--- a/src/app/art/page.test.tsx
+++ b/src/app/art/page.test.tsx
@@ -1,0 +1,25 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Art from "./page";
+
+test("the art page exposes its landmark, heading and reserved slots", () => {
+  render(<Art />);
+
+  expect(screen.getByRole("main")).toBeDefined();
+
+  const heading = screen.getByRole("heading", { level: 1 });
+  expect(heading.textContent).toContain("Art");
+
+  expect(screen.getByText(/schedule & pricing coming soon/i)).toBeDefined();
+  expect(
+    screen.getByRole("img", { name: "Student artwork gallery" }),
+  ).toBeDefined();
+});
+
+test("the page CTA routes to the booking page", () => {
+  render(<Art />);
+
+  expect(
+    screen.getByRole("link", { name: /book a class/i }).getAttribute("href"),
+  ).toBe("/book");
+});

--- a/src/app/art/page.tsx
+++ b/src/app/art/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Placeholder } from "@/components/Placeholder";
+
+export const metadata: Metadata = {
+  title: "Art Classes",
+  description:
+    "Watercolors, ink, collage and printmaking for K–8 kids, inspired by the San Diego coast. Group and private sessions, charter fund eligible.",
+};
+
+export default function Art() {
+  return (
+    <main className="flex-1 pt-[90px] md:pt-nav">
+      <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
+        <p className="mb-7 text-2xs font-extrabold tracking-widest text-purple uppercase">
+          In-person · Group & Private · K–8
+        </p>
+        <h1 className="text-title leading-display mb-4 font-black italic">
+          Art <span className="text-purple">classes.</span>
+        </h1>
+        <p className="leading-relaxed mb-9 max-w-130 text-base text-fog">
+          Watercolors, ink, collage, printmaking — inspired by the coast and
+          whatever sparks curiosity. Every session is different, and full class
+          details are on their way.
+        </p>
+        <Link
+          href="/book"
+          className="rounded-pill mb-12 inline-block bg-purple px-7 py-[13px] text-sm font-black text-white transition-colors duration-fast hover:bg-purple-deep"
+        >
+          Book a class →
+        </Link>
+        {/* Reserved slots for the content pass: real schedule, pricing and
+            student photos. */}
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="rounded-box border-2 border-dashed border-lavender bg-white/60 px-8 py-12 text-center">
+            <span aria-hidden="true" className="mb-3.5 block text-5xl">
+              🎨
+            </span>
+            <p className="leading-normal text-sm text-fog">
+              Schedule & pricing coming soon.
+              <br />
+              <br />
+              Session times, group and private options, and charter-fund details
+              land here.
+            </p>
+          </div>
+          <Placeholder
+            label="Student artwork gallery"
+            className="rounded-box min-h-60"
+          />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/book/page.test.tsx
+++ b/src/app/book/page.test.tsx
@@ -1,0 +1,24 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Book from "./page";
+
+test("the book page exposes its landmark, heading and coming-soon slot", () => {
+  render(<Book />);
+
+  expect(screen.getByRole("main")).toBeDefined();
+
+  const heading = screen.getByRole("heading", { level: 1 });
+  expect(heading.textContent).toContain("Book");
+
+  expect(screen.getByText(/online booking coming soon/i)).toBeDefined();
+});
+
+test("the interim CTA routes to the landing page's interest list", () => {
+  render(<Book />);
+
+  expect(
+    screen
+      .getByRole("link", { name: /join the interest list/i })
+      .getAttribute("href"),
+  ).toBe("/#community");
+});

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Book Now",
+  description:
+    "Book an art class with Wild Coast Kids. Online booking is on its way — join the interest list to grab a spot first.",
+};
+
+export default function Book() {
+  return (
+    <main className="flex-1 pt-[90px] md:pt-nav">
+      <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
+        <p className="mb-7 text-2xs font-extrabold tracking-widest text-purple uppercase">
+          In-person · Group & Private · K–8
+        </p>
+        <h1 className="text-title leading-display mb-4 font-black italic">
+          Book a <span className="text-purple">class.</span>
+        </h1>
+        <p className="leading-relaxed mb-9 max-w-130 text-base text-fog">
+          Watercolors, ink, collage, printmaking — pick a session and come make
+          something wild. Online booking is on its way; until it lands, the
+          interest list is the fastest way to grab a spot.
+        </p>
+        <Link
+          href="/#community"
+          className="rounded-pill mb-12 inline-block bg-purple px-7 py-[13px] text-sm font-black text-white transition-colors duration-fast hover:bg-purple-deep"
+        >
+          Join the interest list →
+        </Link>
+        {/* The reserved slot for the scheduler, once a provider is chosen. */}
+        <div className="rounded-box border-2 border-dashed border-lavender bg-white/60 px-8 py-12 text-center">
+          <span aria-hidden="true" className="mb-3.5 block text-5xl">
+            🗓️
+          </span>
+          <p className="leading-normal text-sm text-fog">
+            Online booking coming soon.
+            <br />
+            <br />
+            The scheduler embeds here once a booking provider is chosen.
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/community/page.test.tsx
+++ b/src/app/community/page.test.tsx
@@ -27,17 +27,12 @@ test("the interest-list form rides on the page, not just the landing", () => {
   ).toBeDefined();
 });
 
-// MUST FAIL, per CLAUDE.md's rule that a bugfix starts with a regression test
-// that failed first. The gate table's mustFail flag judges a whole gate, and
-// the test gate runs the whole suite, so it cannot express "one test in this
-// suite must fail". test.fails is that at test granularity: it passes only
-// while the body throws, so this commit proves the defect and leaves the gate
-// green. The fix commit turns it into a plain test().
-test.fails("the page does not offer a link to itself", () => {
+test("the page does not offer a link to itself", () => {
   render(<Community />);
 
-  // The landing teaser rides in on CommunityForm, and its CTA points at
-  // /community — the page the reader is already on.
+  // This page is what the landing teaser's "Meet the community" points at,
+  // so that link must not ride along here. Regression: it did, until the
+  // form became its own module.
   expect(screen.queryByRole("link", { name: /meet the community/i })).toBe(
     null,
   );

--- a/src/app/community/page.test.tsx
+++ b/src/app/community/page.test.tsx
@@ -1,0 +1,28 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Community from "./page";
+
+test("the community page exposes its landmark, heading and reserved slots", () => {
+  render(<Community />);
+
+  expect(screen.getByRole("main")).toBeDefined();
+
+  const heading = screen.getByRole("heading", { level: 1 });
+  expect(heading.textContent).toContain("community");
+
+  expect(screen.getByText(/community stories coming soon/i)).toBeDefined();
+  expect(
+    screen.getByRole("img", { name: "Community photo gallery" }),
+  ).toBeDefined();
+});
+
+test("the interest-list form rides on the page, not just the landing", () => {
+  render(<Community />);
+
+  // The working form is the page's action: reachable controls, not a copy
+  // of the landing teaser.
+  expect(screen.getByRole("textbox", { name: /your name/i })).toBeDefined();
+  expect(
+    screen.getByRole("button", { name: /join the community/i }),
+  ).toBeDefined();
+});

--- a/src/app/community/page.test.tsx
+++ b/src/app/community/page.test.tsx
@@ -26,3 +26,19 @@ test("the interest-list form rides on the page, not just the landing", () => {
     screen.getByRole("button", { name: /join the community/i }),
   ).toBeDefined();
 });
+
+// MUST FAIL, per CLAUDE.md's rule that a bugfix starts with a regression test
+// that failed first. The gate table's mustFail flag judges a whole gate, and
+// the test gate runs the whole suite, so it cannot express "one test in this
+// suite must fail". test.fails is that at test granularity: it passes only
+// while the body throws, so this commit proves the defect and leaves the gate
+// green. The fix commit turns it into a plain test().
+test.fails("the page does not offer a link to itself", () => {
+  render(<Community />);
+
+  // The landing teaser rides in on CommunityForm, and its CTA points at
+  // /community — the page the reader is already on.
+  expect(screen.queryByRole("link", { name: /meet the community/i })).toBe(
+    null,
+  );
+});

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import { CommunityForm } from "@/components/CommunityForm";
+import { Placeholder } from "@/components/Placeholder";
+
+export const metadata: Metadata = {
+  title: "Community",
+  description:
+    "Families making, wondering and exploring together on San Diego's coast. Join the Wild Coast Kids community for class news and co-op updates.",
+};
+
+export default function Community() {
+  return (
+    <main className="flex-1 pt-[90px] md:pt-nav">
+      <section className="px-gutter-sm pt-section-sm md:px-gutter md:pt-section">
+        <p className="mb-7 text-2xs font-extrabold tracking-widest text-purple uppercase">
+          Families · Updates · Coastal adventures
+        </p>
+        <h1 className="text-title leading-display mb-4 font-black italic">
+          Join the <span className="text-purple">community.</span>
+        </h1>
+        <p className="leading-relaxed mb-9 max-w-130 text-base text-fog">
+          Wild Coast Kids is families making, wondering and exploring together.
+          Here&apos;s where community stories will live — and where you can jump
+          in.
+        </p>
+        {/* Reserved slots for the content pass: stories, meetups and photos. */}
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="rounded-box border-2 border-dashed border-lavender bg-white/60 px-8 py-12 text-center">
+            <span aria-hidden="true" className="mb-3.5 block text-5xl">
+              🏄
+            </span>
+            <p className="leading-normal text-sm text-fog">
+              Community stories coming soon.
+              <br />
+              <br />
+              Photos, testimonials and upcoming meetups land here.
+            </p>
+          </div>
+          <Placeholder
+            label="Community photo gallery"
+            className="rounded-box min-h-60"
+          />
+        </div>
+      </section>
+      <CommunityForm />
+    </main>
+  );
+}

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { CommunityForm } from "@/components/CommunityForm";
+import { InterestListForm } from "@/components/InterestListForm";
 import { Placeholder } from "@/components/Placeholder";
 
 export const metadata: Metadata = {
@@ -42,7 +42,20 @@ export default function Community() {
           />
         </div>
       </section>
-      <CommunityForm />
+      {/* The form alone, not the landing teaser: this is the page that
+          teaser points at. */}
+      <section className="px-gutter-sm pb-section-sm md:px-gutter md:pb-section">
+        <h2 className="text-title leading-display mb-4 font-black italic">
+          Join the <span className="text-purple">interest list.</span>
+        </h2>
+        <p className="leading-relaxed mb-6 max-w-130 text-base text-fog">
+          Drop your info and we&apos;ll reach out with new classes, co-op
+          updates and coastal adventures.
+        </p>
+        <div className="max-w-130">
+          <InterestListForm />
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/app/conditions/page.test.tsx
+++ b/src/app/conditions/page.test.tsx
@@ -1,0 +1,14 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Conditions from "./page";
+
+test("the conditions page exposes its landmark, heading and embed slot", () => {
+  render(<Conditions />);
+
+  expect(screen.getByRole("main")).toBeDefined();
+
+  const heading = screen.getByRole("heading", { level: 1 });
+  expect(heading.textContent).toContain("conditions");
+
+  expect(screen.getByText(/conditions tool coming soon/i)).toBeDefined();
+});

--- a/src/app/conditions/page.tsx
+++ b/src/app/conditions/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Conditions",
+  description:
+    "Real-time surf, tide, wind and visibility for San Diego's coast — built by a local, for families planning tidepool visits and hikes.",
+};
+
+export default function Conditions() {
+  return (
+    <main className="flex-1 pt-[90px] md:pt-nav">
+      <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
+        <p className="mb-7 text-2xs font-extrabold tracking-widest text-ocean uppercase">
+          Surf · Tide · Wind · Visibility
+        </p>
+        <h1 className="text-title leading-display mb-4 font-black italic">
+          Check <span className="text-ocean">conditions</span> first.
+        </h1>
+        <p className="leading-relaxed mb-9 max-w-130 text-base text-fog">
+          Real-time surf, tide, wind and visibility for San Diego&apos;s coast —
+          built by a local, for families planning tidepool visits and hikes.
+          Know before you go.
+        </p>
+        {/* The reserved slot for the conditions tool, same contract as the
+            landing section's: drop the URL and it embeds here. */}
+        <div className="rounded-box border-2 border-dashed border-lavender bg-white/60 px-8 py-12 text-center">
+          <span aria-hidden="true" className="mb-3.5 block text-5xl">
+            🌊
+          </span>
+          <p className="leading-normal text-sm text-fog">
+            Conditions tool coming soon.
+            <br />
+            <br />
+            Drop the URL and it embeds here automatically.
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/coop/page.test.tsx
+++ b/src/app/coop/page.test.tsx
@@ -1,0 +1,27 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import Coop from "./page";
+
+test("the co-op page exposes its landmark, heading and reserved slots", () => {
+  render(<Coop />);
+
+  expect(screen.getByRole("main")).toBeDefined();
+
+  const heading = screen.getByRole("heading", { level: 1 });
+  expect(heading.textContent).toContain("co-op");
+
+  expect(screen.getByText(/full co-op details coming soon/i)).toBeDefined();
+  expect(
+    screen.getByRole("img", { name: "Co-op adventures photo gallery" }),
+  ).toBeDefined();
+});
+
+test("the page CTA routes to the landing page's interest list", () => {
+  render(<Coop />);
+
+  expect(
+    screen
+      .getByRole("link", { name: /join the interest list/i })
+      .getAttribute("href"),
+  ).toBe("/#community");
+});

--- a/src/app/coop/page.tsx
+++ b/src/app/coop/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Placeholder } from "@/components/Placeholder";
+
+export const metadata: Metadata = {
+  title: "Tuesday Co-op",
+  description:
+    "A Tuesday outdoor co-op for K–8 homeschoolers exploring San Diego's wild coast — tidepools, hikes, nature journaling and science.",
+};
+
+export default function Coop() {
+  return (
+    <main className="flex-1 pt-[90px] md:pt-nav">
+      <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
+        <p className="mb-7 text-2xs font-extrabold tracking-widest text-ocean uppercase">
+          Tuesdays · 10am – 1pm · Fall 2026
+        </p>
+        <h1 className="text-title leading-display mb-4 font-black italic">
+          Tuesday <span className="text-ocean">co-op.</span>
+        </h1>
+        <p className="leading-relaxed mb-9 max-w-130 text-base text-fog">
+          Exploring San Diego&apos;s wild coast through tidepools, hikes, nature
+          journaling and hands-on science. Spots are limited for fall, and full
+          co-op details are on their way.
+        </p>
+        <Link
+          href="/#community"
+          className="rounded-pill mb-12 inline-block bg-ocean px-7 py-[13px] text-sm font-black text-white transition-colors duration-fast"
+        >
+          Join the interest list →
+        </Link>
+        {/* Reserved slots for the content pass: the weekly rhythm and photos
+            from past adventures. */}
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="rounded-box border-2 border-dashed border-lavender bg-white/60 px-8 py-12 text-center">
+            <span aria-hidden="true" className="mb-3.5 block text-5xl">
+              🌿
+            </span>
+            <p className="leading-normal text-sm text-fog">
+              Full co-op details coming soon.
+              <br />
+              <br />
+              The weekly rhythm, meeting spots, and fall sign-up details land
+              here.
+            </p>
+          </div>
+          <Placeholder
+            label="Co-op adventures photo gallery"
+            className="rounded-box min-h-60"
+          />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -8,6 +8,12 @@ vi.mock("next/font/google", () => ({
   Montserrat: () => ({ variable: "--font-montserrat" }),
 }));
 
+// The nav's routed links read the current pathname from the app router,
+// which vitest does not mount.
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
 test("the layout wraps every page in the shared nav and footer", () => {
   render(
     <RootLayout params={Promise.resolve({})}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,11 @@ const montserrat = Montserrat({
 });
 
 export const metadata: Metadata = {
-  title: "Wild Coast Kids",
+  // Pages set their own titles; the template keeps the brand on every tab.
+  title: {
+    default: "Wild Coast Kids",
+    template: "%s — Wild Coast Kids",
+  },
   description:
     "Art classes and a Tuesday outdoor co-op for K–8 kids, rooted in the San Diego coast. Charter fund eligible.",
 };

--- a/src/components/CommunityForm.test.tsx
+++ b/src/components/CommunityForm.test.tsx
@@ -34,3 +34,13 @@ test("submitting swaps the form for the success state", () => {
     null,
   );
 });
+
+test("the section teases the full community page", () => {
+  render(<CommunityForm />);
+
+  expect(
+    screen
+      .getByRole("link", { name: /meet the community/i })
+      .getAttribute("href"),
+  ).toBe("/community");
+});

--- a/src/components/CommunityForm.test.tsx
+++ b/src/components/CommunityForm.test.tsx
@@ -1,38 +1,16 @@
 import { expect, test } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { CommunityForm } from "./CommunityForm";
 
-test("every input has an associated label", () => {
+test("the teaser carries the interest-list form alongside it", () => {
   render(<CommunityForm />);
 
-  expect(screen.getByLabelText("Your name")).toBeDefined();
-  expect(screen.getByLabelText("Email")).toBeDefined();
-  expect(screen.getByLabelText("Kids' ages")).toBeDefined();
-  for (const name of ["Art Classes", "Tidepools", "Hikes", "Science"]) {
-    expect(
-      screen.getByRole("checkbox", { name: new RegExp(name) }),
-    ).toBeDefined();
-  }
-});
-
-test("submitting swaps the form for the success state", () => {
-  render(<CommunityForm />);
-
-  fireEvent.change(screen.getByLabelText("Your name"), {
-    target: { value: "Robin Parent" },
-  });
-  fireEvent.change(screen.getByLabelText("Email"), {
-    target: { value: "robin@example.com" },
-  });
-  fireEvent.click(screen.getByRole("checkbox", { name: /tidepools/i }));
-  fireEvent.click(screen.getByRole("button", { name: /join the community/i }));
-
-  // The success state must actually replace the form, not merely render:
-  // the status is announced and the submit button is gone.
-  expect(screen.getByRole("status").textContent).toContain("You're in!");
-  expect(screen.queryByRole("button", { name: /join the community/i })).toBe(
-    null,
-  );
+  // The landing section is the teaser and the form together; the form's own
+  // behavior is asserted in InterestListForm.test.tsx.
+  expect(screen.getByRole("textbox", { name: /your name/i })).toBeDefined();
+  expect(
+    screen.getByRole("button", { name: /join the community/i }),
+  ).toBeDefined();
 });
 
 test("the section teases the full community page", () => {

--- a/src/components/CommunityForm.tsx
+++ b/src/components/CommunityForm.tsx
@@ -1,27 +1,15 @@
-"use client";
-
 import Link from "next/link";
-import { useState } from "react";
-
-const INTERESTS = [
-  { value: "art", emoji: "🎨", label: "Art Classes" },
-  { value: "tidepools", emoji: "🌊", label: "Tidepools" },
-  { value: "hikes", emoji: "🌿", label: "Hikes" },
-  { value: "science", emoji: "🔬", label: "Science" },
-];
-
-/* 16px on touch widths — iOS zooms into any input below 16px on focus. */
-const INPUT_CLASSES =
-  "rounded-tile w-full border-[1.5px] border-lavender bg-cream px-4 py-[13px] text-[16px] text-dark transition-colors duration-fast outline-none focus:border-purple focus:bg-white md:text-base";
+import { InterestListForm } from "./InterestListForm";
 
 /**
- * The interest-list form. Client-side only by decision: submit swaps the
- * form for the success state and no data leaves the page — wiring a real
- * destination (email/sheet/service) is a future slice.
+ * The landing page's interest-list teaser: the pitch, a link on to the fuller
+ * /community page, and the form itself alongside.
+ *
+ * The teaser and the form are separate modules because /community renders the
+ * form without this teaser. Rendering the whole section there put the "Meet
+ * the community" link on the page it points at.
  */
 export function CommunityForm() {
-  const [submitted, setSubmitted] = useState(false);
-
   return (
     <section
       id="community"
@@ -44,109 +32,7 @@ export function CommunityForm() {
           Meet the community →
         </Link>
       </div>
-      {/* min-h ≈ the rendered form, so the success swap doesn't collapse the
-          card and yank the page while the user is looking at it. */}
-      <div className="rounded-card shadow-card min-h-140 bg-white p-9">
-        {submitted ? (
-          <div
-            role="status"
-            className="flex min-h-120 flex-col justify-center px-5 py-10 text-center"
-          >
-            <span aria-hidden="true" className="mb-4 block text-[52px]">
-              🎉
-            </span>
-            <h3 className="mb-2 text-[22px] font-black italic">
-              You&apos;re in!
-            </h3>
-            <p className="leading-normal text-base text-fog">
-              We&apos;ll be in touch soon with updates, new classes and coastal
-              adventures.
-            </p>
-          </div>
-        ) : (
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              setSubmitted(true);
-            }}
-          >
-            <div className="mb-4.5">
-              <label
-                htmlFor="community-name"
-                className="mb-2 block text-2xs font-extrabold tracking-wider uppercase"
-              >
-                Your name
-              </label>
-              <input
-                id="community-name"
-                name="name"
-                type="text"
-                required
-                placeholder="First and last name"
-                className={INPUT_CLASSES}
-              />
-            </div>
-            <div className="mb-4.5">
-              <label
-                htmlFor="community-email"
-                className="mb-2 block text-2xs font-extrabold tracking-wider uppercase"
-              >
-                Email
-              </label>
-              <input
-                id="community-email"
-                name="email"
-                type="email"
-                required
-                placeholder="you@email.com"
-                className={INPUT_CLASSES}
-              />
-            </div>
-            <div className="mb-4.5">
-              <label
-                htmlFor="community-ages"
-                className="mb-2 block text-2xs font-extrabold tracking-wider uppercase"
-              >
-                Kids&apos; ages
-              </label>
-              <input
-                id="community-ages"
-                name="ages"
-                type="text"
-                placeholder="e.g. 6, 9, 12"
-                className={INPUT_CLASSES}
-              />
-            </div>
-            <fieldset className="mb-4.5">
-              <legend className="mb-2 block text-2xs font-extrabold tracking-wider uppercase">
-                Interested in
-              </legend>
-              <div className="mt-2 grid grid-cols-2 gap-2.5">
-                {INTERESTS.map(({ value, emoji, label }) => (
-                  <label
-                    key={value}
-                    className="flex cursor-pointer items-center gap-2 text-sm font-bold"
-                  >
-                    <input
-                      type="checkbox"
-                      name="interest"
-                      value={value}
-                      className="size-4 accent-purple"
-                    />
-                    <span aria-hidden="true">{emoji}</span> {label}
-                  </label>
-                ))}
-              </div>
-            </fieldset>
-            <button
-              type="submit"
-              className="rounded-pill mt-6 w-full cursor-pointer bg-purple p-[15px] text-base font-black tracking-[0.06em] text-white transition-colors duration-fast hover:bg-purple-deep"
-            >
-              Join the community →
-            </button>
-          </form>
-        )}
-      </div>
+      <InterestListForm />
     </section>
   );
 }

--- a/src/components/CommunityForm.tsx
+++ b/src/components/CommunityForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 
 const INTERESTS = [
@@ -32,10 +33,16 @@ export function CommunityForm() {
           <br />
           the <span className="text-purple">loop.</span>
         </h2>
-        <p className="leading-relaxed text-base text-fog">
+        <p className="leading-relaxed mb-6 text-base text-fog">
           Drop your info and we&apos;ll reach out with new classes, co-op
           updates and coastal adventures.
         </p>
+        <Link
+          href="/community"
+          className="rounded-pill inline-block border-2 border-lavender px-[24px] py-[10px] text-sm font-bold text-dark"
+        >
+          Meet the community →
+        </Link>
       </div>
       {/* min-h ≈ the rendered form, so the success swap doesn't collapse the
           card and yank the page while the user is looking at it. */}

--- a/src/components/Conditions.test.tsx
+++ b/src/components/Conditions.test.tsx
@@ -9,6 +9,14 @@ test("the conditions heading and embed slot are reachable at #conditions", () =>
   expect(heading.textContent).toContain("conditions");
   expect(screen.getByText(/conditions tool coming soon/i)).toBeDefined();
 
-  // The nav deep-links here; the id is stable API.
+  // Teasers deep-link here; the id is stable API.
   expect(container.querySelector("section#conditions")).not.toBeNull();
+});
+
+test("the section teases the full conditions page", () => {
+  render(<Conditions />);
+
+  expect(
+    screen.getByRole("link", { name: /learn more/i }).getAttribute("href"),
+  ).toBe("/conditions");
 });

--- a/src/components/Conditions.tsx
+++ b/src/components/Conditions.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export function Conditions() {
   return (
     <section
@@ -12,10 +14,16 @@ export function Conditions() {
           <br />
           first.
         </h2>
-        <p className="leading-relaxed text-base text-white/65">
+        <p className="leading-relaxed mb-6 text-base text-white/65">
           Real-time surf, tide, wind and visibility for San Diego&apos;s coast —
           built by a local, for families planning tidepool visits and hikes.
         </p>
+        <Link
+          href="/conditions"
+          className="rounded-pill inline-block border-2 border-white/50 px-[24px] py-[10px] text-sm font-bold text-white"
+        >
+          Learn more →
+        </Link>
       </div>
       {/* The reserved slot for the future conditions-tool embed. */}
       <div className="rounded-box border-2 border-dashed border-white/20 bg-white/7 px-8 py-12 text-center">

--- a/src/components/InterestListForm.test.tsx
+++ b/src/components/InterestListForm.test.tsx
@@ -1,0 +1,44 @@
+import { expect, test } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { InterestListForm } from "./InterestListForm";
+
+test("every input has an associated label", () => {
+  render(<InterestListForm />);
+
+  expect(screen.getByLabelText("Your name")).toBeDefined();
+  expect(screen.getByLabelText("Email")).toBeDefined();
+  expect(screen.getByLabelText("Kids' ages")).toBeDefined();
+  for (const name of ["Art Classes", "Tidepools", "Hikes", "Science"]) {
+    expect(
+      screen.getByRole("checkbox", { name: new RegExp(name) }),
+    ).toBeDefined();
+  }
+});
+
+test("submitting swaps the form for the success state", () => {
+  render(<InterestListForm />);
+
+  fireEvent.change(screen.getByLabelText("Your name"), {
+    target: { value: "Robin Parent" },
+  });
+  fireEvent.change(screen.getByLabelText("Email"), {
+    target: { value: "robin@example.com" },
+  });
+  fireEvent.click(screen.getByRole("checkbox", { name: /tidepools/i }));
+  fireEvent.click(screen.getByRole("button", { name: /join the community/i }));
+
+  // The success state must actually replace the form, not merely render:
+  // the status is announced and the submit button is gone.
+  expect(screen.getByRole("status").textContent).toContain("You're in!");
+  expect(screen.queryByRole("button", { name: /join the community/i })).toBe(
+    null,
+  );
+});
+
+test("the form carries no link to the community page", () => {
+  render(<InterestListForm />);
+
+  // That link belongs to the landing teaser. Keeping it out of this module
+  // is what lets /community render the form without pointing at itself.
+  expect(screen.queryByRole("link")).toBe(null);
+});

--- a/src/components/InterestListForm.tsx
+++ b/src/components/InterestListForm.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+
+const INTERESTS = [
+  { value: "art", emoji: "🎨", label: "Art Classes" },
+  { value: "tidepools", emoji: "🌊", label: "Tidepools" },
+  { value: "hikes", emoji: "🌿", label: "Hikes" },
+  { value: "science", emoji: "🔬", label: "Science" },
+];
+
+/* 16px on touch widths — iOS zooms into any input below 16px on focus. */
+const INPUT_CLASSES =
+  "rounded-tile w-full border-[1.5px] border-lavender bg-cream px-4 py-[13px] text-[16px] text-dark transition-colors duration-fast outline-none focus:border-purple focus:bg-white md:text-base";
+
+/**
+ * The interest-list form. Client-side only by decision: submit swaps the
+ * form for the success state and no data leaves the page — wiring a real
+ * destination (email/sheet/service) is a future slice.
+ *
+ * Its own module because two routes render it: the landing page wraps it in
+ * a teaser column, and /community renders it alone. The caller owns the
+ * width it sits in; this module owns the card.
+ */
+export function InterestListForm() {
+  const [submitted, setSubmitted] = useState(false);
+
+  return (
+    // min-h ≈ the rendered form, so the success swap doesn't collapse the
+    // card and yank the page while the user is looking at it.
+    <div className="rounded-card shadow-card min-h-140 bg-white p-9">
+      {submitted ? (
+        <div
+          role="status"
+          className="flex min-h-120 flex-col justify-center px-5 py-10 text-center"
+        >
+          <span aria-hidden="true" className="mb-4 block text-[52px]">
+            🎉
+          </span>
+          <h3 className="mb-2 text-[22px] font-black italic">
+            You&apos;re in!
+          </h3>
+          <p className="leading-normal text-base text-fog">
+            We&apos;ll be in touch soon with updates, new classes and coastal
+            adventures.
+          </p>
+        </div>
+      ) : (
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            setSubmitted(true);
+          }}
+        >
+          <div className="mb-4.5">
+            <label
+              htmlFor="community-name"
+              className="mb-2 block text-2xs font-extrabold tracking-wider uppercase"
+            >
+              Your name
+            </label>
+            <input
+              id="community-name"
+              name="name"
+              type="text"
+              required
+              placeholder="First and last name"
+              className={INPUT_CLASSES}
+            />
+          </div>
+          <div className="mb-4.5">
+            <label
+              htmlFor="community-email"
+              className="mb-2 block text-2xs font-extrabold tracking-wider uppercase"
+            >
+              Email
+            </label>
+            <input
+              id="community-email"
+              name="email"
+              type="email"
+              required
+              placeholder="you@email.com"
+              className={INPUT_CLASSES}
+            />
+          </div>
+          <div className="mb-4.5">
+            <label
+              htmlFor="community-ages"
+              className="mb-2 block text-2xs font-extrabold tracking-wider uppercase"
+            >
+              Kids&apos; ages
+            </label>
+            <input
+              id="community-ages"
+              name="ages"
+              type="text"
+              placeholder="e.g. 6, 9, 12"
+              className={INPUT_CLASSES}
+            />
+          </div>
+          <fieldset className="mb-4.5">
+            <legend className="mb-2 block text-2xs font-extrabold tracking-wider uppercase">
+              Interested in
+            </legend>
+            <div className="mt-2 grid grid-cols-2 gap-2.5">
+              {INTERESTS.map(({ value, emoji, label }) => (
+                <label
+                  key={value}
+                  className="flex cursor-pointer items-center gap-2 text-sm font-bold"
+                >
+                  <input
+                    type="checkbox"
+                    name="interest"
+                    value={value}
+                    className="size-4 accent-purple"
+                  />
+                  <span aria-hidden="true">{emoji}</span> {label}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+          <button
+            type="submit"
+            className="rounded-pill mt-6 w-full cursor-pointer bg-purple p-[15px] text-base font-black tracking-[0.06em] text-white transition-colors duration-fast hover:bg-purple-deep"
+          >
+            Join the community →
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/components/Nav.test.tsx
+++ b/src/components/Nav.test.tsx
@@ -21,15 +21,14 @@ test("the nav exposes all four section links by name", () => {
   }
 });
 
-// Anchors flip to routes as each page lands; this table is the flip's record.
-test("each section link points at its current destination", () => {
+test("each section link points at its page", () => {
   render(<Nav />);
 
   for (const [name, href] of [
     ["Art Classes", "/art"],
     ["Tuesday Co-op", "/coop"],
     ["Conditions", "/conditions"],
-    ["Community", "#community"],
+    ["Community", "/community"],
   ]) {
     expect(screen.getByRole("link", { name }).getAttribute("href")).toBe(href);
   }

--- a/src/components/Nav.test.tsx
+++ b/src/components/Nav.test.tsx
@@ -28,7 +28,7 @@ test("each section link points at its current destination", () => {
   for (const [name, href] of [
     ["Art Classes", "/art"],
     ["Tuesday Co-op", "/coop"],
-    ["Conditions", "#conditions"],
+    ["Conditions", "/conditions"],
     ["Community", "#community"],
   ]) {
     expect(screen.getByRole("link", { name }).getAttribute("href")).toBe(href);

--- a/src/components/Nav.test.tsx
+++ b/src/components/Nav.test.tsx
@@ -27,7 +27,7 @@ test("each section link points at its current destination", () => {
 
   for (const [name, href] of [
     ["Art Classes", "/art"],
-    ["Tuesday Co-op", "#coop"],
+    ["Tuesday Co-op", "/coop"],
     ["Conditions", "#conditions"],
     ["Community", "#community"],
   ]) {

--- a/src/components/Nav.test.tsx
+++ b/src/components/Nav.test.tsx
@@ -1,6 +1,12 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { Nav } from "./Nav";
+
+// The routed links read the current pathname; tests render Nav as seen
+// from the landing page.
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
 
 test("the nav exposes all four section links by name", () => {
   render(<Nav />);
@@ -15,11 +21,11 @@ test("the nav exposes all four section links by name", () => {
   }
 });
 
-test("the booking CTA is a link into the art section", () => {
+test("the booking CTA routes to the booking page", () => {
   render(<Nav />);
 
   const cta = screen.getByRole("link", { name: /book now/i });
-  expect(cta.getAttribute("href")).toBe("#art");
+  expect(cta.getAttribute("href")).toBe("/book");
 });
 
 test("the logo slot is a labeled image placeholder", () => {

--- a/src/components/Nav.test.tsx
+++ b/src/components/Nav.test.tsx
@@ -21,6 +21,20 @@ test("the nav exposes all four section links by name", () => {
   }
 });
 
+// Anchors flip to routes as each page lands; this table is the flip's record.
+test("each section link points at its current destination", () => {
+  render(<Nav />);
+
+  for (const [name, href] of [
+    ["Art Classes", "/art"],
+    ["Tuesday Co-op", "#coop"],
+    ["Conditions", "#conditions"],
+    ["Community", "#community"],
+  ]) {
+    expect(screen.getByRole("link", { name }).getAttribute("href")).toBe(href);
+  }
+});
+
 test("the booking CTA routes to the booking page", () => {
   render(<Nav />);
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,13 +1,11 @@
 import { NavLink } from "./NavLink";
 import { Placeholder } from "./Placeholder";
 
-// Entries flip from landing-section anchors to routes as each page lands
-// (docs/plans/nav-pages-scaffolding.md).
 const SECTION_LINKS = [
   { href: "/art", label: "Art Classes" },
   { href: "/coop", label: "Tuesday Co-op" },
   { href: "/conditions", label: "Conditions" },
-  { href: "#community", label: "Community" },
+  { href: "/community", label: "Community" },
 ];
 
 export function Nav() {

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,3 +1,4 @@
+import { NavLink } from "./NavLink";
 import { Placeholder } from "./Placeholder";
 
 const SECTION_LINKS = [
@@ -31,12 +32,12 @@ export function Nav() {
           </a>
         ))}
       </div>
-      <a
-        href="#art"
+      <NavLink
+        href="/book"
         className="rounded-pill shrink-0 bg-yellow px-3.5 py-2 text-2xs font-black tracking-[0.06em] whitespace-nowrap text-ink md:px-5.5 md:py-2.25 md:text-xs"
       >
         Book Now →
-      </a>
+      </NavLink>
     </nav>
   );
 }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -5,7 +5,7 @@ import { Placeholder } from "./Placeholder";
 // (docs/plans/nav-pages-scaffolding.md).
 const SECTION_LINKS = [
   { href: "/art", label: "Art Classes" },
-  { href: "#coop", label: "Tuesday Co-op" },
+  { href: "/coop", label: "Tuesday Co-op" },
   { href: "#conditions", label: "Conditions" },
   { href: "#community", label: "Community" },
 ];

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -6,7 +6,7 @@ import { Placeholder } from "./Placeholder";
 const SECTION_LINKS = [
   { href: "/art", label: "Art Classes" },
   { href: "/coop", label: "Tuesday Co-op" },
-  { href: "#conditions", label: "Conditions" },
+  { href: "/conditions", label: "Conditions" },
   { href: "#community", label: "Community" },
 ];
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,8 +1,10 @@
 import { NavLink } from "./NavLink";
 import { Placeholder } from "./Placeholder";
 
+// Entries flip from landing-section anchors to routes as each page lands
+// (docs/plans/nav-pages-scaffolding.md).
 const SECTION_LINKS = [
-  { href: "#art", label: "Art Classes" },
+  { href: "/art", label: "Art Classes" },
   { href: "#coop", label: "Tuesday Co-op" },
   { href: "#conditions", label: "Conditions" },
   { href: "#community", label: "Community" },
@@ -23,13 +25,13 @@ export function Nav() {
       </div>
       <div className="order-last flex w-full flex-wrap justify-between gap-x-2 md:order-0 md:w-auto md:flex-nowrap md:justify-start md:gap-7">
         {SECTION_LINKS.map(({ href, label }) => (
-          <a
+          <NavLink
             key={href}
             href={href}
-            className="border-b-2 border-transparent pb-0.5 text-[9px] font-extrabold tracking-wider whitespace-nowrap text-dark uppercase transition-colors duration-fast hover:border-yellow md:text-2xs"
+            className="border-b-2 border-transparent pb-0.5 text-[9px] font-extrabold tracking-wider whitespace-nowrap text-dark uppercase transition-colors duration-fast hover:border-yellow aria-[current=page]:border-yellow md:text-2xs"
           >
             {label}
-          </a>
+          </NavLink>
         ))}
       </div>
       <NavLink

--- a/src/components/NavLink.test.tsx
+++ b/src/components/NavLink.test.tsx
@@ -1,0 +1,29 @@
+import { expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NavLink } from "./NavLink";
+
+// usePathname needs a mounted app router; tests steer it per case instead.
+const pathname = vi.hoisted(() => ({ current: "/" }));
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathname.current,
+}));
+
+test("the link to the current page carries aria-current", () => {
+  pathname.current = "/book";
+
+  render(<NavLink href="/book">Book Now</NavLink>);
+
+  expect(
+    screen.getByRole("link", { name: "Book Now" }).getAttribute("aria-current"),
+  ).toBe("page");
+});
+
+test("links to other pages carry no aria-current", () => {
+  pathname.current = "/";
+
+  render(<NavLink href="/book">Book Now</NavLink>);
+
+  expect(
+    screen.getByRole("link", { name: "Book Now" }).getAttribute("aria-current"),
+  ).toBeNull();
+});

--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ComponentProps } from "react";
+
+/**
+ * Nav link that marks the current page for AT and styling. aria-current is
+ * the seam: styles target aria-[current=page] instead of a second "active"
+ * prop that could drift from the real location.
+ */
+export function NavLink(props: ComponentProps<typeof Link>) {
+  const pathname = usePathname();
+
+  return (
+    <Link
+      aria-current={pathname === props.href ? "page" : undefined}
+      {...props}
+    />
+  );
+}

--- a/src/components/ProgramCards.test.tsx
+++ b/src/components/ProgramCards.test.tsx
@@ -20,7 +20,7 @@ test("each card's CTA points where its flow goes", () => {
   render(<ProgramCards />);
 
   const book = screen.getByRole("link", { name: /book a class/i });
-  expect(book.getAttribute("target")).toBe("_blank");
+  expect(book.getAttribute("href")).toBe("/book");
 
   const join = screen.getByRole("link", { name: /join interest list/i });
   expect(join.getAttribute("href")).toBe("#community");

--- a/src/components/ProgramCards.test.tsx
+++ b/src/components/ProgramCards.test.tsx
@@ -25,8 +25,10 @@ test("each card's CTA points where its flow goes", () => {
   const join = screen.getByRole("link", { name: /join interest list/i });
   expect(join.getAttribute("href")).toBe("#community");
 
-  const learnMore = screen.getByRole("link", { name: /learn more/i });
-  expect(learnMore.getAttribute("href")).toBe("/art");
+  const learnMore = screen
+    .getAllByRole("link", { name: /learn more/i })
+    .map((link) => link.getAttribute("href"));
+  expect(learnMore).toEqual(["/art", "/coop"]);
 });
 
 test("the co-op card lists all four activities", () => {

--- a/src/components/ProgramCards.test.tsx
+++ b/src/components/ProgramCards.test.tsx
@@ -24,6 +24,9 @@ test("each card's CTA points where its flow goes", () => {
 
   const join = screen.getByRole("link", { name: /join interest list/i });
   expect(join.getAttribute("href")).toBe("#community");
+
+  const learnMore = screen.getByRole("link", { name: /learn more/i });
+  expect(learnMore.getAttribute("href")).toBe("/art");
 });
 
 test("the co-op card lists all four activities", () => {

--- a/src/components/ProgramCards.tsx
+++ b/src/components/ProgramCards.tsx
@@ -54,12 +54,20 @@ export function ProgramCards() {
                 Outdoors
               </span>
             </div>
-            <Link
-              href="/book"
-              className="rounded-pill self-start bg-yellow px-[26px] py-3 text-sm font-black text-ink"
-            >
-              Book a class →
-            </Link>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/book"
+                className="rounded-pill bg-yellow px-[26px] py-3 text-sm font-black text-ink"
+              >
+                Book a class →
+              </Link>
+              <Link
+                href="/art"
+                className="rounded-pill border-2 border-white/50 px-[24px] py-[10px] text-sm font-bold text-white"
+              >
+                Learn more →
+              </Link>
+            </div>
           </div>
         </article>
 

--- a/src/components/ProgramCards.tsx
+++ b/src/components/ProgramCards.tsx
@@ -114,12 +114,20 @@ export function ProgramCards() {
               Exploring San Diego&apos;s wild coast through science, journaling
               and hands-on discovery. Spots limited for fall.
             </p>
-            <a
-              href="#community"
-              className="rounded-pill self-start bg-yellow px-[26px] py-3 text-sm font-black text-ink"
-            >
-              Join interest list →
-            </a>
+            <div className="flex flex-wrap gap-3">
+              <a
+                href="#community"
+                className="rounded-pill bg-yellow px-[26px] py-3 text-sm font-black text-ink"
+              >
+                Join interest list →
+              </a>
+              <Link
+                href="/coop"
+                className="rounded-pill border-2 border-white/50 px-[24px] py-[10px] text-sm font-bold text-white"
+              >
+                Learn more →
+              </Link>
+            </div>
           </div>
         </article>
       </div>

--- a/src/components/ProgramCards.tsx
+++ b/src/components/ProgramCards.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Placeholder } from "./Placeholder";
 
 const COOP_ACTIVITIES = [
@@ -53,16 +54,12 @@ export function ProgramCards() {
                 Outdoors
               </span>
             </div>
-            {/* TODO(verify): the template ships a bare calendly.com — swap in
-                the real booking URL when it exists. */}
-            <a
-              href="https://calendly.com"
-              target="_blank"
-              rel="noopener noreferrer"
+            <Link
+              href="/book"
               className="rounded-pill self-start bg-yellow px-[26px] py-3 text-sm font-black text-ink"
             >
               Book a class →
-            </a>
+            </Link>
           </div>
         </article>
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -23,10 +23,10 @@ export default defineConfig({
       // run-gates.mjs and run-vitest.mjs sit at 0% on purpose, and both drag
       // these figures down in plain sight rather than quietly.
       thresholds: {
-        statements: 63.36,
-        branches: 73.52,
-        functions: 81.57,
-        lines: 65.93,
+        statements: 67.54,
+        branches: 75,
+        functions: 84.09,
+        lines: 70.19,
       },
     },
   },


### PR DESCRIPTION
## What and why

Second and final PR for [docs/plans/nav-pages-scaffolding.md](docs/plans/nav-pages-scaffolding.md). Five structural-shell routes land, one vertical slice each, and the nav flips from hash anchors to routed links one link per slice — so at every commit the nav only points at pages that exist:

1. **`/book`** — reserved scheduler slot (no provider chosen), interim CTA to the interest list. The routed-link machinery lands here: `NavLink` marks the current page with `aria-current` via `usePathname`; the layout gains the page-title template. The art card's placeholder `calendly.com` link (a `TODO(verify)` since the landing build) now points at `/book` — that TODO is retired.
2. **`/art`** — nav's link row moves onto `NavLink` (yellow underline on the current page); art card gains a Learn more teaser; reserved slots for schedule/pricing and student photos.
3. **`/coop`** — same shape; co-op card teaser; slots for the weekly rhythm and photos.
4. **`/conditions`** — section copy expanded plus the same reserved embed slot under the same contract; landing section keeps its slot and gains a teaser. Which slot ultimately hosts the tool is the tool plan's decision.
5. **`/community`** — hosts the working interest-list form by reusing `CommunityForm`, plus slots for stories/photos; landing section gains a teaser. Last anchor leaves the nav.

Plus a dated plan addendum recording the two build deviations (the extra CTA flip and the active-state machinery landing with `/book` instead of `/art`).

Coverage floor raised to the branch's final actuals (statements 63.36→67.54, branches 73.52→75, functions 81.57→84.09, lines 65.93→70.19).

## Gate output

Run at the final commit (and before every slice commit):

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
```

Coverage summary: Statements 67.54% (77/114), Branches 75% (27/36), Functions 84.09% (37/44), Lines 70.19% (73/104).

## Not done, and why

- **Real content, booking provider, the conditions tool** — the pages are deliberate shells per the plan; each of those is its own later pass/plan.
- **Hero CTAs untouched** — they target the program cards by design, not booking directly.
- **No per-slice issues** — solo sequential work from the plan file (CLAUDE.md §5).
- **Open `TODO(verify)` items: none** — the one this branch touched (calendly booking URL) is retired, not carried.

⚠️ Six slices / ~500 changed lines is slightly over the ~400-line guide; the two-PR split at the layout-refactor boundary was agreed in the planning session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)