### PR TITLE
Test Placeholder's label-visibility default directly

### DIFF
--- a/src/components/Placeholder.test.tsx
+++ b/src/components/Placeholder.test.tsx
@@ -1,0 +1,68 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Placeholder } from "./Placeholder";
+
+test("the label becomes the slot's accessible name", () => {
+  // The label is the whole point of the module: whatever replaces this slot
+  // with a real <img> has to keep the same name, so the name has to be
+  // reachable by role rather than by the text that happens to be drawn.
+  render(<Placeholder label="Logo" />);
+
+  expect(screen.getByRole("img", { name: "Logo" })).toBeDefined();
+});
+
+test("a background slot is named even though it draws no label", () => {
+  render(<Placeholder background label="Hero photo" />);
+
+  // The visible label is what `background` drops; the accessible name is not.
+  expect(screen.getByRole("img", { name: "Hero photo" })).toBeDefined();
+});
+
+test("a foreground slot draws its label by default", () => {
+  render(<Placeholder label="Logo" />);
+
+  expect(screen.getByText("Logo")).toBeDefined();
+});
+
+test("a background slot hides its label by default", () => {
+  // `showLabel = !background`: a fill sits under real content, so its label
+  // would print over that content. Nothing but this asserts the default.
+  render(<Placeholder background label="Hero photo" />);
+
+  expect(screen.queryByText("Hero photo")).toBeNull();
+});
+
+test("showLabel forces a background slot to draw its label", () => {
+  // Hero does exactly this. Without the override its right half is invisible
+  // over the purple and reads as empty (design review, finding 2).
+  render(<Placeholder background showLabel label="Hero photo" />);
+
+  expect(screen.getByText("Hero photo")).toBeDefined();
+});
+
+test("showLabel={false} silences a foreground slot's label", () => {
+  render(<Placeholder showLabel={false} label="Logo" />);
+
+  expect(screen.queryByText("Logo")).toBeNull();
+  // Still an image to a screen reader, just an unlabelled-looking one.
+  expect(screen.getByRole("img", { name: "Logo" })).toBeDefined();
+});
+
+test("a foreground slot carries the dashed frame", () => {
+  // jsdom applies no stylesheets, so the class contract is the seam. The
+  // frame is what tells a reader the slot is a stand-in and not a blank box.
+  render(<Placeholder label="Logo" />);
+
+  expect(screen.getByRole("img", { name: "Logo" }).className).toContain(
+    "border-dashed",
+  );
+});
+
+test("a background slot drops the dashed frame", () => {
+  // A fill sits behind content, where a frame would read as a stray box.
+  render(<Placeholder background label="Hero photo" />);
+
+  expect(
+    screen.getByRole("img", { name: "Hero photo" }).className,
+  ).not.toContain("border-dashed");
+});


### PR DESCRIPTION
Closes #16

## What changed

One test-only slice: adds `src/components/Placeholder.test.tsx`. No production
file is touched.

`Placeholder` has six call sites — the logo, the hero photo slot, the two card
backgrounds, the gallery tiles and the page galleries — and had no test of its
own. Its non-obvious rule, `showLabel = !background`, was asserted nowhere in
either direction, even though `Hero` overrides it explicitly and the reason is
recorded both in a comment and in finding 2 of the 2026-08-11 design review.

## What is asserted

Role-based queries throughout, matching `GalleryRow.test.tsx`; classes asserted
via `className` + `toContain`, following the `StripTrack.test.tsx` precedent for
how this repo tests a class contract in a jsdom that applies no stylesheets.

1. `the label becomes the slot's accessible name` — `getByRole("img", { name })`
   finds a foreground slot. This is the property that has to survive the slot
   being swapped for a real `<img>`.
2. `a background slot is named even though it draws no label` — the same query
   finds a background slot. `background` drops the *visible* label, not the
   accessible name.
3. `a foreground slot draws its label by default` — the label text renders.
4. `a background slot hides its label by default` — the label text does not.
   (3) and (4) together are the default rule, in both directions.
5. `showLabel forces a background slot to draw its label` — the `Hero` case.
6. `showLabel={false} silences a foreground slot's label` — the other direction
   of the override, and it also re-checks that the accessible name survives.
7. `a foreground slot carries the dashed frame` — `border-dashed` present.
8. `a background slot drops the dashed frame` — `border-dashed` absent. (7)
   proves the string is real, so (8)'s negative cannot pass vacuously.

## Sanity check that the tests test something

`showLabel = !background` was inverted to `showLabel = background` transiently
and the suite re-run. Tests 3 and 4 failed; the other six passed, which is the
expected split — only those two are about the default. The mutation was then
reverted with `git checkout --`, and `git status` confirmed the tree contained
only the new untracked test file before staging. `git diff --staged --stat` on
the commit: `1 file changed, 68 insertions(+)`.

## Gate output

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
```

Clean on the first run — the issue #9 jsdom boot flake did not appear.

## What I did not do

- No production file changed, including `Placeholder.tsx`. No bug surfaced
  while writing these; the component behaves as its interface documents.
- No test of `labelClassName` / `className` pass-through. They are unconditional
  string concatenation with no branch, so a test would restate the template
  rather than pin a rule. The dashed-frame assertions already cover the one
  class decision `Placeholder` actually makes.
- No `docs/plans/` entry: one slice, one issue, no decision that outlives it.
- No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
