### PR TITLE
Put the nav in the document flow (shared-module-deepening PR A)

### DIFF
--- a/docs/adr/0003-nav-in-document-flow.md
+++ b/docs/adr/0003-nav-in-document-flow.md
@@ -1,0 +1,64 @@
+# 0003 — The nav sits in the document flow
+
+Date: 2026-08-12. Status: accepted.
+
+## Context
+
+The nav was `position: fixed`, so it occupied no space and every page had to
+reserve some for it. Six modules carried a hand-copied
+`pt-[90px] md:pt-nav` to do that: the five routed pages and `Hero`.
+
+`--spacing-nav: 70px` was described as the nav's height but was not it. By
+arithmetic from the nav's own classes the bar renders around 82px on desktop,
+so the token under-reserved by roughly 12px; the mobile literal `90px` was
+never in the token file at all. Nothing broke visibly because each page's
+first section adds 60–80px of its own padding on top, and nothing could
+notice, because jsdom applies no stylesheets and the gate cannot see a
+rendered layout (ADR-0001).
+
+Separately, `html` carries `motion-safe:scroll-smooth` and the hero's CTAs
+target `#art` and `#coop`, but nothing set `scroll-padding-top` — so anchor
+targets scrolled up underneath the fixed bar.
+
+## Decision
+
+The nav is `sticky top-0` and participates in the document flow. Pages
+reserve nothing; the offset class is deleted from all six modules.
+
+The nav takes its height **from** `--spacing-nav` / `--spacing-nav-sm` via
+`min-h-nav-sm md:min-h-nav`, inverting the old direction. The token is the
+source of the height rather than a description of it, and the two remaining
+consumers — the hero poster's height and `scroll-padding-top` — subtract the
+same tokens, so they are right by construction.
+
+## Consequences
+
+A page can no longer forget the offset, because there is no offset to
+forget. Adding a seventh route requires knowing nothing about the nav.
+
+`min-h-*` rather than a fixed `h-*` is deliberate. Pinning the height would
+make the subtraction exact to the pixel, but it clips the nav when a reader
+scales text up. What that concedes is a few pixels on the poster's height and
+a few pixels of extra gap above an anchor target — neither visible. Clipped
+navigation is very visible. If the nav ever needs to be exactly its token,
+that is the trade being reopened.
+
+`HeroViewport` changes from `min-h-dvh` to `100dvh` minus the nav. It is now
+the only module outside `globals.css` that knows the nav has a height, and it
+knows it only as a subtraction. The poster still measures one window; before
+this change it measured one window with the top ~82px hidden behind the bar.
+
+**`overflow-x-hidden` on `body` was investigated and deliberately left
+alone.** The obvious worry is that it makes `body` a scroll container and
+stops `position: sticky` working. It does not, here: overflow propagates, so
+while the root element's overflow is `visible` — nothing sets it on `html` —
+the body's value is applied to the viewport and `body` itself behaves as
+`overflow: visible`. The hazard is real when overflow sits on `html` or on an
+intermediate ancestor. Recorded because removing it looks like an obvious
+tidy-up and would risk reintroducing horizontal scroll for no gain.
+
+The gate asserts the class contract — that the nav is sticky, that it takes
+the tokens, that the poster subtracts them — in the style
+`StripTrack.test.tsx` established. It cannot assert that the nav actually
+sticks, or that the poster measures exactly one window. That gap is inherited
+from ADR-0001 and closing it means Playwright.

--- a/docs/plans/shared-module-deepening.md
+++ b/docs/plans/shared-module-deepening.md
@@ -1,0 +1,137 @@
+# Shared module deepening
+
+## Problem, from the user's point of view
+
+Two things a visitor meets today are wrong, and both come from one cause:
+the nav is `position: fixed`, so every page separately guesses how much
+room to leave for it.
+
+- Clicking "🎨 Book Art Class" or "Tuesday Co-op →" on the landing page
+  scrolls the target section up under the nav bar. Nothing sets
+  `scroll-padding-top`, and `html` has `motion-safe:scroll-smooth`, so the
+  reader watches their destination slide behind the menu.
+- The desktop offset reserves `--spacing-nav: 70px` for a nav that occupies
+  roughly 82px. Nothing has noticed because each page's first section adds
+  60–80px of its own padding on top.
+
+Nobody can catch either one, because the offset lives as a hand-copied
+class in six unrelated modules and no gate can see a stylesheet.
+
+Behind that sit two shapes the site is made of that have no module at all:
+the reserved slot (six copies) and the pill CTA (eleven call sites across
+five different geometries, including the same "Book a class" rendered two
+different sizes).
+
+## Solution
+
+The nav joins the document flow. Pages stop reserving space for it
+entirely — the offset class is deleted from all five pages and from `Hero`
+— and the two places that still need the nav's height sit next to the nav:
+`scroll-padding-top` in `globals.css`, and the hero poster's height.
+
+Then the reserved slot and the pill each get one module, so the six and
+the eleven become call sites rather than copies.
+
+## Implementation decisions
+
+- **Nav in the document flow, not a better offset.** Rejected: a layout
+  wrapper carrying the padding with `HeroViewport` opting out — keeps the
+  number and adds an opt-out to know about; and tokens-only — fixes the
+  wrong number but leaves the leak, so a sixth page can still forget it.
+- **`overflow-x-hidden` moves off `body` first, as its own slice.** Per
+  spec, setting `overflow-x: hidden` computes `overflow-y` to `auto`, which
+  makes `body` a scroll container — the classic way `position: sticky`
+  silently stops sticking. Both strips already clip through their own
+  `overflow-hidden` wrappers, so it should be removable. This slice goes
+  first because it is the one that can invalidate the approach.
+- **The nav's height is measured in a browser**, not derived from class
+  arithmetic. The arithmetic that found the 70px/82px mismatch is a reason
+  to measure, not a measurement.
+- **The poster stays exactly one viewport.** `HeroViewport` becomes
+  `min-h-[calc(100dvh-var(--spacing-nav))]`. This is the one module that
+  still knows the nav's height, down from six. Rejected: plain `min-h-dvh`,
+  which would drop the marquee below the fold.
+- **`ReservedSlot` takes its copy as props, not children.** The module owns
+  the "X coming soon." / blank line / detail rhythm, because that rhythm is
+  what has been drifting. Two tones — light, and on-ocean — which is two
+  adapters, so the variant is real rather than hypothetical.
+- **`PillLink` carries a closed list of five tones** named for the palette
+  tokens: `yellow`, `purple`, `ocean`, `outline-light`, `outline-dark`.
+  Links only. The interest-list form's submit control stays a `button`, and
+  the nav's Book Now pill keeps its own responsive geometry — it is chrome,
+  not a body CTA. Every `href` goes through `next/link`, hashes included.
+  Rejected: an `as`/`fullWidth` axis, which puts geometry back in the
+  interface; and branching on a leading `#` to emit a bare `<a>`, which
+  hides an invariant the types do not show.
+- No new dependencies. `docs/adr/0003-nav-in-document-flow.md` records the
+  flow decision and the `overflow-x` constraint, because a reader seeing a
+  non-fixed nav under a full-bleed poster will otherwise "fix" it back.
+
+## Test seams
+
+- **Class contract**, following the `StripTrack.test.tsx` precedent that
+  jsdom applies no stylesheets so the contract is the seam: the offset
+  class is absent from every page's `main`, `html` carries the
+  scroll-padding, `PillLink` maps each tone to its classes, `ReservedSlot`
+  renders its label and hides its emoji from assistive tech.
+- **The existing assertions are the regression net for both extractions.**
+  Page tests already assert every reserved slot by its copy and every CTA
+  by its `href`; those assertions stay untouched, and their staying green
+  is the evidence the extraction preserved behavior.
+- **The scroll-padding slice is a bugfix**, so its regression test is
+  committed first and must fail first.
+- **Outside the gate's reach, needs a human in a browser:** that the nav
+  actually sticks after the `overflow-x` change, that the poster still
+  measures exactly one viewport, that anchors land clear of the nav, and
+  that eleven pills look unchanged. ADR-0001 already records why unit tests
+  cannot reach this; both PRs are marked needs-human for it.
+- `npm run gate` green at every commit. The coverage floor rises as the new
+  modules land their tests.
+
+## Slices
+
+PR A — branch `nav-in-flow`:
+
+1. This plan.
+2. Move `overflow-x-hidden` off `body`; confirm both strips still clip.
+3. The nav joins the document flow: measured token, offset deleted from the
+   five pages and `Hero`, `HeroViewport` on `calc`. Ships ADR-0003.
+4. `scroll-padding-top` on `html`, so anchors land clear of the nav.
+   Regression test first.
+
+PR B — branch cut from `main` after PR A merges:
+
+5. Say "interest list" on the interest-list form's submit control.
+6. Rename `CommunityForm` to the teaser it now is.
+7. `ReservedSlot`, and its six call sites.
+8. `PillLink`, and its eleven call sites.
+
+Slices 5 and 6 are the two gaps left open by the `/community` fix in
+`nav-pages-scaffolding.md`; they lead PR B because they are small and
+because slice 5 is what makes `CONTEXT.md`'s interest-list entry true of
+the code. If PR B grows past the reviewable guide, it splits between
+slices 7 and 8 — they share no files with each other.
+
+Per-slice issues are skipped, per CLAUDE.md §5: these are sequential, they
+touch the same files, and two people could not pick up two of them without
+colliding.
+
+## Out of scope
+
+Real copy, images and logo; the booking provider and its embed; the
+conditions tool itself; a form backend; dark mode.
+
+Also deliberately not done:
+
+- **Naming the conditions embed slot as its own module.** The reserved slot
+  for it exists twice, so the future one-line swap is two — but it is cheap
+  once slice 7 lands, and it is only ×2. Its own slice, later.
+- **A data-driven `ProgramCard`.** The two cards diverge structurally (an
+  activity grid against a badge row), so the module would need about a
+  dozen parameters — an interface as complex as the implementation it
+  hides. Shallow by construction.
+- **A routes or links map module.** Fails the deletion test: delete it and
+  the strings simply inline again. Constants concentrate nothing.
+- **A generic `PageShell`.** The five page openings are near-identical, but
+  the part that actually matters is the nav offset, and slice 3 removes
+  that without inventing a module.

--- a/docs/plans/shared-module-deepening.md
+++ b/docs/plans/shared-module-deepening.md
@@ -116,6 +116,41 @@ Per-slice issues are skipped, per CLAUDE.md §5: these are sequential, they
 touch the same files, and two people could not pick up two of them without
 colliding.
 
+## Addendum — 2026-08-12 (correction, before slice 2)
+
+**Slice 2 is dropped, and the constraint that justified it was wrong.**
+
+The plan above claims `overflow-x: hidden` on `body` makes `body` a scroll
+container and breaks `position: sticky`. That is the wrong reading of the
+spec for this configuration. Overflow propagates: when the root element's
+overflow is `visible` — nothing sets it on `html` here — the **body's**
+overflow value is applied to the viewport instead, and `body` itself is
+then treated as `overflow: visible`. So `body` is not a scroll container,
+and sticky descendants behave normally. The gotcha is real when overflow
+sits on `html` or on an intermediate ancestor, neither of which applies.
+
+So `overflow-x-hidden` stays where it is. Removing it would have risked
+reintroducing the horizontal scroll it was presumably added to suppress,
+to fix a problem that was not there.
+
+**Slice 3 changes shape as a result.** The plan said to measure the nav's
+height and write it into the token. That keeps the token _describing_ an
+emergent value, which is the same drift that produced the 70px/82px
+mismatch in the first place — it would just be correct for a while longer.
+
+Instead the dependency inverts: the nav takes its height **from** the
+token (`min-h-nav-sm md:min-h-nav`), so the token is the source of truth
+rather than a description of one. Nothing needs measuring, and the two
+remaining consumers — the hero poster's height and `scroll-padding-top` —
+are correct by construction rather than by vigilance.
+
+`min-h-*` rather than a fixed `h-*`: pinning the height exactly would
+guarantee the calc is exact to the pixel, but it clips the nav if a reader
+scales text up. The inexactness this concedes is a few pixels on the
+poster's height and a few pixels of extra gap above an anchor target, and
+neither is visible; clipped navigation is. The trade is recorded in
+ADR-0003.
+
 ## Out of scope
 
 Real copy, images and logo; the booking provider and its embed; the

--- a/src/app/art/page.tsx
+++ b/src/app/art/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function Art() {
   return (
-    <main className="flex-1 pt-[90px] md:pt-nav">
+    <main className="flex-1">
       <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
         <p className="mb-7 text-2xs font-extrabold tracking-widest text-purple uppercase">
           In-person · Group & Private · K–8

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function Book() {
   return (
-    <main className="flex-1 pt-[90px] md:pt-nav">
+    <main className="flex-1">
       <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
         <p className="mb-7 text-2xs font-extrabold tracking-widest text-purple uppercase">
           In-person · Group & Private · K–8

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function Community() {
   return (
-    <main className="flex-1 pt-[90px] md:pt-nav">
+    <main className="flex-1">
       <section className="px-gutter-sm pt-section-sm md:px-gutter md:pt-section">
         <p className="mb-7 text-2xs font-extrabold tracking-widest text-purple uppercase">
           Families · Updates · Coastal adventures

--- a/src/app/conditions/page.tsx
+++ b/src/app/conditions/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
 
 export default function Conditions() {
   return (
-    <main className="flex-1 pt-[90px] md:pt-nav">
+    <main className="flex-1">
       <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
         <p className="mb-7 text-2xs font-extrabold tracking-widest text-ocean uppercase">
           Surf · Tide · Wind · Visibility

--- a/src/app/coop/page.tsx
+++ b/src/app/coop/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function Coop() {
   return (
-    <main className="flex-1 pt-[90px] md:pt-nav">
+    <main className="flex-1">
       <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
         <p className="mb-7 text-2xs font-extrabold tracking-widest text-ocean uppercase">
           Tuesdays · 10am – 1pm · Fall 2026

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,7 +48,14 @@
   --spacing-gutter-sm: 24px;
   --spacing-section: 80px;
   --spacing-section-sm: 60px;
-  --spacing-nav: 70px;
+  /* The nav takes its height *from* these, rather than these describing the
+     height it happens to render at. That direction is the point: the old
+     70px described a nav that measured about 82px, and nothing could notice.
+     The nav sets min-h from them, so text scaling can still grow it; the two
+     consumers (the hero poster's height, scroll-padding-top) tolerate being
+     a few pixels under far better than the nav tolerates clipping. */
+  --spacing-nav: 84px;
+  --spacing-nav-sm: 90px;
 
   /* Radii */
   --radius-tile: 12px;

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -28,3 +28,30 @@ test("the layout wraps every page in the shared nav and footer", () => {
   expect(screen.getByRole("contentinfo")).toBeDefined();
   expect(screen.getByRole("main")).toBeDefined();
 });
+
+// MUST FAIL: the bug this asserts against is live. See the note in
+// src/app/community/page.test.tsx for why test.fails stands in for the gate
+// table's mustFail flag. The fix commit turns this into a plain test().
+//
+// The h-full assertion above the scroll-pt ones is deliberate: it proves the
+// className was read from somewhere real, so this cannot pass by throwing on
+// an undefined it never found.
+test.fails("anchor targets come to rest below the nav, not under it", () => {
+  render(
+    <RootLayout params={Promise.resolve({})}>
+      <main>page content</main>
+    </RootLayout>,
+  );
+
+  // React hoists <html> and <body> onto the real document rather than into
+  // the render container, so the layout's root classes are read from
+  // documentElement — querySelect("html") on the container finds nothing.
+  const html = document.documentElement.className;
+  expect(html).toContain("h-full");
+
+  // html carries motion-safe:scroll-smooth and the hero's CTAs target #art
+  // and #coop, so without scroll-padding the browser scrolls those sections
+  // flush to the top of the viewport — behind the nav.
+  expect(html).toContain("scroll-pt-nav-sm");
+  expect(html).toContain("md:scroll-pt-nav");
+});

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -29,14 +29,7 @@ test("the layout wraps every page in the shared nav and footer", () => {
   expect(screen.getByRole("main")).toBeDefined();
 });
 
-// MUST FAIL: the bug this asserts against is live. See the note in
-// src/app/community/page.test.tsx for why test.fails stands in for the gate
-// table's mustFail flag. The fix commit turns this into a plain test().
-//
-// The h-full assertion above the scroll-pt ones is deliberate: it proves the
-// className was read from somewhere real, so this cannot pass by throwing on
-// an undefined it never found.
-test.fails("anchor targets come to rest below the nav, not under it", () => {
+test("anchor targets come to rest below the nav, not under it", () => {
   render(
     <RootLayout params={Promise.resolve({})}>
       <main>page content</main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,9 +25,12 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: LayoutProps<"/">) {
   return (
+    // scroll-pt keeps an anchored section clear of the nav when the browser
+    // scrolls to it. Same tokens the nav sets its own height from, so the
+    // gap and the bar cannot drift apart.
     <html
       lang="en"
-      className={`${montserrat.variable} h-full antialiased motion-safe:scroll-smooth`}
+      className={`${montserrat.variable} scroll-pt-nav-sm md:scroll-pt-nav h-full antialiased motion-safe:scroll-smooth`}
     >
       <body className="flex min-h-full flex-col overflow-x-hidden bg-cream font-sans text-dark">
         <Nav />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,7 +2,7 @@ import { Placeholder } from "./Placeholder";
 
 export function Hero() {
   return (
-    <section className="relative grid flex-1 overflow-hidden bg-purple pt-[90px] pb-15 md:grid-cols-2 md:pt-nav md:pb-0">
+    <section className="relative grid flex-1 overflow-hidden bg-purple pb-15 md:grid-cols-2 md:pb-0">
       <div className="relative z-10 col-start-1 row-start-1 flex flex-col justify-center px-6 pt-5 md:px-12 md:py-15">
         <p className="mb-7 text-2xs font-extrabold tracking-widest text-yellow uppercase">
           📍 San Diego · K–8 · Outdoors

--- a/src/components/HeroViewport.test.tsx
+++ b/src/components/HeroViewport.test.tsx
@@ -38,3 +38,18 @@ test("the marquee rides inside the viewport block", () => {
 
   expect(screen.getAllByText("Art Classes").length).toBeGreaterThan(0);
 });
+
+test("the poster is the window less the nav, at both widths", () => {
+  const { container } = render(<HeroViewport />);
+
+  // The marquee sits at the poster's bottom edge, so if this block were a
+  // full 100dvh the nav above it would push the marquee off screen. Both
+  // breakpoints subtract, because the nav is taller on the two-row layout.
+  const poster = container.firstElementChild;
+  expect(poster?.className).toContain(
+    "min-h-[calc(100dvh-var(--spacing-nav-sm))]",
+  );
+  expect(poster?.className).toContain(
+    "md:min-h-[calc(100dvh-var(--spacing-nav))]",
+  );
+});

--- a/src/components/HeroViewport.tsx
+++ b/src/components/HeroViewport.tsx
@@ -3,12 +3,17 @@ import { Marquee } from "./Marquee";
 
 /**
  * The opening poster: hero fills the window and the marquee sits at its
- * bottom edge. min-h-dvh (not a hard h-dvh) by decision — on short screens
- * the block grows instead of clipping the hero stack.
+ * bottom edge. min-h (not a hard height) by decision — on short screens the
+ * block grows instead of clipping the hero stack.
+ *
+ * The nav sits in the document flow above this, so the poster is the window
+ * less the nav. That subtraction is the only place outside globals.css that
+ * knows the nav has a height at all — down from six modules that each
+ * reserved space for it while it was fixed.
  */
 export function HeroViewport() {
   return (
-    <div className="flex min-h-dvh flex-col">
+    <div className="flex min-h-[calc(100dvh-var(--spacing-nav-sm))] flex-col md:min-h-[calc(100dvh-var(--spacing-nav))]">
       <Hero />
       <Marquee />
     </div>

--- a/src/components/Nav.test.tsx
+++ b/src/components/Nav.test.tsx
@@ -41,6 +41,28 @@ test("the booking CTA routes to the booking page", () => {
   expect(cta.getAttribute("href")).toBe("/book");
 });
 
+test("the nav occupies its own space instead of floating over the page", () => {
+  render(<Nav />);
+
+  // jsdom applies no stylesheets, so the class contract is the seam (as in
+  // StripTrack.test.tsx). This one is load-bearing: while the nav was fixed,
+  // five pages and Hero each carried their own copy of its height to leave
+  // room for it. Sticky means nothing has to know.
+  const nav = screen.getByRole("navigation");
+  expect(nav.className).toContain("sticky");
+  expect(nav.className).not.toContain("fixed");
+});
+
+test("the nav takes its height from the nav tokens", () => {
+  render(<Nav />);
+
+  // The token is the source of the height, not a description of it. The
+  // hero's poster and scroll-padding-top both subtract these same tokens.
+  const nav = screen.getByRole("navigation");
+  expect(nav.className).toContain("min-h-nav-sm");
+  expect(nav.className).toContain("md:min-h-nav");
+});
+
 test("the logo slot is a labeled image placeholder", () => {
   render(<Nav />);
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -13,7 +13,10 @@ export function Nav() {
     // Two rows below md — logo and CTA above, links spread beneath — because
     // the four links plus the pill cannot share one 375px row (design
     // review, must-fix). md: restores the template's single row.
-    <nav className="fixed inset-x-0 top-0 z-50 flex flex-wrap items-center justify-between gap-y-2 border-b-2 border-purple bg-cream px-3 py-2.5 md:flex-nowrap md:px-8 md:py-3.5">
+    // sticky, not fixed: the nav occupies its own space, so no page has to
+    // reserve any for it. min-h comes from the nav tokens, which is what
+    // makes the hero's height and scroll-padding-top right by construction.
+    <nav className="min-h-nav-sm md:min-h-nav sticky top-0 z-50 flex flex-wrap items-center justify-between gap-y-2 border-b-2 border-purple bg-cream px-3 py-2.5 md:flex-nowrap md:px-8 md:py-3.5">
       <div className="size-10 shrink-0 overflow-hidden rounded-full md:size-13">
         <Placeholder
           label="Wild Coast Kids logo"


### PR DESCRIPTION
Plan: [`docs/plans/shared-module-deepening.md`](docs/plans/shared-module-deepening.md). No issue — per-slice issues were skipped under CLAUDE.md §5, since these are sequential and touch the same files.

## What changed

The nav was `position: fixed`, so it occupied no space and **six modules each carried a copy of its height** to leave room: the five routed pages and `Hero`. The token they leaned on described the nav rather than setting it, and had drifted — `--spacing-nav: 70px` reserved space for a bar rendering around 82px, while the mobile value was a `90px` literal in no token file at all. Nothing broke visibly, because every page's first section adds 60–80px of its own padding on top, and nothing could notice, because the gate cannot see a rendered layout.

| Commit | Slice |
|---|---|
| `816a93f` | The plan |
| `47e3725` | Correct the `overflow-x` claim and drop slice 2 |
| `3b91c05` | Put the nav in the document flow (ships ADR-0003) |
| `404fc1c` | Prove anchor targets scroll under the nav, MUST FAIL |
| `47c5d6e` | Keep anchored sections clear of the nav |

Sticky deletes the question rather than answering it better: pages reserve nothing because there is nothing to reserve, and a seventh route needs to know nothing about the nav. The dependency also inverts — the nav takes its height *from* the tokens via `min-h`, so they are the source rather than a description, and the one remaining consumer (the hero poster) subtracts the same tokens and is right by construction.

`47c5d6e` also fixes a live bug that predates this branch: `html` carries `motion-safe:scroll-smooth` and the hero CTAs target `#art`/`#coop`, but nothing set `scroll-padding-top`, so those sections scrolled up behind the bar.

## Two corrections made along the way

**The `overflow-x` constraint in the plan was wrong.** The plan opened by claiming `overflow-x: hidden` on `body` makes it a scroll container and breaks sticky. It does not, here: overflow propagates, so while `html`'s own overflow is `visible` the body's value is applied to the viewport and `body` behaves as `overflow: visible`. Slice 2 was dropped and `overflow-x-hidden` left alone — removing it would have risked reintroducing horizontal scroll to fix a problem that was not there. Recorded as a dated addendum, and in ADR-0003 so nobody "tidies" it later.

**The first draft of the regression test passed for the wrong reason.** It read the root class from `container.querySelector("html")`, which is `null` — React hoists `<html>`/`<body>` onto the real document — so it "failed" by throwing on `undefined` without ever proving the bug. It now reads `document.documentElement` and asserts `h-full` first, so the className is known to have come from somewhere real.

## Gates

Run at `47c5d6e`:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
```

Because a Tailwind class naming a nonexistent token fails silently, I also checked the built stylesheet rather than trusting the class names. All six utilities emit real rules:

```
scroll-padding-top:var(--spacing-nav)        scroll-padding-top:var(--spacing-nav-sm)
min-height:var(--spacing-nav)                min-height:var(--spacing-nav-sm)
min-height:calc(100dvh - var(--spacing-nav)) min-height:calc(100dvh - var(--spacing-nav-sm))
--spacing-nav:84px                           --spacing-nav-sm:90px
```

## needs-human — please check in a browser

The gate asserts the class contract, per the `StripTrack.test.tsx` precedent. It cannot assert any of this, per ADR-0001:

1. The nav actually sticks on scroll.
2. The hero poster still measures one window, with the marquee at its bottom edge — at desktop and at 375px.
3. Clicking "🎨 Book Art Class" lands the Art card clear of the nav.
4. No horizontal scrollbar at 375px (nothing here should have changed it, but `overflow-x-hidden` was under discussion).

**The nav's height changed on desktop**, from an effective ~82px bar with 70px reserved to 84px reserved and occupied. Page content therefore sits a little lower than before. That is the correction, not a regression, but it is the visible difference to look at first.

## Not done

- `84px` and `90px` are chosen, not measured — that is the point of the inversion, since the nav now takes its height from them. If the bar looks wrong, one token is the fix.
- Slices 5–8 (the interest-list CTA copy, the `CommunityForm` rename, `ReservedSlot`, `PillLink`) are PR B, cut from `main` after this merges.
