### PR TITLE
Describe the routed structure in INFORMATION_ARCHITECTURE.md

### DIFF
--- a/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
+++ b/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
@@ -115,7 +115,11 @@ lands on `/art` first; that page's CTA is "Book a class →" → `/book`.
   whatever list it is given; adding photos is a data change, not a layout one.
 - **Programs**: the grid accepts a third card if an offering is added.
 - **Conditions**: the dashed box is the reserved slot for the future embed.
-- Anything beyond that (blog, schedules, multiple pages) is a new IA exercise.
+- **A new program area** is a route beside the existing five, plus a teaser
+  section on `/` that links to it. That path is established; adding one
+  decides nothing new.
+- Anything beyond that (a blog, real schedules, nested or dynamic routes) is a
+  new IA exercise.
 
 ## URL Strategy
 

--- a/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
+++ b/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
@@ -2,23 +2,35 @@
 
 ## Site Map
 
-One page. All navigation is intra-page anchors.
+Six routes. The landing page keeps a teaser for each program area; the routed
+pages carry the fuller version.
 
 - Home `/`
-  - Art Classes `/#art` (anchor: art program card)
-  - Tuesday Co-op `/#coop` (anchor: co-op program card)
-  - Conditions `/#conditions` (anchor: conditions section)
-  - Community `/#community` (anchor: interest-list form)
+  - Art Classes `/art`
+  - Tuesday Co-op `/coop`
+  - Conditions `/conditions`
+  - Community `/community`
+  - Book Now `/book` (utility; not in the nav's link row)
+
+One anchor survives: `/#community`, the interest-list section on the landing
+page. See _URL Strategy_ for the anchors that were retired.
 
 ## Navigation Model
 
-- **Primary navigation**: fixed top bar with four anchor links — Art Classes,
-  Tuesday Co-op, Conditions, Community. That is the maximum; no dropdowns.
-- **Secondary navigation**: none. In-content CTAs cross-link: hero buttons →
-  `#art` / `#coop`, co-op card → `#community`.
-- **Utility navigation**: the yellow "Book Now" pill in the nav (→ `#art`).
-- **Mobile navigation**: same links, tighter spacing and smaller type ≤768px.
-  No hamburger — four short links fit.
+- **Primary navigation**: sticky top bar — in the document flow, not fixed
+  (ADR-0003) — with four routed links: Art Classes `/art`, Tuesday Co-op
+  `/coop`, Conditions `/conditions`, Community `/community`. That is the
+  maximum; no dropdowns. The link for the current route carries
+  `aria-current="page"`.
+- **Secondary navigation**: none. In-content CTAs cross-link — hero → `/book`
+  and `/coop`; art card → `/book` and `/art`; co-op card → `#community` and
+  `/coop`; conditions teaser → `/conditions`; interest-list teaser →
+  `/community`. Back the other way, `/art` → `/book`, and `/book` and `/coop`
+  → `/#community`.
+- **Utility navigation**: the yellow "Book Now" pill in the nav (→ `/book`).
+- **Mobile navigation**: same links, no hamburger. Below `md` the bar wraps to
+  two rows — logo and Book Now pill above, the four links spread beneath —
+  because the four links plus the pill do not fit one 375px row.
 
 ## Content Hierarchy
 
@@ -39,21 +51,41 @@ One page. All navigation is intra-page anchors.
 Cut from the template: editorial block ("Real kids…") and the yellow
 wordmark banner. Decided in the brief; not deferred.
 
+### The routed pages
+
+`/art`, `/coop`, `/conditions`, `/community` and `/book` share one shape: an
+eyebrow line, an italic title, a lead paragraph, at most one CTA, then
+reserved slots where real content lands. They are structural shells — the
+schedule, pricing, photos, booking scheduler and conditions tool are all
+labeled placeholders, by decision in `docs/plans/nav-pages-scaffolding.md`.
+
+`/community` is the one that differs: below its reserved slots it renders the
+interest-list form under its own heading, without the landing page's teaser
+column — otherwise the "Meet the community" CTA would sit on the page it
+points at.
+
 ## User Flows
 
 ### Book an art class
 
 1. Parent lands on `/`, sees hero + marquee.
-2. Clicks "Book Art Class" (hero), "Book Now" (nav), or scrolls to the art card.
-3. Arrives at `#art`, reads tags (charter eligible, all levels, outdoors).
-4. Clicks "Book a class →" — external booking link (`TODO(verify)`; opens new
-   tab once real).
+2. Clicks "Book Art Class" (hero), "Book Now" (nav), or "Book a class →" on
+   the art card.
+3. Arrives at `/book`. No booking provider is chosen yet, so the page says so
+   in a reserved slot and offers the interest list instead.
+4. Clicks "Join the interest list →" → `/#community`.
+
+Longer way round: "Learn more →" on the art card, or Art Classes in the nav,
+lands on `/art` first; that page's CTA is "Book a class →" → `/book`.
 
 ### Join the co-op interest list
 
-1. Parent lands on `/`, clicks "Tuesday Co-op →" (hero or nav) → `#coop`.
-2. Reads the activities grid and fall details.
-3. Clicks "Join interest list →" → `#community`.
+1. Parent lands on `/`, clicks "Tuesday Co-op →" (hero) or Tuesday Co-op
+   (nav) → `/coop`.
+2. Reads the fall details and the lead paragraph.
+3. Clicks "Join the interest list →" → `/#community`, the interest-list
+   section back on the landing page. The co-op card on `/` reaches the same
+   place with the same-page `#community`.
 4. Fills name, email, kids' ages, interest checkboxes → submits.
 5. Sees the "You're in!" success state (client-side only for now).
 
@@ -87,7 +119,20 @@ wordmark banner. Decided in the brief; not deferred.
 
 ## URL Strategy
 
-- Pattern: single route `/`; sections addressed as `/#<section-id>`.
-- Anchor ids are stable API: `art`, `coop`, `conditions`, `community` — they
-  are shared with the template and must not be renamed casually.
+- Pattern: six static routes — `/`, `/art`, `/coop`, `/conditions`,
+  `/community`, `/book`. The slugs are the short ids the sections carried
+  before the routes existed, not the labels (`/art`, not `/art-classes`).
+- **One anchor id remains, and it is stable API**: `community`, on the
+  `SnapSection` wrapping the interest-list teaser on `/`. Three things point
+  at it — the co-op card as `#community`, and `/book` and `/coop` as
+  `/#community` — so it must not be renamed casually.
+- **`art`, `coop` and `conditions` are retired.** `#art` and `#coop` went when
+  the landing page became snap sections: both cards share one snap stop, so
+  the two anchors were the same screen, and an anchor onto an element inside a
+  section lands at a non-snap position. `#conditions` followed. No `id` for
+  any of the three survives in `src/`, so a leftover `/#art`, `/#coop` or
+  `/#conditions` link now resolves to the top of the landing page. Use the
+  route instead.
+- Anchor targets clear the sticky nav via `scroll-pt-nav-sm md:scroll-pt-nav`
+  on `html`, which subtracts the same tokens the nav sets its height from.
 - No dynamic segments, no query parameters.

--- a/docs/plans/ia-doc-routed-structure.md
+++ b/docs/plans/ia-doc-routed-structure.md
@@ -1,0 +1,99 @@
+# IA doc describes the routed structure
+
+Issue: [#25](https://github.com/cweber12/wild-coast-kids/issues/25).
+
+## Problem, from the reader's point of view
+
+`.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md` is the document
+that defines this site's URL structure. It says the site is one page navigated
+by four intra-page anchors, and lists `/#art`, `/#coop`, `/#conditions` and
+`/#community` as its addresses.
+
+Five of those statements are false against the code:
+
+- `src/components/Nav.tsx` links to `/art`, `/coop`, `/conditions` and
+  `/community` — routes, not anchors — with `/book` on the Book Now pill.
+  Six routes exist under `src/app/`.
+- The only surviving `id` in `src/` is `community`, on the `SnapSection`
+  wrapping the interest-list teaser (`src/app/page.tsx`). `#art` and `#coop`
+  were retired by the section-snapping work; `#conditions` by issue #17.
+- The nav is `sticky top-0` and sits in the document flow, not `fixed`
+  (`docs/adr/0003-nav-in-document-flow.md`).
+- Below `md` the nav wraps to two rows rather than merely tightening.
+- "Anything beyond that (blog, schedules, multiple pages) is a new IA
+  exercise" — multiple pages arrived in `docs/plans/nav-pages-scaffolding.md`.
+
+`/#conditions` is the sharpest: it reads as a live URL in the URL-structure
+document and resolves to nothing.
+
+## Solution
+
+Correct the four sections of `INFORMATION_ARCHITECTURE.md` that make claims
+about routing — Site Map, Navigation Model, User Flows, URL Strategy — plus
+the one sentence in Content Growth Plan that says multiple pages do not exist,
+and add a short Content Hierarchy subsection for the routed pages, which the
+document does not mention at all.
+
+Every route, link target and id written into the document is read out of the
+code, not out of the issue text.
+
+## Implementation decisions
+
+- **The code wins.** The document is the thing that drifted; nothing under
+  `src/` changes. Where the issue's summary of the code and the code disagree,
+  the code is what gets written down. (It did disagree once: the issue lists
+  four routed nav links and omits `/book`, which is a sixth route and the
+  target of the Book Now pill and of three in-content CTAs.)
+- **Anchors are described as retired, not silently deleted.** The URL Strategy
+  section names `#art`, `#coop` and `#conditions` as retired and says what a
+  surviving link to one would now do. A reader arriving from an old link or an
+  old review needs to be told the anchor is gone, not to find no trace of it.
+- **`#community` is documented as the one survivor**, with its call sites, so
+  the "stable API" sentence keeps a referent instead of being deleted.
+- **Two slices, because the causes differ.** Slice 1 is the routing
+  correction, which is issue #25. Slice 2 restores the last true statement in
+  Content Growth Plan, which the routes falsified. They commit separately so
+  the routing correction can be reverted on its own.
+
+## Verification seams
+
+The gate does not read prose, so verification is two greps stated in the PR
+body rather than a test:
+
+1. Every `/#`- and `#`-style URL left in the document, checked against
+   `grep -rn 'id=' src/` — only `community` may appear.
+2. Every route the document lists, checked against the directories under
+   `src/app/`.
+
+Plus `npm run gate`, which must stay green on a docs-only change.
+
+## Considered and rejected
+
+- **Rewriting the whole document to match today's code.** The document has
+  drift from the section-snapping work too — the home page's section order,
+  a `GalleryStrip` component that is now `GalleryRow`, and a gallery described
+  as auto-scrolling when it now has prev/next controls. Different change,
+  different cause; folding it in would make one commit that cannot be
+  described without "and". Filed separately.
+- **Deleting the retired anchors and saying nothing.** Cheapest edit, worst
+  document: the next person to find a `/#conditions` link elsewhere in the
+  repo learns nothing about why it is dead.
+- **Leaving Content Hierarchy alone entirely.** It would then describe the
+  hierarchy of one of six pages without saying the other five exist, which is
+  the same class of error this issue is fixing.
+- **Adding a gate that greps prose for dead anchors.** Tempting, but the gate
+  table judges the repo, and `.design/` holds dated records that are
+  _supposed_ to contain historical URLs (`DESIGN_REVIEW.md`). A gate that
+  cannot tell a record from a spec would have to be silenced immediately.
+
+## Out of scope
+
+- `DESIGN_REVIEW.md` and `DESIGN_REVIEW-2026-08-11.md` — dated records of what
+  was found on a given day. Rewriting a review to match today's code destroys
+  the thing that makes it evidence.
+- `TASKS.md` — a record of work completed against the brief as it then stood.
+- `DESIGN_BRIEF.md` — its drift is a judgement call about design direction,
+  tracked as #26.
+- Any file under `src/`. This is a factual correction to prose.
+- Whether the routed structure is the _right_ structure. #26 asks that; this
+  plan only makes the document agree with what was built.


### PR DESCRIPTION
Closes #25

`INFORMATION_ARCHITECTURE.md` is the document that defines this site's URL
structure, and it still described a single page navigated by four anchors.
`/#conditions` was the sharpest case — a live-looking URL, in the one document
a reader consults to learn what the URLs are, that resolves to nothing.

Docs only. Nothing under `src/` changes.

## Slices

1. **`44b08d7` Plan the IA doc's correction to the routed structure** —
   `docs/plans/ia-doc-routed-structure.md`: what is wrong, what gets
   corrected, what was considered and rejected, and which `.design/` files are
   dated records that must not be rewritten.
2. **`d787435` Describe the routed structure in the IA doc** — Site Map,
   Navigation Model, User Flows and URL Strategy rewritten against the code;
   Content Hierarchy gains a subsection for the five routed pages it never
   mentioned. Retired anchors are named as retired rather than deleted, so a
   reader holding an old `/#art` link learns why it is dead.
3. **`8ad47b4` Stop the growth plan calling multiple pages a new IA
   exercise** — the last sentence of Content Growth Plan said multiple pages
   would need a fresh IA exercise. Its own commit because the change that
   falsified it was the routed pages, not the anchor retirements.

## Verification

The gate does not read prose, so the two checks the issue asks for were run by
hand. Both from the branch tip.

### 1. Every `#`-style URL left in the document, against the ids in `src/`

```
$ grep -n '`[^`]*#[a-z][^`]*`' .design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
15:One anchor survives: `/#community`, the interest-list section on the landing
26:  and `/coop`; art card → `/book` and `/art`; co-op card → `#community` and
29:  → `/#community`.
76:4. Clicks "Join the interest list →" → `/#community`.
86:3. Clicks "Join the interest list →" → `/#community`, the interest-list
88:   place with the same-page `#community`.
131:  at it — the co-op card as `#community`, and `/book` and `/coop` as
132:  `/#community` — so it must not be renamed casually.
133:- **`art`, `coop` and `conditions` are retired.** `#art` and `#coop` went when
136:  section lands at a non-snap position. `#conditions` followed. No `id` for
137:  any of the three survives in `src/`, so a leftover `/#art`, `/#coop` or
138:  `/#conditions` link now resolves to the top of the landing page. Use the
```

Every anchor used as an **address** names `community`. Lines 133–138 are the
only mentions of `art`, `coop` and `conditions` as anchors, and they sit
inside the sentence declaring those ids retired — not offered as URLs.

`community` exists:

```
$ grep -rn 'id=' src/
src/app/page.tsx:24:      <SnapSection id="community">
src/components/InterestListForm.tsx:63:              id="community-name"
src/components/InterestListForm.tsx:79:              id="community-email"
src/components/InterestListForm.tsx:95:              id="community-ages"
src/components/SnapSection.test.tsx:102:    <SnapSection id="community">
src/components/SnapSection.tsx:66:      id={id}
```

`src/app/page.tsx:24` is the anchor target. The three `community-*` ids are
form-control ids, not anchor targets. No `id="art"`, `id="coop"` or
`id="conditions"` exists anywhere in `src/`.

### 2. Every route the document lists has a directory under `src/app/`

```
$ grep -o '`/[a-z]*`' .design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md | sort -u
`/`
`/art`
`/book`
`/community`
`/conditions`
`/coop`

$ ls -d src/app/*/
src/app/art/
src/app/book/
src/app/community/
src/app/conditions/
src/app/coop/
```

Five for five, plus `/` = `src/app/page.tsx`. Nothing is listed that does not
exist, and no route exists that the document omits.

### 3. `npm run gate`

```
$ npm run gate

> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
```

Green at every commit on the branch, and on `main` before the first one. No
sign of the #9 flake on any run.

## Where the issue's description of the code disagreed with the code

The issue says the nav "points at `/art`, `/coop`, `/conditions`,
`/community`". True, but incomplete: `src/components/Nav.tsx` also carries the
Book Now pill at `/book`, and `src/app/book/` is a **sixth route**. `/book` is
the target of the hero's first CTA, the art card's "Book a class" and `/art`'s
own CTA — it is not a minor extra. The document now lists six routes. The code
won; the issue text did not.

## Anything I did not do

- **`DESIGN_REVIEW.md`, `DESIGN_REVIEW-2026-08-11.md`, `TASKS.md`,
  `DESIGN_BRIEF.md`** — untouched, per the issue's scope.
- **The rest of `INFORMATION_ARCHITECTURE.md`'s drift.** The document also
  predates the snap-section reorder: Content Hierarchy has Quote + stats
  fourth when `src/app/page.tsx` renders it last, describes the gallery as
  auto-scrolling when it now has prev/next controls, and the Component Reuse
  Map names a `GalleryStrip` that is really `GalleryRow`. Different change,
  different cause, so it is **#27** rather than commits on this branch.
- **No gate for dead anchors in prose.** Considered and rejected in the plan:
  `.design/` deliberately holds dated records that are *supposed* to contain
  historical URLs, and a grep gate cannot tell a record from a spec.
- **#26 is untouched and undecided.** One thing found while reading that bears
  on it, below.

## For a human — bears on #26, not decided here

#26 asks whether the routed structure is right at all, or whether the brief's
anchor model was the spec and the code drifted. Reading for this issue turned
up that the routes were **a deliberate, written decision**, not drift:
`docs/plans/nav-pages-scaffolding.md` records the hybrid IA (sections stay on
`/`, five routes added beside them), names the alternatives it rejected —
stripping the landing page down, and keeping anchors while adding only
`/book` and `/conditions` — and explains the one-link-at-a-time flip so a
routed link never pointed at a route that did not exist. `docs/plans/section-snapping.md`
then records why `#art` and `#coop` specifically had to go: both cards share
one snap stop, so the two anchors addressed the same screen.

That does not settle #26 — a decision can be recorded and still be wrong —
but it means the question is "should this decision be revisited", not "did
the code drift from the brief". Deliberately not decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
