### PR TITLE
Exclude docs/ and .design/ from Tailwind source detection

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,14 @@
 @import "tailwindcss";
 
+/* Tailwind's automatic source detection scans every non-gitignored file in the
+   project, so a class name written in prose compiles into the shipped
+   stylesheet. That makes "the class is in the built CSS" stop proving a
+   component uses it — the check several PRs rely on to confirm a utility emits
+   real CSS rather than silently resolving to nothing. Paths are relative to
+   this file, so ../../ is the repo root. */
+@source not "../../docs";
+@source not "../../.design";
+
 /* Wild Coast Kids design tokens — coastal pop editorial.
    Canonical record: .design/wild-coast-kids-landing/DESIGN_TOKENS.css.
    One fixed, art-directed palette: no dark mode by decision (see


### PR DESCRIPTION
Closes #15

## What changed and why

One slice, one file: `src/app/globals.css` gains two `@source not` directives
excluding the repo's prose directories from Tailwind's automatic source
detection.

```css
@source not "../../docs";
@source not "../../.design";
```

`globals.css` lives in `src/app/`, so `../../` resolves to the repo root — the
verification below is what proves those paths actually reach `docs/` and
`.design/` rather than missing silently.

The dead `snap-none` rule is a few bytes. What it actually broke is the
verification technique PRs #12, #13 and #14 leaned on: reading the built
stylesheet to confirm a utility emits real CSS rather than silently resolving to
nothing. While prose is scanned, a class named only in a plan file is
indistinguishable in the built CSS from one a component wires up, so the check
proves nothing. Scoping detection restores it.

## Verification

The built stylesheet is at `.next/static/chunks/*.css`, not the
`.next/static/css/*.css` the issue predicted — Next 16 emits app CSS into the
chunks directory. Same file, different path.

**Baseline, before the change** (build from `origin/main`, counting substring
occurrences in the built stylesheet, since it is minified onto one line):

```
snap-none            1
justify-center-safe  2
min-h-footer         1
scroll-pt-nav-sm     1
```

**After the change**, rebuilt from clean (`rm -rf .next && npm run build`):

```
$ grep -o 'snap-none' .next/static/chunks/*.css; echo "snap-none exit=$?"
snap-none exit=1
```

Exit 1, no output: `snap-none` is gone.

```
$ grep -o 'justify-center-safe{[^}]*}' .next/static/chunks/*.css
justify-center-safe{justify-content:safe center}
justify-center-safe{justify-content:safe center}

$ grep -o 'min-h-footer{[^}]*}' .next/static/chunks/*.css
min-h-footer{min-height:var(--spacing-footer)}

$ grep -o 'scroll-pt-nav-sm{[^}]*}' .next/static/chunks/*.css
scroll-pt-nav-sm{scroll-padding-top:var(--spacing-nav-sm)}
```

All three genuinely-used utilities still emit their real declarations. That
pairing is the point — a blanket exclusion would satisfy the absence alone.

**Full gate**, first run, no re-runs and no flake:

```
$ npm run gate

> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
```

## Additional check: is anything else still leaking?

Every class selector in the built stylesheet was extracted and checked against a
literal search of `src/`. Twenty-five strings did not match, and all twenty-five
are false positives from the naive extractor — font-module hashes
(`montserrat_4dcf74cb-module__LaYLyG__className`), decimal fragments of numeric
values (`25rem`, `666667rem`, `40282e38px`), and CSS keywords appearing after a
dot (`contents`, `lowercase`, `woff2`). No prose-only class names survive.

## What I did not do

- **Did not exclude the root-level Markdown files.** `README.md`, `CONTEXT.md`,
  `CLAUDE.md` and `AGENTS.md` sit at the repo root and are still scanned. None
  of them currently contributes a class to the built stylesheet (per the check
  above), so there is nothing to fix today — but the same hazard applies to them
  the moment someone writes a utility name in one. Reporting rather than
  expanding scope.
- **No test in the commit.** The property this slice asserts lives in the build
  output, and the gate table has no row that inspects the built stylesheet.
  Adding one is a different change with its own justification; the evidence above
  is the verification for this slice.
- Touched nothing outside `src/app/globals.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
