### PR TITLE
Fit the landing page's stops to a 555px screen

### DIFF
--- a/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
+++ b/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
@@ -169,6 +169,23 @@ rewritten, so the original intent stays readable.
   recorded here because "one screen per section" is a brief-level claim, and
   it is currently false below roughly 780px of usable height.
 
+## Addendum — 2026-08-15 (stops need a big enough window)
+
+- **"One screen per section" is now a scoped claim, and a true one.** The page
+  is six stops on a window at least `md` wide and 45rem (720px) tall, and an
+  ordinary scrolling page with its section padding back on anything smaller.
+  The threshold is measured, not chosen: the tallest stop the page has is the
+  program cards at 623px, plus the 84px nav. This replaces the note above,
+  which recorded the claim as false below ~780px. See issue #37 and
+  `docs/plans/stop-height-threshold.md`.
+- **The gallery is the exception, and it is still open.** Between `md` and `lg`
+  the gallery stop's height grows with viewport _width_ — 734px at 1023px wide
+  — so a window around 1000px wide has one stop that overflows its screen no
+  matter how tall the window is. "Gallery strip: same single-row strip at all
+  widths" is doing the damage: below `lg` that row is one 85%-wide tile, and
+  the two-up step it used to have at `md` went away with the aspect-ratio work.
+  Issue #40.
+
 ## Out of Scope
 
 - Real photography or a logo — labeled placeholders ship; swapping in real

--- a/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
+++ b/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
@@ -169,22 +169,38 @@ rewritten, so the original intent stays readable.
   recorded here because "one screen per section" is a brief-level claim, and
   it is currently false below roughly 780px of usable height.
 
-## Addendum — 2026-08-15 (stops need a big enough window)
+## Addendum — 2026-08-15 (the stops fit a 555px screen)
 
-- **"One screen per section" is now a scoped claim, and a true one.** The page
-  is six stops on a window at least `md` wide and 45rem (720px) tall, and an
-  ordinary scrolling page with its section padding back on anything smaller.
-  The threshold is measured, not chosen: the tallest stop the page has is the
-  program cards at 623px, plus the 84px nav. This replaces the note above,
-  which recorded the claim as false below ~780px. See issue #37 and
-  `docs/plans/stop-height-threshold.md`.
-- **The gallery is the exception, and it is still open.** Between `md` and `lg`
-  the gallery stop's height grows with viewport _width_ — 734px at 1023px wide
-  — so a window around 1000px wide has one stop that overflows its screen no
-  matter how tall the window is. "Gallery strip: same single-row strip at all
-  widths" is doing the damage: below `lg` that row is one 85%-wide tile, and
-  the two-up step it used to have at `md` went away with the aspect-ratio work.
-  Issue #40.
+- **"One screen per section" is true again, and the sections were changed to
+  make it true.** The page is six stops on a window at least `lg` wide and
+  39rem (624px) tall, and an ordinary scrolling page with its section padding
+  back on anything smaller. **A stop is 540px**, and every section is built to
+  fit that. This replaces the note above, which recorded the claim as false
+  below ~780px of usable height.
+
+  The number comes from the machine the site is reviewed on rather than from
+  the design: a 1920x1080 display at 125% scaling gives a maximised Chrome a
+  639px viewport and no more, so 555px is what a stop actually gets there. An
+  earlier attempt at this fixed the overflow by switching the stops off below
+  720px, which would have made the whole mechanic invisible on that machine.
+  See issue #37 and `docs/plans/stop-height-threshold.md`.
+
+- **What it cost the compositions.** The poster's text column lost 80px of
+  padding and 28px of internal margin — invisible above the threshold, because
+  the column is centred in a box already a screen tall. The program cards lost
+  16px of padding and 22px of line box around a decorative emoji. The interest
+  list's form card lost 56px it had only because it was sized to its success
+  state rather than to the form. No type sizes changed, and no copy was cut.
+
+- **The `md`–`lg` band no longer snaps.** The cards' two columns are narrow
+  enough there that the CTA pills wrap, which padding cannot fix. That band
+  swipes and scrolls — the same rule the gallery already follows.
+
+- **The gallery is still the exception.** Its stop's height grows with viewport
+  _width_ without limit — 473px at 1536, 559 at 1920, 703 at 2560 — so on a
+  short window it overflows above about 1850px wide. "Gallery strip: same
+  single-row strip at all widths" is what does it. Issue #40; the fix is the
+  `gallery-fit` cap already designed for issue #38.
 
 ## Out of Scope
 

--- a/.design/wild-coast-kids-landing/DESIGN_REVIEW.md
+++ b/.design/wild-coast-kids-landing/DESIGN_REVIEW.md
@@ -151,6 +151,19 @@ is a separate, straightforwardly unfinished piece of interaction design.
     three fit, which is why it went unseen. Present on `main` and unrelated to
     the gallery. _Filed as its own issue; it is a page-level constraint, not a
     section's bug._
+    _Fixed, issue #37 (2026-08-15)._ The one-screen layout is gated on a
+    `stops` variant — `md` wide and 45rem tall — so a window this short is an
+    ordinary scrolling page with the sections' own padding back and nothing to
+    fight. The threshold is the program cards' 623px, which is their height at
+    the 768–940px widths where their columns wrap most, plus the 84px nav; the
+    577 measured here is not their worst case.
+    Measuring across widths also turned up a **twelfth** finding, filed as
+    issue #40 and _not_ fixed: the gallery stop's height grows with viewport
+    _width_ between `md` and `lg`, from 543px at 768 to 734px at 1023, then
+    collapsing to 347 once `lg` fits three tiles. No height threshold reaches
+    it. It is a regression from finding 10's fix, which dropped the two-up tile
+    step at `md`; at 1536 and 1900, the widths both of these findings were
+    checked at, `lg` applies and the band is invisible.
 
 ## What Works Well
 

--- a/.design/wild-coast-kids-landing/DESIGN_REVIEW.md
+++ b/.design/wild-coast-kids-landing/DESIGN_REVIEW.md
@@ -151,19 +151,34 @@ is a separate, straightforwardly unfinished piece of interaction design.
     three fit, which is why it went unseen. Present on `main` and unrelated to
     the gallery. _Filed as its own issue; it is a page-level constraint, not a
     section's bug._
-    _Fixed, issue #37 (2026-08-15)._ The one-screen layout is gated on a
-    `stops` variant — `md` wide and 45rem tall — so a window this short is an
-    ordinary scrolling page with the sections' own padding back and nothing to
-    fight. The threshold is the program cards' 623px, which is their height at
-    the 768–940px widths where their columns wrap most, plus the 84px nav; the
-    577 measured here is not their worst case.
+    _Fixed, issue #37 (2026-08-15)._ **The three sections were trimmed to fit,
+    rather than the snapping being switched off above them.** All six stops now
+    come in under 540px, and the page snaps at 1536×639 with every stop whole:
+    the hero at 532, the cards at 531, the interest list at 504.
+
+    The first attempt did switch the snapping off instead, on a `stops` variant
+    of 45rem. That was wrong for a reason worth recording, because it is this
+    finding's own mistake repeated: **1920×1080 at 125% scaling is 864 CSS
+    pixels, and Chrome's furniture takes 177, so a maximised window cannot
+    exceed a 639px viewport on this machine.** A 720px threshold would have made
+    the mechanic permanently invisible here. The variant survives at
+    `lg` × 39rem (624px) — below the ceiling by design.
+
+    Where the height was hiding, none of it in the compositions: 120px of
+    padding on the poster's text column, which is centred in a box already a
+    screen tall and therefore unaffected above the threshold; 22px of line box
+    around a decorative emoji at `text-[44px]`; and 56px on the interest form's
+    card, which was sized to its success state rather than to the form.
+
     Measuring across widths also turned up a **twelfth** finding, filed as
     issue #40 and _not_ fixed: the gallery stop's height grows with viewport
-    _width_ between `md` and `lg`, from 543px at 768 to 734px at 1023, then
-    collapsing to 347 once `lg` fits three tiles. No height threshold reaches
-    it. It is a regression from finding 10's fix, which dropped the two-up tile
-    step at `md`; at 1536 and 1900, the widths both of these findings were
-    checked at, `lg` applies and the band is invisible.
+    _width_ without limit — 473px at 1536, 559 at 1920, 703 at 2560 — so on a
+    639px-tall window it overflows above about 1850px wide. No height threshold
+    reaches it. Between `md` and `lg` it was worse still, 734px at 1023, a
+    regression from finding 10's fix dropping the two-up tile step; that half is
+    moot now that the band has no stops. At 1536 and 1900, the widths both of
+    these findings were checked at, it stays inside its stop, which is why it
+    went unseen.
 
 ## What Works Well
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,11 +47,16 @@ is six of them. A stop owns its height and its surface, and the content inside
 it adds no vertical padding of its own — the stop is already supplying that
 space, and padding on both is counted twice.
 
-A stop exists only on a window big enough to hold one: from `md` wide and
-`45rem` tall, expressed as the `stops` variant in `globals.css`. Below either
+A stop exists only on a window big enough to hold one: from `lg` wide and
+`39rem` tall, expressed as the `stops` variant in `globals.css`. Below either
 threshold the page has no stops at all — the sections put their own padding
-back and it scrolls normally. The height half is the newer one, and the reason
-is in `docs/plans/stop-height-threshold.md`.
+back and it scrolls normally.
+
+A stop is **540px** tall at that threshold, and every section is built to fit
+it. Content that does not is a bug in the section: the budget is the constraint
+sections are designed against, not a number to raise.
+`docs/plans/stop-height-threshold.md` has the measurements and the reason the
+threshold cannot go above 39rem.
 _Avoid_: slide, panel, screen (a section is the content; the stop is the screen
 it fills)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,10 +42,16 @@ moving, and a row the reader drives is not a strip.
 _Avoid_: carousel, ticker, marquee (the marquee is one strip, not the concept)
 
 **Stop**:
-One screen of the landing page, which the viewport comes to rest on from `md`
-up. The page is six of them. A stop owns its height and its surface, and the
-content inside it adds no vertical padding of its own — the stop is already
-supplying that space, and padding on both is counted twice.
+One screen of the landing page, which the viewport comes to rest on. The page
+is six of them. A stop owns its height and its surface, and the content inside
+it adds no vertical padding of its own — the stop is already supplying that
+space, and padding on both is counted twice.
+
+A stop exists only on a window big enough to hold one: from `md` wide and
+`45rem` tall, expressed as the `stops` variant in `globals.css`. Below either
+threshold the page has no stops at all — the sections put their own padding
+back and it scrolls normally. The height half is the newer one, and the reason
+is in `docs/plans/stop-height-threshold.md`.
 _Avoid_: slide, panel, screen (a section is the content; the stop is the screen
 it fills)
 

--- a/docs/plans/section-snapping.md
+++ b/docs/plans/section-snapping.md
@@ -169,10 +169,10 @@ Also deliberately not done:
 
 Issue #37, `docs/plans/stop-height-threshold.md`.
 
-- **"`md` and up only" is now "`md` and up, and 45rem tall".** The reasoning
+- **"`md` and up only" is now "`lg` and up, and 39rem tall".** The reasoning
   above sized the stops against phones and a 900px window, and never against a
   scaled desktop. A 1080p display at 125% Windows scaling reports a 639px
-  viewport, which leaves a stop 555px; the hero needs 612, the program cards
+  viewport, which leaves a stop 555px; the hero needed 612, the program cards
   623 at their tallest and the interest list 560. `md:` alone let mandatory
   snapping run over three over-tall sections.
 
@@ -181,6 +181,18 @@ Issue #37, `docs/plans/stop-height-threshold.md`.
   heights, centring and snap alignment, and the sections' `py-0` — sits behind
   it instead. `md:snap-start` in the decisions and test seams above therefore
   reads `stops:snap-start` in the code.
+
+- **The three over-tall sections were trimmed to fit, not gated around.** A
+  stop is 540px and every section comes in under it. The threshold exists for
+  windows smaller still, not to excuse a section from the budget. That order
+  matters: the first attempt set the threshold above the sections instead, at a
+  height the reviewer's display cannot reach, which would have retired the
+  whole mechanic on the machine it is judged on.
+
+- **`lg`, not `md`, for the width.** Between 768 and 1023 the cards' columns
+  are narrow enough that the CTA pills wrap, and no padding buys that back. The
+  premise above — "two sections cannot fit a phone" — turns out to extend to
+  tablets for the same reason.
 
 - **`motion-reduce:snap-none` was never implemented**, and this addendum is
   where that stops being invisible. The code expresses the same intent with

--- a/docs/plans/section-snapping.md
+++ b/docs/plans/section-snapping.md
@@ -164,3 +164,31 @@ Also deliberately not done:
 - **The `#conditions` id.** Nothing links to it — the teaser points at the
   `/conditions` route — but `Conditions.test.tsx` asserts it as stable API.
   Retiring it is its own slice.
+
+## Addendum — 2026-08-15 (the stops need a height threshold too)
+
+Issue #37, `docs/plans/stop-height-threshold.md`.
+
+- **"`md` and up only" is now "`md` and up, and 45rem tall".** The reasoning
+  above sized the stops against phones and a 900px window, and never against a
+  scaled desktop. A 1080p display at 125% Windows scaling reports a 639px
+  viewport, which leaves a stop 555px; the hero needs 612, the program cards
+  623 at their tallest and the interest list 560. `md:` alone let mandatory
+  snapping run over three over-tall sections.
+
+  The gate is now a `stops` custom variant carrying both conditions, and every
+  class this plan put behind `md:` — the snap type on `html`, `SnapSection`'s
+  heights, centring and snap alignment, and the sections' `py-0` — sits behind
+  it instead. `md:snap-start` in the decisions and test seams above therefore
+  reads `stops:snap-start` in the code.
+
+- **`motion-reduce:snap-none` was never implemented**, and this addendum is
+  where that stops being invisible. The code expresses the same intent with
+  `motion-safe:` on the enabling classes, which is why `snap-none` is a
+  FORBIDDEN row in `scripts/built-css.mjs` — the two lines of prose above are
+  its only occurrences in the repo, and its appearance in the built stylesheet
+  would mean this file was feeding Tailwind's scanner.
+
+- **Rejecting `proximity` still holds**, for a second reason: it would have
+  left the over-tall stops over-tall and only stopped the page fighting about
+  it.

--- a/docs/plans/stop-height-threshold.md
+++ b/docs/plans/stop-height-threshold.md
@@ -1,0 +1,156 @@
+# Landing page stops: a height threshold
+
+Status: agreed 2026-08-15. Issue #37. Follow-up from `section-snapping.md`,
+which designed the stops against a window nobody re-measured.
+
+## The problem, from the reader's point of view
+
+On a 1080p display at 125% Windows scaling — the owner's own machine — Chrome
+reports a 1536x639 viewport, and a stop gets 555px after the nav. Three of the
+six stops need more than that, so `justify-center-safe` start-aligns them,
+exactly as finding 1 of `DESIGN_REVIEW.md` asked it to. The result reads as
+three separate faults: sections that are not centred, a page with no vertical
+breathing room, and mandatory snapping that refuses to settle where you left
+it.
+
+None of those is a bug in a section. The page promises one screen per section
+and the screen is smaller than the promise assumed.
+
+## What the stops actually need
+
+Measured on `main` at 2026-08-15, in Chrome, by rendering the page into an
+iframe of a fixed CSS size and reading the content height of each stop's child.
+The rig reproduces the numbers in issue #37 exactly at 1536x639, which is what
+makes the rest of the sweep trustworthy.
+
+| viewport width | hero | gallery | cards | conditions | interest | quotes |
+| -------------- | ---- | ------- | ----- | ---------- | -------- | ------ |
+| 768            | 570  | 543     | 623   | 277        | 560      | 304    |
+| 900            | 588  | 642     | 623   | 299        | 560      | 295    |
+| 1023           | 556  | 734     | 550   | 296        | 560      | 313    |
+| 1024           | 556  | 347     | 550   | 296        | 560      | 313    |
+| 1280           | 602  | 415     | 565   | 312        | 560      | 339    |
+| 1536           | 612  | 473     | 577   | 312        | 560      | 297    |
+| 1920           | 612  | 559     | 577   | 289        | 560      | 297    |
+
+Two things the 1536-only measurement in the issue could not show:
+
+- **The program cards are tallest at the narrow end**, 623px from 768 to about
+  940, not the 577 they measure at 1536. Two columns at their narrowest wrap
+  the most copy. 623 is the worst case on the page.
+- **The hero's height has a ceiling.** `--text-display` clamps at 80px from
+  about 1334px wide up, so the hero stops growing at 612 and stays there.
+
+## The solution
+
+One custom variant, meaning "this window can hold a stop":
+
+```css
+@custom-variant stops (@media (min-width: 48rem) and (min-height: 45rem));
+```
+
+Every class that describes the one-screen layout moves from `md:` to `stops:`.
+Below the threshold the landing page is an ordinary scrolling page with its
+section padding back — the same code path phones have had since
+`section-snapping.md`, reached by a second door.
+
+The brief claims one screen per section. That claim was false below roughly
+780px of usable height; this makes it true by scoping it to the windows where
+the page can keep it.
+
+## Implementation decisions
+
+**45rem (720px), derived from the worst stop.** The program cards' 623 plus the
+84px nav is 707; 45rem is the next whole rem above it. Every stop the threshold
+covers therefore fits at every width from `md` up, with 13px to spare. The
+number is a measurement, not a taste — if content grows, re-run the sweep and
+move it, rather than nudging a section until it fits.
+
+**The gallery is excluded, and that is issue #40.** Between `md` and `lg` a
+tile is `w-[85%]` with `aspect-4/3`, so that stop's height grows linearly with
+viewport _width_ — 543 at 768, 734 at 1023, then 347 the moment `lg` lets three
+tiles share the row. Covering it would need a 818px threshold, which would
+switch the stops off on a 1440x810 laptop to protect a 940-1023px band; and it
+would still be the wrong fix, because no `min-height` can bound an overflow
+driven by the other axis. It is a regression from #19 (`f4c3408` dropped the
+two-up step at `md`) and is filed as its own issue. **After this lands, a
+window around 1000px wide still has one over-tall stop.** Said plainly here
+because the alternative is a plan that reads as if the page were fixed.
+
+**The variant carries the width condition too**, rather than stacking
+`md:stops:`. One name for one layout mode: a call site cannot then have the
+height half without the width half, which is exactly the drift the `--spacing-nav`
+token was introduced to stop. `stops:` reads as "when this window has stops",
+and `stops` is the word `CONTEXT.md` already uses for the thing.
+
+**The children's padding moves with it.** `GallerySection`, `ProgramCards`,
+`Conditions`, `InterestListTeaser` and `QuoteStats` drop their own vertical
+padding at `md` because the stop supplies that space — `CONTEXT.md`'s Stop
+entry says so. Gate the stop's height without gating the padding and a 639px
+window gets six sections butted flush together, which is a worse page than the
+one being fixed. This is the half most likely to be forgotten, so it gets its
+own assertions.
+
+**What stays on `md`.** `md:px-gutter`, `md:grid-cols-2`, `md:gap-*`, `Hero`'s
+`md:pb-0` and `HeroViewport`'s `md:min-h-[calc(100dvh-var(--spacing-nav))]` are
+about width, or about the poster filling the window — a decision that predates
+the stops and survives them. `scroll-pt-nav` stays ungated: the nav is sticky,
+so `#community` needs the offset whether or not anything snaps.
+
+**Reduced motion is untouched.** Today `motion-safe:` gates the snap type but
+not the forced heights, so a reader who asked for reduced motion still gets
+screen-tall centred sections without snapping. That asymmetry predates this
+change and is not what #37 is about; noted so the next reader does not think
+this plan decided it.
+
+**No new dependencies. No ADR** — ADR-0003 already records the nav and
+scrolling model, and a threshold is not a dependency, a data format or a
+threading contract.
+
+## Test seams
+
+Class contract, per the `StripTrack.test.tsx` precedent that jsdom applies no
+stylesheets:
+
+- **`SnapSection.test.tsx`:** the snap alignment, both height calcs and the
+  centring carry `stops:`.
+- **`layout.test.tsx`:** `html` carries `motion-safe:stops:snap-y` and
+  `motion-safe:stops:snap-mandatory`.
+- **The five children's tests:** each carries its `py-section-sm`
+  unconditionally _and_ `stops:py-0`. This is the seam for the half that
+  jsdom-free eyes would skip.
+
+Beyond the class names:
+
+- **`built-css.mjs` gains a `REQUIRED` row for `snap-start`.** This is the
+  assertion that matters most. A `@custom-variant` Tailwind does not register
+  makes every `stops:` class compile to nothing at all — silently, and
+  invisibly to jsdom, since the class name is still in the markup. The row
+  turns that into a red gate. It proves the variant compiles and emits
+  declarations; **it does not prove 720 is the right number.** That stays a
+  browser measurement, recorded above.
+- **Outside the gate, needs a human in a browser:** that a 1536x639 window is
+  an ordinary padded page with no snapping, and that a tall window is unchanged
+  — six stops, centred. Inherited from ADR-0001.
+
+## Slices
+
+1. This plan.
+2. Gate the one-screen layout on window height: the variant, the seven call
+   sites, the class-contract tests and the built-CSS row. One slice, because
+   gating the stops without gating the padding leaves the page worse than it
+   started — there is no half of this that is independently shippable.
+3. Catch the docs up: `CONTEXT.md`'s Stop entry, the brief addendum, an
+   addendum here on `section-snapping.md`, finding 11 of `DESIGN_REVIEW.md`.
+
+## Out of scope
+
+- **The gallery's width-driven height** — issue #40.
+- **Snapping on phones**, still deliberately off.
+- **`proximity` snapping**, rejected twice now: `section-snapping.md` rejected
+  it as too weak to read as intentional, and it would leave the over-tall stops
+  over-tall.
+- **Shrinking the sections to fit 555px**, which cannot work without cutting
+  the hero's display type or its padding — the one composition every review so
+  far has said is right.
+- The reduced-motion asymmetry described above.

--- a/docs/plans/stop-height-threshold.md
+++ b/docs/plans/stop-height-threshold.md
@@ -154,3 +154,94 @@ Beyond the class names:
   the hero's display type or its padding — the one composition every review so
   far has said is right.
 - The reduced-motion asymmetry described above.
+
+## Addendum — 2026-08-15: the threshold was answering the wrong question
+
+The 45rem threshold above is wrong, and the reason is a number nobody measured
+before choosing it.
+
+```
+screen.height       864   1920x1080 at 125% scaling
+screen.availHeight  816   less the Windows taskbar
+Chrome's furniture  177   tab strip, address bar
+max viewport        639   <- maximised, on this display, full stop
+```
+
+**The owner's display cannot produce a 720px viewport in a normal window.** Not
+by resizing: 639 is the ceiling a maximised Chrome gets, and only F11 fullscreen
+clears it. So a 45rem threshold does not merely switch the stops off "on short
+windows" — it switches them off permanently on the only machine the site is
+reviewed from, and leaves issue #38, the two-stop gallery grid, permanently
+unbuildable there, since its own plan needs a stop taller than this one has.
+
+The body of this plan reasoned carefully about which windows should keep the
+stops and never asked whether the reviewer's window could be one of them. That
+is the same failure as the original bug — designing against an assumed viewport
+— committed one level up.
+
+**Decision reversed.** The stops are made to fit 555px rather than switched off
+above it. The threshold survives, at a number that admits the machine it was
+written for.
+
+### The new arithmetic
+
+| quantity              | value                                |
+| --------------------- | ------------------------------------ |
+| reviewer's viewport   | 639                                  |
+| less the nav          | 555 available                        |
+| target for every stop | **540** (15px of headroom)           |
+| threshold             | **39rem = 624** (540 + the 84px nav) |
+
+39rem, not 40. 40rem is 640px — one pixel above the ceiling above, which would
+have reproduced the whole problem in a plan written to fix it.
+
+### The trims, measured at 1536 before and after
+
+| stop          | was | where the height was                                | change                                                    | now |
+| ------------- | --- | --------------------------------------------------- | --------------------------------------------------------- | --- |
+| hero          | 612 | 120px of `md:py-15`, 441px of content               | `md:py-5`                                                 | 532 |
+| program cards | 577 | `p-9`; the emoji renders 66px tall at `text-[44px]` | `p-7`, `leading-none` on the emoji, two margins tightened | 531 |
+| interest list | 560 | `min-h-140` on the form card                        | card `min-h-126`, success `min-h-108`                     | 504 |
+| gallery       | 473 | —                                                   | —                                                         | 473 |
+| conditions    | 312 | —                                                   | —                                                         | 312 |
+| quotes        | 297 | —                                                   | —                                                         | 297 |
+
+Two of the three cost almost nothing, which is why this was the wrong trade to
+refuse:
+
+- **The hero's padding is not binding on a tall window.** The text column is
+  `justify-center` inside a box already `100dvh - nav` tall, so above the
+  threshold the content is centred in the same space whatever the padding is.
+  Cutting it changes the poster only on the windows that need it cut.
+- **The interest list's `min-h` contradicted its own comment.** The comment says
+  it is sized so the success swap does not collapse the card, "≈ the rendered
+  form" — but the form is 431px of content in a 72px-padded card, 503 tall,
+  while the success state's own `min-h-120` makes it 552. The card was sized to
+  the success state and the form paid 57px for it. Both are now derived from the
+  form's measured content, which is what the comment always claimed.
+
+### The width half moves to `lg`
+
+`(min-width: 64rem) and (min-height: 39rem)`.
+
+Between 768 and 1023 the cards are 623 and the trim only reaches 585. The extra
+is not padding: the two CTA pills wrap to a second line there (97px against 43)
+and the co-op paragraph runs 61 against 41, because the two columns are ~360px
+wide. Closing that needs shorter pill labels or stacked CTAs and shorter copy —
+composition changes that would show at every width to fix one band.
+
+`lg` instead makes that band an ordinary scrolling page. This is the rule
+`gallery-aspect-rhythm.md` already chose for the gallery — "small screens
+swipe, large screens grid" — now applied to the page rather than to one section,
+and it dissolves the `md`–`lg` half of issue #40: there is no stop in that band
+to overflow. _Rejected: keeping `md`._ It buys snapping on tablets at the cost
+of copy changes on desktops, and leaves an over-tall gallery stop behind anyway.
+
+### What is still not fixed
+
+Issue #40 survives above `lg`, in the other direction: the gallery's tiles are a
+percentage of the row with a fixed aspect, so its stop grows with width without
+limit — 473 at 1536, 559 at 1920, 703 at 2560. It clears the 540 budget to about
+1750px wide and exceeds it beyond that. The fix is the `gallery-fit` cap already
+designed in `gallery-aspect-rhythm.md`, which derives the grid's max width from
+the stop's height; it belongs to #38 and #40, not here.

--- a/scripts/built-css.mjs
+++ b/scripts/built-css.mjs
@@ -83,8 +83,8 @@ export const FORBIDDEN = [
 /** @type {AtRuleExpectation[]} */
 export const AT_RULES = [
   {
-    prelude: "@media (min-width:48rem) and (min-height:45rem)",
-    why: "the `stops` variant gates the landing page's one-screen layout on it, and 45rem is the measured height a stop needs — see docs/plans/stop-height-threshold.md",
+    prelude: "@media (min-width:64rem) and (min-height:39rem)",
+    why: "the `stops` variant gates the landing page's one-screen layout on it; 39rem is the trimmed height a stop needs plus the nav, and it has to stay under the 640px ceiling a 125%-scaled 1080p display imposes — see docs/plans/stop-height-threshold.md",
   },
 ];
 

--- a/scripts/built-css.mjs
+++ b/scripts/built-css.mjs
@@ -59,6 +59,35 @@ export const FORBIDDEN = [
   },
 ];
 
+/**
+ * At-rules that must appear *and* wrap at least one rule that declares
+ * something.
+ *
+ * A `REQUIRED` row cannot do this job. An unregistered `@custom-variant` makes
+ * every class using it compile to nothing at all, silently, while the class
+ * name stays in the markup where jsdom still finds it — so the class contract
+ * in the component tests cannot see the failure either. The obvious utility to
+ * require instead, `snap-start`, is also written bare on the gallery tiles, so
+ * a rule for it exists either way: a false pass. Only the at-rule proves both
+ * that Tailwind registered the variant and that it registered *these*
+ * conditions.
+ *
+ * A prelude holds no class name, so unlike the tables above these are plain
+ * strings — there is nothing here for Tailwind's scanner to compile.
+ *
+ * @typedef {object} AtRuleExpectation
+ * @property {string} prelude  Verbatim, as the minified build emits it.
+ * @property {string} why      Printed with the row, so a failure explains itself.
+ */
+
+/** @type {AtRuleExpectation[]} */
+export const AT_RULES = [
+  {
+    prelude: "@media (min-width:48rem) and (min-height:45rem)",
+    why: "the `stops` variant gates the landing page's one-screen layout on it, and 45rem is the measured height a stop needs — see docs/plans/stop-height-threshold.md",
+  },
+];
+
 /** Utilities that must appear *and* emit at least one declaration. */
 /** @type {Expectation[]} */
 export const REQUIRED = [
@@ -92,11 +121,12 @@ function escapeForRegExp(text) {
  * whose body holds at least one declaration.
  *
  * The token may be variant-prefixed: two of the required utilities are used in
- * src/ only under `md:`, so the built selector escapes the variant into the
- * class name and a matcher anchored on a leading dot would report a working
- * utility as missing. Matching a bare substring instead would count a mention
- * in a comment as a pass, which is the failure this whole check exists to
- * remove.
+ * src/ only under a variant — one under `md:`, one under `stops:` — so the
+ * built selector escapes the variant into the class name and a matcher
+ * anchored on a leading dot would report a working utility as missing. Naming
+ * which two is exactly what the guard test at the foot of the test file
+ * forbids. Matching a bare substring instead would count a mention in a
+ * comment as a pass, which is the failure this whole check exists to remove.
  *
  * @param {string} css
  * @param {string} utility
@@ -111,6 +141,52 @@ export function rulesFor(css, utility) {
   return [...css.matchAll(rule)]
     .filter((match) => DECLARATION.test(match[1]))
     .map((match) => match[0]);
+}
+
+/**
+ * Every rule inside `css` that has a selector and declares something, as
+ * `selector{body}` pairs. Used to read an at-rule's contents as evidence.
+ *
+ * @param {string} css
+ * @returns {string[]} The selectors, in source order.
+ */
+function selectorsIn(css) {
+  return [...css.matchAll(/([^{}]+)\{([^{}]*)\}/g)]
+    .filter((match) => DECLARATION.test(match[2]))
+    .map((match) => match[1].trim())
+    .filter((selector) => !selector.startsWith("@"));
+}
+
+/**
+ * The body of every at-rule in `css` with this prelude.
+ *
+ * Brace-balanced rather than matched with a regex: the `stops` variant nests
+ * inside `@media (prefers-reduced-motion:no-preference)` for the snap classes,
+ * and `[^{}]*` would stop at the first inner brace and report an at-rule that
+ * wraps working rules as empty.
+ *
+ * @param {string} css
+ * @param {string} prelude
+ * @returns {string[]}
+ */
+export function atRuleBodies(css, prelude) {
+  const bodies = [];
+  const opener = `${prelude}{`;
+
+  for (let from = 0; ;) {
+    const start = css.indexOf(opener, from);
+    if (start === -1) return bodies;
+
+    let depth = 0;
+    let end = start + prelude.length;
+    for (; end < css.length; end += 1) {
+      if (css[end] === "{") depth += 1;
+      else if (css[end] === "}" && (depth -= 1) === 0) break;
+    }
+
+    bodies.push(css.slice(start + opener.length, end));
+    from = end + 1;
+  }
 }
 
 /**
@@ -164,6 +240,18 @@ export function auditStylesheets(stylesheets) {
       lines.push(`FAIL  ${utility} emits no declarations — ${expectation.why}`);
     } else {
       for (const rule of rules) lines.push(`ok    ${rule}`);
+    }
+  }
+
+  for (const { prelude, why } of AT_RULES) {
+    const wrapped = atRuleBodies(css, prelude).flatMap(selectorsIn);
+    if (wrapped.length === 0) {
+      ok = false;
+      lines.push(
+        `FAIL  ${prelude} wraps no rule that declares anything — ${why}`,
+      );
+    } else {
+      lines.push(`ok    ${prelude} wraps ${wrapped.join(" ")}`);
     }
   }
 

--- a/scripts/built-css.test.mjs
+++ b/scripts/built-css.test.mjs
@@ -10,8 +10,10 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  AT_RULES,
   FORBIDDEN,
   REQUIRED,
+  atRuleBodies,
   auditStylesheets,
   checkBuiltCss,
   findStylesheets,
@@ -29,6 +31,7 @@ const PROBE = "gate-probe";
 const compiled = () =>
   [
     ...REQUIRED.map((expectation) => `.${utilityName(expectation)}{color:red}`),
+    ...AT_RULES.map(({ prelude }) => `${prelude}{.${PROBE}{color:red}}`),
     ".unrelated{display:block}",
   ].join("");
 
@@ -98,6 +101,42 @@ describe("rulesFor", () => {
   });
 });
 
+describe("atRuleBodies", () => {
+  const PRELUDE = "@media (min-width:48rem)";
+
+  test("returns the body of a matching at-rule", () => {
+    expect(atRuleBodies(`${PRELUDE}{.${PROBE}{a:b}}`, PRELUDE)).toEqual([
+      `.${PROBE}{a:b}`,
+    ]);
+  });
+
+  // The shape the real build emits: the snap classes sit under the variant
+  // *inside* a prefers-reduced-motion query. A [^{}]* matcher would stop at
+  // the first inner brace and call a working at-rule empty.
+  test("keeps a nested at-rule whole", () => {
+    const css = `${PRELUDE}{@media (prefers-reduced-motion:no-preference){.${PROBE}{a:b}}}`;
+    expect(atRuleBodies(css, PRELUDE)).toEqual([
+      `@media (prefers-reduced-motion:no-preference){.${PROBE}{a:b}}`,
+    ]);
+  });
+
+  test("finds every occurrence, not just the first", () => {
+    const css = `${PRELUDE}{.a{c:d}}.x{y:z}${PRELUDE}{.b{c:d}}`;
+    expect(atRuleBodies(css, PRELUDE)).toEqual([".a{c:d}", ".b{c:d}"]);
+  });
+
+  // A prelude that is a prefix of the emitted one is a different query, and
+  // reading it as a match would pass a threshold nobody chose.
+  test("does not match a longer prelude that starts with this one", () => {
+    const css = `${PRELUDE} and (min-height:45rem){.${PROBE}{a:b}}`;
+    expect(atRuleBodies(css, PRELUDE)).toEqual([]);
+  });
+
+  test("yields nothing when the prelude is absent", () => {
+    expect(atRuleBodies(".other{a:b}", PRELUDE)).toEqual([]);
+  });
+});
+
 describe("auditStylesheets", () => {
   test("passes when every required utility emits declarations", () => {
     expect(auditStylesheets(sheet(compiled())).ok).toBe(true);
@@ -143,12 +182,50 @@ describe("auditStylesheets", () => {
   });
 
   test("reads every stylesheet, not only the first", () => {
-    const split = REQUIRED.map((expectation, index) => ({
-      path: `${index}.css`,
-      css: `.${utilityName(expectation)}{color:red}`,
-    }));
+    const split = [
+      ...REQUIRED.map((expectation, index) => ({
+        path: `required-${index}.css`,
+        css: `.${utilityName(expectation)}{color:red}`,
+      })),
+      ...AT_RULES.map(({ prelude }, index) => ({
+        path: `at-rule-${index}.css`,
+        css: `${prelude}{.${PROBE}{color:red}}`,
+      })),
+    ];
 
     expect(auditStylesheets(split).ok).toBe(true);
+  });
+
+  // The failure this row exists for: an @custom-variant Tailwind never
+  // registered emits no query at all, and every class behind it vanishes
+  // while its name stays in the markup where the component tests still see it.
+  test("fails when a required at-rule is missing entirely", () => {
+    const { prelude, why } = AT_RULES[0];
+    const css = compiled().replace(`${prelude}{.${PROBE}{color:red}}`, "");
+    const { ok, lines } = auditStylesheets(sheet(css));
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toContain(`FAIL  ${prelude} wraps no rule`);
+    expect(lines.join("\n")).toContain(why);
+  });
+
+  // Present but empty is the other half: Tailwind emits the query and then
+  // compiles nothing into it if no source uses the variant.
+  test("fails when a required at-rule wraps nothing that declares anything", () => {
+    const { prelude } = AT_RULES[0];
+    const css = compiled().replace(
+      `${prelude}{.${PROBE}{color:red}}`,
+      `${prelude}{.${PROBE}{}}`,
+    );
+
+    expect(auditStylesheets(sheet(css)).ok).toBe(false);
+  });
+
+  test("prints the selectors a required at-rule wraps, as evidence", () => {
+    const { prelude } = AT_RULES[0];
+    const { lines } = auditStylesheets(sheet(compiled()));
+
+    expect(lines.join("\n")).toContain(`ok    ${prelude} wraps .${PROBE}`);
   });
 
   test("names the files it read", () => {
@@ -157,9 +234,10 @@ describe("auditStylesheets", () => {
   });
 
   // An empty table would make the row green while asserting nothing at all.
-  test("both expectation tables have rows", () => {
+  test("every expectation table has rows", () => {
     expect(FORBIDDEN.length).toBeGreaterThan(0);
     expect(REQUIRED.length).toBeGreaterThan(0);
+    expect(AT_RULES.length).toBeGreaterThan(0);
   });
 });
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,15 +14,21 @@
    their own vertical padding because the stop supplies it — is all gated on
    this one variant rather than on md.
 
-   The height half is why it exists: a 1080p display at 125% scaling gives a
-   639px viewport, 555px after the nav, and the program cards need 623 at their
-   tallest. 45rem is that 623 plus the 84px nav, rounded up to the next whole
-   rem. Below it the page scrolls normally, exactly as a phone's does.
+   39rem, because 40 would be too many. A 1920x1080 display at 125% scaling is
+   864 CSS pixels tall; the taskbar takes 48 and Chrome's own furniture 177, so
+   a maximised window's viewport tops out at 639. 40rem is 640 — one pixel past
+   the ceiling, and the stops would never appear on that machine at all. 39rem
+   is 624: the 540px every stop is trimmed to fit, plus the 84px nav.
 
-   The width half is carried here rather than left as a stacked md: so that a
-   call site cannot take one half without the other. See
-   docs/plans/stop-height-threshold.md for the measurements. */
-@custom-variant stops (@media (min-width: 48rem) and (min-height: 45rem));
+   64rem, not 48, for the width. Between 768 and 1023 the program cards' two
+   columns are narrow enough that the CTA pills wrap to a second line, which no
+   amount of padding buys back. That band scrolls instead — the same rule the
+   gallery already follows, small screens swipe and large screens grid.
+
+   Both halves live here rather than as a stacked lg: so that a call site
+   cannot take one without the other. See docs/plans/stop-height-threshold.md
+   for the measurements, including the ones that moved these numbers. */
+@custom-variant stops (@media (min-width: 64rem) and (min-height: 39rem));
 
 /* Wild Coast Kids design tokens — coastal pop editorial.
    Canonical record: .design/wild-coast-kids-landing/DESIGN_TOKENS.css.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,21 @@
 @source not "../../docs";
 @source not "../../.design";
 
+/* "This window can hold a stop." The landing page's one-screen layout — the
+   snap type, the stops' forced heights and centring, and the sections dropping
+   their own vertical padding because the stop supplies it — is all gated on
+   this one variant rather than on md.
+
+   The height half is why it exists: a 1080p display at 125% scaling gives a
+   639px viewport, 555px after the nav, and the program cards need 623 at their
+   tallest. 45rem is that 623 plus the 84px nav, rounded up to the next whole
+   rem. Below it the page scrolls normally, exactly as a phone's does.
+
+   The width half is carried here rather than left as a stacked md: so that a
+   call site cannot take one half without the other. See
+   docs/plans/stop-height-threshold.md for the measurements. */
+@custom-variant stops (@media (min-width: 48rem) and (min-height: 45rem));
+
 /* Wild Coast Kids design tokens — coastal pop editorial.
    Canonical record: .design/wild-coast-kids-landing/DESIGN_TOKENS.css.
    One fixed, art-directed palette: no dark mode by decision (see

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -49,7 +49,7 @@ test("anchor targets come to rest below the nav, not under it", () => {
   expect(html).toContain("md:scroll-pt-nav");
 });
 
-test("snapping is enabled only from md up, and only when motion is safe", () => {
+test("snapping is enabled only where a stop fits, and only when motion is safe", () => {
   render(
     <RootLayout params={Promise.resolve({})}>
       <main>page content</main>
@@ -62,7 +62,11 @@ test("snapping is enabled only from md up, and only when motion is safe", () => 
   // disabling one: that way snapping is never switched on for a reader who
   // asked for reduced motion, with no dependence on which utility the
   // stylesheet happens to emit last.
-  expect(html).toContain("motion-safe:md:snap-y");
-  expect(html).toContain("motion-safe:md:snap-mandatory");
+  expect(html).toContain("motion-safe:stops:snap-y");
+  expect(html).toContain("motion-safe:stops:snap-mandatory");
   expect(html).not.toContain("motion-reduce:");
+
+  // Width alone is not enough — three stops overflow a 639px viewport, so
+  // snapping over them reads as the page refusing to settle (issue #37).
+  expect(html).not.toContain("motion-safe:md:snap");
 });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,10 +27,12 @@ export default function RootLayout({ children }: LayoutProps<"/">) {
   return (
     // scroll-pt keeps an anchored section clear of the nav when the browser
     // scrolls to it. Same tokens the nav sets its own height from, so the
-    // gap and the bar cannot drift apart.
+    // gap and the bar cannot drift apart. It stays on md rather than on the
+    // stops variant: the nav is sticky, so an anchor needs the offset whether
+    // or not anything on the page snaps.
     <html
       lang="en"
-      className={`${montserrat.variable} scroll-pt-nav-sm md:scroll-pt-nav h-full antialiased motion-safe:scroll-smooth motion-safe:md:snap-y motion-safe:md:snap-mandatory`}
+      className={`${montserrat.variable} scroll-pt-nav-sm md:scroll-pt-nav h-full antialiased motion-safe:scroll-smooth motion-safe:stops:snap-y motion-safe:stops:snap-mandatory`}
     >
       <body className="flex min-h-full flex-col overflow-x-hidden bg-cream font-sans text-dark">
         <Nav />

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -27,7 +27,7 @@ test("#community lands on a snap stop, not mid-section", () => {
   const target = container.querySelector("#community");
 
   expect(target?.tagName).toBe("SECTION");
-  expect(target?.className).toContain("md:snap-start");
+  expect(target?.className).toContain("stops:snap-start");
 });
 
 test("the parent quotes close the page, below the interest list", () => {

--- a/src/components/Conditions.test.tsx
+++ b/src/components/Conditions.test.tsx
@@ -17,3 +17,19 @@ test("the section teases the full conditions page", () => {
     screen.getByRole("link", { name: /learn more/i }).getAttribute("href"),
   ).toBe("/conditions");
 });
+
+test("the section puts its own padding back where there is no stop", () => {
+  const { container } = render(<Conditions />);
+
+  // See GallerySection.test.tsx: the stop supplies this space, and only a
+  // window big enough to hold a stop has one.
+  // Listed rather than searched for, so a stray vertical padding fails too.
+  // Spelling the md-gated class here to assert its absence would compile it
+  // into the shipped stylesheet, which is the hazard scripts/built-css.mjs
+  // documents.
+  const vertical = (container.firstElementChild?.className ?? "")
+    .split(/\s+/)
+    .filter((className) => /(^|:)p[byt]-/.test(className));
+
+  expect(vertical.sort()).toEqual(["py-section-sm", "stops:py-0"].sort());
+});

--- a/src/components/Conditions.tsx
+++ b/src/components/Conditions.tsx
@@ -3,7 +3,7 @@ import { ReservedSlot } from "./ReservedSlot";
 
 export function Conditions() {
   return (
-    <section className="px-gutter-sm py-section-sm grid items-center gap-8 md:grid-cols-2 md:gap-12 md:px-gutter md:py-0">
+    <section className="px-gutter-sm py-section-sm grid items-center gap-8 md:grid-cols-2 md:gap-12 md:px-gutter stops:py-0">
       <div>
         <h2 className="text-title leading-tight mb-3.5 font-black text-white italic">
           Check

--- a/src/components/GallerySection.test.tsx
+++ b/src/components/GallerySection.test.tsx
@@ -59,3 +59,21 @@ test("the reader drives the row", () => {
   ).toBeDefined();
   expect(screen.getByRole("button", { name: /next artwork/i })).toBeDefined();
 });
+
+test("the section puts its own padding back where there is no stop", () => {
+  const { container } = render(<GallerySection />);
+
+  // A stop supplies this section's vertical space, so the section drops its
+  // own to avoid counting it twice — but only where a stop exists. Gated on
+  // md instead, a 639px window would get six sections butted flush together
+  // (issue #37).
+  // Listed rather than searched for, so a stray vertical padding fails too.
+  // Spelling the md-gated class here to assert its absence would compile it
+  // into the shipped stylesheet, which is the hazard scripts/built-css.mjs
+  // documents.
+  const vertical = (container.firstElementChild?.className ?? "")
+    .split(/\s+/)
+    .filter((className) => /(^|:)p[byt]-/.test(className));
+
+  expect(vertical.sort()).toEqual(["py-section-sm", "stops:py-0"].sort());
+});

--- a/src/components/GallerySection.tsx
+++ b/src/components/GallerySection.tsx
@@ -21,7 +21,7 @@ export function GallerySection() {
   return (
     // Surface lives on the SnapSection wrapping this, so it fills the stop
     // rather than only the height of the content.
-    <section className="py-section-sm md:py-0">
+    <section className="py-section-sm stops:py-0">
       <div className="mb-10 flex flex-col items-start gap-3 px-gutter-sm md:flex-row md:items-end md:justify-between md:px-gutter">
         <h2 className="text-title leading-tight font-black italic">
           What kids

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -4,7 +4,12 @@ import { Placeholder } from "./Placeholder";
 export function Hero() {
   return (
     <section className="relative grid flex-1 overflow-hidden bg-purple pb-15 md:grid-cols-2 md:pb-0">
-      <div className="relative z-10 col-start-1 row-start-1 flex flex-col justify-center px-6 pt-5 md:px-12 md:py-15">
+      {/* md:py-5, not the py-15 this started at. The column is justify-center
+          inside a cell already `100dvh - nav` tall, so on a tall window the
+          padding is not binding — the content is centred in the same space
+          either way — and on a 555px stop those 80px were most of what made
+          the poster overflow it (issue #37). */}
+      <div className="relative z-10 col-start-1 row-start-1 flex flex-col justify-center px-6 pt-5 md:px-12 md:py-5">
         <p className="mb-7 text-2xs font-extrabold tracking-widest text-yellow uppercase">
           📍 San Diego · K–8 · Outdoors
         </p>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -4,23 +4,29 @@ import { Placeholder } from "./Placeholder";
 export function Hero() {
   return (
     <section className="relative grid flex-1 overflow-hidden bg-purple pb-15 md:grid-cols-2 md:pb-0">
-      {/* md:py-5, not the py-15 this started at. The column is justify-center
-          inside a cell already `100dvh - nav` tall, so on a tall window the
-          padding is not binding — the content is centred in the same space
-          either way — and on a 555px stop those 80px were most of what made
-          the poster overflow it (issue #37). */}
-      <div className="relative z-10 col-start-1 row-start-1 flex flex-col justify-center px-6 pt-5 md:px-12 md:py-5">
-        <p className="mb-7 text-2xs font-extrabold tracking-widest text-yellow uppercase">
+      {/* md:pt-5 md:pb-14, not the symmetric py-15 this started at. Padding on
+          this column is not binding on a tall window — it is justify-center
+          inside a cell already `100dvh - nav` tall, so the content is centred
+          in the same space whatever the padding — which is why trimming it is
+          what let the poster into a 555px stop (issue #37).
+
+          The bottom half is asymmetric on purpose. The "San Diego, CA · K–8"
+          line below is absolutely positioned to the section's bottom edge, and
+          when the section shrinks to the stop the centred content catches up
+          with it and prints straight through the CTA pills. pb-14 reserves the
+          51px that line occupies, so the two cannot meet at any window height. */}
+      <div className="relative z-10 col-start-1 row-start-1 flex flex-col justify-center px-6 pt-5 md:px-12 md:pt-5 md:pb-14">
+        <p className="mb-5 text-2xs font-extrabold tracking-widest text-yellow uppercase">
           📍 San Diego · K–8 · Outdoors
         </p>
-        <h1 className="text-display leading-display mb-8 font-black text-cream italic">
+        <h1 className="text-display leading-display mb-6 font-black text-cream italic">
           Kids who
           <br />
           make,
           <span className="block text-yellow">wonder.</span>
         </h1>
         {/* white/90, up from the template's /70: 4.79:1 vs a failing 3.60:1 */}
-        <p className="leading-relaxed mb-9 max-w-80 text-base text-white/90">
+        <p className="leading-relaxed mb-6 max-w-80 text-base text-white/90">
           Art classes and outdoor co-op rooted in the California coast. Charter
           fund eligible.
         </p>

--- a/src/components/InterestListForm.test.tsx
+++ b/src/components/InterestListForm.test.tsx
@@ -44,3 +44,39 @@ test("the form carries no link to the community page", () => {
   // is what lets /community render the form without pointing at itself.
   expect(screen.queryByRole("link")).toBe(null);
 });
+
+test("the success swap does not change the card's height", () => {
+  const { container } = render(<InterestListForm />);
+  const card = container.firstElementChild as HTMLElement;
+
+  // jsdom applies no stylesheets, so the seam is the arithmetic the class
+  // names encode: Tailwind's spacing scale is n x 4px, and box-sizing is
+  // border-box, so the card's min-height has to be the success state's plus
+  // the card's own padding. They used to be 560 and 552 — the card sized to
+  // the success state rather than to the form, costing the interest-list stop
+  // 57px it did not have to spend (issue #37).
+  const scale = (className: string, prefix: string) => {
+    const found = new RegExp("(?:^| )" + prefix + "-(\\d+)(?: |$)").exec(
+      className,
+    );
+    if (!found) throw new Error(`no ${prefix}- utility in "${className}"`);
+    return Number(found[1]) * 4;
+  };
+
+  const cardMinHeight = scale(card.className, "min-h");
+  const cardPadding = scale(card.className, "p") * 2;
+
+  fireEvent.change(screen.getByLabelText("Your name"), {
+    target: { value: "Robin Parent" },
+  });
+  fireEvent.change(screen.getByLabelText("Email"), {
+    target: { value: "robin@example.com" },
+  });
+  fireEvent.click(
+    screen.getByRole("button", { name: /join the interest list/i }),
+  );
+
+  expect(
+    scale(screen.getByRole("status").className, "min-h") + cardPadding,
+  ).toBe(cardMinHeight);
+});

--- a/src/components/InterestListForm.tsx
+++ b/src/components/InterestListForm.tsx
@@ -28,11 +28,18 @@ export function InterestListForm() {
   return (
     // min-h ≈ the rendered form, so the success swap doesn't collapse the
     // card and yank the page while the user is looking at it.
-    <div className="rounded-card shadow-card min-h-140 bg-white p-9">
+    //
+    // Both numbers are derived from that form: it measures 431px of content
+    // inside 36px of padding, so the card is 126 (504px) and the success state
+    // 108 (432px), and the swap is exactly height-neutral. They used to be 140
+    // and 120, which sized the card to the *success* state — 552px against the
+    // form's 503 — and cost the interest-list stop 57px it did not have to
+    // spend. `InterestListForm.test.tsx` now asserts the two agree.
+    <div className="rounded-card shadow-card min-h-126 bg-white p-9">
       {submitted ? (
         <div
           role="status"
-          className="flex min-h-120 flex-col justify-center px-5 py-10 text-center"
+          className="flex min-h-108 flex-col justify-center px-5 py-10 text-center"
         >
           <span aria-hidden="true" className="mb-4 block text-[52px]">
             🎉

--- a/src/components/InterestListTeaser.test.tsx
+++ b/src/components/InterestListTeaser.test.tsx
@@ -22,3 +22,19 @@ test("the section teases the full community page", () => {
       .getAttribute("href"),
   ).toBe("/community");
 });
+
+test("the section puts its own padding back where there is no stop", () => {
+  const { container } = render(<InterestListTeaser />);
+
+  // See GallerySection.test.tsx: the stop supplies this space, and only a
+  // window big enough to hold a stop has one.
+  // Listed rather than searched for, so a stray vertical padding fails too.
+  // Spelling the md-gated class here to assert its absence would compile it
+  // into the shipped stylesheet, which is the hazard scripts/built-css.mjs
+  // documents.
+  const vertical = (container.firstElementChild?.className ?? "")
+    .split(/\s+/)
+    .filter((className) => /(^|:)p[byt]-/.test(className));
+
+  expect(vertical.sort()).toEqual(["py-section-sm", "stops:py-0"].sort());
+});

--- a/src/components/InterestListTeaser.tsx
+++ b/src/components/InterestListTeaser.tsx
@@ -13,7 +13,7 @@ export function InterestListTeaser() {
   return (
     // The #community anchor lives on the SnapSection wrapping this, so the
     // links that target it land on a snap stop rather than mid-section.
-    <section className="px-gutter-sm py-section-sm grid items-start gap-10 md:grid-cols-2 md:gap-20 md:px-gutter md:py-0">
+    <section className="px-gutter-sm py-section-sm grid items-start gap-10 md:grid-cols-2 md:gap-20 md:px-gutter stops:py-0">
       <div>
         <h2 className="text-title leading-display mb-4 font-black italic">
           Stay in

--- a/src/components/ProgramCards.test.tsx
+++ b/src/components/ProgramCards.test.tsx
@@ -34,3 +34,19 @@ test("the co-op card lists all four activities", () => {
     expect(screen.getByText(name)).toBeDefined();
   }
 });
+
+test("the cards put their own padding back where there is no stop", () => {
+  const { container } = render(<ProgramCards />);
+
+  // See GallerySection.test.tsx: the stop supplies this space, and only a
+  // window big enough to hold a stop has one.
+  // Listed rather than searched for, so a stray vertical padding fails too.
+  // Spelling the md-gated class here to assert its absence would compile it
+  // into the shipped stylesheet, which is the hazard scripts/built-css.mjs
+  // documents.
+  const vertical = (container.firstElementChild?.className ?? "")
+    .split(/\s+/)
+    .filter((className) => /(^|:)p[byt]-/.test(className));
+
+  expect(vertical.sort()).toEqual(["pb-section-sm", "stops:pb-0"].sort());
+});

--- a/src/components/ProgramCards.tsx
+++ b/src/components/ProgramCards.tsx
@@ -8,8 +8,16 @@ const COOP_ACTIVITIES = [
   { emoji: "🔬", name: "Science" },
 ];
 
+/* p-7, not the p-9 this started at: a card has to come in under the 540px a
+   stop budgets (issue #37), and 16px of padding is the cheapest of the three
+   places that height was hiding. */
 const CARD_BASE =
-  "rounded-card relative flex min-h-[520px] flex-col justify-between overflow-hidden p-9 transition-transform duration-fast hover:-translate-y-1";
+  "rounded-card relative flex min-h-[520px] flex-col justify-between overflow-hidden p-7 transition-transform duration-fast hover:-translate-y-1";
+
+/* leading-none on a decorative glyph: at text-[44px] the default line box
+   renders 66px tall, so 22px of the card's height was line-height around an
+   emoji. Nothing moves visually. */
+const CARD_EMOJI = "mb-4 block text-[44px] leading-none";
 
 export function ProgramCards() {
   return (
@@ -28,7 +36,7 @@ export function ProgramCards() {
             [ 01 ]
           </p>
           <div className="relative z-10 flex flex-col">
-            <span aria-hidden="true" className="mb-4 block text-[44px]">
+            <span aria-hidden="true" className={CARD_EMOJI}>
               🎨
             </span>
             <h2 className="text-card leading-display mb-2 font-black text-white italic">
@@ -78,7 +86,7 @@ export function ProgramCards() {
             [ 02 ]
           </p>
           <div className="relative z-10 flex flex-col">
-            <span aria-hidden="true" className="mb-4 block text-[44px]">
+            <span aria-hidden="true" className={CARD_EMOJI}>
               🌿
             </span>
             <h2 className="text-card leading-display mb-2 font-black text-white italic">
@@ -93,7 +101,7 @@ export function ProgramCards() {
               {COOP_ACTIVITIES.map(({ emoji, name }) => (
                 <li
                   key={name}
-                  className="rounded-tile bg-white/12 p-3 text-center"
+                  className="rounded-tile bg-white/12 p-2.5 text-center"
                 >
                   <span aria-hidden="true" className="mb-1 block text-[22px]">
                     {emoji}

--- a/src/components/ProgramCards.tsx
+++ b/src/components/ProgramCards.tsx
@@ -13,7 +13,7 @@ const CARD_BASE =
 
 export function ProgramCards() {
   return (
-    <div className="px-gutter-sm pb-section-sm md:px-gutter md:pb-0">
+    <div className="px-gutter-sm pb-section-sm md:px-gutter stops:pb-0">
       <div className="grid gap-4 md:grid-cols-2">
         <article className={`${CARD_BASE} bg-purple`}>
           <Placeholder

--- a/src/components/QuoteStats.test.tsx
+++ b/src/components/QuoteStats.test.tsx
@@ -30,3 +30,19 @@ test("the closing section carries no divider at all", () => {
   // and it separates nothing: the section above is never on screen with it.
   expect(container.firstElementChild?.className).not.toContain("border-");
 });
+
+test("the section puts its own padding back where there is no stop", () => {
+  const { container } = render(<QuoteStats />);
+
+  // See GallerySection.test.tsx: the stop supplies this space, and only a
+  // window big enough to hold a stop has one.
+  // Listed rather than searched for, so a stray vertical padding fails too.
+  // Spelling the md-gated class here to assert its absence would compile it
+  // into the shipped stylesheet, which is the hazard scripts/built-css.mjs
+  // documents.
+  const vertical = (container.firstElementChild?.className ?? "")
+    .split(/\s+/)
+    .filter((className) => /(^|:)p[byt]-/.test(className));
+
+  expect(vertical.sort()).toEqual(["py-section-sm", "stops:py-0"].sort());
+});

--- a/src/components/QuoteStats.tsx
+++ b/src/components/QuoteStats.tsx
@@ -18,7 +18,7 @@ export function QuoteStats() {
     // No divider: this stop and the one above it are never on screen at the
     // same time, and once the stop fills its screen a top border draws hard
     // against the nav rather than separating anything.
-    <section className="px-gutter-sm py-section-sm md:px-gutter md:py-0">
+    <section className="px-gutter-sm py-section-sm md:px-gutter stops:py-0">
       <div className="grid gap-8 md:grid-cols-2 md:gap-12">
         {QUOTES.map(({ lead, tail }) => (
           <figure key={lead}>

--- a/src/components/SnapSection.test.tsx
+++ b/src/components/SnapSection.test.tsx
@@ -5,7 +5,7 @@ import { SnapSection } from "./SnapSection";
 // jsdom applies no stylesheets, so the class contract is the seam, as in
 // StripTrack.test.tsx.
 
-test("a section is a snap stop a screen tall, from md up", () => {
+test("a section is a snap stop a screen tall, where a stop fits", () => {
   const { container } = render(
     <SnapSection>
       <p>content</p>
@@ -13,9 +13,9 @@ test("a section is a snap stop a screen tall, from md up", () => {
   );
 
   const section = container.firstElementChild;
-  expect(section?.className).toContain("md:snap-start");
+  expect(section?.className).toContain("stops:snap-start");
   expect(section?.className).toContain(
-    "md:min-h-[calc(100dvh-var(--spacing-nav))]",
+    "stops:min-h-[calc(100dvh-var(--spacing-nav))]",
   );
 });
 
@@ -30,23 +30,24 @@ test("centring never pushes content off the top of the stop", () => {
   // of a snap stop cannot be scrolled to — content taller than the box
   // becomes unreachable. The safe variant falls back to start-alignment.
   const section = container.firstElementChild;
-  expect(section?.className).toContain("md:justify-center-safe");
-  expect(section?.className).not.toMatch(/md:justify-center(?!-safe)/);
+  expect(section?.className).toContain("stops:justify-center-safe");
+  expect(section?.className).not.toMatch(/stops:justify-center(?!-safe)/);
 });
 
-test("nothing is forced below md", () => {
+test("nothing is forced on a window too small for a stop", () => {
   const { container } = render(
     <SnapSection>
       <p>content</p>
     </SnapSection>,
   );
 
-  // Two of the landing page's sections are taller than a phone viewport, so
-  // a phone gets an ordinary page: every class here is md-scoped.
+  // Two sections are taller than a phone viewport and three are taller than a
+  // 639px desktop one, so outside the stops variant the page is an ordinary
+  // scrolling one: every class here is scoped to it.
   const classes = container.firstElementChild?.className.split(/\s+/) ?? [];
   expect(classes.length).toBeGreaterThan(0);
   for (const className of classes) {
-    expect(className.startsWith("md:")).toBe(true);
+    expect(className.startsWith("stops:")).toBe(true);
   }
 });
 
@@ -60,8 +61,8 @@ test("a content-height section keeps its own height but stays a stop", () => {
   // The hero, which brings its own height and fills the screen at every
   // width rather than only from md up.
   const section = container.firstElementChild;
-  expect(section?.className).toContain("md:snap-start");
-  expect(section?.className).not.toContain("md:min-h-");
+  expect(section?.className).toContain("stops:snap-start");
+  expect(section?.className).not.toContain("stops:min-h-");
 });
 
 test("the closing stop leaves room for the footer", () => {
@@ -74,7 +75,7 @@ test("the closing stop leaves room for the footer", () => {
   // Both tokens are the ones the nav and footer set their own heights from,
   // so the three agree by construction and nothing measures anything.
   expect(container.firstElementChild?.className).toContain(
-    "md:min-h-[calc(100dvh-var(--spacing-nav)-var(--spacing-footer))]",
+    "stops:min-h-[calc(100dvh-var(--spacing-nav)-var(--spacing-footer))]",
   );
 });
 

--- a/src/components/SnapSection.tsx
+++ b/src/components/SnapSection.tsx
@@ -42,10 +42,10 @@ const TONES = {
  * point of the module.
  *
  * Everything is behind the `stops` variant: wide enough *and* tall enough for
- * a stop. Two of the landing page's sections are taller than a phone viewport,
- * and three are taller than a 639px desktop one, so outside that window there
- * is no snapping and no forced height — the page scrolls normally, and the
- * sections put their own vertical padding back.
+ * a stop. Below it — a phone, a tablet, a short window — there is no snapping
+ * and no forced height, and the sections put their own vertical padding back.
+ * The six stops are trimmed to fit the 540px that variant guarantees, so a
+ * stop that overflows is a bug in the section, not in this box.
  *
  * `justify-center-safe`, not `justify-center`: plain centring pushes an
  * over-tall child out of *both* ends of the box, and the top end of a snap

--- a/src/components/SnapSection.tsx
+++ b/src/components/SnapSection.tsx
@@ -10,14 +10,14 @@ type SnapSectionProps = {
   tone?: "cream" | "mist" | "ocean";
 };
 
-const CENTRED = "md:flex md:flex-col md:justify-center-safe";
+const CENTRED = "stops:flex stops:flex-col stops:justify-center-safe";
 
 const HEIGHTS = {
-  screen: `md:min-h-[calc(100dvh-var(--spacing-nav))] ${CENTRED}`,
+  screen: `stops:min-h-[calc(100dvh-var(--spacing-nav))] ${CENTRED}`,
   /* The footer sits below this stop and shares its screen, so the stop is
      the window less the nav less the footer. Both come from tokens the nav
      and footer set their own heights from, so nothing measures anything. */
-  "screen-less-footer": `md:min-h-[calc(100dvh-var(--spacing-nav)-var(--spacing-footer))] ${CENTRED}`,
+  "screen-less-footer": `stops:min-h-[calc(100dvh-var(--spacing-nav)-var(--spacing-footer))] ${CENTRED}`,
   /* The hero brings its own height, and fills the screen at every width
      rather than only from md up. */
   content: "",
@@ -41,9 +41,11 @@ const TONES = {
  * fold. Holding that subtraction here rather than at six call sites is the
  * point of the module.
  *
- * Everything is `md` and up. Two of the landing page's sections are taller
- * than a phone viewport, so below `md` there is no snapping and no forced
- * height — a phone gets an ordinary scrolling page.
+ * Everything is behind the `stops` variant: wide enough *and* tall enough for
+ * a stop. Two of the landing page's sections are taller than a phone viewport,
+ * and three are taller than a 639px desktop one, so outside that window there
+ * is no snapping and no forced height — the page scrolls normally, and the
+ * sections put their own vertical padding back.
  *
  * `justify-center-safe`, not `justify-center`: plain centring pushes an
  * over-tall child out of *both* ends of the box, and the top end of a snap
@@ -51,9 +53,10 @@ const TONES = {
  * the moment the content stops fitting, so the top of a section is always
  * reachable.
  *
- * Children do not add their own vertical padding at `md` — this box supplies
- * the space. Padding on both would be counted twice, which is what pushed
- * sections past the height they had to fit in.
+ * Children do not add their own vertical padding under `stops` — this box
+ * supplies the space. Padding on both would be counted twice, which is what
+ * pushed sections past the height they had to fit in. They gate that on the
+ * same variant, so the padding comes back wherever this height does not apply.
  */
 export function SnapSection({
   children,
@@ -64,7 +67,7 @@ export function SnapSection({
   return (
     <section
       id={id}
-      className={`md:snap-start ${TONES[tone]} ${HEIGHTS[height]}`}
+      className={`stops:snap-start ${TONES[tone]} ${HEIGHTS[height]}`}
     >
       {children}
     </section>


### PR DESCRIPTION
Closes #37

Three of the six stops were taller than the 555px a stop gets on the machine
this site is reviewed from. **They are now trimmed to fit it**, and the page
snaps at 1536×639 with every stop whole.

Plan: `docs/plans/stop-height-threshold.md`.

## This PR changed direction mid-flight — read this first

The first three commits fixed #37 by switching the stops **off** below 720px of
window height. That was wrong, and the review caught it:

```
screen.height       864   1920x1080 at 125% scaling
screen.availHeight  816   less the taskbar
Chrome's furniture  177
max viewport        639   <- maximised, on this display, full stop
```

**A 720px threshold cannot be met on that display.** So the fix did not switch
snapping off "on short windows" — it switched it off permanently on the only
machine the site is reviewed from, and left #38 unbuildable there. That is the
original bug committed one level up: reasoning about which windows keep the
stops without checking whether the reviewer's could be one of them.

The commits are kept rather than squashed away, and `c9e73ef` records the
reversal, because the mistake is instructive and the infrastructure from those
commits — the variant, the at-rule gate row — is what the fix is built on.

## What shipped

| stop | was | where the height was | change | now |
| --- | --- | --- | --- | --- |
| hero | 612 | 120px of `md:py-15`, 28px of internal margin | `md:pt-5 md:pb-14`, three margins | **532** |
| program cards | 577 | `p-9`; the emoji renders 66px tall at `text-[44px]` | `p-7`, `leading-none`, tighter activity tiles | **531** |
| interest list | 560 | `min-h-140` on the form card | card `min-h-126`, success `min-h-108` | **504** |
| gallery | 473 | — | — | 473 |
| conditions / quotes | 312 / 297 | — | — | unchanged |

**No type sizes changed and no copy was cut.** Two of the three cost nothing
visible:

- **The poster's padding is not binding on a tall window.** Its text column is
  `justify-center` inside a cell already `100dvh - nav` tall, so the content is
  centred in the same space whatever the padding is. Cutting it changes the
  poster only on the windows that needed it cut.
- **The interest list's `min-h` contradicted its own comment.** It claimed to be
  sized to the rendered form; the form is 431px of content in a 36px-padded card
  (503), while the success state's `min-h-120` made it 552. The card was sized to
  the success state and the stop paid 57px for it. Both now derive from the form,
  and a new test asserts the swap is height-neutral — **it fails on the old
  560/552 pair** (`expected 552 to be 560`).

The variant survives at **`(min-width: 64rem) and (min-height: 39rem)`**. 39rem
because 40rem is 640px, one pixel above the ceiling above. 64rem because between
768 and 1023 the cards' columns are narrow enough that the CTA pills wrap to a
second line, which padding cannot buy back; that band scrolls, the same rule the
gallery already follows.

## A regression I introduced and fixed (`2661293`)

Cutting the hero's padding moved the section's bottom edge up 57px while its
centred content only rose 29 — and "San Diego, CA · K–8" is absolutely
positioned to that bottom edge, so it printed straight through the CTA pills.
Measured: the label's full 15px inside the CTA row's band.

Fixed by reserving the line's space as the column's bottom padding rather than
nudging the label, since that padding is free above the threshold. Clearance
now: 5px at 1536×624 (the tightest window the variant admits), 13px at
1536×639, 233px at 1920×1080.

## Verification

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

`stylesheet` row evidence, reading the real build:

```
read  .next\static\chunks\2_s3r9dha3t7s.css
ok    snap-none absent
ok    .justify-center-safe{justify-content:safe center}
ok    .stops\:justify-center-safe{justify-content:safe center}
ok    .md\:min-h-footer{min-height:var(--spacing-footer)}
ok    .scroll-pt-nav-sm{scroll-padding-top:var(--spacing-nav-sm)}
ok    @media (min-width:64rem) and (min-height:39rem) wraps .stops\:flex .stops\:min-h-\[calc\(100dvh-var\(--spacing-nav\)\)\] .stops\:min-h-\[calc\(100dvh-var\(--spacing-nav\)-var\(--spacing-footer\)\)\] .stops\:snap-start .stops\:flex-col .stops\:justify-center-safe .stops\:py-0 .stops\:pb-0 .motion-safe\:stops\:snap-y .motion-safe\:stops\:snap-mandatory
```

In Chrome, at **1536×639** — the window #37 was filed from:

- `scroll-snap-type: y mandatory`; all six stops report `scroll-snap-align:
  start` and fit the 555px available.
- The six stop edges land at exactly `0, 555, 1110, 1666, 2221, 2776`, and
  scrolling to 137 / 900 / 1450 / 2100 settles on one every time.
- The interest list is a whole screen for the first time — form, checkboxes and
  submit button all above the fold. That stop was clipped in the review.

Swept elsewhere: every stop fits at 1024×624, 1280×624, 1536×624 (the threshold
window, where the hero lands at exactly its 540 budget), 1536×639, 1700×639,
1920×1080 and 2200×1200.

## Not done

- **#40.** The gallery's stop still grows with viewport width without limit —
  473 at 1536, 559 at 1920, 703 at 2560 — so on a 639px-tall window it overflows
  **above about 1850px wide**. Below that, including at your window, it fits.
  Its `md`–`lg` half is moot now that the band has no stops. The real fix is the
  `gallery-fit` cap already designed in `gallery-aspect-rhythm.md`, which
  derives the grid's max width from the stop's height; that belongs to #38.
- **#38**, the two-stop gallery grid, is now unblocked at 1536×639 — that was
  the point of getting the stops to fit.
- **Phone and tablet snapping**, and **`proximity`**, both still rejected.
- **The reduced-motion asymmetry** — `motion-safe:` gates the snap type but not
  the forced heights. Pre-existing, out of scope, now written down.
