### PR TITLE
Give each gallery image its own aspect ratio

### DIFF
--- a/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
+++ b/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
@@ -150,6 +150,25 @@ rewritten, so the original intent stays readable.
 - **The Calendly `TODO(verify)` is retired** — booking CTAs point at
   `/book`, and the provider decision sits behind that page.
 
+## Addendum — 2026-08-14 (gallery tiles)
+
+- **Gallery tiles are no longer one shape.** "Gallery strip: same single-row
+  strip at all widths; image tiles shrink" now reads: a row is two 4:3 tiles
+  and one 16:9 at one height, so the wide tile is wider rather than shorter,
+  and the wide slot alternates right, left, right down the rows. The shares
+  are the ratios normalised — 0.3 : 0.3 : 0.4 — so every row totals the same
+  width whatever the order. From `lg` three tiles fill a screenful; below it
+  the reader swipes one at a time. See `docs/plans/gallery-aspect-rhythm.md`.
+- **Which images are wide is not a content decision yet.** The nine labels are
+  example content from the reference template; the aspect tagging is marked
+  provisional in `galleryImages.ts` and belongs to the real photography pass.
+- **The stops do not fit every window.** Measured at 1536×639 — a 1080p
+  display at 125% scaling — the hero, the program cards and the interest list
+  are taller than the 555px a stop has, so they start-align instead of
+  centring. The snapping was designed against ~782px. Filed as its own issue;
+  recorded here because "one screen per section" is a brief-level claim, and
+  it is currently false below roughly 780px of usable height.
+
 ## Out of Scope
 
 - Real photography or a logo — labeled placeholders ship; swapping in real

--- a/.design/wild-coast-kids-landing/DESIGN_REVIEW.md
+++ b/.design/wild-coast-kids-landing/DESIGN_REVIEW.md
@@ -135,6 +135,22 @@ is a separate, straightforwardly unfinished piece of interaction design.
 10. **Uniform tiles.** Finding 4 of the previous review stands: the template
     mixed aspect ratios and the row flattens them. Worth revisiting once the
     tiles are larger, since the rhythm will read more strongly.
+    _Fixed, issue #19 (2026-08-14)._ A row is now two 4:3 tiles and one 16:9
+    at one height, the wide slot alternating right, left, right. Three fill a
+    screenful from `lg`, which also made the 4:3 tiles larger — 417px against
+    348px at a 1536px window — so the rhythm has the size to read.
+
+11. **The stops do not fit a 555px viewport.** Found while verifying finding
+    10 at the owner's own window, 1536×639 (a 1080p display at 125% Windows
+    scaling, less Chrome's furniture). Against the 555px a stop then has, the
+    hero needs 612, the program cards 577 and the interest list 560. All three
+    therefore start-align instead of centring — `justify-center-safe` doing
+    exactly what finding 1 asked it to — and mandatory snapping over an
+    over-tall section reads as the page refusing to settle.
+    This review was conducted at 1900×866, where 782px is available and all
+    three fit, which is why it went unseen. Present on `main` and unrelated to
+    the gallery. _Filed as its own issue; it is a page-level constraint, not a
+    section's bug._
 
 ## What Works Well
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,10 +36,24 @@ swapping in the photograph changes nothing for assistive tech.
 _Avoid_: stub, dummy image, reserved slot (that is for content, not images)
 
 **Strip**:
-A band of content that loops horizontally — the yellow marquee and the gallery
-film strip. Every strip moves at one shared pixels-per-second speed, whatever
-its width.
+A band of content that loops horizontally. The yellow marquee is the only one
+left: the gallery was a strip until PR #14 gave it controls and stopped it
+moving, and a row the reader drives is not a strip.
 _Avoid_: carousel, ticker, marquee (the marquee is one strip, not the concept)
+
+**Stop**:
+One screen of the landing page, which the viewport comes to rest on from `md`
+up. The page is six of them. A stop owns its height and its surface, and the
+content inside it adds no vertical padding of its own — the stop is already
+supplying that space, and padding on both is counted twice.
+_Avoid_: slide, panel, screen (a section is the content; the stop is the screen
+it fills)
+
+**Tall / wide**:
+The two shapes a gallery tile comes in — 4:3 and 16:9. A row of the gallery is
+two tall and one wide at a single height, so the wide tile is the wider one
+rather than the shorter one, and the wide slot alternates side down the rows.
+_Avoid_: portrait (a tall tile is landscape too, just less so), thumbnail
 
 **Pill**:
 The site's call-to-action shape: a fully-rounded link. Five tones, and the list

--- a/docs/adr/0005-breakpoint-divergent-layouts.md
+++ b/docs/adr/0005-breakpoint-divergent-layouts.md
@@ -1,0 +1,79 @@
+# 0005 — Breakpoint-divergent layouts render twice
+
+Date: 2026-08-14. Status: accepted.
+
+## Context
+
+The gallery shows the same nine images two ways. Below `lg` it is one
+horizontally scrolling row the reader swipes a tile at a time. At `lg` and up
+it is a static grid split across two snap stops, because one stop cannot hold
+three rows at a readable size — see `docs/plans/gallery-aspect-rhythm.md`.
+
+Those two layouts want the images in different places in the DOM. The swipe row
+needs all nine in one scroll container. The grid needs three in stop A and six
+in stop B, in separate `<section>` elements, because a snap stop is a box and
+two stops are two boxes.
+
+CSS cannot reparent. `display: contents` was investigated and does not help:
+flattening stop A's wrappers to make the tiles join one scroller also flattens
+the heading into it, which would make "What kids make here." a slide in the
+gallery.
+
+The alternatives were to give phones several short rows instead of one — three
+rows of two, where a two-tile row does not scroll at all and the reader has
+more to scroll past, not less — or to show phones fewer images than desktops,
+which drops content silently.
+
+This repo has a stated preference against duplicated DOM. PR #14 removed the
+looping gallery strip, and `GallerySection.test.tsx` records the gain: every
+placeholder is rendered once "full stop", where the strip had rendered each
+twice and relied on `aria-hidden` to keep the copy quiet.
+
+## Decision
+
+A layout that genuinely diverges by breakpoint may render its content twice,
+with each copy hidden at the widths where it does not apply — `lg:hidden` on
+one, `hidden lg:*` on the other.
+
+The gallery does this: a swipe row holding nine tiles and a grid holding nine
+tiles, one of the two hidden at every width. Eighteen nodes in the document,
+nine visible.
+
+Three obligations come with it, and they are what make this a decision rather
+than a shortcut:
+
+- **Exactly one copy is visible at any width.** Not "usually one" — the hidden
+  copy uses `display: none`, so it is out of the layout, out of the tab order
+  and out of the accessibility tree.
+- **The tests assert names per layout, not per document.** `getAllByRole` in
+  jsdom sees both copies, because jsdom applies no stylesheets; an assertion
+  written against the whole document would either fail or have to be weakened
+  to "at least one", which asserts nothing.
+- **One list, two render sites.** The duplication is two `.map()` calls over a
+  single exported array, never two copies of the content. If the two ever
+  disagree, that is a bug the composition tests catch.
+
+## Consequences
+
+This is not the marquee's duplication returning. That strip rendered the same
+tiles twice _in the same layout, both visible_, as a mechanism — the second
+copy existed so the loop had something to scroll into, and `aria-hidden` was
+needed precisely because both were on screen. Here the copies are alternatives:
+never both rendered, so nothing needs hiding from assistive tech by hand, and
+deleting one would delete a layout rather than tidy a mechanism.
+
+The cost is that the accessibility guarantee moves from provable to
+browser-verified. In jsdom, nine names appear twice; only `display: none`
+makes that untrue, and the gate cannot see it. That gap is inherited from
+ADR-0001 and closing it means Playwright.
+
+When photographs replace the placeholders, the hidden copy must not be
+fetched. `loading="lazy"` covers it — a `display: none` image never enters the
+viewport, so it never loads — but it stops being free the moment anyone writes
+an eager `<img>`, and a phone would then pay for nine desktop images it cannot
+see.
+
+The rule has a boundary worth stating: this licenses duplication when the
+layouts genuinely diverge in DOM structure, not when they differ only in size,
+spacing or direction. Those are one layout with variant classes, which is what
+every other section on this site is.

--- a/docs/plans/gallery-aspect-rhythm.md
+++ b/docs/plans/gallery-aspect-rhythm.md
@@ -191,6 +191,58 @@ composition that depends on it. One branch and one PR: well inside the
 reviewable guide, and no two people could take these slices without colliding,
 so splitting them into issues would buy nothing.
 
+## Addendum — 2026-08-14: slice 3 is descoped, and why
+
+Slice 2 shipped. Before building slice 3, the owner reported the landing page
+snapping badly, and measurement in a browser at their own window moved the
+decision.
+
+Their viewport is 1536×639 CSS pixels: a 1920×1080 display at 125% Windows
+scaling gives 1536×864, and Chrome's own furniture takes 177px more. That
+leaves **555px** for a stop, against the ~782px this repo's snapping was built
+and reviewed at (`DESIGN_REVIEW.md` records 1900×866).
+
+Measured on plain `main` and on this branch at that window, content height per
+stop against the 555px available:
+
+| stop          | main | this branch | overflows by |
+| ------------- | ---- | ----------- | ------------ |
+| hero          | 612  | 612         | 57           |
+| gallery       | 421  | 473         | —            |
+| cards         | 577  | 577         | 22           |
+| conditions    | 312  | 312         | —            |
+| interest list | 560  | 560         | 5            |
+| quotes        | 297  | 297         | —            |
+
+Identical but for the gallery, which grew and still fits. So the reported
+breakage is a property of the page at short viewports, not of this work: three
+sections are taller than their stop, `justify-center-safe` therefore
+start-aligns them rather than centring, and mandatory snapping over an
+over-tall section is what makes the page feel like it will not settle.
+
+That reaches this plan through the numbers. A 4:3 tile at 1536px wide:
+
+| layout                              | tile width |
+| ----------------------------------- | ---------- |
+| `main` before this branch, 4 across | 348        |
+| slice 2, three across with rhythm   | **417**    |
+| slice 3's grid, capped at 555px     | **322**    |
+
+Slice 2 already makes the artwork larger on that screen. Slice 3 would make it
+smaller than it was before this issue started — the failure this plan predicted
+for tablets, which turns out to apply to the owner's own laptop. The two-stop
+grid only pays for itself above roughly 800px of usable height, which is a
+premise the page does not currently meet.
+
+**Decision:** this issue ends after slice 2 and the documentation slice. The
+height problem is filed as its own issue, since it affects the hero, the
+program cards and the interest list on `main` and has nothing to do with the
+gallery. The two-stop grid is filed separately and blocked on it.
+
+Slices 3 and 4 above are therefore superseded: 3 is not built, and 4 becomes
+slice 3 of this branch. The rest of this file records what was decided for the
+grid, and stands as the design for the issue that will build it.
+
 ## Out of scope
 
 Real photography, and the final decision about which images are wide. Renaming

--- a/docs/plans/gallery-aspect-rhythm.md
+++ b/docs/plans/gallery-aspect-rhythm.md
@@ -1,0 +1,199 @@
+# Gallery aspect rhythm and the two-stop grid
+
+Issue #19. The design decisions in this file were taken with the repo owner in
+an interview on 2026-08-14; where a decision was theirs rather than derived,
+this file says so.
+
+## Problem, from the user's point of view
+
+Every tile in the gallery is 4:3, so nine pieces of children's artwork read as
+one uniform contact sheet. The reference template varied its aspect ratios, and
+that print-zine rhythm is part of the "coastal pop editorial" direction in the
+brief. This was finding 4 of `DESIGN_REVIEW-2026-08-11.md` and is finding 10 of
+the current `DESIGN_REVIEW.md`, deferred both times because the tiles were too
+small for the variation to read.
+
+Underneath that sits a second complaint: the artwork is small. At a 1900px
+window a tile is 439px wide, and the row shows four of them with a fifth
+half-visible — a strip of thumbnails rather than a gallery of work.
+
+## Solution
+
+The gallery becomes two stops, and its tiles come in two shapes.
+
+**At `lg` and up** the paged row is replaced by a static grid across two snap
+stops. Stop A carries the heading, the intro line and one row of three. Stop B
+carries two more rows of three and nothing else. Every row is two 4:3 tiles and
+one 16:9 tile, all the same height, so the wide one is wider; the wide tile
+alternates **right / left / right** down the three rows.
+
+**Below `lg`** the existing paged row stays, showing one tile at a time at 85%
+of the row's width with the next peeking. All nine images are reachable there;
+the wide ones are simply shorter in their slot and vertically centred.
+
+At a 1900×866 window a 4:3 tile goes from 439×329 to 473×355, and the wide
+tiles are 631×355. At 768 the swipe tile is 571 wide.
+
+## Implementation decisions
+
+- **Equal heights, unequal widths.** A row holds one height; the 16:9 tile
+  takes the extra width. Because every row holds the same set of ratios, every
+  row totals the same width whatever the order — so alternating the wide tile's
+  position keeps the grid's outer edges flush, which is what makes the rhythm
+  read as deliberate rather than as a hole. _Rejected: equal columns with the
+  wide tile shorter._ With only three rows, the empty surface under a short
+  tile reads as a gap, and alternating its position moves the gap around
+  instead of making a pattern.
+
+- **16:9 for the wide tile**, chosen by the owner from 3:2, 16:9 and 2:1. It is
+  the ratio the web already assumes, and the contrast with 4:3 is unmistakable:
+  631px against 473px. 3:2 was only 13% wider than its neighbours, which risks
+  reading as a wobble rather than as variation; 2:1 crops a photographed
+  painting too hard.
+
+- **Widths are 30 / 30 / 40 of the row.** Not a magic ratio: 4/3 : 4/3 : 16/9
+  normalises to exactly 0.3 : 0.3 : 0.4. So a tile is a percentage of the row
+  plus `aspect-4/3` or `aspect-video`, and equal heights fall out arithmetically
+  rather than being asserted by a second rule that could disagree.
+
+- **The grid's width is capped from the stop's height**, not from the window's
+  width, and the grid is centred:
+
+  ```
+  max-width: calc((100dvh - var(--spacing-nav) - 4.5rem) * 20 / 9 + 3rem)
+  ```
+
+  Two rows want 813px at a 1900px window and the stop offers about 782px, so
+  width-first sizing overflows. `4.5rem` is the 24px row gap plus 24px of
+  breathing space above and below; `3rem` is the two 24px gaps inside a row;
+  `20/9` is half of the 40/9 row-width-per-unit-height that the 30/30/40 shares
+  imply. `--spacing-nav` is the same token `SnapSection` subtracts, so nothing
+  here measures anything or invents a constant. _Rejected: letting the grid
+  overflow._ That is must-fix 1 of the last review returning — `justify-center-safe`
+  start-aligns an over-tall section, so the second row would sit below the fold
+  with nothing to say it is there. _Rejected: shrinking the gutters on short
+  windows._ The gutter is a page-wide rhythm token; bending it for one section
+  at some window heights makes the gallery's edges disagree with every other
+  stop's.
+
+  It lives in an `@utility gallery-fit` in `globals.css` rather than as an
+  arbitrary value in JSX — the `no-scrollbar` precedent — so the arithmetic
+  carries its explanation, and so the `stylesheet` gate row can assert it emits
+  real CSS.
+
+- **One tile size across all three rows.** Stop A has spare height, but a row
+  that is 4% larger there would land its left and right edges at a different
+  inset from stop B's, and a snap is an animated scroll, so both are briefly on
+  screen. The three rows are one grid the snap divides.
+
+- **The grid starts at `lg`, not at `md`.** Three-across at 768px gives a
+  192×144 tile — smaller than the 278px tile the same artwork gets on a phone,
+  and the opposite of this issue's purpose. Tablets keep the swipe row, where a
+  tile at 768 is 571 wide. So the responsive rule is one line: small screens
+  swipe, large screens grid. _Rejected: three presentations_ (swipe on phones,
+  a 3-up paged row on tablets, a grid on laptops) — three things to design,
+  test and keep in agreement instead of two.
+
+- **Stop B is wrapped in `hidden lg:contents` in `page.tsx`.** `SnapSection`'s
+  `min-h` starts at `md`, so between 768 and 1024 an empty stop B would be a
+  blank mist screen. `display: contents` at `lg` dissolves the wrapper so the
+  section behaves exactly as a direct child, and `main.children` still counts
+  the stops.
+
+- **Both stops are mist, and stop B carries no heading.** The owner's call: the
+  second stop follows the first immediately, so nothing needs restating. It
+  costs nothing for assistive tech — a `<section>` with no accessible name is
+  not exposed as a landmark, and a screen reader reads linearly, so the heading
+  precedes all nine images however the stops fall.
+
+- **Nine tiles render twice** — once in the swipe row, once in the grid — with
+  one layout hidden at any width. See `docs/adr/0005-breakpoint-divergent-layouts.md`;
+  it is the decision most likely to be re-litigated, because PR #14 was
+  partly celebrated for deleting the marquee's duplicated DOM.
+
+- **An image carries its own aspect**: `GALLERY_IMAGES` becomes
+  `{ label, aspect }`, and the gate asserts the composition invariants over the
+  data. _Rejected: deriving the aspect from the index._ It cannot break, but
+  reordering the list then silently re-crops the images, which becomes a live
+  hazard the moment photographs replace placeholders. _Rejected: three literal
+  rows._ The alternation rule would exist nowhere, so no test could call a
+  wrong row wrong.
+
+- **Which three images are wide is provisional.** The owner's call: the current
+  labels are example content from the reference template, not a brief for the
+  real photographs, and the tagging will be redone when those arrive. Positions
+  3, 4 and 9 are tagged wide to produce the right/left/right rhythm, and the
+  source says so, in the same spirit as the placeholder quote in `QuoteStats`.
+
+- **`GalleryRow` keeps its name and its behaviour.** It shows one tile at a
+  time rather than a row of them below `lg`, which strains the name, but
+  renaming a module PR #14 just landed is a change of its own with its own
+  justification, not a rider on this one. Its `scrollBy(clientWidth)` still
+  lands one tile per press: at 768 a press moves 672px against a 595px stride,
+  and `snap-mandatory` pulls back to the nearer snap point.
+
+- **Tiles in the swipe row take `self-center`.** A flex child defaults to
+  `stretch`, which forces a height and makes `aspect-ratio` yield nothing; the
+  wide tiles would be stretched to the 4:3 tiles' height. Centring keeps the
+  row's height set by its tallest tile, so nothing jumps mid-swipe. It sits on
+  the tile rather than as `items-center` on the row because `GalleryRow`
+  deliberately owns no tile geometry.
+
+- **24px between tiles, both axes** — `--spacing-gutter-sm`, a token the page
+  already has. Owner's call, and nearly free: because height caps the tile size,
+  going from 16px to 32px only moves a tile from 511 to 500 wide at 1900.
+
+- No new dependencies.
+
+## Test seams
+
+The gate can prove the data and the class contract. It cannot prove that two
+rows fit an 866px window, because jsdom applies no stylesheets (ADR-0001). That
+division was agreed rather than discovered:
+
+- **The composition invariants, over the data** — this is the seam that makes
+  the rhythm a rule rather than an accident. Rows chunk by three; every row is
+  two 4:3 and one 16:9; the wide tile alternates right/left/right; the list
+  length is a multiple of three. A tenth image or a mistagged one fails the
+  gate instead of quietly going ragged.
+- **The class contract**, per the `StripTrack`/`SnapSection` precedent: the
+  swipe row carries `lg:hidden`, the grid `hidden lg:*`, the grid container
+  `gallery-fit`, tiles their width and aspect classes.
+- **Accessible names, per layout.** `GallerySection.test.tsx`'s "exposed
+  exactly once" assertion cannot survive two render sites unchanged; it becomes
+  once per visible layout, scoped to a container. That the hidden copy leaves
+  the accessibility tree is `display: none` doing its job, and is a browser
+  fact, not a jsdom-provable one.
+- **`page.test.tsx`:** the landing page is seven stops, not six.
+- **The `stylesheet` gate row:** `gallery-fit` must emit a declaration, so a
+  typo inside the `calc()` is caught by the build rather than by an eye.
+- **Outside the gate, needs a human in a browser:** that two rows fit at
+  1900×866 and 1280×800, that nothing clips at 1024, that the A→B snap reads as
+  continuation rather than as a new section, that a swipe moves one tile at 375
+  and 768, and whether the side margins on a short wide window read as intent.
+
+## Slices
+
+1. This plan and ADR-0005.
+2. Images carry their aspect, and the row varies its ratios. `galleryImages.ts`,
+   the aspect-to-class mapping, and the 30/30/40 shares applied inside the
+   existing paged row at `lg` and up. This stands alone: it is the original
+   issue — the tiles stop being uniform — with the composition unchanged.
+3. The grid takes over at `lg`, across two stops. `GalleryOpening` and
+   `GalleryContinued`, `gallery-fit`, `GalleryRow` becomes `lg:hidden`,
+   `page.tsx` gains stop B and `page.test.tsx` counts seven.
+4. The documentation catches up: `CONTEXT.md` gains **Stop** and corrects
+   **Strip** to mean the marquee alone, `DESIGN_BRIEF.md` gets a dated addendum,
+   and finding 10 of `DESIGN_REVIEW.md` is closed.
+
+Slice 2 before 3 so the tile geometry exists and is verified before the
+composition that depends on it. One branch and one PR: well inside the
+reviewable guide, and no two people could take these slices without colliding,
+so splitting them into issues would buy nothing.
+
+## Out of scope
+
+Real photography, and the final decision about which images are wide. Renaming
+`GalleryRow`. A browser-driven gate row — it would genuinely prove the fit, but
+it is a new dev dependency and an architecture decision, so it is its own issue
+with its own ADR. Any change to the other five stops.

--- a/src/components/GalleryRow.tsx
+++ b/src/components/GalleryRow.tsx
@@ -44,7 +44,7 @@ export function GalleryRow({ label, children }: GalleryRowProps) {
         tabIndex={0}
         role="group"
         aria-label={label}
-        className="no-scrollbar flex snap-x snap-mandatory gap-4 overflow-x-auto px-gutter-sm motion-safe:scroll-smooth md:px-gutter"
+        className="no-scrollbar flex snap-x snap-mandatory gap-6 overflow-x-auto px-gutter-sm motion-safe:scroll-smooth md:px-gutter"
       >
         {children}
       </div>

--- a/src/components/GallerySection.test.tsx
+++ b/src/components/GallerySection.test.tsx
@@ -25,6 +25,32 @@ test("every image slot is exposed to assistive tech exactly once", () => {
   }
 });
 
+test("a wide tile takes the wider share of the row", () => {
+  render(<GallerySection />);
+
+  // jsdom applies no stylesheets, so the class contract is the seam. What it
+  // guards is the arithmetic: the shares are the aspect ratios normalised, so
+  // 0.4 against 0.3 is what makes three tiles one height and a full row.
+  const wide = screen.getByRole("img", { name: "Neon chalk art" });
+  const tall = screen.getByRole("img", { name: "Mixed media art" });
+
+  expect(wide.className).toContain("aspect-video");
+  expect(wide.className).toContain("lg:w-[calc((100%-3rem)*0.4)]");
+  expect(tall.className).toContain("aspect-4/3");
+  expect(tall.className).toContain("lg:w-[calc((100%-3rem)*0.3)]");
+});
+
+test("tiles are centred rather than stretched", () => {
+  render(<GallerySection />);
+
+  // A flex child defaults to stretch, which forces a height and leaves
+  // aspect-ratio with nothing to decide — every 16:9 tile would be pulled up
+  // to a 4:3 tile's height and the variation would vanish silently.
+  expect(
+    screen.getByRole("img", { name: "Neon chalk art" }).className,
+  ).toContain("self-center");
+});
+
 test("the reader drives the row", () => {
   render(<GallerySection />);
 

--- a/src/components/GallerySection.tsx
+++ b/src/components/GallerySection.tsx
@@ -1,17 +1,21 @@
 import { GalleryRow } from "./GalleryRow";
 import { Placeholder } from "./Placeholder";
+import { GALLERY_IMAGES, type GalleryAspect } from "./galleryImages";
 
-const GALLERY_IMAGES = [
-  "Art class at the park",
-  "Mixed media art",
-  "Neon chalk art",
-  "Sunset painting",
-  "Watercolor houses",
-  "Cactus collage",
-  "Pixel art",
-  "Kids with artwork",
-  "Dinosaur watercolor",
-];
+/* What a tile's aspect costs it in width. Two 4:3 tiles and one 16:9 share a
+   row at one height, and 4/3 : 4/3 : 16/9 normalises to exactly 0.3 : 0.3 :
+   0.4 — so the shares are the ratios, and the three tiles come out the same
+   height without a second rule saying so. The subtraction is the two gap-6
+   gaps between them, so a row of three fills the container exactly — Tailwind
+   emits these as `width: calc(30% - .9rem)` and `calc(40% - 1.2rem)`.
+
+   The shares only apply from lg, where three tiles share a screenful. Below
+   that the row shows one tile at a time at 85% with the next peeking, and the
+   wide ones are simply shorter. */
+const TILE_ASPECT_CLASSES: Record<GalleryAspect, string> = {
+  tall: "aspect-4/3 lg:w-[calc((100%-3rem)*0.3)]",
+  wide: "aspect-video lg:w-[calc((100%-3rem)*0.4)]",
+};
 
 export function GallerySection() {
   return (
@@ -34,15 +38,18 @@ export function GallerySection() {
           you want to look at should not slide away, and one you missed
           should be one press back. */}
       <GalleryRow label="Artwork from Wild Coast Kids classes">
-        {GALLERY_IMAGES.map((label) => (
+        {GALLERY_IMAGES.map(({ label, aspect }) => (
           <Placeholder
             key={label}
             label={label}
-            /* Tiles are a fraction of the row rather than a fixed size, so a
-               whole number of them is visible at every width and they grow
-               to fill the stop: two from md, three from lg, four from xl.
-               The subtraction in each calc is the gap-4 between them. */
-            className="rounded-thumb aspect-4/3 w-[85%] shrink-0 snap-start overflow-hidden md:w-[calc((100%-1rem)/2)] lg:w-[calc((100%-2rem)/3)] xl:w-[calc((100%-3rem)/4)]"
+            /* self-center rather than the flex default: stretch forces a
+               height, which makes aspect-ratio yield nothing and pulls the
+               16:9 tiles up to the height of the 4:3 ones. Centred, the row
+               takes its height from its tallest tile and a swipe past a wide
+               one does not make the page jump. It sits here rather than as
+               items-center on the row because GalleryRow owns no tile
+               geometry. */
+            className={`rounded-thumb w-[85%] shrink-0 snap-start self-center overflow-hidden ${TILE_ASPECT_CLASSES[aspect]}`}
             labelClassName="whitespace-normal"
           />
         ))}

--- a/src/components/galleryImages.test.ts
+++ b/src/components/galleryImages.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "vitest";
+import { GALLERY_IMAGES, type GalleryImage } from "./galleryImages";
+
+const ROW_LENGTH = 3;
+
+/* The rows are chunks of the list rather than a structure in it, so the
+   chunking lives here with the assertions that need it. Nothing in the app
+   asks for rows yet — the paged row shows three at a time because the tiles
+   are sized to fill it — so a helper in the module would be a seam with no
+   caller. */
+function rows(): GalleryImage[][] {
+  const chunks: GalleryImage[][] = [];
+
+  for (let start = 0; start < GALLERY_IMAGES.length; start += ROW_LENGTH) {
+    chunks.push(GALLERY_IMAGES.slice(start, start + ROW_LENGTH));
+  }
+
+  return chunks;
+}
+
+test("the gallery divides into whole rows of three", () => {
+  // A tenth image does not make a longer gallery, it makes a row of one
+  // against an edge the other rows do not share.
+  expect(GALLERY_IMAGES.length % ROW_LENGTH).toBe(0);
+});
+
+test("every row is two tall tiles and one wide one", () => {
+  // The row's total width is what keeps the grid's edges flush, and it is only
+  // constant while every row holds the same set of ratios. Mistag one image
+  // and one row gets narrower than the others.
+  for (const row of rows()) {
+    expect(row.filter((image) => image.aspect === "tall")).toHaveLength(2);
+    expect(row.filter((image) => image.aspect === "wide")).toHaveLength(1);
+  }
+});
+
+test("the wide tile alternates side down the rows", () => {
+  // Right, left, right. This is the rhythm the issue asked for, and the only
+  // place the rule is written down — the data satisfies it, the layout reads
+  // the data, and neither states it.
+  rows().forEach((row, index) => {
+    const expected = index % 2 === 0 ? ROW_LENGTH - 1 : 0;
+
+    expect(row.findIndex((image) => image.aspect === "wide")).toBe(expected);
+  });
+});

--- a/src/components/galleryImages.ts
+++ b/src/components/galleryImages.ts
@@ -1,0 +1,45 @@
+/**
+ * The gallery's nine image slots, in the order they are laid out.
+ *
+ * A row of the gallery is three of these — two `tall` and one `wide`, sharing
+ * one height, so the wide one is the wider tile rather than the shorter one.
+ * The wide slot alternates right, left, right down the rows, which is what
+ * gives the gallery its print-zine rhythm without ragging its edges: every row
+ * holds the same set of ratios, so every row totals the same width whatever
+ * the order. See docs/plans/gallery-aspect-rhythm.md.
+ *
+ * The aspect belongs to the image rather than to its position. Deriving it
+ * from the index cannot break, but it silently re-crops the gallery whenever
+ * the list is reordered, which stops being harmless the moment photographs
+ * replace the placeholders. `galleryImages.test.ts` asserts the composition
+ * invariants over this list instead, so a tenth image or a mistagged one fails
+ * the gate rather than quietly going ragged.
+ */
+
+/** `tall` is 4:3, `wide` is 16:9. */
+export type GalleryAspect = "tall" | "wide";
+
+export type GalleryImage = {
+  /** Describes the future photograph; doubles as the accessible name. */
+  label: string;
+  aspect: GalleryAspect;
+};
+
+/* PLACEHOLDER TAGGING, to replace with the real content pass. These labels are
+   example content carried over from the reference template, not a brief for
+   the photographs that will replace them, and which three images are wide is
+   the owner's decision once those exist. Positions 3, 4 and 9 are wide here
+   because that is what produces the right/left/right rhythm the layout is
+   built around — marked rather than left to be discovered, the same way the
+   invented quote in QuoteStats is. */
+export const GALLERY_IMAGES: GalleryImage[] = [
+  { label: "Art class at the park", aspect: "tall" },
+  { label: "Mixed media art", aspect: "tall" },
+  { label: "Neon chalk art", aspect: "wide" },
+  { label: "Sunset painting", aspect: "wide" },
+  { label: "Watercolor houses", aspect: "tall" },
+  { label: "Cactus collage", aspect: "tall" },
+  { label: "Pixel art", aspect: "tall" },
+  { label: "Kids with artwork", aspect: "tall" },
+  { label: "Dinosaur watercolor", aspect: "wide" },
+];


### PR DESCRIPTION
Closes #19.

The gallery's nine tiles were all 4:3, so nine pieces of children's work read as one contact sheet. This gives them two shapes and a rhythm — and, at the window this was reviewed on, makes them bigger.

## What changed

**Slice 1 — the plan.** `docs/plans/gallery-aspect-rhythm.md` and `docs/adr/0005-breakpoint-divergent-layouts.md`.

**Slice 2 — the aspect rhythm.** A row is two 4:3 tiles and one 16:9 at a single height, so the wide tile is *wider* rather than shorter. That is what makes the composition work: `4/3 : 4/3 : 16/9` normalises to exactly `0.3 : 0.3 : 0.4`, so every row totals the same width whatever the order, and the wide slot can alternate right/left/right without ragging the edges. Equal columns with a shorter wide tile would have left a hole that moves around instead.

The aspect belongs to the image, not to its index. Deriving it from position cannot break, but it silently re-crops the gallery whenever the list is reordered — which stops being harmless once photographs replace placeholders. `galleryImages.test.ts` asserts the invariants over the data instead.

Below `lg` nothing changes shape: one tile at a time at 85%, wide ones simply shorter. `self-center` is load-bearing there — a flex child defaults to `stretch`, which forces a height and leaves `aspect-ratio` deciding nothing.

**Slice 3 — the docs.** `CONTEXT.md` still called the gallery a strip, which stopped being true in PR #14; it gains **Stop** (a word the plans and reviews already use) and the **tall/wide** pair. Finding 10 of `DESIGN_REVIEW.md` is closed and the brief gets a dated addendum.

## What I did not do, and why

The two-view grid from the comment on #19 is **not** in this PR. It is filed as #38, blocked on #37.

Verifying the work at the owner's own window — 1536x639, a 1080p display at 125% Windows scaling — turned up that a snap stop there has 555px, against the ~782px this repo's snapping was designed and reviewed at. Three sections on `main` are taller than their stop: hero by 57px, program cards by 22px, interest list by 5px. That is #37, and it is not caused by this branch — the numbers are identical on `main`.

It reaches this PR through the arithmetic. A 4:3 tile at 1536px wide:

| layout | tile width |
| --- | --- |
| `main` before this PR, 4 across | 348 |
| this PR, 3 across with the rhythm | **417** |
| the two-stop grid, capped at 555px | **322** |

The grid would have made the artwork smaller than it was before the issue started. It pays for itself above roughly 800px of usable height, which the page does not currently offer. The full design for it is written down in the plan file and carried into #38, so nothing is lost.

Also not done: extending the `stylesheet` gate row to arbitrary-value utilities. It cannot currently assert one — Tailwind escapes `%`, `(`, `*` and `.` in the selector, so `rulesFor`'s matcher never matches `lg:w-[calc((100%-3rem)*0.3)]`. I verified by hand that both share utilities emit `width:calc(30% - .9rem)` and `calc(40% - 1.2rem)` from a clean build. Fixing the matcher belongs to that module's own issue.

## Verification

`npm run gate` at `d097e10`:

```
… format
… lint
… typecheck
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

New tests: the three composition invariants over the data (whole rows of three, two tall and one wide per row, wide alternates right/left/right), plus the class contract for the width shares and for `self-center`.

Not provable by the gate, checked in a browser at 1536x639: the rhythm reads, three tiles fill a screenful from `lg`, the row's height does not jump when a swipe passes a wide tile, and the gallery stop fits with 82px to spare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)