### PR TITLE
Bring the nav's touch targets to 44px below md

### DIFF
--- a/docs/adr/0004-touch-target-sizes.md
+++ b/docs/adr/0004-touch-target-sizes.md
@@ -1,0 +1,85 @@
+# 0004 — Touch targets are 44px below `md`, 24px above it
+
+Date: 2026-08-14. Status: accepted.
+
+## Context
+
+Two design reviews reported the nav links as "~30px tall, below the 44px
+guideline" — finding 5 of `DESIGN_REVIEW-2026-08-11.md`, then finding 9 of
+`DESIGN_REVIEW.md` — and nothing happened either time. Part of why nothing
+happened is that "the 44px guideline" names no criterion, so there was no
+way to tell whether the nav was failing a requirement or missing an
+aspiration, and therefore no way to argue about what it was worth breaking to
+fix it.
+
+It also turned out the figure was wrong. The links are about 15px tall, not
+30 (`text-[9px]` at Montserrat's normal line-height, plus `pb-0.5`, plus
+`border-b-2`; the anchor is inline-level in a flex container with no
+`items-*`, so nothing stretches it). 30px would have cleared WCAG 2.2 AA;
+15px does not. A vague standard let a criterion failure be recorded twice as
+a style note.
+
+WCAG 2.2 has two target-size criteria, and the difference is the whole
+question:
+
+- **2.5.8 Target Size (Minimum)**, level **AA**: 24×24 CSS px, with an
+  exception for undersized targets that are far enough apart.
+- **2.5.5 Target Size (Enhanced)**, level **AAA**: 44×44. Apple's HIG gives
+  the same number for touch.
+
+The site already has 44px in it: the gallery controls added in PR #14 are
+`size-11`. So the choice is not between a standard and nothing; it is
+between one standard and two.
+
+## Decision
+
+**44×44 below `md`. 24×24 at `md` and above.**
+
+A pointer is a finger below `md` and a mouse above it, and the two are not
+the same instrument. This is written as a breakpoint rule rather than a
+pointer-media-query rule because the layout already branches at `md` and a
+second, invisible axis of variation would be worse than a slightly blunt
+one.
+
+Where an element has no background, it takes 44px at every breakpoint — the
+box growing is invisible, so there is nothing to buy by restricting it.
+Where an element is a visible shape, it takes 44 only below `md`, because
+growing it above `md` is a redesign.
+
+## Consequences
+
+The reviews get a criterion to cite instead of a number, and this repo gets
+a fact about itself that is true or false rather than better or worse.
+
+Adopting AAA for touch and AA for pointer is deliberately mixed, and the
+honest reason is cost, not principle: 44px on a phone is affordable and 44px
+on desktop would force visible changes to compositions that are finished.
+Anyone revisiting this should know it was a trade and not a reading of the
+spec.
+
+**The gate cannot check this.** jsdom applies no stylesheets (ADR-0001), so
+no test can measure a rendered box, and this ADR therefore describes a
+property that is asserted by a human looking at a screen. The compromise is
+to name the target in one place — a shared constant composed by every
+interactive element in a component — so tests can assert that each element
+_refers to_ the standard even though they cannot confirm it holds. That
+catches the failure this repo actually has, which is drift: an element added
+later without the class. It does not catch the class being wrong. Closing
+that gap means Playwright, and is the same gap ADR-0001 and ADR-0003 already
+record.
+
+**WCAG 1.4.10 Reflow is at the same level and pulls the other way.** It
+requires the page to work at 320 CSS px, which is also what a reader gets at
+400% zoom on a 1280px screen. Targets grown to 44px are wider as well as
+taller, and at 320px the nav's four labels already cannot share a row. The
+resolution is that nothing in the nav is a fixed height — every height is
+`min-h`, per ADR-0003 — so content that no longer fits grows its container
+instead of being clipped or hidden. A bar that is taller than its token at
+320px is a visible degradation; a link scrolled off the edge of a row is an
+invisible one. This decision prefers the visible failure, and that
+preference is the part most likely to be re-litigated.
+
+`PillLink` does not meet this standard: `text-sm` with `py-3.25` comes to
+about 41px, across eleven call sites (issue #30). The standard is adopted
+knowing one shared component already violates it, rather than being narrowed
+until everything passes.

--- a/docs/plans/nav-touch-targets.md
+++ b/docs/plans/nav-touch-targets.md
@@ -1,0 +1,204 @@
+# Nav touch targets
+
+Issue: #18. Supersedes nothing; builds on `docs/adr/0003-nav-in-document-flow.md`.
+
+## Problem, from the user's point of view
+
+On a phone the four nav links are almost impossible to hit. They are 9px
+uppercase text with 2px of bottom padding and a 2px border, so the tappable
+box is about the height of the text itself — a reader aiming for "Tuesday
+Co-op" hits nothing at all, or hits the link above it. The row also runs
+edge to edge, so the outer two links sit against the screen bezel, and it is
+crowded up against the logo and the Book Now pill with 8px between them.
+
+The Book Now pill has the same defect and matters more, because it is the
+one thing the page is asking a visitor to do.
+
+This has survived two design reviews — finding 5 of
+`DESIGN_REVIEW-2026-08-11.md` and finding 9 of `DESIGN_REVIEW.md` — because
+no gate can see a rendered layout (ADR-0001) and a human had to decide
+whether the fix was worth what it costs.
+
+### Correction to the recorded figure
+
+Both reviews record the links as "~30px tall". By arithmetic from the class
+list — `text-[9px]` at Montserrat's normal line-height (≈1.22) = 11px, plus
+`pb-0.5` = 2px, plus `border-b-2` = 2px — the box is about **15px**. The
+anchor is an inline-level box in a flex container with no `items-*`, so
+nothing stretches it.
+
+The direction of the error matters. 30px clears WCAG 2.2 AA 2.5.8 (24×24);
+15px does not, and the spacing exception cannot rescue it because the pill
+sits 8px above. The reviews under-reported a criterion failure as a
+guideline miss.
+
+The reviews are dated artifacts and are **not** rewritten. The corrected
+figure lives here and in the PR body.
+
+`TODO(verify)`: every dimension in this plan is arithmetic from the class
+list and Montserrat's metrics. Nothing was measured in a browser, because
+the repo has no browser tooling. Confirm at 375px before the final commit.
+
+## Solution
+
+Below `md`, every interactive element in the nav is at least 44×44. The bar
+grows from 90px to 116px to hold them, the mobile gutter comes into line
+with the rest of the site, and the links stop hugging the screen edges.
+
+At `md` and above the nav renders exactly as it does today.
+
+## Implementation decisions
+
+- **44 below `md`, 24 at `md` and above.** WCAG 2.5.5 (AAA) / Apple HIG
+  where a finger is doing the pointing; WCAG 2.5.8 (AA) where a mouse is.
+  Recorded as ADR-0004, because it is the criterion every later target-size
+  question gets measured against — starting with `PillLink`. Rejected: 44
+  everywhere, which buys nothing on desktop that 24 does not already give
+  and would force a visible redesign of an approved layout; and 24
+  everywhere, which is the floor rather than the standard on the device
+  where this actually goes wrong.
+
+- **The anchor becomes the target; an inner `<span>` keeps the underline.**
+  The active and hover indicator is `border-b-2` on the anchor, which is at
+  the anchor's box edge by definition — pad the anchor to 44px and the
+  yellow rule under the current page drifts ~14px below the text. Moving the
+  border to a child keeps the existing idiom
+  (`border-transparent` → `border-yellow`) and keeps the rule against the
+  text at every size. The anchor takes `group`, the span takes
+  `group-hover:` and `group-aria-[current=page]:`, so hovering the new
+  padding lights the underline; without that the enlarged target would
+  respond only over the glyphs, which reads as broken. Rejected:
+  `text-decoration` with `underline-offset`, which works and needs no extra
+  node but abandons the border idiom the repo already uses; letting the rule
+  fall to the bottom of the 44px box, which is a legitimate tab-bar look but
+  is a redesign of the active state nobody asked for; and an
+  absolutely-positioned `after:` hit area, which leaves the visuals
+  untouched but would overlap the pill's target 8px above — overlapping
+  targets are a worse defect than small ones.
+
+- **A shared `TOUCH_TARGET` constant**, `"flex min-h-11 items-center"`,
+  composed by both the links and the pill. The failure this repo actually
+  suffers is drift: a fifth link or a restyled pill silently shipping
+  without the target, exactly as the height offset drifted across six
+  modules before ADR-0003. One name means one place to be wrong, and the
+  test asserts every interactive child of the nav carries it.
+
+- **The pill takes `md:min-h-0`.** The links have no background, so their
+  box growing to 44px at `md` is invisible — the logo already sets that row
+  at 52px. The pill is a yellow capsule, so the same class would visibly
+  grow it from ~31px to 44px on a desktop layout that was signed off. It
+  already clears the 24px floor at 31px, so it takes 44 only below `md`.
+
+- **The mobile gutter goes `px-3` → `px-gutter-sm` (12px → 24px).** Every
+  other module in the repo uses `px-gutter-sm md:px-gutter`; the nav's
+  hand-rolled `px-3 md:px-8` is the only exception, and the 12px version is
+  what puts the outer links against the bezel. Only the mobile half changes:
+  bringing `md:px-8` to `md:px-gutter` would move the logo and pill 16px
+  inward on an approved layout, and belongs to its own issue.
+
+- **The slack is absorbed into the links, not left as gap.** At 375px a 24px
+  gutter leaves 327px for ~286px of text, so ~42px is spare. Spent as
+  `px-1.5` on each link with `-mx-1.5` on the container, the labels land
+  exactly where they would if it were spent as gap — flush with the 24px
+  gutter, ~6px of air between boxes — but the 44px boxes very nearly touch,
+  so no tap inside the row falls in a dead zone. Rejected: equal-width
+  columns (`flex-1`), which cannot work — 327/4 = 82px and "TUESDAY CO-OP"
+  is ~85px.
+
+- **Horizontal padding is reset at `md`** (`md:px-0 md:mx-0`, `md:gap-7`
+  unchanged). Keeping it and retuning the gap cannot reproduce today's
+  desktop exactly: the padding also adds 6px outside the first and last
+  links, so preserving the 28px text spacing widens the group by 12px and
+  shifts the outer labels apart under `justify-between`. `md` needs no
+  horizontal padding anyway — 44px of height already clears 24×24.
+
+- **`--spacing-nav-sm` 90px → 116px.** `8 + 44 + 12 + 44 + 8`: `py-2`, the
+  logo/pill row now set by the 44px pill, `gap-y-3` (up from `gap-y-2`,
+  which is the crowding in the issue), the link row, `py-2`. Per ADR-0003
+  the hero poster and `scroll-padding-top` subtract the same token, so both
+  follow with no module touched. `--spacing-nav` stays 84px: at `md` the
+  52px logo still sets the row and `14 + 52 + 14 = 80` is still under it.
+
+- **116px of sticky chrome on a phone is accepted.** It is 17.4% of a
+  375×667 screen and costs the poster 26px (577px → 551px, ~4.5%). There is
+  no cheaper shape: the 44px pill sets one row, the 44px links set the
+  other, and the issue asks for _more_ separation between them, so trimming
+  padding claws back 6px against the complaint that started this. Rejected:
+  a fixed bottom bar, which occupies no space and so puts back the
+  reserve-room-for-the-nav problem ADR-0003 deleted from six modules, costs
+  ~7% of every screen instead of 26px once, needs a `scroll-padding-bottom`
+  counterpart, and puts app chrome in competition with the page's primary
+  action; a hamburger, which hits every target trivially and would shrink
+  the bar to ~64px but hides a four-item IA behind a tap on a marketing site
+  and brings a stateful disclosure widget — `aria-expanded`, focus
+  management, Escape, outside-click, scroll lock — with it; `static md:sticky`,
+  which reclaims the reading area but makes Book Now unreachable mid-page on
+  the device where reaching it matters most; and shrinking the labels below
+  9px, which fixes tapping by making legibility worse.
+
+- **Below ~340px the links wrap to a third row.** Four labels cannot share a
+  row at any gutter down there — ~286px of text against 272px — and they
+  already spill today, where 286px of text plus 24px of gap exceeds the
+  296px available. `flex-wrap` stays, the bar grows to ~160px, and nothing
+  clips: every height in this nav is `min-h`, which ADR-0003 chose
+  deliberately so the bar could grow under text scaling rather than clip.
+  This matters because WCAG 1.4.10 Reflow is an AA criterion at 320px — the
+  same level as the target-size floor — and it is also what a reader gets at
+  400% zoom on a 1280px screen. The bar exceeding its token there is a known
+  and visible degradation, recorded rather than hidden. Rejected: a
+  horizontally scrollable row, which keeps the bar exactly its token but
+  puts a link off-screen with no affordance — `GalleryRow` needed explicit
+  controls for that reason and a nav has no room for them; and a custom
+  sub-375px breakpoint, which adds to the design system to move the failure
+  point from 340px to 330px.
+
+- No new dependencies. No new components. `NavLink` stays thin — it knows
+  about `aria-current` and nothing else.
+
+## Test seams
+
+Per ADR-0001, jsdom applies no stylesheets, so **the gate cannot assert the
+property this whole issue is about.** A test that the class list contains
+`min-h-11` proves someone typed `min-h-11`. It is worth saying plainly that
+this issue exists because class-contract tests did not catch the defect.
+
+- **Every interactive child of the nav carries `TOUCH_TARGET`.** Iterating
+  `getAllByRole("link")` rather than asserting a literal per element is what
+  makes this more than a tautology: it fails when a link is added or the
+  pill is restyled without the target, which is the drift that actually
+  happens.
+- **The indicator is on the inner span, not the anchor**, so the refactor
+  cannot silently regress into padding the underline away from the text.
+- **The existing `Nav.test.tsx` contract assertions stay green** — sticky,
+  not fixed, `min-h-nav-sm md:min-h-nav`. The refactor commit must not
+  disturb them.
+- **Outside the gate, needs a human in a browser:** that the targets measure
+  44px, that 116px does not spoil the poster at 375px, that `md` really is
+  unchanged, and the wrap behaviour at 320px. Inherited from ADR-0001;
+  closing it means Playwright, which is its own plan.
+- `npm run gate` green at every commit.
+
+## Slices
+
+1. This plan.
+2. `docs/adr/0004-touch-target-sizes.md` — 44 on touch, 24 on pointer.
+3. Move the nav link's indicator onto an inner span. No visual change; the
+   commit exists so the next one's diff is only about targets, and so a
+   revert of the token does not drag the refactor with it.
+4. Bring the nav's touch targets to 44px below `md`: `TOUCH_TARGET` on the
+   links and the pill, gutter to `px-gutter-sm`, slack absorbed as
+   `px-1.5`/`-mx-1.5`, `gap-y-3`, `--spacing-nav-sm` 90 → 116.
+
+Strictly ordered. Slice 3 before 4 because 4's padding is what would move
+the underline.
+
+## Out of scope
+
+- **`PillLink`'s ~41px.** `text-sm` + `py-3.25` misses the 44px floor across
+  eleven call sites, and growing it changes the hero and program-card
+  compositions this issue never looked at. Filed separately.
+- **The `md` gutter**, `md:px-8` → `md:px-gutter`. A real consistency defect,
+  but it moves an approved desktop layout and is not about touch targets.
+- **Playwright**, and the geometry gate that would actually verify this.
+- **A visible desktop redesign.** `md` and above render identically.
+- **The interest-list form's controls**, not audited here.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,7 +64,12 @@
      consumers (the hero poster's height, scroll-padding-top) tolerate being
      a few pixels under far better than the nav tolerates clipping. */
   --spacing-nav: 84px;
-  --spacing-nav-sm: 90px;
+  /* 8 + 44 + 12 + 44 + 8: py-2, the logo/pill row now set by the 44px pill,
+     gap-y-3, the link row, py-2. Both rows carry 44px touch targets below md
+     (ADR-0004), which is what took this from 90px. Below ~340px the links
+     wrap to a third row and the bar exceeds this; min-h means it grows
+     rather than clips, and the poster is min-h too, so it absorbs it. */
+  --spacing-nav-sm: 116px;
   /* Same inversion as the nav tokens: the footer takes its height from this
      rather than this describing whatever the footer happens to render at.
      The closing snap stop subtracts both, so quotes and footer share exactly

--- a/src/components/Nav.test.tsx
+++ b/src/components/Nav.test.tsx
@@ -63,6 +63,33 @@ test("the nav takes its height from the nav tokens", () => {
   expect(nav.className).toContain("md:min-h-nav");
 });
 
+test("the current-page underline sits on the label, not on the link box", () => {
+  render(<Nav />);
+
+  // A bottom border is drawn at its own element's box edge, so an indicator
+  // on the anchor would move with the touch target. Keeping it on an inner
+  // span is what lets the anchor grow to 44px without the yellow rule
+  // drifting below the text. group-* wiring is part of the contract: without
+  // it the enlarged target would respond only over the glyphs.
+  for (const name of [
+    "Art Classes",
+    "Tuesday Co-op",
+    "Conditions",
+    "Community",
+  ]) {
+    const link = screen.getByRole("link", { name });
+    const label = link.firstElementChild;
+
+    expect(link.className).not.toContain("border-b");
+    expect(link.classList.contains("group")).toBe(true);
+    expect(label?.className).toContain("border-b-2");
+    expect(label?.className).toContain("group-hover:border-yellow");
+    expect(label?.className).toContain(
+      "group-aria-[current=page]:border-yellow",
+    );
+  }
+});
+
 test("the logo slot is a labeled image placeholder", () => {
   render(<Nav />);
 

--- a/src/components/Nav.test.tsx
+++ b/src/components/Nav.test.tsx
@@ -63,6 +63,22 @@ test("the nav takes its height from the nav tokens", () => {
   expect(nav.className).toContain("md:min-h-nav");
 });
 
+test("every target in the nav carries the 44px touch target", () => {
+  render(<Nav />);
+
+  // Iterating every link rather than asserting a literal per element is the
+  // point: this fails when a fifth link is added or the pill is restyled
+  // without composing TOUCH_TARGET, which is the drift that actually happens.
+  // It cannot prove the rendered box is 44px -- jsdom applies no stylesheets
+  // (ADR-0001) -- so that stays a human check at 375px.
+  const links = screen.getAllByRole("link");
+  expect(links).toHaveLength(5);
+
+  for (const link of links) {
+    expect(link.className).toContain("min-h-11");
+  }
+});
+
 test("the current-page underline sits on the label, not on the link box", () => {
   render(<Nav />);
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,6 +1,12 @@
 import { NavLink } from "./NavLink";
 import { Placeholder } from "./Placeholder";
 
+// 44px, per ADR-0004. Named once and composed by every interactive element in
+// the bar, because the failure this repo has is drift -- a link added later
+// without it -- and one name is one place to be wrong. The gate can assert
+// that an element refers to this; it cannot assert the rendered box (ADR-0001).
+const TOUCH_TARGET = "flex min-h-11 items-center";
+
 const SECTION_LINKS = [
   { href: "/art", label: "Art Classes" },
   { href: "/coop", label: "Tuesday Co-op" },
@@ -16,7 +22,7 @@ export function Nav() {
     // sticky, not fixed: the nav occupies its own space, so no page has to
     // reserve any for it. min-h comes from the nav tokens, which is what
     // makes the hero's height and scroll-padding-top right by construction.
-    <nav className="min-h-nav-sm md:min-h-nav sticky top-0 z-50 flex flex-wrap items-center justify-between gap-y-2 border-b-2 border-purple bg-cream px-3 py-2.5 md:flex-nowrap md:px-8 md:py-3.5">
+    <nav className="min-h-nav-sm md:min-h-nav px-gutter-sm sticky top-0 z-50 flex flex-wrap items-center justify-between gap-y-3 border-b-2 border-purple bg-cream py-2 md:flex-nowrap md:px-8 md:py-3.5">
       <div className="size-10 shrink-0 overflow-hidden rounded-full md:size-13">
         <Placeholder
           label="Wild Coast Kids logo"
@@ -24,7 +30,13 @@ export function Nav() {
           labelClassName="min-h-0 p-1 text-[7px] leading-[1.15]"
         />
       </div>
-      <div className="order-last flex w-full flex-wrap justify-between gap-x-2 md:order-0 md:w-auto md:flex-nowrap md:justify-start md:gap-7">
+      {/* -mx-1.5 cancels the links' own padding at the ends of the row, so the
+          first and last labels stay flush with the gutter while their boxes
+          reach past it. Below md the boxes meet; the padding and the negative
+          margin both reset at md, where the row has room and 44px of height
+          already clears the 24px pointer floor. Wrapping to a third row below
+          ~340px is deliberate -- see ADR-0004. */}
+      <div className="order-last -mx-1.5 flex w-full flex-wrap justify-between md:order-0 md:mx-0 md:w-auto md:flex-nowrap md:justify-start md:gap-7">
         {SECTION_LINKS.map(({ href, label }) => (
           // The indicator is a bottom border, and a border is drawn at its
           // own element's box edge. On the anchor it would track the touch
@@ -34,7 +46,7 @@ export function Nav() {
           <NavLink
             key={href}
             href={href}
-            className="group text-[9px] font-extrabold tracking-wider whitespace-nowrap text-dark uppercase md:text-2xs"
+            className={`${TOUCH_TARGET} group px-1.5 text-[9px] font-extrabold tracking-wider whitespace-nowrap text-dark uppercase md:px-0 md:text-2xs`}
           >
             <span className="border-b-2 border-transparent pb-0.5 transition-colors duration-fast group-hover:border-yellow group-aria-[current=page]:border-yellow">
               {label}
@@ -42,9 +54,13 @@ export function Nav() {
           </NavLink>
         ))}
       </div>
+      {/* md:min-h-0 because the pill is a visible shape, not just a hit area:
+          at md the same 44px would grow the yellow capsule from ~31px, which
+          is a redesign rather than a fix. ~31px already clears the pointer
+          floor (ADR-0004). */}
       <NavLink
         href="/book"
-        className="rounded-pill shrink-0 bg-yellow px-3.5 py-2 text-2xs font-black tracking-[0.06em] whitespace-nowrap text-ink md:px-5.5 md:py-2.25 md:text-xs"
+        className={`${TOUCH_TARGET} rounded-pill shrink-0 bg-yellow px-3.5 text-2xs font-black tracking-[0.06em] whitespace-nowrap text-ink md:min-h-0 md:px-5.5 md:py-2.25 md:text-xs`}
       >
         Book Now →
       </NavLink>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -26,12 +26,19 @@ export function Nav() {
       </div>
       <div className="order-last flex w-full flex-wrap justify-between gap-x-2 md:order-0 md:w-auto md:flex-nowrap md:justify-start md:gap-7">
         {SECTION_LINKS.map(({ href, label }) => (
+          // The indicator is a bottom border, and a border is drawn at its
+          // own element's box edge. On the anchor it would track the touch
+          // target rather than the label; on an inner span it keeps hugging
+          // the text however large the target grows. group-* so the whole
+          // target lights the underline, not just the glyphs.
           <NavLink
             key={href}
             href={href}
-            className="border-b-2 border-transparent pb-0.5 text-[9px] font-extrabold tracking-wider whitespace-nowrap text-dark uppercase transition-colors duration-fast hover:border-yellow aria-[current=page]:border-yellow md:text-2xs"
+            className="group text-[9px] font-extrabold tracking-wider whitespace-nowrap text-dark uppercase md:text-2xs"
           >
-            {label}
+            <span className="border-b-2 border-transparent pb-0.5 transition-colors duration-fast group-hover:border-yellow group-aria-[current=page]:border-yellow">
+              {label}
+            </span>
           </NavLink>
         ))}
       </div>

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -26,10 +26,10 @@ export default defineConfig({
       // run-vitest.mjs sit at 0% on purpose, and both drag these figures down
       // in plain sight rather than quietly.
       thresholds: {
-        statements: 72.99,
+        statements: 73.18,
         branches: 80.48,
         functions: 86.79,
-        lines: 75.39,
+        lines: 75.59,
       },
     },
   },


### PR DESCRIPTION
Closes #18.

## What changed

Four commits, in order.

**`d68008b` Plan the nav touch-target fix** — `docs/plans/nav-touch-targets.md`. Nine decisions with what was rejected and why.

**`e55a698` Adopt 44px touch targets below md, 24px above** — `docs/adr/0004-touch-target-sizes.md`. Both reviews measured the nav against "the 44px guideline", which names no criterion, so there was no way to say whether the nav failed a requirement or missed an aspiration. WCAG 2.2 has two: 24×24 at AA (2.5.8) and 44×44 at AAA (2.5.5). This picks AAA for touch and AA for pointer, and says plainly that the split is about cost rather than principle.

**`ddf534f` Move the nav link indicator onto an inner span** — no visual change. A bottom border is drawn at its own element's box edge, so while the indicator lived on the anchor it would track the touch target; growing the anchor to 44px would have dragged the yellow rule ~14px below the label. The span keeps the existing `border-transparent` → `border-yellow` idiom; the anchor takes `group` and the span `group-hover:` / `group-aria-[current=page]:`, because hover styled from the glyphs alone makes the enlarged target feel broken over its own padding.

**`3bd0d0a` Bring the nav's touch targets to 44px below md** — every interactive element composes one named `TOUCH_TARGET`. The pill takes `md:min-h-0` (it is a visible shape, so 44px at `md` would grow the yellow capsule, not just its hit area; ~31px already clears the pointer floor). The links take 44px at every breakpoint because they have no background — at `md` the 52px logo still sets that row, so nothing moves and `--spacing-nav` stays 84px. The gutter joins the rest of the site at `px-gutter-sm`; the ~42px of slack that leaves goes into the links as `px-1.5` with `-mx-1.5` cancelling it at the row ends, so labels land where they would anyway but no tap inside the row hits a dead zone. `--spacing-nav-sm` 90px → 116px; per ADR-0003 the poster and `scroll-padding-top` follow with no module touched.

## Correction to the recorded figure

Both reviews record the links as ~30px tall. By arithmetic they are **~15px** (`text-[9px]` at Montserrat's ≈1.22 normal line-height, plus `pb-0.5`, plus `border-b-2`; the anchor is inline-level in a flex container with no `items-*`). 30px would clear AA; 15px does not, and the spacing exception cannot rescue it because the pill sat 8px above. The reviews are dated artifacts and are not rewritten — the correction lives in the plan and the ADR.

## The trade this issue was held open for

116px is 17.4% of a 375×667 screen and costs the hero poster 26px (577 → 551). There is no cheaper two-row shape: the 44px pill sets one row, the 44px links the other. A fixed bottom bar, a hamburger, and `static md:sticky` were each considered and rejected in the plan.

## Gate output

`npm run gate` cannot pass on my machine — see #31, where two agent worktrees under `.claude/` (not gitignored) are walked by vitest, eslint and Tailwind. Rather than paste a scoped hand-run, this is the full gate from a **fresh clone of this branch, rebased on `d31363a`, after `npm ci`** — the same thing CI does:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build

GATE EXIT: 0
```

Coverage: statements 73.18% (101/138), branches 80.48% (33/41), functions 86.79% (46/53), lines 75.59% (96/127). Floor raised from 72.99/80.48/86.79/75.39 to match, per the note in `vitest.config.mts`.

I also verified in the built stylesheet that every new utility emits a real rule rather than resolving to nothing — `min-h-11` → `calc(var(--spacing) * 11)`, `px-gutter-sm`, `-mx-1.5`, `md:min-h-0`, and both `group-*` variants — and that `--spacing-nav-sm:116px` reaches the output with `--spacing-nav:84px` unchanged.

## What this does not do

- **Verify 44 rendered pixels.** jsdom applies no stylesheets (ADR-0001), so the tests assert that every link composes `TOUCH_TARGET`, iterating rather than asserting a literal per element — that catches drift, not a wrong value. **This needs a look at 375px before merge**, which is why #18 keeps `needs-human`.
- **Every dimension quoted here is arithmetic**, not measurement. There is no browser tooling in this repo. `TODO(verify)`: the ~15px, the ~286px of label text, and the resulting 116px.
- **`PillLink`'s ~41px** across eleven call sites — #30.
- **The `md` gutter** (`md:px-8` vs the site's `px-gutter`). A real consistency defect, but it moves an approved desktop layout and is not about touch targets.
- **Below ~340px the links wrap to a third row** and the bar exceeds its token. Deliberate and documented in ADR-0004: every height is `min-h`, so it grows rather than clips, and a visible degradation beats a link scrolled out of reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)