### PR TITLE
Make Tailwind source detection opt-in, scanning src/ only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -281,7 +281,15 @@ learn, and say what it cost — the reason is what stops it being re-litigated.
 These are the rules that are specific to this repo and would be wrong elsewhere:
 domain constraints, external system quirks, threading contracts, data formats. -->
 
-_(nothing yet)_
+**Prose never reaches the stylesheet.** Tailwind's source detection is opt-in
+here: `src/app/globals.css` imports it with `source(none)` and names `src/` as
+the only scanned directory. That is what makes "the class is in the built CSS"
+evidence that a component uses it — the reading the `stylesheet` gate row and
+several PRs before it depend on. It also means this file, `CONTEXT.md` and
+`README.md` may name a utility while explaining a convention — `snap-none`,
+say — without compiling it into the shipped stylesheet. The gate asserts that
+exact name stays absent, so this sentence is the check's canary as well as its
+documentation. See `docs/adr/0006-opt-in-tailwind-source-detection.md`.
 
 ---
 

--- a/docs/adr/0006-opt-in-tailwind-source-detection.md
+++ b/docs/adr/0006-opt-in-tailwind-source-detection.md
@@ -1,0 +1,80 @@
+# 0006 — Tailwind source detection is opt-in, not opt-out
+
+Date: 2026-08-15. Status: accepted.
+
+## Context
+
+Tailwind v4 scans every non-gitignored file in the project by default and
+compiles any utility name it finds. Prose counts: a class name written in a
+plan, a review or an instruction file becomes a real rule in the shipped
+stylesheet.
+
+That is not merely dead CSS. This repo reads the built stylesheet as evidence.
+The `stylesheet` gate row (`scripts/check-built-css.mjs`, ADR 0002's split)
+asserts that `justify-center-safe`, `min-h-footer` and `scroll-pt-nav-sm` emit
+real declarations, and that `snap-none` does not — because "the class is in the
+built CSS" is what proves a utility resolved to something rather than silently
+to nothing. Every one of those assertions rests on the scanner seeing only
+files that are actually shipped. The moment prose feeds it, presence stops
+proving anything.
+
+PR #22 (issue #15) excluded `docs/` and `.design/`. `README.md`, `CONTEXT.md`,
+`CLAUDE.md` and `AGENTS.md` sit at the repo root, outside both, and were still
+scanned. Issue #24 filed that as latent: an audit of the built stylesheet at
+the time found no prose-only class had survived, so there was nothing to
+remove. Planting one sentence in `CLAUDE.md` that names `snap-none` while
+explaining the convention was enough to make the gate red, which is exactly the
+document the issue predicted would do it by accident.
+
+`scripts/` was scanned too, and had been paid for. `built-css.mjs` could not
+write the names it checks as plain strings, because doing so would compile them
+into the very stylesheet it reads — a forbidden name present because the table
+forbids it, required names emitted by the table rather than by the app. It
+carried the class names split into `segments: ["snap", "none"]`, a
+`utilityName()` join, and a guard test walking `scripts/` to fail if anyone ever
+spelled one in full.
+
+## Decision
+
+`src/app/globals.css` imports Tailwind with automatic detection switched off
+and names the application directory as the only source:
+
+```css
+@import "tailwindcss" source(none);
+@source "../../src";
+```
+
+Detection is therefore opt-in. A new source directory has to be declared before
+its classes compile.
+
+## Consequences
+
+The rejected alternative was to keep detection automatic and add the four root
+files to the existing `@source not` list. It is a smaller diff and it fixes
+today's instance. It does not fix the shape: the hazard returns silently the
+next time anyone adds a Markdown file, a config, or a fixture at the root, and
+nothing fails at the moment it is introduced — the audit that found it this
+time was manual and one-off. Opt-out means the correct list is "everything
+anyone will ever add", which is not a list that can be maintained.
+
+Inverting also retires the `scripts/` workaround rather than leaving it to be
+re-derived. `built-css.mjs` now spells the utilities it checks as plain
+strings, `utilityName()` is gone, and the guard test that walked `scripts/` is
+deleted — that test existed only to enforce a constraint this decision removes.
+The comment explaining why names were split is gone with it, which is most of
+the win: the next reader of that file no longer has to understand a defence
+against a hazard that no longer exists.
+
+The cost is a new failure mode with an unhelpful symptom. If someone adds a
+component outside `src/`, its utilities compile to nothing and the page renders
+unstyled with no error — Tailwind does not warn about a class it never saw. The
+opt-out arrangement would have compiled them silently instead. Both are silent;
+this one fails toward missing CSS rather than toward CSS that lies, and the
+`stylesheet` gate row catches the case that matters by asserting real
+declarations rather than mere presence.
+
+The invariant is now stated in CLAUDE.md's _Project invariants_, and the
+sentence that states it names `snap-none` on purpose. It is the canary: it sits
+in a root Markdown file, the gate forbids it, and it would fail the moment
+detection stopped being opt-in. The documentation and the regression test are
+the same sentence.

--- a/scripts/built-css.mjs
+++ b/scripts/built-css.mjs
@@ -4,9 +4,9 @@
  * Tailwind compiles a utility only when it finds the class name in a scanned
  * source, so the built stylesheet is where you learn whether a utility emits
  * real CSS or silently resolves to nothing. That reading only holds while
- * nothing outside the app feeds the scanner, which is what the `@source not`
- * lines in src/app/globals.css are for. Both directions are asserted here:
- * absence alone is also satisfied by an exclusion that compiled nothing.
+ * nothing outside the app feeds the scanner, which is what the `source(none)`
+ * import in src/app/globals.css is for. Both directions are asserted here:
+ * absence alone is also satisfied by a source list that compiled nothing.
  *
  * The only filesystem call takes the directory to read as an argument, so the
  * whole file is tested against a temp directory rather than a real build. Add
@@ -24,37 +24,16 @@ import { join } from "node:path";
 export const STYLESHEET_ROOT = ".next/static";
 
 /**
- * An expectation names its utility in segments rather than as a whole class
- * name, and `scripts/` is the reason: Tailwind's automatic source detection
- * scans this directory exactly as it scanned `docs/` before PR #22, so a
- * literal class name written here compiles into the very stylesheet this file
- * reads. That does not merely fail the row, it empties it — the forbidden name
- * would be present because this table names it, and the required ones would
- * emit from this table rather than from the app. No segment below is a
- * Tailwind utility on its own, so nothing compiles from them.
- *
- * `built-css.test.mjs` walks scripts/ and fails if any file spells one of
- * these names, so this stays true without anyone having to remember it.
- *
- * Issue #24 proposes replacing the exclusions with a positive `@source` for
- * `src/`, which inverts detection to opt-in and covers this directory. When it
- * lands, delete that test and make these plain strings.
- *
  * @typedef {object} Expectation
- * @property {string[]} segments  The class name, split so no part is a utility.
- * @property {string} why         Printed with the row, so a failure explains itself.
+ * @property {string} utility  The class name, as it is written in src/.
+ * @property {string} why      Printed with the row, so a failure explains itself.
  */
-
-/** @param {Expectation} expectation @returns {string} */
-export function utilityName({ segments }) {
-  return segments.join("-");
-}
 
 /** Utilities that must appear nowhere in the built stylesheet. */
 /** @type {Expectation[]} */
 export const FORBIDDEN = [
   {
-    segments: ["snap", "none"],
+    utility: "snap-none",
     why: "in no file under src/. CLAUDE.md's Project invariants names it while stating that prose never reaches the stylesheet, and that sentence is this row's canary: a root Markdown file is exactly what the opt-out arrangement could not exclude, so its return means detection has stopped being opt-in",
   },
 ];
@@ -92,15 +71,15 @@ export const AT_RULES = [
 /** @type {Expectation[]} */
 export const REQUIRED = [
   {
-    segments: ["justify", "center", "safe"],
+    utility: "justify-center-safe",
     why: "SnapSection centres a stop's content with it, and safe centring is what keeps an over-tall section reachable",
   },
   {
-    segments: ["min", "h", "footer"],
+    utility: "min-h-footer",
     why: "Footer takes its height from the --spacing-footer token through it",
   },
   {
-    segments: ["scroll", "pt", "nav", "sm"],
+    utility: "scroll-pt-nav-sm",
     why: "the root element offsets every snap stop by the nav height with it",
   },
 ];
@@ -120,13 +99,12 @@ function escapeForRegExp(text) {
  * Every rule in `css` whose selector carries this utility as a class token and
  * whose body holds at least one declaration.
  *
- * The token may be variant-prefixed: two of the required utilities are used in
- * src/ only under a variant — one under `md:`, one under `stops:` — so the
- * built selector escapes the variant into the class name and a matcher
- * anchored on a leading dot would report a working utility as missing. Naming
- * which two is exactly what the guard test at the foot of the test file
- * forbids. Matching a bare substring instead would count a mention in a
- * comment as a pass, which is the failure this whole check exists to remove.
+ * The token may be variant-prefixed, and one of the required utilities has no
+ * other form: `min-h-footer` is written in src/ only as `md:min-h-footer`, so
+ * the built selector escapes the variant into the class name and a matcher
+ * anchored on a leading dot would report a working utility as missing.
+ * Matching a bare substring instead would count a mention in a comment as a
+ * pass, which is the failure this whole check exists to remove.
  *
  * @param {string} css
  * @param {string} utility
@@ -222,22 +200,20 @@ export function auditStylesheets(stylesheets) {
   const lines = stylesheets.map((sheet) => `read  ${sheet.path}`);
   let ok = true;
 
-  for (const expectation of FORBIDDEN) {
-    const utility = utilityName(expectation);
+  for (const { utility, why } of FORBIDDEN) {
     if (css.includes(utility)) {
       ok = false;
-      lines.push(`FAIL  ${utility} is in the built CSS — ${expectation.why}`);
+      lines.push(`FAIL  ${utility} is in the built CSS — ${why}`);
     } else {
       lines.push(`ok    ${utility} absent`);
     }
   }
 
-  for (const expectation of REQUIRED) {
-    const utility = utilityName(expectation);
+  for (const { utility, why } of REQUIRED) {
     const rules = rulesFor(css, utility);
     if (rules.length === 0) {
       ok = false;
-      lines.push(`FAIL  ${utility} emits no declarations — ${expectation.why}`);
+      lines.push(`FAIL  ${utility} emits no declarations — ${why}`);
     } else {
       for (const rule of rules) lines.push(`ok    ${rule}`);
     }

--- a/scripts/built-css.mjs
+++ b/scripts/built-css.mjs
@@ -55,7 +55,7 @@ export function utilityName({ segments }) {
 export const FORBIDDEN = [
   {
     segments: ["snap", "none"],
-    why: "in no file under src/; only prose in docs/plans/section-snapping.md, so its return means a directory outside the app is feeding Tailwind's scanner",
+    why: "in no file under src/. CLAUDE.md's Project invariants names it while stating that prose never reaches the stylesheet, and that sentence is this row's canary: a root Markdown file is exactly what the opt-out arrangement could not exclude, so its return means detection has stopped being opt-in",
   },
 ];
 

--- a/scripts/built-css.test.mjs
+++ b/scripts/built-css.test.mjs
@@ -1,12 +1,5 @@
 import { afterEach, describe, expect, test } from "vitest";
-import {
-  mkdirSync,
-  mkdtempSync,
-  readdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -18,19 +11,16 @@ import {
   checkBuiltCss,
   findStylesheets,
   rulesFor,
-  utilityName,
 } from "./built-css.mjs";
 
-// Utilities are named in segments in the table under test, so the literals
-// here are invented ones that Tailwind compiles to nothing. Spelling a real
-// one would put it in the shipped stylesheet — see the guard test at the foot
-// of this file.
+// An invented name rather than a real utility, so that what these tests assert
+// about the matcher stays true whatever rows the table happens to hold.
 const PROBE = "gate-probe";
 
 /** A stylesheet that satisfies every expectation, so tests can break one. */
 const compiled = () =>
   [
-    ...REQUIRED.map((expectation) => `.${utilityName(expectation)}{color:red}`),
+    ...REQUIRED.map((expectation) => `.${expectation.utility}{color:red}`),
     ...AT_RULES.map(({ prelude }) => `${prelude}{.${PROBE}{color:red}}`),
     ".unrelated{display:block}",
   ].join("");
@@ -143,7 +133,7 @@ describe("auditStylesheets", () => {
   });
 
   test("fails when a required utility emits nothing", () => {
-    const utility = utilityName(REQUIRED[0]);
+    const { utility } = REQUIRED[0];
     const css = compiled().replace(`.${utility}{color:red}`, "");
     const { ok, lines } = auditStylesheets(sheet(css));
 
@@ -153,10 +143,10 @@ describe("auditStylesheets", () => {
     );
   });
 
-  // Absence has to be asserted as well as presence: a broken exclusion is how
-  // prose gets back into the shipped stylesheet.
+  // Absence has to be asserted as well as presence: a source list that reaches
+  // past src/ is how prose gets back into the shipped stylesheet.
   test("fails when a forbidden utility is present", () => {
-    const utility = utilityName(FORBIDDEN[0]);
+    const { utility } = FORBIDDEN[0];
     const { ok, lines } = auditStylesheets(
       sheet(`${compiled()}.${utility}{scroll-snap-type:none}`),
     );
@@ -166,7 +156,7 @@ describe("auditStylesheets", () => {
   });
 
   test("fails on a forbidden utility mentioned anywhere, rule or not", () => {
-    const utility = utilityName(FORBIDDEN[0]);
+    const { utility } = FORBIDDEN[0];
     expect(auditStylesheets(sheet(`${compiled()}/* ${utility} */`)).ok).toBe(
       false,
     );
@@ -185,7 +175,7 @@ describe("auditStylesheets", () => {
     const split = [
       ...REQUIRED.map((expectation, index) => ({
         path: `required-${index}.css`,
-        css: `.${utilityName(expectation)}{color:red}`,
+        css: `.${expectation.utility}{color:red}`,
       })),
       ...AT_RULES.map(({ prelude }, index) => ({
         path: `at-rule-${index}.css`,
@@ -277,31 +267,5 @@ describe("checkBuiltCss", () => {
 
     expect(ok).toBe(false);
     expect(lines.join("\n")).toContain("no stylesheet to read");
-  });
-});
-
-// The regression that made this row assert nothing on its first run: Tailwind
-// scans scripts/, so a utility named here in full compiles into the stylesheet
-// this row reads. The forbidden one then always fails and the required ones
-// always pass, whatever the app does. Names are built at runtime for the same
-// reason. Delete this once issue #24 makes source detection opt-in for src/.
-describe("the checker's own sources", () => {
-  test("no file under scripts/ spells a utility the table checks", () => {
-    // import.meta.dirname, not a URL derived from import.meta.url: the jsdom
-    // environment shadows the global URL, and Node's fileURLToPath rejects
-    // what jsdom's constructor returns for a file: URL.
-    const directory = import.meta.dirname;
-    const utilities = [...FORBIDDEN, ...REQUIRED].map(utilityName);
-    const offenders = [];
-
-    for (const name of readdirSync(directory)) {
-      if (!name.endsWith(".mjs")) continue;
-      const source = readFileSync(join(directory, name), "utf8");
-      for (const utility of utilities) {
-        if (source.includes(utility)) offenders.push(`${name}: ${utility}`);
-      }
-    }
-
-    expect(offenders).toEqual([]);
   });
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,13 +1,20 @@
-@import "tailwindcss";
+/* `source(none)` switches off Tailwind's automatic detection, which would
+   otherwise scan every non-gitignored file in the project and compile any
+   utility it found in prose. That would make "the class is in the built CSS"
+   stop proving a component uses it — the reading the `stylesheet` gate row and
+   several PRs before it depend on to confirm a utility emits real CSS rather
+   than silently resolving to nothing.
 
-/* Tailwind's automatic source detection scans every non-gitignored file in the
-   project, so a class name written in prose compiles into the shipped
-   stylesheet. That makes "the class is in the built CSS" stop proving a
-   component uses it — the check several PRs rely on to confirm a utility emits
-   real CSS rather than silently resolving to nothing. Paths are relative to
-   this file, so ../../ is the repo root. */
-@source not "../../docs";
-@source not "../../.design";
+   So the app names its own sources instead. Detection is opt-in: a directory
+   outside src/ compiles nothing until it is declared here. The list this
+   replaces was the opposite shape, naming docs/ and .design/ as exclusions,
+   and it could only ever name the places prose had already reached — the root
+   Markdown files were outside it. See
+   docs/adr/0006-opt-in-tailwind-source-detection.md.
+
+   Paths are relative to this file, so ../../ is the repo root. */
+@import "tailwindcss" source(none);
+@source "../../src";
 
 /* "This window can hold a stop." The landing page's one-screen layout — the
    snap type, the stops' forced heights and centring, and the sections dropping


### PR DESCRIPTION
Closes #24.

Tailwind's source detection is now opt-in: `src/app/globals.css` imports with
`source(none)` and declares `src/` as the only scanned directory. The `docs/`
and `.design/` exclusions PR #22 added are gone, replaced rather than extended.

## Why inverting rather than naming the root files

The issue offered both shapes and asked which was chosen. An exclusion list can
only name the places prose has already reached — `README.md`, `CONTEXT.md`,
`CLAUDE.md` and `AGENTS.md` were outside PR #22's list precisely because nobody
was thinking about the repo root at the time. Adding those four fixes today's
instance and leaves the shape that produced it: the hazard returns silently the
next time anyone adds a file at the root, and nothing fails when it does. The
correct exclusion list is "everything anyone will ever add", which is not a
list that can be maintained.

Reasoning, the rejected alternative and the new failure mode this creates are
in `docs/adr/0006-opt-in-tailwind-source-detection.md`.

`@import "tailwindcss" source(none)` was verified against the installed
Tailwind 4.3.3 rather than assumed — a bare `@source` adds to automatic
detection instead of replacing it, so the `source(none)` half is load-bearing.

## Slices

1. **`4cc51b6`** — ADR 0006. No plan file: the issue body plus the ADR already
   carry the problem, the decision, the rejected option and the verification.
2. **`331a29f`** — the fix, with the regression test that failed first.
3. **`a6624be`** — retire the `scripts/` workaround the fix makes unnecessary.

## The regression test

The issue filed this as **latent** — an audit of the built stylesheet found no
prose-only class had survived, so there was nothing to remove and nothing for
the gate to catch. A fix with no failing test is not verified, so slice 2 makes
it non-latent first.

`CLAUDE.md`'s _Project invariants_ section, empty until now, states the rule and
names `snap-none` while doing so. That is exactly the accident #24 predicted: an
instruction file quoting a utility to explain a convention. The `stylesheet`
gate row already forbids that name, so no new row was needed — the canary
activates the assertion that was already there.

`mustFail` in `scripts/gates.mjs` is per gate row, not per expectation, so
declaring `stylesheet` MUST FAIL would have masked its five other assertions.
The failure is therefore demonstrated by hand rather than committed red.

**With the canary planted and detection still opt-out** (`CLAUDE.md` change
only, on top of `main`):

```
read  .next\static\chunks\1m_qgekh9ol1e.css
FAIL  snap-none is in the built CSS — in no file under src/; only prose in docs/plans/section-snapping.md, so its return means a directory outside the app is feeding Tailwind's scanner
ok    .justify-center-safe{justify-content:safe center}
ok    .stops\:justify-center-safe{justify-content:safe center}
ok    .md\:min-h-footer{min-height:var(--spacing-footer)}
ok    .scroll-pt-nav-sm{scroll-padding-top:var(--spacing-nav-sm)}
ok    @media (min-width:64rem) and (min-height:39rem) wraps ...
exit=1
```

One sentence in an instruction file put a real `scroll-snap-type:none` rule in
the shipped stylesheet.

## Verification

Both directions matter here, because an over-broad source list would satisfy
the absence half by compiling nothing at all. The `REQUIRED` and `AT_RULES`
rows are what rule that out:

```
read  .next\static\chunks\0grvebf8v-nuc.css
ok    snap-none absent
ok    .justify-center-safe{justify-content:safe center}
ok    .stops\:justify-center-safe{justify-content:safe center}
ok    .md\:min-h-footer{min-height:var(--spacing-footer)}
ok    .scroll-pt-nav-sm{scroll-padding-top:var(--spacing-nav-sm)}
ok    @media (min-width:64rem) and (min-height:39rem) wraps .stops\:flex .stops\:min-h-\[calc\(100dvh-var\(--spacing-nav\)\)\] .stops\:min-h-\[calc\(100dvh-var\(--spacing-nav\)-var\(--spacing-footer\)\)\] .stops\:snap-start .stops\:flex-col .stops\:justify-center-safe .stops\:py-0 .stops\:pb-0 .motion-safe\:stops\:snap-y .motion-safe\:stops\:snap-mandatory
exit=0
```

`npm run gate` at the tip, after `rm -rf .next` (Next's build cache will
otherwise serve a stylesheet built from the old source list):

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

`scripts/built-css.test.mjs`: 27 passed — one fewer than before, the deleted
guard test.

## Slice 3, and a second canary

The segment-splitting in `built-css.mjs` existed only because Tailwind scanned
`scripts/`: a class name written there in full compiled into the very
stylesheet the file reads, which would have made the forbidden name present
because the table forbids it and the required ones emit from the table rather
than from the app. `utilityName()`, the `segments` arrays and the test walking
`scripts/` for spelled-out names are all deleted — that test enforced a
constraint this PR removes.

Unplanned but free: `snap-none` is now written in full in
`scripts/built-css.mjs`, so the row fails on its own source if `scripts/` ever
feeds the scanner again.

## Not done, and one correction

- **No manual audit of the built stylesheet for other prose-only classes.** #24
  called for one only if #23 had not landed. It has, so the gate is the
  evidence.
- **Two comments were stale, not merely obsolete, and are corrected in slice 3.**
  One still described the `@source not` lines. The other claimed two required
  utilities are used in `src/` only under a variant; only `min-h-footer` is —
  `justify-center-safe` is written both bare and under `stops:` in
  `SnapSection.tsx`, which the build output confirms by emitting both
  selectors. That was wrong before this PR, not broken by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
