### PR TITLE
Retire the unused #conditions id

### DIFF
--- a/src/components/Conditions.test.tsx
+++ b/src/components/Conditions.test.tsx
@@ -2,15 +2,12 @@ import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { Conditions } from "./Conditions";
 
-test("the conditions heading and embed slot are reachable at #conditions", () => {
-  const { container } = render(<Conditions />);
+test("the conditions teaser renders its heading and embed slot", () => {
+  render(<Conditions />);
 
   const heading = screen.getByRole("heading", { level: 2 });
   expect(heading.textContent).toContain("conditions");
   expect(screen.getByText(/conditions tool coming soon/i)).toBeDefined();
-
-  // Teasers deep-link here; the id is stable API.
-  expect(container.querySelector("section#conditions")).not.toBeNull();
 });
 
 test("the section teases the full conditions page", () => {

--- a/src/components/Conditions.tsx
+++ b/src/components/Conditions.tsx
@@ -3,10 +3,7 @@ import { ReservedSlot } from "./ReservedSlot";
 
 export function Conditions() {
   return (
-    <section
-      id="conditions"
-      className="px-gutter-sm py-section-sm grid items-center gap-8 md:grid-cols-2 md:gap-12 md:px-gutter md:py-0"
-    >
+    <section className="px-gutter-sm py-section-sm grid items-center gap-8 md:grid-cols-2 md:gap-12 md:px-gutter md:py-0">
       <div>
         <h2 className="text-title leading-tight mb-3.5 font-black text-white italic">
           Check


### PR DESCRIPTION
Closes #17

## What changed and why

One slice: remove `id="conditions"` from `src/components/Conditions.tsx`, and
remove the assertion that protected it from `src/components/Conditions.test.tsx`.

Nothing deep-links to the anchor. The nav moved to routed links in PR #11 and
the teaser's own CTA points at the `/conditions` **route**, not the anchor.
`#art` and `#coop` were retired for the same reason in PR #14; `#conditions`
was left behind only because it was out of that plan's scope.

The test is what kept the id alive. It asserted the id and described it as
stable API, which reads as protecting a contract that has no other end:

```tsx
// Teasers deep-link here; the id is stable API.
expect(container.querySelector("section#conditions")).not.toBeNull();
```

That assertion and its comment are gone. The heading and embed-slot assertions
stay, and the test was renamed from *"the conditions heading and embed slot are
reachable at #conditions"* to *"the conditions teaser renders its heading and
embed slot"*, because the old name no longer described what it checks. The
second test (the CTA points at `/conditions`) is untouched.

The `/conditions` route (`src/app/conditions/`) is unaffected — only the
in-page anchor is retired.

## Search evidence

The precondition for this change is that no live caller references the anchor.
Repo-wide search, run from the branch before the edit:

```
$ git grep -n -- "#conditions"
.design/wild-coast-kids-landing/DESIGN_BRIEF.md:87:- **Nav anchors**: links smooth-scroll to `#art`, `#coop`, `#conditions`,
.design/wild-coast-kids-landing/DESIGN_REVIEW.md:118:   - "Nav anchors: links smooth-scroll to `#art`, `#coop`, `#conditions`,
.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md:10:  - Conditions `/#conditions` (anchor: conditions section)
.design/wild-coast-kids-landing/TASKS.md:57:- [x] **Conditions section**: Ocean-blue `#conditions` split — heading/copy
docs/plans/section-snapping.md:164:- **The `#conditions` id.** Nothing links to it — the teaser points at the
src/components/Conditions.test.tsx:5:test("the conditions heading and embed slot are reachable at #conditions", () => {
src/components/Conditions.test.tsx:13:  expect(container.querySelector("section#conditions")).not.toBeNull();
```

Every hit outside `Conditions.test.tsx` is prose in a design doc or the plan
file. **No application code references the anchor.**

Cross-checked case-insensitively for `conditions` across all of `src/` to be
sure no href was building the anchor by another route. Every non-prose hit is
either the `/conditions` route, the component/test identifiers, or copy text:

```
src/components/Nav.tsx:7:  { href: "/conditions", label: "Conditions" },
src/components/Conditions.tsx:22:        <PillLink href="/conditions" tone="outline-light">
src/components/Conditions.test.tsx:21:  ).toBe("/conditions");
src/components/Nav.test.tsx:30:    ["Conditions", "/conditions"],
```

Both links that exist are `/conditions` (the route). Neither is `/#conditions`.

## Gate output

`npm run gate`, run on the committed tree. Literal output:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
```

All five gates green on the first run — the known jsdom boot flake (#9) did not
appear.

## What I did not do

- **The stale design-doc prose is untouched.** `DESIGN_BRIEF.md`,
  `DESIGN_REVIEW.md`, `INFORMATION_ARCHITECTURE.md` and `TASKS.md` still
  describe smooth-scrolling nav anchors including `#conditions`, and
  `INFORMATION_ARCHITECTURE.md` still lists `/#conditions` as a URL. That prose
  was already stale for `#art` and `#coop` after PR #11 and PR #14; bringing the
  design docs in line with the routed-nav reality is its own change, not a side
  effect of this one.
- **No other id was removed**, and nothing else was tidied.
