### PR TITLE
Assert the built stylesheet in a gate row

### DIFF
--- a/docs/plans/assert-built-stylesheet.md
+++ b/docs/plans/assert-built-stylesheet.md
@@ -156,3 +156,55 @@ the same regression from the other side.
 ## Addenda
 
 <!-- Dated entries when the plan changes. Never rewrite the above. -->
+
+### 2026-08-14 — the checker fed itself into the stylesheet it checks
+
+The first run of the finished row failed, and it was right to. `scripts/` is
+scanned by Tailwind's automatic source detection exactly like `docs/` and
+`.design/` were before PR #22, so writing the utility names into
+`scripts/built-css.mjs` compiled them into the build the row then read:
+
+```
+FAIL  snap-none is in the built CSS — …
+ok    .min-h-footer{min-height:var(--spacing-footer)}
+ok    .md\:min-h-footer{min-height:var(--spacing-footer)}
+```
+
+`.snap-none{scroll-snap-type:none}` was in the output for the first time, and
+the bare `.min-h-footer` rule beside the `md:` one had not been there an hour
+earlier. Both came from the new expectation table.
+
+This is worse than a failing row: it makes the row assert nothing. The
+forbidden name is present because the checker names it, and the required
+utilities emit because the checker names them — so the check would stay green
+after the app stopped using any of them. A gate that cannot fail is the thing
+this issue was filed about, one level up.
+
+**The fix, and why not the obvious one.** The obvious fix is a third
+`@source not` line for `scripts/` in `src/app/globals.css`. That file is out of
+scope here by decision — the exclusions belong to issue #24, which proposes
+replacing them with a positive `@source "../../src"`, inverting detection from
+opt-out to opt-in and covering `scripts/` along with the root Markdown it was
+filed about.
+
+So the table spells each utility in segments — `["snap", "none"]` — joined at
+runtime, and no file under `scripts/` contains a whole utility name, comments
+included. No segment is itself a Tailwind utility, so nothing compiles from
+them. A test walks `scripts/*.mjs` and fails if any file spells one of the
+names, so the constraint is enforced rather than remembered.
+
+The indirection is a workaround for a scanner, and it says so in the file.
+**When #24 lands, delete that test and make the segments plain strings** — the
+positive `@source` removes the reason for both.
+
+**What this adds to #24.** #24 records the hazard as latent, on the grounds
+that no prose-only class survived the audit of PR #22. It is live now, and
+`scripts/` is a directory that issue does not mention.
+
+### 2026-08-14 — a third slice: the coverage floor
+
+The new module is well covered and the new entry point is not, and the net is
+upward on all four measures. `vitest.config.mts` says the floor is what the
+repo achieves today and is raised when coverage rises, so leaving it where it
+was would let this change quietly buy slack the next one could spend. Raising
+it is its own commit, because it is its own change.

--- a/docs/plans/assert-built-stylesheet.md
+++ b/docs/plans/assert-built-stylesheet.md
@@ -1,0 +1,158 @@
+# Plan: a gate row that asserts the built stylesheet
+
+Status: agreed 2026-08-14. Issue #23. Follow-up from PR #22 (issue #15).
+
+## The problem, from the point of view of someone working here
+
+Several PRs in this repo verified a Tailwind utility by looking for it in the
+built stylesheet: if the class compiles to real declarations it is there, and if
+the utility silently resolved to nothing it is not. PR #22 made that reading
+trustworthy again by stopping `docs/` and `.design/` from feeding Tailwind's
+source detection, so a class name written in prose no longer compiles into the
+shipped CSS.
+
+Nothing enforces any of it. `scripts/gates.mjs` has rows for format, lint,
+typecheck, test and build; none of them looks at what the build produced. Delete
+the two `@source not` lines from `src/app/globals.css`, or add a new prose
+directory, and `npm run gate` is still green. PR #22 was merged knowingly
+without this test and said so in its body rather than letting the omission pass
+unnoticed. This is that omission.
+
+Two things make the check worth encoding in code rather than prose.
+
+**The path in prose was already wrong.** Issue #15 told a reader to check
+`.next/static/css/*.css`. That directory does not exist — Next 16 emits app CSS
+to `.next/static/chunks/*.css`. A grep against a missing path matches nothing,
+which reads exactly like "the class is absent": the precise false pass the check
+exists to eliminate.
+
+**Absence alone proves nothing.** "`snap-none` is not in the built CSS" is also
+satisfied by an exclusion so broad it compiled no utilities at all. The
+assertion has to be two-sided.
+
+## The solution
+
+A `stylesheet` row in the gate table, after `build`, running
+`node scripts/check-built-css.mjs`. It reads every `.css` file the build emitted
+and asserts both directions:
+
+- **absent:** `snap-none` appears nowhere. It is in no file under `src/`; its
+  only occurrences are two lines of prose in
+  `docs/plans/section-snapping.md`, which planned `motion-reduce:snap-none` for
+  a snapping model the implementation ended up expressing with `motion-safe:`
+  variants instead. If it reappears in the built CSS, a directory outside the
+  app is feeding Tailwind's scanner again.
+- **present, emitting declarations:** `justify-center-safe`, `min-h-footer` and
+  `scroll-pt-nav-sm` each compile to at least one rule with at least one
+  declaration in its body — not merely appear as a substring.
+
+The row prints the rules it matched, so a green run is evidence rather than an
+assertion. If no stylesheet is found the row FAILS. It does not skip: the state
+it needs is produced by the gate run itself two rows earlier, so absence is a
+failure, not an unavailable machine. CLAUDE.md's skip clause is for state a
+fresh clone lacks, which this is not.
+
+## Implementation decisions
+
+**A Node script the row invokes, not an inline shell command.** The obvious
+one-liner is the issue's own
+`grep -o 'justify-center-safe{[^}]*}' ... | sort -u`. Rejected: this repo is
+developed on Windows/PowerShell as well as bash, `grep`, `sort` and glob
+expansion are not portable across those shells, and the `command` string in the
+table is not a place a regression test can reach. A script is the same shape as
+everything else in `scripts/`.
+
+**The path is globbed, never hardcoded to one filename.** The chunk file is
+content-hashed (`0-xeu_cey1th1.css` today), so naming it would break on the next
+build. The row walks `.next/static` recursively for `*.css` rather than
+`.next/static/chunks` specifically — the drift that prompted this issue was
+Next moving app CSS between subdirectories of `.next/static`, and a walk from
+the parent survives it. Finding zero files fails.
+
+**A class token, not a substring.** `min-h-footer` and `justify-center-safe` are
+used in `src/` only under the `md:` variant, so the built selectors are
+`.md\:min-h-footer` and `.md\:justify-center-safe`. A matcher anchored on
+`.min-h-footer` would have reported the utility missing while it was present and
+working — the false failure that mirrors the false pass. The matcher accepts a
+class selector whose token _ends_ in the utility name, allowing variant
+prefixes, and requires the rule body to hold a declaration.
+
+**Two-sided by table, so adding an expectation is adding a row**, matching the
+gate table it hangs off. `FORBIDDEN` and `REQUIRED` each carry the reason the
+entry is there, and the reason is printed, so a failure explains itself.
+
+**No new dependency and no ADR.** ADR 0002 already records why the gate runner
+is a Node script with a table and why the verdict logic is separated from the
+plumbing; this row follows that decision rather than making a new one.
+
+## Test seams
+
+The seam is the directory. `scripts/built-css.mjs` holds the expectation tables,
+the class matcher and the audit; the only filesystem call takes the directory to
+read as an argument, so every test runs against a temp directory of synthetic
+CSS instead of a real build. That gives direct tests of the three cases the real
+build cannot produce on demand:
+
+- a required utility present only as a substring (a comment, a prefix of a
+  longer name) or with an empty rule body — must FAIL,
+- a forbidden utility present — must FAIL,
+- no stylesheet at all — must FAIL, not skip.
+
+`scripts/check-built-css.mjs` is the entry point and stays thin — resolve, read,
+print, exit — for the same reason `run-gates.mjs` does (ADR 0002): it is the
+part that cannot be tested without faking the OS, so it is kept small enough to
+read in one sitting. Its uncovered lines show in the coverage ratio in plain
+sight rather than being excluded.
+
+The table ordering is itself a test in `gates.test.mjs`: the row is meaningless
+before `build` has run, and nothing else in the table states that dependency.
+
+## Slices
+
+One implementation slice, after the plan commit.
+
+1. **The plan.** This file.
+2. **The `stylesheet` gate row**, with the script it runs and that script's
+   tests. Splitting the script from the row would leave a first slice that
+   delivers a layer nothing reaches — the thing CLAUDE.md's vertical-slice rule
+   exists to prevent — and the whole change is under 200 lines.
+
+## Considered and rejected
+
+**An inline `grep` pipeline in the row's `command`.** Rejected above: not
+portable off bash, and untestable.
+
+**Putting the audit in `scripts/gates.mjs`.** That file is the gate table and
+the rules for reading it, and its header promises it touches neither processes
+nor the filesystem. Stylesheet knowledge does not belong to it.
+
+**Asserting the exact declaration text** (`min-height:var(--spacing-footer)`).
+Rejected: it would pin the row to Tailwind's minifier output and to the token's
+current value, so an unrelated rename of `--spacing-footer` fails a gate that is
+supposed to be about whether the utility compiled at all. "At least one
+declaration" is the property that matters.
+
+**A `mustFail` companion row that deletes the `@source not` lines and expects
+the gate to fail.** It is the only way to prove the exclusions are what keeps
+`snap-none` out, but it means mutating a tracked file during a gate run.
+Rejected as too invasive for the value; the forbidden-class assertion catches
+the same regression from the other side.
+
+## Out of scope
+
+- **`src/app/globals.css`.** The `@source not` lines are not touched here.
+  Changing the exclusions is issue #24.
+- **Proving a component _uses_ a utility.** Tailwind scans comments in `src/`
+  too — the bare `.justify-center-safe` rule in today's output comes from the
+  JSDoc in `SnapSection.tsx` that explains the choice, not from a `className`.
+  This row proves a utility compiles to real CSS; that a component carries the
+  class is asserted by the component tests (`SnapSection.test.tsx`,
+  `layout.test.tsx`).
+- **Any other build output** — HTML, JS, the route manifest. One property, one
+  row.
+- **The intermittent 5s test-timeout flake under parallel jsdom boot**
+  (issue #9). Not touched.
+
+## Addenda
+
+<!-- Dated entries when the plan changes. Never rewrite the above. -->

--- a/scripts/built-css.mjs
+++ b/scripts/built-css.mjs
@@ -1,0 +1,204 @@
+/**
+ * What the built stylesheet must and must not contain, and the reading of it.
+ *
+ * Tailwind compiles a utility only when it finds the class name in a scanned
+ * source, so the built stylesheet is where you learn whether a utility emits
+ * real CSS or silently resolves to nothing. That reading only holds while
+ * nothing outside the app feeds the scanner, which is what the `@source not`
+ * lines in src/app/globals.css are for. Both directions are asserted here:
+ * absence alone is also satisfied by an exclusion that compiled nothing.
+ *
+ * The only filesystem call takes the directory to read as an argument, so the
+ * whole file is tested against a temp directory rather than a real build. Add
+ * an expectation by adding a row. See docs/plans/assert-built-stylesheet.md.
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Where `next build` leaves the app's CSS. The chunk filename is
+ * content-hashed, and Next 16 moved app CSS from `css/` to `chunks/` inside
+ * this directory — which is the drift that made the prose version of this
+ * check silently match nothing — so the walk starts one level above both.
+ */
+export const STYLESHEET_ROOT = ".next/static";
+
+/**
+ * An expectation names its utility in segments rather than as a whole class
+ * name, and `scripts/` is the reason: Tailwind's automatic source detection
+ * scans this directory exactly as it scanned `docs/` before PR #22, so a
+ * literal class name written here compiles into the very stylesheet this file
+ * reads. That does not merely fail the row, it empties it — the forbidden name
+ * would be present because this table names it, and the required ones would
+ * emit from this table rather than from the app. No segment below is a
+ * Tailwind utility on its own, so nothing compiles from them.
+ *
+ * `built-css.test.mjs` walks scripts/ and fails if any file spells one of
+ * these names, so this stays true without anyone having to remember it.
+ *
+ * Issue #24 proposes replacing the exclusions with a positive `@source` for
+ * `src/`, which inverts detection to opt-in and covers this directory. When it
+ * lands, delete that test and make these plain strings.
+ *
+ * @typedef {object} Expectation
+ * @property {string[]} segments  The class name, split so no part is a utility.
+ * @property {string} why         Printed with the row, so a failure explains itself.
+ */
+
+/** @param {Expectation} expectation @returns {string} */
+export function utilityName({ segments }) {
+  return segments.join("-");
+}
+
+/** Utilities that must appear nowhere in the built stylesheet. */
+/** @type {Expectation[]} */
+export const FORBIDDEN = [
+  {
+    segments: ["snap", "none"],
+    why: "in no file under src/; only prose in docs/plans/section-snapping.md, so its return means a directory outside the app is feeding Tailwind's scanner",
+  },
+];
+
+/** Utilities that must appear *and* emit at least one declaration. */
+/** @type {Expectation[]} */
+export const REQUIRED = [
+  {
+    segments: ["justify", "center", "safe"],
+    why: "SnapSection centres a stop's content with it, and safe centring is what keeps an over-tall section reachable",
+  },
+  {
+    segments: ["min", "h", "footer"],
+    why: "Footer takes its height from the --spacing-footer token through it",
+  },
+  {
+    segments: ["scroll", "pt", "nav", "sm"],
+    why: "the root element offsets every snap stop by the nav height with it",
+  },
+];
+
+/** A rule body counts as emitting CSS only if it holds a declaration. */
+const DECLARATION = /[\w-]+\s*:\s*\S/;
+
+/**
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeForRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Every rule in `css` whose selector carries this utility as a class token and
+ * whose body holds at least one declaration.
+ *
+ * The token may be variant-prefixed: two of the required utilities are used in
+ * src/ only under `md:`, so the built selector escapes the variant into the
+ * class name and a matcher anchored on a leading dot would report a working
+ * utility as missing. Matching a bare substring instead would count a mention
+ * in a comment as a pass, which is the failure this whole check exists to
+ * remove.
+ *
+ * @param {string} css
+ * @param {string} utility
+ * @returns {string[]} The matched rules, verbatim, for printing as evidence.
+ */
+export function rulesFor(css, utility) {
+  const rule = new RegExp(
+    `\\.[^{}(),\\s]*?${escapeForRegExp(utility)}(?![\\w-])[^{}]*\\{([^{}]*)\\}`,
+    "g",
+  );
+
+  return [...css.matchAll(rule)]
+    .filter((match) => DECLARATION.test(match[1]))
+    .map((match) => match[0]);
+}
+
+/**
+ * @typedef {object} Stylesheet
+ * @property {string} path
+ * @property {string} css
+ */
+
+/**
+ * @typedef {object} Audit
+ * @property {boolean} ok
+ * @property {string[]} lines  What to print, whether it passed or failed.
+ */
+
+/**
+ * Read every expectation against the stylesheets the build emitted.
+ *
+ * @param {Stylesheet[]} stylesheets
+ * @returns {Audit}
+ */
+export function auditStylesheets(stylesheets) {
+  // Not a skip: this row runs after `build` in the same gate run, so nothing
+  // to read means the build produced nothing to read. Reporting it as anything
+  // but a failure reproduces the false pass the row exists to eliminate.
+  if (stylesheets.length === 0) {
+    return {
+      ok: false,
+      lines: ["FAIL  no stylesheet to read — did `npm run build` produce one?"],
+    };
+  }
+
+  const css = stylesheets.map((sheet) => sheet.css).join("\n");
+  const lines = stylesheets.map((sheet) => `read  ${sheet.path}`);
+  let ok = true;
+
+  for (const expectation of FORBIDDEN) {
+    const utility = utilityName(expectation);
+    if (css.includes(utility)) {
+      ok = false;
+      lines.push(`FAIL  ${utility} is in the built CSS — ${expectation.why}`);
+    } else {
+      lines.push(`ok    ${utility} absent`);
+    }
+  }
+
+  for (const expectation of REQUIRED) {
+    const utility = utilityName(expectation);
+    const rules = rulesFor(css, utility);
+    if (rules.length === 0) {
+      ok = false;
+      lines.push(`FAIL  ${utility} emits no declarations — ${expectation.why}`);
+    } else {
+      for (const rule of rules) lines.push(`ok    ${rule}`);
+    }
+  }
+
+  return { ok, lines };
+}
+
+/**
+ * Every `.css` file under `directory`, at any depth, in a stable order.
+ * A missing directory yields none, which `auditStylesheets` fails on.
+ *
+ * @param {string} directory
+ * @returns {string[]}
+ */
+export function findStylesheets(directory) {
+  if (!existsSync(directory)) return [];
+
+  const found = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) found.push(...findStylesheets(path));
+    else if (entry.name.endsWith(".css")) found.push(path);
+  }
+
+  return found.sort();
+}
+
+/**
+ * @param {string} directory
+ * @returns {Audit}
+ */
+export function checkBuiltCss(directory) {
+  const stylesheets = findStylesheets(directory).map((path) => ({
+    path,
+    css: readFileSync(path, "utf8"),
+  }));
+
+  return auditStylesheets(stylesheets);
+}

--- a/scripts/built-css.test.mjs
+++ b/scripts/built-css.test.mjs
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  FORBIDDEN,
+  REQUIRED,
+  auditStylesheets,
+  checkBuiltCss,
+  findStylesheets,
+  rulesFor,
+  utilityName,
+} from "./built-css.mjs";
+
+// Utilities are named in segments in the table under test, so the literals
+// here are invented ones that Tailwind compiles to nothing. Spelling a real
+// one would put it in the shipped stylesheet — see the guard test at the foot
+// of this file.
+const PROBE = "gate-probe";
+
+/** A stylesheet that satisfies every expectation, so tests can break one. */
+const compiled = () =>
+  [
+    ...REQUIRED.map((expectation) => `.${utilityName(expectation)}{color:red}`),
+    ".unrelated{display:block}",
+  ].join("");
+
+const sheet = (css) => [{ path: "built.css", css }];
+
+const temporary = [];
+
+/** A throwaway build directory, so the filesystem walk is tested for real. */
+const buildDirectory = (files) => {
+  const root = mkdtempSync(join(tmpdir(), "built-css-"));
+  temporary.push(root);
+  for (const [path, contents] of Object.entries(files)) {
+    const full = join(root, path);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, contents);
+  }
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporary.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("rulesFor", () => {
+  test("finds a bare utility and returns the rule as evidence", () => {
+    expect(rulesFor(`.${PROBE}{min-height:var(--x)}`, PROBE)).toEqual([
+      `.${PROBE}{min-height:var(--x)}`,
+    ]);
+  });
+
+  // Two of the required utilities are written in src/ only under md:, so this
+  // is the real build's shape. A matcher anchored on a leading dot would call
+  // a working utility missing.
+  test("finds a variant-prefixed utility", () => {
+    expect(rulesFor(`.md\\:${PROBE}{min-height:var(--x)}`, PROBE)).toEqual([
+      `.md\\:${PROBE}{min-height:var(--x)}`,
+    ]);
+  });
+
+  test("finds it inside an at-rule", () => {
+    expect(rulesFor(`@media (min-width:48rem){.${PROBE}{a:b}}`, PROBE)).toEqual(
+      [`.${PROBE}{a:b}`],
+    );
+  });
+
+  // The false pass the two-sided check exists to remove: the name is in the
+  // file, but no rule emits it.
+  test("ignores the name in a comment", () => {
+    expect(rulesFor(`/* ${PROBE} is a token */.other{a:b}`, PROBE)).toEqual([]);
+  });
+
+  test("ignores a rule whose body declares nothing", () => {
+    expect(rulesFor(`.${PROBE}{}`, PROBE)).toEqual([]);
+  });
+
+  test("does not accept a longer utility that starts with this one", () => {
+    expect(rulesFor(`.${PROBE}-2{min-height:1px}`, PROBE)).toEqual([]);
+  });
+
+  test("returns every matching rule, not just the first", () => {
+    expect(rulesFor(`.${PROBE}{c:d}.md\\:${PROBE}{c:d}`, PROBE)).toEqual([
+      `.${PROBE}{c:d}`,
+      `.md\\:${PROBE}{c:d}`,
+    ]);
+  });
+});
+
+describe("auditStylesheets", () => {
+  test("passes when every required utility emits declarations", () => {
+    expect(auditStylesheets(sheet(compiled())).ok).toBe(true);
+  });
+
+  test("fails when a required utility emits nothing", () => {
+    const utility = utilityName(REQUIRED[0]);
+    const css = compiled().replace(`.${utility}{color:red}`, "");
+    const { ok, lines } = auditStylesheets(sheet(css));
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toContain(
+      `FAIL  ${utility} emits no declarations`,
+    );
+  });
+
+  // Absence has to be asserted as well as presence: a broken exclusion is how
+  // prose gets back into the shipped stylesheet.
+  test("fails when a forbidden utility is present", () => {
+    const utility = utilityName(FORBIDDEN[0]);
+    const { ok, lines } = auditStylesheets(
+      sheet(`${compiled()}.${utility}{scroll-snap-type:none}`),
+    );
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toContain(`FAIL  ${utility} is in the built CSS`);
+  });
+
+  test("fails on a forbidden utility mentioned anywhere, rule or not", () => {
+    const utility = utilityName(FORBIDDEN[0]);
+    expect(auditStylesheets(sheet(`${compiled()}/* ${utility} */`)).ok).toBe(
+      false,
+    );
+  });
+
+  // The failure this row exists for: a grep against a path that no longer
+  // exists reads exactly like "the class is absent".
+  test("fails, rather than passing vacuously, when there is nothing to read", () => {
+    const { ok, lines } = auditStylesheets([]);
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toContain("no stylesheet to read");
+  });
+
+  test("reads every stylesheet, not only the first", () => {
+    const split = REQUIRED.map((expectation, index) => ({
+      path: `${index}.css`,
+      css: `.${utilityName(expectation)}{color:red}`,
+    }));
+
+    expect(auditStylesheets(split).ok).toBe(true);
+  });
+
+  test("names the files it read", () => {
+    const { lines } = auditStylesheets(sheet(compiled()));
+    expect(lines[0]).toBe("read  built.css");
+  });
+
+  // An empty table would make the row green while asserting nothing at all.
+  test("both expectation tables have rows", () => {
+    expect(FORBIDDEN.length).toBeGreaterThan(0);
+    expect(REQUIRED.length).toBeGreaterThan(0);
+  });
+});
+
+describe("findStylesheets", () => {
+  // The filename is content-hashed and the subdirectory has moved once
+  // already, so the walk has to find CSS wherever under the root it landed.
+  test("finds css at any depth, in a stable order", () => {
+    const root = buildDirectory({
+      "chunks/b.css": "",
+      "chunks/nested/a.css": "",
+      "media/logo.svg": "",
+      "chunks/app.js": "",
+    });
+
+    expect(findStylesheets(root)).toEqual([
+      join(root, "chunks", "b.css"),
+      join(root, "chunks", "nested", "a.css"),
+    ]);
+  });
+
+  test("a missing directory yields nothing rather than throwing", () => {
+    expect(
+      findStylesheets(join(tmpdir(), "built-css-absent-directory")),
+    ).toEqual([]);
+  });
+});
+
+describe("checkBuiltCss", () => {
+  test("passes on a build directory whose css satisfies the table", () => {
+    const root = buildDirectory({ "chunks/0-hash.css": compiled() });
+    expect(checkBuiltCss(root).ok).toBe(true);
+  });
+
+  test("fails on a build directory with no css at all", () => {
+    const root = buildDirectory({ "chunks/app.js": "" });
+    const { ok, lines } = checkBuiltCss(root);
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toContain("no stylesheet to read");
+  });
+});
+
+// The regression that made this row assert nothing on its first run: Tailwind
+// scans scripts/, so a utility named here in full compiles into the stylesheet
+// this row reads. The forbidden one then always fails and the required ones
+// always pass, whatever the app does. Names are built at runtime for the same
+// reason. Delete this once issue #24 makes source detection opt-in for src/.
+describe("the checker's own sources", () => {
+  test("no file under scripts/ spells a utility the table checks", () => {
+    // import.meta.dirname, not a URL derived from import.meta.url: the jsdom
+    // environment shadows the global URL, and Node's fileURLToPath rejects
+    // what jsdom's constructor returns for a file: URL.
+    const directory = import.meta.dirname;
+    const utilities = [...FORBIDDEN, ...REQUIRED].map(utilityName);
+    const offenders = [];
+
+    for (const name of readdirSync(directory)) {
+      if (!name.endsWith(".mjs")) continue;
+      const source = readFileSync(join(directory, name), "utf8");
+      for (const utility of utilities) {
+        if (source.includes(utility)) offenders.push(`${name}: ${utility}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/scripts/check-built-css.mjs
+++ b/scripts/check-built-css.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+/**
+ * The `stylesheet` gate row: asserts what `next build` actually emitted.
+ *
+ * Entry-point plumbing only — resolve, print, exit. Everything that decides
+ * the verdict lives in built-css.mjs, where it is unit-tested against a temp
+ * directory (ADR 0002, same split as run-gates.mjs and gates.mjs).
+ */
+import { checkBuiltCss, STYLESHEET_ROOT } from "./built-css.mjs";
+
+const { ok, lines } = checkBuiltCss(STYLESHEET_ROOT);
+
+console.log(lines.join("\n"));
+process.exit(ok ? 0 : 1);

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -27,6 +27,10 @@ export const GATES = [
   // CLAUDE.md says this command must fail.
   { name: "test", command: "npm run test:coverage" },
   { name: "build", command: "npm run build" },
+  // Reads what the build just emitted, so it has to follow it. Not a skip when
+  // the stylesheet is missing: the state it needs is produced by the row above,
+  // so absence is a failure. See docs/plans/assert-built-stylesheet.md.
+  { name: "stylesheet", command: "node scripts/check-built-css.mjs" },
 ];
 
 /**

--- a/scripts/gates.test.mjs
+++ b/scripts/gates.test.mjs
@@ -138,4 +138,14 @@ describe("the gate table", () => {
     const names = GATES.map((entry) => entry.name);
     expect(new Set(names).size).toBe(names.length);
   });
+
+  // The stylesheet row reads what the build emitted, and nothing else in the
+  // table states that dependency. Ahead of build it would read a stale
+  // stylesheet, or none — see the 2026-08-11 addendum in
+  // docs/plans/gate-command.md for the last time an ordering assumption that
+  // no row stated cost a CI run.
+  test("the stylesheet row runs after the build that produces its input", () => {
+    const order = GATES.map((entry) => entry.name);
+    expect(order.indexOf("stylesheet")).toBeGreaterThan(order.indexOf("build"));
+  });
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -22,14 +22,14 @@ export default defineConfig({
       //      (see docs/adr/0002);
       //   2. covered code was deleted, which pulls the whole-project ratio
       //      toward the 0% plumbing even though no test was lost.
-      // Nothing is excluded to flatter the number: run-gates.mjs and
-      // run-vitest.mjs sit at 0% on purpose, and both drag these figures down
-      // in plain sight rather than quietly.
+      // Nothing is excluded to flatter the number: run-gates.mjs,
+      // run-vitest.mjs and check-built-css.mjs sit at 0% on purpose, and all
+      // three drag these figures down in plain sight rather than quietly.
       thresholds: {
-        statements: 72.99,
-        branches: 80.48,
-        functions: 86.79,
-        lines: 75.39,
+        statements: 78.83,
+        branches: 81.81,
+        functions: 89.06,
+        lines: 79.76,
       },
     },
   },


### PR DESCRIPTION
Closes #23

Adds a `stylesheet` gate row that reads what `next build` emitted and asserts
both directions of the property PR #22 restored but left unenforced.

Plan: `docs/plans/assert-built-stylesheet.md`.

## Slices

1. **`Plan the gate row that asserts the built stylesheet`** — the plan file.
2. **`Record that the checker fed itself into the stylesheet`** — a dated
   addendum, written when verification broke the plan (see below).
3. **`Add a stylesheet gate row asserting the built CSS`** — the row, the
   script it runs, and their tests.
4. **`Raise the coverage floor to what the repo now achieves`** — the ratchet
   `vitest.config.mts` asks for when coverage rises.

## What the row does

- **Globs, never names a file.** It walks `.next/static` recursively for
  `*.css`. Issue #15's prose said `.next/static/css/*.css`, which Next 16 does
  not emit, and the chunk filename is content-hashed. Starting a level above
  `chunks/` survives the relocation that made the prose version silently match
  nothing.
- **Fails, does not skip, when there is no stylesheet.** The state it needs is
  produced by the `build` row directly above it, so absence is a failure.
  CLAUDE.md's skip clause is for state a fresh clone lacks; this is not that.
- **Matches a class token, not a substring.** `min-h-footer` and
  `justify-center-safe` are written in `src/` only under `md:`, so the built
  selectors are `.md\:min-h-footer` and `.md\:justify-center-safe`. A matcher
  anchored on a leading dot would have reported a working utility as missing.
  A rule only counts if its body holds a declaration, so a name in a comment is
  not a pass.
- **A Node script, not an inline shell command.** The issue's
  `grep -o … | sort -u` is bash-only and this repo is also developed on
  Windows/PowerShell; a `command` string is also not somewhere a regression
  test can reach. Same split as `run-gates.mjs`/`gates.mjs` (ADR 0002): logic in
  `scripts/built-css.mjs`, tested against temp directories;
  `scripts/check-built-css.mjs` is thin plumbing.

## The bug verification found — in this PR's own first run

The row failed the first time it ran, and it was right to:

```
  FAIL  stylesheet

--- stylesheet ---
read  .next\static\chunks\1bf95eurh02pa.css
FAIL  snap-none is in the built CSS — in no file under src/; only prose in docs/plans/section-snapping.md, …
ok    .justify-center-safe{justify-content:safe center}
ok    .md\:justify-center-safe{justify-content:safe center}
ok    .min-h-footer{min-height:var(--spacing-footer)}
ok    .md\:min-h-footer{min-height:var(--spacing-footer)}
ok    .scroll-pt-nav-sm{scroll-padding-top:var(--spacing-nav-sm)}
```

`scripts/` feeds Tailwind's source detection exactly as `docs/` and `.design/`
did before PR #22. Writing the utility names into the checker compiled them
into the build the checker then read: `.snap-none{scroll-snap-type:none}` was in
the output for the first time, and the bare `.min-h-footer` rule beside the
`md:` one had not been there an hour before.

That is worse than a failing row — it makes the row assert **nothing**. The
forbidden name is present because the checker names it; the required ones emit
because the checker names them. The check would stay green after the app
stopped using any of them.

The obvious fix is a third `@source not` line for `scripts/`. `globals.css` is
out of scope here by decision — the exclusions are issue #24's, which proposes
replacing them with a positive `@source "../../src"` (opt-in rather than
opt-out), and that covers `scripts/` too. So instead the table spells each
utility in segments (`["snap", "none"]`) joined at runtime, no file under
`scripts/` contains a whole utility name including comments, and a test walks
`scripts/*.mjs` and fails if one appears. **When #24 lands, delete that test and
make the segments plain strings.**

This also upgrades #24: it records the hazard as latent, and `scripts/` is a
live instance it does not mention.

It is also the strongest evidence available that the row can fail for the
reason it exists: a directory outside the app fed the scanner, and the row
caught it — the same failure mode a deleted `@source not` line would produce.

## Gate output

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

The `stylesheet` row's own evidence (the runner prints only failing rows, so
this is the same command run on its own):

```
$ node scripts/check-built-css.mjs
read  .next\static\chunks\0-xeu_cey1th1.css
ok    snap-none absent
ok    .justify-center-safe{justify-content:safe center}
ok    .md\:justify-center-safe{justify-content:safe center}
ok    .md\:min-h-footer{min-height:var(--spacing-footer)}
ok    .scroll-pt-nav-sm{scroll-padding-top:var(--spacing-nav-sm)}
```

Note the chunk hash is back to `0-xeu_cey1th1.css` — byte-identical to the
build from before any of this work — and the two rules the checker had been
generating for itself are gone.

Coverage, which sets the raised floor:

```
Statements   : 78.83% ( 149/189 )
Branches     : 81.81% ( 45/55 )
Functions    : 89.06% ( 57/64 )
Lines        : 79.76% ( 134/168 )
```

The guard test was verified to fail, not merely to pass: dropping a file into
`scripts/` containing a literal `snap-none` produced

```
+ [
+   "guard-probe.mjs: snap-none",
+ ]
```

before it was deleted.

## What I did not do

- **`src/app/globals.css` is untouched**, including the `@source not` line for
  `scripts/` that this PR's own failure argues for. That file belongs to #24.
  The workaround above is documented in the plan and in the module, and is
  meant to be deleted when #24 lands.
- **No `mustFail` companion row** that deletes the `@source not` lines and
  expects a failure. It is the only way to prove those lines are what keeps
  `snap-none` out, but it means mutating a tracked file during a gate run.
  Rejected as too invasive; the accidental proof above covers the same ground.
- **I did not verify by hand what the row would report with the exclusions
  removed.** That means editing the out-of-scope file, so the accidental
  reproduction stands in its place.
- **Nothing touching `vitest.config.mts` timeouts or issue #9.** The flake did
  not appear in any run here — every `npm run gate` in this branch passed
  first time.
- **Proving a component *uses* a utility** is still out of reach and out of
  scope: Tailwind scans comments in `src/` too, which is why a bare
  `.justify-center-safe` rule exists at all — it comes from the JSDoc in
  `SnapSection.tsx`. That a component carries the class stays the component
  tests' job.

No open `TODO(verify)` items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
