### PR TITLE
Keep the gates inside the checkout they judge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# agent sessions: git worktrees at .claude/worktrees/<id>/ are full copies of
+# the repo on other branches, and the harness keeps local session state here
+# too. Prettier and Tailwind's source detection both read this file, so leaving
+# it out means formatting another branch's code and compiling its class names
+# into this branch's stylesheet.
+/.claude/

--- a/docs/plans/scope-gates-to-this-checkout.md
+++ b/docs/plans/scope-gates-to-this-checkout.md
@@ -184,3 +184,27 @@ one was locked and in use. The harness's placement is not this repo's to change.
 ## Addenda
 
 <!-- Dated entries when the plan changes. Never rewrite the above. -->
+
+### 2026-08-14 — slice 5 did not fire, and the whole thing was run end to end
+
+**The coverage floor did not move.** Slice 5 was conditional and the condition
+never arose: coverage after all three scopings is 78.94 / 81.81 / 89.06 / 79.88,
+identical to before. `coverage.include` covers `scripts/**/*.mjs`, so a new file
+there looked like it would shift the ratio, but vitest excludes test files from
+instrumentation by default and this change adds no source. No slice, no commit.
+
+**The three tests pass individually against a synthetic probe; the gate was
+also run against the real thing.** A worktree was created at
+`.claude/worktrees/verify-31` on `issue-25-ia-routed-structure` — the same
+condition #31 and #29 were filed under — and given a badly formatted file, a
+file with a lint error, and a component using `rotate-45`, a utility no file in
+this checkout mentions. With `.next/` removed first, so the build cache could
+not hide the Tailwind half:
+
+- all six gate rows PASS;
+- the built stylesheet contains no `.rotate-45` rule;
+- vitest collects 27 files, every one of them under `src/` or `scripts/`.
+
+The 27 is worth writing down because it contradicts the issues' arithmetic:
+they say the repo has 25 test files. It had 26 by the time this branch was cut
+(#32 and #33 merged in between), and this branch adds `gate-scope.test.mjs`.

--- a/docs/plans/scope-gates-to-this-checkout.md
+++ b/docs/plans/scope-gates-to-this-checkout.md
@@ -1,0 +1,186 @@
+# Plan: keep the gates inside this checkout
+
+Status: agreed 2026-08-14. Issues #31 and #29 (the same defect, filed twice).
+
+## The problem, from the point of view of someone working here
+
+Concurrent agent sessions create git worktrees at `.claude/worktrees/<id>/`.
+Each one is a full second copy of the repo, checked out on a **different
+branch**, living inside this checkout. `.claude/` is not in `.gitignore`, and
+none of the gate tooling is scoped to the tree it is supposed to be judging, so
+most of the gates walk into those copies and report on code that is not on this
+branch.
+
+`npm run gate` therefore goes red — or, worse, ships wrong output — depending on
+whether an unrelated agent happens to have a worktree open. CI on a fresh clone
+has no worktrees and is unaffected, so local and CI disagree. CLAUDE.md says that
+divergence is the first bug to fix, and it is the same failure mode as #4: a gate
+that fails for reasons unrelated to the tree teaches people to re-run until
+green.
+
+The build half is not merely noisy, it **ships**. Tailwind's automatic source
+detection scans every non-gitignored file, so class names from an unmerged
+branch compile into this branch's stylesheet. #31's reporter found two utilities
+deleted on `issue-18-nav-touch-targets` still present in the production CSS,
+emitted from two worktree copies of `Nav.tsx`. That is the same defect class as
+#15 (`docs/`, `.design/`) and #24 (root Markdown), except that a worktree can
+contribute class names that exist on no branch anyone is looking at. It also
+defeats the `stylesheet` row that #23 added, whose whole premise is that
+presence in the built CSS means the app uses it.
+
+## What was actually measured
+
+Both issues propose a fix without establishing which gates the fix reaches. It
+was reproduced before planning: a worktree was created at
+`.claude/worktrees/repro-31` on `issue-25-ia-routed-structure`, a probe file
+planted inside it, and every gate run with and without `/.claude/` in
+`.gitignore`.
+
+| Gate                | Walks into `.claude/`?                                | Fixed by `.gitignore` alone? |
+| ------------------- | ----------------------------------------------------- | ---------------------------- |
+| `format` (prettier) | yes — flagged the probe's bad formatting              | **yes**                      |
+| `lint` (eslint)     | yes — flagged the probe's unused disable directive    | **no**                       |
+| `typecheck` (tsc)   | **no**                                                | n/a                          |
+| `test` (vitest)     | yes — 51 test files collected where the repo has 25   | **no**                       |
+| `build` (tailwind)  | yes — the probe's `rotate-45` landed in the built CSS | **yes**                      |
+| `stylesheet`        | no — reads `.next/` only                              | n/a                          |
+
+Two claims in the issues are wrong, and both would have produced a fix that
+looked complete and was not:
+
+- **#31: "vitest can then be left alone."** Vitest does not read `.gitignore`.
+  With `/.claude/` ignored it still collected 51 files. ESLint's flat config
+  does not read `.gitignore` either — it kept reporting the probe, and it also
+  reports `coverage/`, which has been gitignored all along.
+- **#29: "`typecheck` passes only by luck."** TypeScript's wildcard `include`
+  excludes dot-directories by design. A type error planted in
+  `.claude/worktrees/repro-31/probe/bad.ts` was not reported; the identical
+  error at the repo root was. `typecheck` is not affected and is not touched.
+
+One trap worth recording, because it will mislead the next person who verifies
+the Tailwind half: the first rebuild after adding the ignore rule **still
+contained the leaked class**. That was Next's build cache. `.next/` has to be
+removed before the stylesheet reflects a source-detection change.
+
+## The solution
+
+Three independent one-line scopings, one per tool that was measured to descend:
+
+1. `/.claude/` in `.gitignore` — settles `format` and `build`.
+2. `**/.claude/**` added to vitest's `test.exclude` — settles `test`.
+3. `.claude/**` added to eslint's existing `globalIgnores` — settles `lint`.
+
+Each names the same directory in the vocabulary its own tool understands.
+
+## Implementation decisions
+
+**`/.claude/`, not `/.claude/worktrees/`.** Nothing under `.claude/` is tracked
+(`git ls-files .claude` is empty), and the harness writes local session state
+and `settings.local.json` there too — all of it equally feeds prettier and
+Tailwind. The narrower rule would name only the symptom that happened to be
+observed. If something under `.claude/` ever needs tracking, a `!` negation is
+one line and the reason for it will be explicit.
+
+**Three one-liners, not a shared module.** A `scripts/gate-scope.mjs` exporting
+the pattern to all three consumers was considered and rejected: three strings in
+three different glob dialects do not deduplicate cleanly, the module would be
+indirection with no logic in it, and it would be a new abstraction that outlives
+the task — so it would need an ADR to justify a constant. The drift risk it
+guards against is covered instead by the tests below, which assert each tool's
+own answer rather than the text of any config.
+
+**`exclude` extends `configDefaults.exclude`, it does not replace it.** Setting
+`test.exclude` overrides vitest's defaults wholesale, and the default is
+`["**/node_modules/**", "**/.git/**"]`. Dropping that while fixing this would
+trade one class of foreign test files for another. The spread is the part of
+this change most likely to be broken by a later edit, so it is what the test
+pins.
+
+**No new dependency, no ADR.** Nothing here is a decision that outlives the
+task; it is three configs being told what tree they are judging.
+
+## Test seams
+
+The seam is each tool's own ignore decision. Nothing here asserts the text of a
+config file — a test that reads `.gitignore` looking for a line passes just as
+happily when the line has stopped working. All three ask the tool:
+
+- **git:** `git check-ignore --quiet <path>` on an agent-worktree path exits 0.
+  This is the mechanism prettier and Tailwind both read, so it covers `format`
+  and `build` through the thing they actually consult. Rule-based, so it needs
+  no fixture on disk.
+- **vitest:** plant a `probe.test.ts` under `.claude/`, spawn
+  `node scripts/run-vitest.mjs list --filesOnly`, assert the probe is absent —
+  and assert a known real test file is present, so the check cannot pass by
+  listing nothing. `list` collects without running, so it costs about a second.
+- **eslint:** `new ESLint().isPathIgnored()` returns true for a worktree path
+  and false for a file under `src/`, again two-sided.
+
+They live in one new file, `scripts/gate-scope.test.mjs`, grown one block per
+slice.
+
+**The vitest test writes into `.claude/`, which is otherwise the harness's
+territory.** It is the only place the property can be asserted — a probe
+anywhere else proves nothing about this defect. It goes in a uniquely named
+directory removed in a `finally`, and it is planted directly under `.claude/`
+rather than inside `.claude/worktrees/`, so it can never be mistaken for, or
+collide with, a real worktree.
+
+**Nothing in `scripts/` may spell a Tailwind utility.** `built-css.test.mjs`
+enforces this and the addendum to `docs/plans/assert-built-stylesheet.md`
+explains why: this directory feeds the scanner. The probe fixture is named for
+what it is and carries no class names.
+
+## Slices
+
+1. **The plan.** This file.
+2. **Ignore `/.claude/` in git**, with the `git check-ignore` test.
+3. **Scope vitest's discovery to this checkout**, with the `vitest list` test.
+4. **Scope eslint to this checkout**, with the `isPathIgnored` test.
+5. **The coverage floor**, if slices 2–4 move it. Same reasoning as the third
+   slice of `assert-built-stylesheet.md`: the floor is what the repo achieves
+   today, and raising it is its own change.
+
+Slices 2–4 are independent of each other; the order is the order the gate table
+runs in.
+
+## Considered and rejected
+
+**`.gitignore` alone, as #31 suggests.** Measured above: it leaves `lint` and
+`test` broken. It is a necessary third of the fix, not the whole one.
+
+**Positive scoping — pointing each tool at `src/` and `scripts/` — as #29
+suggests.** Genuinely narrower, and it would not need revisiting when the next
+tool starts writing into the repo. Rejected for eslint, which is where it breaks
+down: flat config has no single positive root, so it would mean attaching
+`files` to every block inherited from `eslint-config-next` and re-attaching them
+whenever that preset changes. Doing it for vitest but not eslint would leave two
+tools scoped in opposite directions for no reason a reader could recover.
+`@source "../../src"` for Tailwind is the same idea and belongs to #24, which
+already owns it.
+
+**A `mustFail` gate row that creates a worktree and expects the gate to go red.**
+The only way to prove the whole gate set is scoped rather than three tools
+individually. Rejected: it means creating and destroying git worktrees during a
+gate run, on CI, for a property three cheap tests already cover from the inside.
+
+**Deleting or relocating the worktrees.** #31 says explicitly not to; at least
+one was locked and in use. The harness's placement is not this repo's to change.
+
+## Out of scope
+
+- **`typecheck`.** Measured as unaffected. Adding a `.claude` exclusion to
+  `tsconfig.json` would be a change with no failure behind it.
+- **`src/app/globals.css`.** The `@source not` lines are untouched. Inverting
+  them to a positive `@source` is #24.
+- **`coverage/` being linted.** `npx eslint` reports one warning from
+  `coverage/block-navigation.js` today, because eslint does not read
+  `.gitignore`. Real, pre-existing, and a different directory with a different
+  reason; it does not fail the gate (warnings exit 0). Filed separately rather
+  than folded in here.
+- **The agent harness's choice to put worktrees inside the repo.** Not this
+  repo's decision.
+
+## Addenda
+
+<!-- Dated entries when the plan changes. Never rewrite the above. -->

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,11 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Agent sessions put git worktrees at `.claude/worktrees/<id>/` — full
+    // copies of the repo on other branches. Flat config walks dot-directories
+    // and reads no .gitignore, so nothing else keeps this run inside the
+    // branch it is meant to be judging.
+    ".claude/**",
   ]),
 ]);
 

--- a/scripts/gate-scope.test.mjs
+++ b/scripts/gate-scope.test.mjs
@@ -25,6 +25,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { ESLint } from "eslint";
 import { afterEach, describe, expect, it } from "vitest";
 
 /**
@@ -154,4 +155,17 @@ describe("vitest", () => {
       expect(collected).toContain(COLLECTED_HERE);
     },
   );
+});
+
+describe("eslint", () => {
+  // Asked of eslint's own resolver rather than by running it: `npm run lint`
+  // over a clean worktree reports nothing either way, so a green run would say
+  // only that the other branch happens to lint.
+  it("ignores agent worktrees", async () => {
+    expect(await new ESLint().isPathIgnored(IN_AGENT_WORKTREE)).toBe(true);
+  });
+
+  it("does not ignore this checkout's own source", async () => {
+    expect(await new ESLint().isPathIgnored(IN_THIS_CHECKOUT)).toBe(false);
+  });
 });

--- a/scripts/gate-scope.test.mjs
+++ b/scripts/gate-scope.test.mjs
@@ -1,0 +1,66 @@
+/**
+ * The gates must judge this checkout and nothing else.
+ *
+ * Agent sessions put git worktrees at `.claude/worktrees/<id>/` — full copies
+ * of the repo on other branches, inside this one. Every tool that walks the
+ * tree has to be told to stay out, and each speaks its own dialect: git has
+ * `.gitignore`, vitest has `test.exclude`, eslint has `globalIgnores`. See
+ * docs/plans/scope-gates-to-this-checkout.md.
+ *
+ * Each assertion asks the tool itself rather than reading the config that
+ * configures it. A test that greps `.gitignore` for a line passes just as
+ * happily once the line has stopped meaning anything. Both directions are
+ * checked, because "excludes the worktree" is also satisfied by a rule so broad
+ * it excludes the repo.
+ *
+ * Nothing here may spell a Tailwind utility: this directory feeds the scanner,
+ * for the reasons in the addendum to docs/plans/assert-built-stylesheet.md.
+ */
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+/**
+ * A file in an agent worktree. The id is fake and the file need not exist —
+ * `git check-ignore` answers from the rules, not the filesystem — so this
+ * asserts the rule without depending on an agent having a session open.
+ */
+const IN_AGENT_WORKTREE =
+  ".claude/worktrees/agent-0000000000000000/src/components/Header.tsx";
+
+/** A file that is part of this checkout and must stay visible to every gate. */
+const IN_THIS_CHECKOUT = "src/app/page.tsx";
+
+/**
+ * Whether git ignores `path`. This is the mechanism prettier and Tailwind's
+ * source detection both consult, so it is what settles the `format` and `build`
+ * rows.
+ *
+ * `git check-ignore --quiet` exits 0 for ignored and 1 for not ignored. Any
+ * other status is git failing rather than answering, and is rethrown: reporting
+ * a broken git as "not ignored" would turn an unrunnable test into a red one
+ * and send the reader after the wrong bug.
+ *
+ * @param {string} path
+ * @returns {boolean}
+ */
+function gitIgnores(path) {
+  try {
+    execFileSync("git", ["check-ignore", "--quiet", "--", path], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch (error) {
+    if (error.status === 1) return false;
+    throw error;
+  }
+}
+
+describe("git", () => {
+  it("ignores agent worktrees", () => {
+    expect(gitIgnores(IN_AGENT_WORKTREE)).toBe(true);
+  });
+
+  it("does not ignore this checkout's own source", () => {
+    expect(gitIgnores(IN_THIS_CHECKOUT)).toBe(false);
+  });
+});

--- a/scripts/gate-scope.test.mjs
+++ b/scripts/gate-scope.test.mjs
@@ -22,6 +22,7 @@ import {
   mkdirSync,
   mkdtempSync,
   rmSync,
+  rmdirSync,
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -96,6 +97,10 @@ afterEach(() => {
  * itself is removed again only if this test created it; a session's own
  * directory is left alone.
  *
+ * That branch only runs where `.claude/` does not already exist, which is CI
+ * and never a machine with a session open — so it went out red once. Removing
+ * `.claude/` locally is how to exercise it here.
+ *
  * @returns {string} The planted file's path, slash-separated like vitest's own
  *   output.
  */
@@ -106,7 +111,17 @@ function plantForeignTestFile() {
   const directory = mkdtempSync(join(AGENT_DIRECTORY, "gate-scope-probe-"));
   cleanups.push(() => {
     rmSync(directory, { recursive: true, force: true });
-    if (!agentDirectoryExisted) rmSync(AGENT_DIRECTORY, { force: true });
+    if (agentDirectoryExisted) return;
+
+    // Only while it is still empty, and `rmdirSync` refusing a non-empty
+    // directory is exactly that check. A session that started mid-run owns
+    // whatever else is in there, so leaving it is the right outcome, not a
+    // swallowed failure — anything other than ENOTEMPTY still propagates.
+    try {
+      rmdirSync(AGENT_DIRECTORY);
+    } catch (error) {
+      if (error.code !== "ENOTEMPTY") throw error;
+    }
   });
 
   const file = join(directory, "probe.test.ts");

--- a/scripts/gate-scope.test.mjs
+++ b/scripts/gate-scope.test.mjs
@@ -17,7 +17,15 @@
  * for the reasons in the addendum to docs/plans/assert-built-stylesheet.md.
  */
 import { execFileSync } from "node:child_process";
-import { describe, expect, it } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 
 /**
  * A file in an agent worktree. The id is fake and the file need not exist —
@@ -63,4 +71,87 @@ describe("git", () => {
   it("does not ignore this checkout's own source", () => {
     expect(gitIgnores(IN_THIS_CHECKOUT)).toBe(false);
   });
+});
+
+/** Where agent sessions live. Created here only if a session has not already. */
+const AGENT_DIRECTORY = ".claude";
+
+/** A test file of this checkout's that must stay collected. */
+const COLLECTED_HERE = "scripts/gates.test.mjs";
+
+/** @type {(() => void)[]} */
+const cleanups = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) cleanups.pop()();
+});
+
+/**
+ * Plant a file vitest's default glob would collect, inside the directory the
+ * gates are supposed to stay out of, and undo it afterwards.
+ *
+ * It sits directly under `.claude/` rather than in `.claude/worktrees/`, so it
+ * can never be mistaken for a real worktree or collide with one. `.claude/`
+ * itself is removed again only if this test created it; a session's own
+ * directory is left alone.
+ *
+ * @returns {string} The planted file's path, slash-separated like vitest's own
+ *   output.
+ */
+function plantForeignTestFile() {
+  const agentDirectoryExisted = existsSync(AGENT_DIRECTORY);
+  if (!agentDirectoryExisted) mkdirSync(AGENT_DIRECTORY);
+
+  const directory = mkdtempSync(join(AGENT_DIRECTORY, "gate-scope-probe-"));
+  cleanups.push(() => {
+    rmSync(directory, { recursive: true, force: true });
+    if (!agentDirectoryExisted) rmSync(AGENT_DIRECTORY, { force: true });
+  });
+
+  const file = join(directory, "probe.test.ts");
+  writeFileSync(
+    file,
+    'import { expect, it } from "vitest";\n' +
+      'it("is not this checkout\'s test", () => expect(1).toBe(1));\n',
+  );
+
+  return file.replaceAll("\\", "/");
+}
+
+/**
+ * The test files vitest would run, asked of vitest itself. `list` collects
+ * without running, so this costs about a second and cannot recurse into this
+ * suite.
+ *
+ * @returns {string[]}
+ */
+function collectedTestFiles() {
+  const listed = execFileSync(
+    process.execPath,
+    ["scripts/run-vitest.mjs", "list", "--filesOnly"],
+    { encoding: "utf8" },
+  );
+
+  return listed
+    .split("\n")
+    .map((line) => line.trim().replaceAll("\\", "/"))
+    .filter(Boolean);
+}
+
+describe("vitest", () => {
+  // The timeout is raised because this spawns a second vitest from a cold
+  // start, which the 5s default does not reliably cover on CI.
+  it(
+    "does not collect test files from agent sessions",
+    { timeout: 60_000 },
+    () => {
+      const planted = plantForeignTestFile();
+      const collected = collectedTestFiles();
+
+      expect(collected).not.toContain(planted);
+      // Two-sided: an exclusion that collected nothing would also satisfy the
+      // line above, and would take the whole suite with it.
+      expect(collected).toContain(COLLECTED_HERE);
+    },
+  );
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
@@ -11,6 +11,14 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
+    // Agent sessions put git worktrees at `.claude/worktrees/<id>/` — full
+    // copies of the repo on other branches — so the default glob collects a
+    // second and third suite and runs them against this branch's config.
+    // Vitest reads no .gitignore, so ignoring the directory in git does not
+    // reach here. Spread rather than replace: setting `exclude` overrides
+    // vitest's defaults wholesale, and dropping node_modules while fixing this
+    // would trade one kind of foreign test file for another.
+    exclude: [...configDefaults.exclude, "**/.claude/**"],
     coverage: {
       provider: "v8",
       include: ["src/**/*.{ts,tsx}", "scripts/**/*.mjs"],


### PR DESCRIPTION
Closes #31
Closes #29

#29 and #31 are the same defect filed twice. Both are fixed here, so both close.

A git worktree at `.claude/worktrees/<id>/` is a full copy of the repo on a
different branch, living inside this checkout. Nothing told the gate tooling to
stay out of it, so most rows reported on code that is not on this branch — and
the build shipped another branch's class names.

## What was measured before anything was changed

Both issues propose a fix without establishing which gates it reaches, so it was
reproduced first: a worktree on `issue-25-ia-routed-structure`, a probe planted
inside it, every gate run with and without `/.claude/` in `.gitignore`.

| Gate                | Walks into `.claude/`?                                | Fixed by `.gitignore` alone? |
| ------------------- | ----------------------------------------------------- | ---------------------------- |
| `format` (prettier) | yes — flagged the probe's bad formatting              | **yes**                      |
| `lint` (eslint)     | yes — flagged the probe's unused disable directive    | **no**                       |
| `typecheck` (tsc)   | **no**                                                | n/a                          |
| `test` (vitest)     | yes — 51 test files collected where the repo has 26   | **no**                       |
| `build` (tailwind)  | yes — the probe's `rotate-45` landed in the built CSS | **yes**                      |
| `stylesheet`        | no — reads `.next/` only                              | n/a                          |

Two claims in the issues are wrong, and either would have produced a fix that
looked complete and was not:

- **#31's "vitest can then be left alone" is wrong.** Vitest reads no
  `.gitignore`; with `/.claude/` ignored it still collected 51 files. ESLint's
  flat config reads none either — it kept reporting the probe, and it still
  reports `coverage/`, which has been gitignored all along.
- **#29's "`typecheck` passes only by luck" is wrong.** TypeScript's wildcard
  `include` excludes dot-directories by design. A type error planted in the
  worktree was not reported; the identical error at the repo root was.
  `typecheck` is not affected and is not touched here.

So the fix is three scopings, not one.

## Slices

1. **`fa75a91` — the plan.** `docs/plans/scope-gates-to-this-checkout.md`,
   including the measurement above, since the conclusion alone is not
   reproducible.
2. **`9cf2c89` — ignore `/.claude/` in git.** Settles `format` and `build`,
   which both read `.gitignore`.
3. **`3aec5cc` — scope vitest.** `exclude: [...configDefaults.exclude,
   "**/.claude/**"]`. The spread matters: setting `exclude` replaces vitest's
   defaults wholesale, so writing the pattern alone would drop `node_modules`
   and trade one kind of foreign test file for another.
4. **`a6c49aa` — scope eslint.** `.claude/**` added to the existing
   `globalIgnores`.
5. **`d10a2d2` — plan addendum.** The conditional coverage slice did not fire
   (see below), plus the end-to-end run.

Each of 2–4 has its test in the same commit, and each test was run red first —
the `git check-ignore`, `vitest list` and `isPathIgnored` assertions each failed
for the right reason before the config change that fixes them.

## The tests ask the tool, not the config

A test that greps `.gitignore` for a line passes just as happily once the line
has stopped matching anything. `scripts/gate-scope.test.mjs` asks each tool for
its own answer instead:

- **git:** `git check-ignore --quiet` on an agent-worktree path. This is the
  mechanism prettier and Tailwind both consult, so it covers two rows through
  the thing they actually read. Rule-based, so no fixture on disk.
- **vitest:** plants a file vitest's default glob would collect, under
  `.claude/`, then spawns `vitest list --filesOnly` and asserts it is absent.
- **eslint:** `new ESLint().isPathIgnored()`. Running the linter would not do —
  a worktree whose code happens to be clean produces a green run either way,
  proving only that the other branch lints.

All three are two-sided: each also asserts a real file of this checkout's is
*not* excluded, so a rule broad enough to hide the repo fails too.

## End-to-end verification, not just the probes

A worktree was recreated at `.claude/worktrees/verify-31` on
`issue-25-ia-routed-structure` and given a badly formatted file, a file with a
lint error, and a component using `rotate-45` — a utility no file in this
checkout mentions. `.next/` was removed first, because Next's build cache hides
the Tailwind half for one rebuild (this cost time during the investigation and
is written down in the plan).

Result: all six rows PASS, the built stylesheet contains no `.rotate-45` rule,
and vitest collects 27 files, every one under `src/` or `scripts/`. The worktree
was then removed.

## Gate output

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

Coverage after the change is 78.94 / 81.81 / 89.06 / 79.88 — byte-identical to
before, so the planned fifth slice raising the floor was not needed. Vitest
excludes test files from instrumentation, and this change adds no source.

## What is not done here

- **`typecheck`.** Measured as unaffected; an exclusion there would be a change
  with no failure behind it.
- **`coverage/` being linted.** `npx eslint` reports one warning from
  `coverage/block-navigation.js`, because eslint reads no `.gitignore`. Real and
  pre-existing, but a different directory for a different reason, and it does
  not fail the row — warnings exit 0. Left for its own issue rather than folded
  in.
- **`src/app/globals.css`.** The `@source not` lines are untouched; inverting
  them to a positive `@source` is #24.
- **Anything about where the harness puts worktrees.** #31 says not to touch the
  existing ones, and the placement is not this repo's decision.
