### PR TITLE
Stop eslint reading the coverage report the gate writes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,12 @@ const eslintConfig = defineConfig([
     // and reads no .gitignore, so nothing else keeps this run inside the
     // branch it is meant to be judging.
     ".claude/**",
+    // Vendored istanbul output, written by the `test` row that runs one line
+    // above `lint` in the gate table. Gitignored and in .prettierignore, but
+    // eslint reads neither, so this is the only place it is excluded — and
+    // without it the row's verdict turns on whether coverage has been
+    // generated, which is a local/CI disagreement waiting to happen.
+    "coverage/**",
   ]),
 ]);
 

--- a/scripts/gate-scope.test.mjs
+++ b/scripts/gate-scope.test.mjs
@@ -41,6 +41,13 @@ const IN_AGENT_WORKTREE =
 const IN_THIS_CHECKOUT = "src/app/page.tsx";
 
 /**
+ * Vendored istanbul output, written by the `test` row of the gate that runs
+ * immediately before `lint`. Rule-based like the above, so this holds on a
+ * fresh clone where no coverage report has been produced yet.
+ */
+const IN_GENERATED_OUTPUT = "coverage/block-navigation.js";
+
+/**
  * Whether git ignores `path`. This is the mechanism prettier and Tailwind's
  * source detection both consult, so it is what settles the `format` and `build`
  * rows.
@@ -178,6 +185,13 @@ describe("eslint", () => {
   // only that the other branch happens to lint.
   it("ignores agent worktrees", async () => {
     expect(await new ESLint().isPathIgnored(IN_AGENT_WORKTREE)).toBe(true);
+  });
+
+  // The `test` row writes coverage/ and `lint` runs next, so without this the
+  // linter reads the output of the gate row before it — and its verdict on a
+  // bare `npm run lint` depends on whether that row has ever run.
+  it("ignores the coverage report the gate produces", async () => {
+    expect(await new ESLint().isPathIgnored(IN_GENERATED_OUTPUT)).toBe(true);
   });
 
   it("does not ignore this checkout's own source", async () => {


### PR DESCRIPTION
Closes #35

One slice, one line, plus the assertion that keeps it. No plan file: the issue
already states the problem and the fix, and a `docs/plans/` entry for a
six-word config change would be ceremony rather than record.

## What was wrong

`npm run lint` reported on `coverage/block-navigation.js` — vendored istanbul
output, written by the `test` row that runs on the line above `lint` in
`scripts/gates.mjs`:

```
$ npx eslint
C:\...\wild-coast-kids\coverage\block-navigation.js
  1:1  warning  Unused eslint-disable directive (no problems were reported)

✖ 1 problem (0 errors, 1 warning)
```

`coverage/` is gitignored and listed in `.prettierignore`. ESLint flat config
reads neither, and its only default ignores are `**/node_modules/` and `.git/`,
so nothing excluded it.

## Why it was worth fixing rather than tolerating

- It is a gate reading its own generated output — CLAUDE.md's "never let
  generated output be picked up as input on the next run", one directory over.
- It stayed green by luck. Warnings exit 0, so the row passed. The file is
  emitted by a dependency this repo does not control; a version of it that
  trips an *error* rule turns `lint` red for a reason nobody can act on.
- The verdict depended on whether `coverage/` exists. Mid-gate it always does,
  because `test:coverage` has just run. On a fresh clone it does not. That is
  the same local/CI disagreement #31 and #4 were about, in miniature.

## The change

`"coverage/**"` added to the existing `globalIgnores` in `eslint.config.mjs`,
beside the `.claude/**` entry from #31, with a comment saying why it cannot
rely on `.gitignore`.

The seam #31 built took the test unchanged: `scripts/gate-scope.test.mjs`
already asks `new ESLint().isPathIgnored()` for its own verdict rather than
reading the config, so this is one more assertion in its `eslint` block. It was
run red first. The block stays two-sided — `src/app/page.tsx` must still not be
ignored, so a rule broad enough to hide the repo fails.

The assertion is rule-based, so it holds on a fresh clone where no coverage
report has been generated.

## Considered and rejected

**`includeIgnoreFile` from `@eslint/compat`,** which would make eslint read
`.gitignore` and fix this class of defect for every future entry at once.
Rejected: it is a new dependency, so by CLAUDE.md it is an architecture decision
needing a plan and an ADR — not something to slip into a one-line bugfix. It is
also broader than wanted; `.gitignore` covers build output that eslint has no
opinion about either way. Worth its own issue if a third directory turns up.

## Gate output

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

`npx eslint` now prints nothing and exits 0.
