### PR TITLE
Interest-list naming, ReservedSlot and PillLink (shared-module-deepening PR B)

### DIFF
--- a/docs/plans/shared-module-deepening.md
+++ b/docs/plans/shared-module-deepening.md
@@ -151,6 +151,24 @@ poster's height and a few pixels of extra gap above an anchor target, and
 neither is visible; clipped navigation is. The trade is recorded in
 ADR-0003.
 
+## Addendum — 2026-08-13 (PR B build)
+
+- **Slice 5 covered one more CTA than planned.** The plan scoped it to the
+  form's submit control, but the co-op card said "Join interest list"
+  without the article. `CONTEXT.md` says every CTA that joins the interest
+  list reads "Join the interest list", so both moved together — the point
+  of the slice is that the glossary becomes true of the code.
+- **`CommunityForm` became `InterestListTeaser`.** Both halves of the name
+  come from the glossary.
+- **`PillLink` unifies geometry as well as tone**, which the plan implied
+  but did not say. Eleven call sites carried five paddings; they converge
+  on the one the hero and the page CTAs already used, so the most common
+  pill is unchanged and the rest move two or three pixels. Solid and
+  outline now differ by exactly the border width so their outer boxes line
+  up — already true on the program cards, not in the hero.
+- **The coverage floor rises** to what the repo now achieves, per the rule
+  in the threshold comment.
+
 ## Out of scope
 
 Real copy, images and logo; the booking provider and its embed; the

--- a/src/app/art/page.tsx
+++ b/src/app/art/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import Link from "next/link";
+import { PillLink } from "@/components/PillLink";
 import { Placeholder } from "@/components/Placeholder";
 import { ReservedSlot } from "@/components/ReservedSlot";
 
@@ -24,12 +24,11 @@ export default function Art() {
           whatever sparks curiosity. Every session is different, and full class
           details are on their way.
         </p>
-        <Link
-          href="/book"
-          className="rounded-pill mb-12 inline-block bg-purple px-7 py-[13px] text-sm font-black text-white transition-colors duration-fast hover:bg-purple-deep"
-        >
-          Book a class →
-        </Link>
+        <div className="mb-12">
+          <PillLink href="/book" tone="purple">
+            Book a class →
+          </PillLink>
+        </div>
         {/* Reserved slots for the content pass: real schedule, pricing and
             student photos. */}
         <div className="grid gap-4 md:grid-cols-2">

--- a/src/app/art/page.tsx
+++ b/src/app/art/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Placeholder } from "@/components/Placeholder";
+import { ReservedSlot } from "@/components/ReservedSlot";
 
 export const metadata: Metadata = {
   title: "Art Classes",
@@ -32,18 +33,11 @@ export default function Art() {
         {/* Reserved slots for the content pass: real schedule, pricing and
             student photos. */}
         <div className="grid gap-4 md:grid-cols-2">
-          <div className="rounded-box border-2 border-dashed border-lavender bg-white/60 px-8 py-12 text-center">
-            <span aria-hidden="true" className="mb-3.5 block text-5xl">
-              🎨
-            </span>
-            <p className="leading-normal text-sm text-fog">
-              Schedule & pricing coming soon.
-              <br />
-              <br />
-              Session times, group and private options, and charter-fund details
-              land here.
-            </p>
-          </div>
+          <ReservedSlot
+            emoji="🎨"
+            headline="Schedule & pricing coming soon."
+            detail="Session times, group and private options, and charter-fund details land here."
+          />
           <Placeholder
             label="Student artwork gallery"
             className="rounded-box min-h-60"

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import Link from "next/link";
+import { PillLink } from "@/components/PillLink";
 import { ReservedSlot } from "@/components/ReservedSlot";
 
 export const metadata: Metadata = {
@@ -23,12 +23,11 @@ export default function Book() {
           something wild. Online booking is on its way; until it lands, the
           interest list is the fastest way to grab a spot.
         </p>
-        <Link
-          href="/#community"
-          className="rounded-pill mb-12 inline-block bg-purple px-7 py-[13px] text-sm font-black text-white transition-colors duration-fast hover:bg-purple-deep"
-        >
-          Join the interest list →
-        </Link>
+        <div className="mb-12">
+          <PillLink href="/#community" tone="purple">
+            Join the interest list →
+          </PillLink>
+        </div>
         <ReservedSlot
           emoji="🗓️"
           headline="Online booking coming soon."

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { ReservedSlot } from "@/components/ReservedSlot";
 
 export const metadata: Metadata = {
   title: "Book Now",
@@ -28,18 +29,11 @@ export default function Book() {
         >
           Join the interest list →
         </Link>
-        {/* The reserved slot for the scheduler, once a provider is chosen. */}
-        <div className="rounded-box border-2 border-dashed border-lavender bg-white/60 px-8 py-12 text-center">
-          <span aria-hidden="true" className="mb-3.5 block text-5xl">
-            🗓️
-          </span>
-          <p className="leading-normal text-sm text-fog">
-            Online booking coming soon.
-            <br />
-            <br />
-            The scheduler embeds here once a booking provider is chosen.
-          </p>
-        </div>
+        <ReservedSlot
+          emoji="🗓️"
+          headline="Online booking coming soon."
+          detail="The scheduler embeds here once a booking provider is chosen."
+        />
       </section>
     </main>
   );

--- a/src/app/community/page.test.tsx
+++ b/src/app/community/page.test.tsx
@@ -23,7 +23,7 @@ test("the interest-list form rides on the page, not just the landing", () => {
   // of the landing teaser.
   expect(screen.getByRole("textbox", { name: /your name/i })).toBeDefined();
   expect(
-    screen.getByRole("button", { name: /join the community/i }),
+    screen.getByRole("button", { name: /join the interest list/i }),
   ).toBeDefined();
 });
 

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { InterestListForm } from "@/components/InterestListForm";
 import { Placeholder } from "@/components/Placeholder";
+import { ReservedSlot } from "@/components/ReservedSlot";
 
 export const metadata: Metadata = {
   title: "Community",
@@ -25,17 +26,11 @@ export default function Community() {
         </p>
         {/* Reserved slots for the content pass: stories, meetups and photos. */}
         <div className="grid gap-4 md:grid-cols-2">
-          <div className="rounded-box border-2 border-dashed border-lavender bg-white/60 px-8 py-12 text-center">
-            <span aria-hidden="true" className="mb-3.5 block text-5xl">
-              🏄
-            </span>
-            <p className="leading-normal text-sm text-fog">
-              Community stories coming soon.
-              <br />
-              <br />
-              Photos, testimonials and upcoming meetups land here.
-            </p>
-          </div>
+          <ReservedSlot
+            emoji="🏄"
+            headline="Community stories coming soon."
+            detail="Photos, testimonials and upcoming meetups land here."
+          />
           <Placeholder
             label="Community photo gallery"
             className="rounded-box min-h-60"

--- a/src/app/conditions/page.tsx
+++ b/src/app/conditions/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ReservedSlot } from "@/components/ReservedSlot";
 
 export const metadata: Metadata = {
   title: "Conditions",
@@ -21,19 +22,12 @@ export default function Conditions() {
           built by a local, for families planning tidepool visits and hikes.
           Know before you go.
         </p>
-        {/* The reserved slot for the conditions tool, same contract as the
-            landing section's: drop the URL and it embeds here. */}
-        <div className="rounded-box border-2 border-dashed border-lavender bg-white/60 px-8 py-12 text-center">
-          <span aria-hidden="true" className="mb-3.5 block text-5xl">
-            🌊
-          </span>
-          <p className="leading-normal text-sm text-fog">
-            Conditions tool coming soon.
-            <br />
-            <br />
-            Drop the URL and it embeds here automatically.
-          </p>
-        </div>
+        {/* Same slot the landing section carries, on this page's surface. */}
+        <ReservedSlot
+          emoji="🌊"
+          headline="Conditions tool coming soon."
+          detail="Drop the URL and it embeds here automatically."
+        />
       </section>
     </main>
   );

--- a/src/app/coop/page.tsx
+++ b/src/app/coop/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Placeholder } from "@/components/Placeholder";
+import { ReservedSlot } from "@/components/ReservedSlot";
 
 export const metadata: Metadata = {
   title: "Tuesday Co-op",
@@ -32,18 +33,11 @@ export default function Coop() {
         {/* Reserved slots for the content pass: the weekly rhythm and photos
             from past adventures. */}
         <div className="grid gap-4 md:grid-cols-2">
-          <div className="rounded-box border-2 border-dashed border-lavender bg-white/60 px-8 py-12 text-center">
-            <span aria-hidden="true" className="mb-3.5 block text-5xl">
-              🌿
-            </span>
-            <p className="leading-normal text-sm text-fog">
-              Full co-op details coming soon.
-              <br />
-              <br />
-              The weekly rhythm, meeting spots, and fall sign-up details land
-              here.
-            </p>
-          </div>
+          <ReservedSlot
+            emoji="🌿"
+            headline="Full co-op details coming soon."
+            detail="The weekly rhythm, meeting spots, and fall sign-up details land here."
+          />
           <Placeholder
             label="Co-op adventures photo gallery"
             className="rounded-box min-h-60"

--- a/src/app/coop/page.tsx
+++ b/src/app/coop/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import Link from "next/link";
+import { PillLink } from "@/components/PillLink";
 import { Placeholder } from "@/components/Placeholder";
 import { ReservedSlot } from "@/components/ReservedSlot";
 
@@ -24,12 +24,11 @@ export default function Coop() {
           journaling and hands-on science. Spots are limited for fall, and full
           co-op details are on their way.
         </p>
-        <Link
-          href="/#community"
-          className="rounded-pill mb-12 inline-block bg-ocean px-7 py-[13px] text-sm font-black text-white transition-colors duration-fast"
-        >
-          Join the interest list →
-        </Link>
+        <div className="mb-12">
+          <PillLink href="/#community" tone="ocean">
+            Join the interest list →
+          </PillLink>
+        </div>
         {/* Reserved slots for the content pass: the weekly rhythm and photos
             from past adventures. */}
         <div className="grid gap-4 md:grid-cols-2">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
-import { CommunityForm } from "@/components/CommunityForm";
 import { Conditions } from "@/components/Conditions";
 import { GallerySection } from "@/components/GallerySection";
 import { HeroViewport } from "@/components/HeroViewport";
+import { InterestListTeaser } from "@/components/InterestListTeaser";
 import { ProgramCards } from "@/components/ProgramCards";
 import { QuoteStats } from "@/components/QuoteStats";
 
@@ -13,7 +13,7 @@ export default function Home() {
       <ProgramCards />
       <QuoteStats />
       <Conditions />
-      <CommunityForm />
+      <InterestListTeaser />
     </main>
   );
 }

--- a/src/components/CommunityForm.test.tsx
+++ b/src/components/CommunityForm.test.tsx
@@ -9,7 +9,7 @@ test("the teaser carries the interest-list form alongside it", () => {
   // behavior is asserted in InterestListForm.test.tsx.
   expect(screen.getByRole("textbox", { name: /your name/i })).toBeDefined();
   expect(
-    screen.getByRole("button", { name: /join the community/i }),
+    screen.getByRole("button", { name: /join the interest list/i }),
   ).toBeDefined();
 });
 

--- a/src/components/Conditions.tsx
+++ b/src/components/Conditions.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { PillLink } from "./PillLink";
 import { ReservedSlot } from "./ReservedSlot";
 
 export function Conditions() {
@@ -19,12 +19,9 @@ export function Conditions() {
           Real-time surf, tide, wind and visibility for San Diego&apos;s coast —
           built by a local, for families planning tidepool visits and hikes.
         </p>
-        <Link
-          href="/conditions"
-          className="rounded-pill inline-block border-2 border-white/50 px-[24px] py-[10px] text-sm font-bold text-white"
-        >
+        <PillLink href="/conditions" tone="outline-light">
           Learn more →
-        </Link>
+        </PillLink>
       </div>
       <ReservedSlot
         emoji="🌊"

--- a/src/components/Conditions.tsx
+++ b/src/components/Conditions.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ReservedSlot } from "./ReservedSlot";
 
 export function Conditions() {
   return (
@@ -25,18 +26,12 @@ export function Conditions() {
           Learn more →
         </Link>
       </div>
-      {/* The reserved slot for the future conditions-tool embed. */}
-      <div className="rounded-box border-2 border-dashed border-white/20 bg-white/7 px-8 py-12 text-center">
-        <span aria-hidden="true" className="mb-3.5 block text-5xl">
-          🌊
-        </span>
-        <p className="leading-normal text-sm text-white/45">
-          Conditions tool coming soon.
-          <br />
-          <br />
-          Drop the URL and it embeds here automatically.
-        </p>
-      </div>
+      <ReservedSlot
+        emoji="🌊"
+        headline="Conditions tool coming soon."
+        detail="Drop the URL and it embeds here automatically."
+        tone="ocean"
+      />
     </section>
   );
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,3 +1,4 @@
+import { PillLink } from "./PillLink";
 import { Placeholder } from "./Placeholder";
 
 export function Hero() {
@@ -19,18 +20,12 @@ export function Hero() {
           fund eligible.
         </p>
         <div className="flex flex-wrap gap-3">
-          <a
-            href="#art"
-            className="rounded-pill bg-yellow px-7 py-[13px] text-sm font-black text-ink"
-          >
+          <PillLink href="#art" tone="yellow">
             🎨 Book Art Class
-          </a>
-          <a
-            href="#coop"
-            className="rounded-pill border-2 border-white/50 px-[26px] py-[13px] text-sm font-bold text-white"
-          >
+          </PillLink>
+          <PillLink href="#coop" tone="outline-light">
             Tuesday Co-op →
-          </a>
+          </PillLink>
         </div>
       </div>
       <div className="relative col-start-2 row-start-1 hidden md:block">

--- a/src/components/InterestListForm.test.tsx
+++ b/src/components/InterestListForm.test.tsx
@@ -25,14 +25,16 @@ test("submitting swaps the form for the success state", () => {
     target: { value: "robin@example.com" },
   });
   fireEvent.click(screen.getByRole("checkbox", { name: /tidepools/i }));
-  fireEvent.click(screen.getByRole("button", { name: /join the community/i }));
+  fireEvent.click(
+    screen.getByRole("button", { name: /join the interest list/i }),
+  );
 
   // The success state must actually replace the form, not merely render:
   // the status is announced and the submit button is gone.
   expect(screen.getByRole("status").textContent).toContain("You're in!");
-  expect(screen.queryByRole("button", { name: /join the community/i })).toBe(
-    null,
-  );
+  expect(
+    screen.queryByRole("button", { name: /join the interest list/i }),
+  ).toBe(null);
 });
 
 test("the form carries no link to the community page", () => {

--- a/src/components/InterestListForm.tsx
+++ b/src/components/InterestListForm.tsx
@@ -124,7 +124,7 @@ export function InterestListForm() {
             type="submit"
             className="rounded-pill mt-6 w-full cursor-pointer bg-purple p-[15px] text-base font-black tracking-[0.06em] text-white transition-colors duration-fast hover:bg-purple-deep"
           >
-            Join the community →
+            Join the interest list →
           </button>
         </form>
       )}

--- a/src/components/InterestListTeaser.test.tsx
+++ b/src/components/InterestListTeaser.test.tsx
@@ -1,9 +1,9 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { CommunityForm } from "./CommunityForm";
+import { InterestListTeaser } from "./InterestListTeaser";
 
 test("the teaser carries the interest-list form alongside it", () => {
-  render(<CommunityForm />);
+  render(<InterestListTeaser />);
 
   // The landing section is the teaser and the form together; the form's own
   // behavior is asserted in InterestListForm.test.tsx.
@@ -14,7 +14,7 @@ test("the teaser carries the interest-list form alongside it", () => {
 });
 
 test("the section teases the full community page", () => {
-  render(<CommunityForm />);
+  render(<InterestListTeaser />);
 
   expect(
     screen

--- a/src/components/InterestListTeaser.tsx
+++ b/src/components/InterestListTeaser.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { InterestListForm } from "./InterestListForm";
+import { PillLink } from "./PillLink";
 
 /**
  * The landing page's interest-list teaser: the pitch, a link on to the fuller
@@ -25,12 +25,9 @@ export function InterestListTeaser() {
           Drop your info and we&apos;ll reach out with new classes, co-op
           updates and coastal adventures.
         </p>
-        <Link
-          href="/community"
-          className="rounded-pill inline-block border-2 border-lavender px-[24px] py-[10px] text-sm font-bold text-dark"
-        >
+        <PillLink href="/community" tone="outline-dark">
           Meet the community →
-        </Link>
+        </PillLink>
       </div>
       <InterestListForm />
     </section>

--- a/src/components/InterestListTeaser.tsx
+++ b/src/components/InterestListTeaser.tsx
@@ -9,7 +9,7 @@ import { InterestListForm } from "./InterestListForm";
  * form without this teaser. Rendering the whole section there put the "Meet
  * the community" link on the page it points at.
  */
-export function CommunityForm() {
+export function InterestListTeaser() {
   return (
     <section
       id="community"

--- a/src/components/PillLink.test.tsx
+++ b/src/components/PillLink.test.tsx
@@ -1,0 +1,72 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PillLink } from "./PillLink";
+
+test("the destination reaches the rendered link", () => {
+  render(
+    <PillLink href="/book" tone="yellow">
+      Book a class →
+    </PillLink>,
+  );
+
+  expect(
+    screen.getByRole("link", { name: /book a class/i }).getAttribute("href"),
+  ).toBe("/book");
+});
+
+test("a hash destination stays a working same-page anchor", () => {
+  render(
+    <PillLink href="#community" tone="yellow">
+      Join the interest list →
+    </PillLink>,
+  );
+
+  // Hashes go through next/link like any other href rather than branching on
+  // a leading "#", which would be an invariant the types do not show.
+  expect(
+    screen
+      .getByRole("link", { name: /join the interest list/i })
+      .getAttribute("href"),
+  ).toBe("#community");
+});
+
+test("each tone brings its own surface", () => {
+  const tones = [
+    ["yellow", "bg-yellow"],
+    ["purple", "bg-purple"],
+    ["ocean", "bg-ocean"],
+    ["outline-light", "border-white/50"],
+    ["outline-dark", "border-lavender"],
+  ] as const;
+
+  for (const [tone, expected] of tones) {
+    const { getByRole, unmount } = render(
+      <PillLink href="/book" tone={tone}>
+        {tone}
+      </PillLink>,
+    );
+    expect(getByRole("link").className).toContain(expected);
+    unmount();
+  }
+});
+
+test("every pill shares one geometry", () => {
+  // The whole point of the module: "Book a class" rendered one size on the
+  // program card and another on /art before this existed.
+  const { getByRole: solid, unmount } = render(
+    <PillLink href="/book" tone="yellow">
+      solid
+    </PillLink>,
+  );
+  expect(solid("link").className).toContain("px-7 py-3.25");
+  unmount();
+
+  const { getByRole: outline } = render(
+    <PillLink href="/art" tone="outline-light">
+      outline
+    </PillLink>,
+  );
+  // 2px narrower each side, so the border lands the outer box in the same
+  // place as the solid pill's.
+  expect(outline("link").className).toContain("px-6.5 py-2.75");
+});

--- a/src/components/PillLink.tsx
+++ b/src/components/PillLink.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+export type PillTone =
+  "yellow" | "purple" | "ocean" | "outline-light" | "outline-dark";
+
+/* Solid and outline pills carry different padding so their outer boxes match:
+   the outline's 2px border makes up the difference. That pairing was already
+   right on the program cards and wrong in the hero, which is the drift this
+   module removes. */
+const TONES: Record<PillTone, string> = {
+  yellow: "bg-yellow px-7 py-3.25 font-black text-ink",
+  purple:
+    "bg-purple px-7 py-3.25 font-black text-white transition-colors duration-fast hover:bg-purple-deep",
+  ocean: "bg-ocean px-7 py-3.25 font-black text-white",
+  "outline-light":
+    "border-2 border-white/50 px-6.5 py-2.75 font-bold text-white",
+  "outline-dark": "border-2 border-lavender px-6.5 py-2.75 font-bold text-dark",
+};
+
+type PillLinkProps = {
+  href: string;
+  /** Picks the surface the pill sits on. The list is closed on purpose. */
+  tone: PillTone;
+  children: ReactNode;
+};
+
+/**
+ * The site's call-to-action shape: a fully-rounded link.
+ *
+ * The interface is a destination and a tone, and nothing else. Growing a
+ * className escape hatch or a size axis would put geometry back in the
+ * interface, which is what left eleven call sites writing five different
+ * paddings for the same idea. Callers that need spacing around a pill wrap
+ * it; they do not reach through it.
+ *
+ * Hash destinations go through next/link like any other href — it renders a
+ * plain anchor and same-page hashes work.
+ */
+export function PillLink({ href, tone, children }: PillLinkProps) {
+  return (
+    <Link
+      href={href}
+      className={`rounded-pill inline-block text-sm ${TONES[tone]}`}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/src/components/ProgramCards.test.tsx
+++ b/src/components/ProgramCards.test.tsx
@@ -22,7 +22,7 @@ test("each card's CTA points where its flow goes", () => {
   const book = screen.getByRole("link", { name: /book a class/i });
   expect(book.getAttribute("href")).toBe("/book");
 
-  const join = screen.getByRole("link", { name: /join interest list/i });
+  const join = screen.getByRole("link", { name: /join the interest list/i });
   expect(join.getAttribute("href")).toBe("#community");
 
   const learnMore = screen

--- a/src/components/ProgramCards.tsx
+++ b/src/components/ProgramCards.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { PillLink } from "./PillLink";
 import { Placeholder } from "./Placeholder";
 
 const COOP_ACTIVITIES = [
@@ -55,18 +55,12 @@ export function ProgramCards() {
               </span>
             </div>
             <div className="flex flex-wrap gap-3">
-              <Link
-                href="/book"
-                className="rounded-pill bg-yellow px-[26px] py-3 text-sm font-black text-ink"
-              >
+              <PillLink href="/book" tone="yellow">
                 Book a class →
-              </Link>
-              <Link
-                href="/art"
-                className="rounded-pill border-2 border-white/50 px-[24px] py-[10px] text-sm font-bold text-white"
-              >
+              </PillLink>
+              <PillLink href="/art" tone="outline-light">
                 Learn more →
-              </Link>
+              </PillLink>
             </div>
           </div>
         </article>
@@ -115,18 +109,12 @@ export function ProgramCards() {
               and hands-on discovery. Spots limited for fall.
             </p>
             <div className="flex flex-wrap gap-3">
-              <a
-                href="#community"
-                className="rounded-pill bg-yellow px-[26px] py-3 text-sm font-black text-ink"
-              >
+              <PillLink href="#community" tone="yellow">
                 Join the interest list →
-              </a>
-              <Link
-                href="/coop"
-                className="rounded-pill border-2 border-white/50 px-[24px] py-[10px] text-sm font-bold text-white"
-              >
+              </PillLink>
+              <PillLink href="/coop" tone="outline-light">
                 Learn more →
-              </Link>
+              </PillLink>
             </div>
           </div>
         </article>

--- a/src/components/ProgramCards.tsx
+++ b/src/components/ProgramCards.tsx
@@ -119,7 +119,7 @@ export function ProgramCards() {
                 href="#community"
                 className="rounded-pill bg-yellow px-[26px] py-3 text-sm font-black text-ink"
               >
-                Join interest list →
+                Join the interest list →
               </a>
               <Link
                 href="/coop"

--- a/src/components/ReservedSlot.test.tsx
+++ b/src/components/ReservedSlot.test.tsx
@@ -1,0 +1,42 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ReservedSlot } from "./ReservedSlot";
+
+test("the headline and the detail both reach the reader", () => {
+  render(
+    <ReservedSlot
+      emoji="🗓️"
+      headline="Online booking coming soon."
+      detail="The scheduler embeds here once a booking provider is chosen."
+    />,
+  );
+
+  expect(screen.getByText(/online booking coming soon/i)).toBeDefined();
+  expect(screen.getByText(/the scheduler embeds here/i)).toBeDefined();
+});
+
+test("the emoji is decoration, not content", () => {
+  const { container } = render(
+    <ReservedSlot emoji="🌊" headline="Coming soon." detail="Lands here." />,
+  );
+
+  // A screen reader announcing "wave" before every one of these would be
+  // noise; the headline already says what the slot is for.
+  const emoji = container.querySelector("span");
+  expect(emoji?.textContent).toBe("🌊");
+  expect(emoji?.getAttribute("aria-hidden")).toBe("true");
+});
+
+test("the tone follows the surface the slot sits on", () => {
+  const { container: light } = render(
+    <ReservedSlot emoji="🎨" headline="Soon." detail="Here." />,
+  );
+  const { container: ocean } = render(
+    <ReservedSlot emoji="🌊" headline="Soon." detail="Here." tone="ocean" />,
+  );
+
+  // Two adapters are what make the tone a real variant rather than a
+  // hypothetical one: five slots sit on cream, one on the ocean section.
+  expect(light.firstElementChild?.className).toContain("border-lavender");
+  expect(ocean.firstElementChild?.className).toContain("border-white/20");
+});

--- a/src/components/ReservedSlot.tsx
+++ b/src/components/ReservedSlot.tsx
@@ -1,0 +1,54 @@
+type ReservedSlotProps = {
+  /** Sets the mood of the slot; hidden from assistive tech. */
+  emoji: string;
+  /** Names what is coming, e.g. "Online booking coming soon." */
+  headline: string;
+  /** One sentence on what will land here when it does. */
+  detail: string;
+  /** `ocean` for slots sitting on the ocean-blue section; `light` elsewhere. */
+  tone?: "light" | "ocean";
+};
+
+const TONES = {
+  light: {
+    frame: "border-lavender bg-white/60",
+    text: "text-fog",
+  },
+  ocean: {
+    frame: "border-white/20 bg-white/7",
+    text: "text-white/45",
+  },
+};
+
+/**
+ * A labeled stand-in for content that is decided but not yet built — a
+ * schedule, a scheduler embed, the conditions tool.
+ *
+ * The copy arrives as props rather than children on purpose: the blank line
+ * between the headline and the detail is part of the shape, and it is
+ * exactly what drifted while six call sites each wrote their own.
+ */
+export function ReservedSlot({
+  emoji,
+  headline,
+  detail,
+  tone = "light",
+}: ReservedSlotProps) {
+  const { frame, text } = TONES[tone];
+
+  return (
+    <div
+      className={`rounded-box border-2 border-dashed px-8 py-12 text-center ${frame}`}
+    >
+      <span aria-hidden="true" className="mb-3.5 block text-5xl">
+        {emoji}
+      </span>
+      <p className={`leading-normal text-sm ${text}`}>
+        {headline}
+        <br />
+        <br />
+        {detail}
+      </p>
+    </div>
+  );
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -23,10 +23,10 @@ export default defineConfig({
       // run-gates.mjs and run-vitest.mjs sit at 0% on purpose, and both drag
       // these figures down in plain sight rather than quietly.
       thresholds: {
-        statements: 67.54,
-        branches: 75,
-        functions: 84.09,
-        lines: 70.19,
+        statements: 69.16,
+        branches: 75.67,
+        functions: 85.1,
+        lines: 71.81,
       },
     },
   },


### PR DESCRIPTION
Plan: [`docs/plans/shared-module-deepening.md`](docs/plans/shared-module-deepening.md). Follows #12. No issue — per-slice issues skipped under CLAUDE.md §5.

## What changed

| Commit | Slice |
|---|---|
| `5c5984c` | Say "Join the interest list" on every CTA that joins it |
| `4406d43` | Rename `CommunityForm` to `InterestListTeaser` |
| `0cd71b5` | Give the reserved slot one module |
| `e7fa109` | Put a seam under the pill CTA |
| `4cac365` | Raise the coverage floor and record the build |

The first two close the gaps left open by the `/community` fix in #11. The form's submit control said "Join the community", which collides with `/community` the page — about to mean calendar, groups and message board — and the co-op card said "Join interest list" without the article. `CONTEXT.md` had already settled the term; this makes the glossary true of the code rather than aspirational. `CommunityForm` has contained no form since the split, so it becomes `InterestListTeaser`, both halves from the glossary.

**`ReservedSlot`** replaces the dashed "coming soon" box at six call sites — the five routed pages and the landing page's conditions teaser. Copy arrives as props rather than children so the module owns the blank line between headline and detail; that rhythm is exactly what drifts when six call sites each write it. Two tones, because five sit on cream and one on the ocean section — two adapters make the variant real.

**`PillLink`** replaces eleven hand-written CTAs that had drifted into five geometries. Interface is a destination and a tone, tone list closed at five. Excluded, by the reasoning that closed the list: the nav's Book Now pill (chrome, own responsive sizing), the form's submit (a button, not a link), and the three card badges (not interactive).

## Gates

Run at `4cac365`:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
```

Coverage floor raised to what the repo now achieves, per the rule in its own comment: 67.54/75/84.09/70.19 → 69.16/75.67/85.1/71.81.

Both extractions are verified by assertions that **predate them and are untouched here** — the page tests already assert every reserved slot by its copy and every CTA by its `href`. Their staying green is the evidence that nothing a reader can see changed.

As in #12, I checked the built stylesheet rather than trusting class names, since a Tailwind class naming a nonexistent value fails silently:

```
px-6\.5{padding-inline:calc(var(--spacing) * 6.5)}
py-3\.25{padding-block:calc(var(--spacing) * 3.25)}
py-2\.75{padding-block:calc(var(--spacing) * 2.75)}
```

## needs-human — one deliberate visual change

**Pill geometry converges.** Eleven call sites carried five paddings. They converge on the one the hero and page CTAs already used, so the most common pill is pixel-identical and the rest move by two or three pixels. Solid and outline now differ by exactly the border width, so their outer boxes line up — already true on the program cards, not in the hero, where the outline pill sat 4px taller than the yellow one.

Worth a look at: the hero's two CTAs side by side, the program cards' pairs, and the `/art`, `/book`, `/coop` page CTAs.

Everything else here should be pixel-identical. `ReservedSlot` reproduces the existing markup exactly, in both tones.

## Not done

- Naming the conditions embed slot as its own module. It is ×2 and cheap now that `ReservedSlot` exists, but it is the smallest leverage on the list — recorded as out of scope in the plan.
- `Placeholder` still has no test of its own, despite six call sites and a branching default. Not in this plan's scope; worth its own slice.
