### PR TITLE
Make the design brief describe the site that exists

### DIFF
--- a/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
+++ b/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
@@ -10,22 +10,30 @@ conversations and a style template, not on the web.
 
 ## Solution
 
-A single high-energy landing page. The first window sells the identity: a bold
-purple hero with the marquee strip pinned exactly at the bottom edge of the
-viewport, so the page opens as one composed poster. Scrolling reveals proof
-(a film strip of kids' work gliding across the screen in sync with the marquee),
-then the two offerings as big tactile cards, then social proof, the conditions
-teaser, and finally the interest-list form. One page, two calls to action:
-book an art class, join the co-op list.
+A high-energy landing page, with a routed page behind each of its sections. The
+first window sells the identity: a bold purple hero with the marquee strip
+pinned exactly at the bottom edge of the viewport, so the page opens as one
+composed poster. Scrolling reveals proof (a row of kids' work the reader pages
+through), then the two offerings as big tactile cards, then the conditions
+teaser, then the interest-list form, and finally social proof closing the page.
+Two calls to action throughout: book an art class, join the co-op list.
+
+On a window at least `lg` wide and 39rem tall the six sections are snap stops,
+one screen each. Anything smaller is an ordinary scrolling page with the
+sections' own padding back.
 
 ## Experience Principles
 
 1. **Poster first, page second** — the opening viewport is a fixed composition
-   (hero + marquee at the fold), not the top of a scroll. Layout decisions that
-   break the one-window fit on desktop are wrong.
-2. **Motion as identity, never as obstacle** — the two synced strips give the
-   page its pulse, but they pause on hover and stop entirely under
-   `prefers-reduced-motion`. Energy must never cost legibility or access.
+   (hero + marquee at the fold), not the top of a scroll. This now applies to
+   every stop, not only the first: a section that cannot be composed inside the
+   540px a stop gets is a bug in the section, not a reason to raise the budget.
+2. **Motion as identity, never as obstacle** — the marquee gives the page its
+   pulse, pausing on hover and stopping entirely under
+   `prefers-reduced-motion`. Motion decorates; it does not carry. The gallery
+   is the artwork the page is offering as proof, so the reader drives it rather
+   than a clock. Energy must never cost legibility or access.
+   See `docs/adr/0007-reader-driven-gallery-over-synced-motion.md`.
 3. **Loud surfaces, quiet mechanics** — colors and type shout; the plumbing
    stays boring. Semantic HTML, role-reachable landmarks, a form that works
    with a keyboard. Nothing clever where clever isn't visible.
@@ -62,30 +70,48 @@ the design language.
 
 ## Component Inventory
 
-| Component      | Status | Notes                                                                                    |
-| -------------- | ------ | ---------------------------------------------------------------------------------------- |
-| Nav            | New    | Fixed top bar: logo placeholder, anchor links, yellow pill CTA                           |
-| HeroViewport   | New    | `min-h-dvh` flex column wrapping Hero + Marquee; marquee sits at the bottom edge         |
-| Hero           | New    | Purple split layout, italic 900 headline, two CTAs, photo placeholder (hidden on mobile) |
-| Marquee        | New    | Yellow looping text strip, duplicated track, pause on hover                              |
-| GallerySection | New    | Header ("What kids make here.") + GalleryStrip                                           |
-| GalleryStrip   | New    | Single-row infinite film strip of image placeholders, speed-synced to Marquee            |
-| ProgramCards   | New    | Two large cards (Art Classes / Tuesday Co-op) with tags, activities grid, CTAs           |
-| QuoteStats     | New    | Parent quote + K–8 / Charter stat tiles                                                  |
-| Conditions     | New    | Ocean-blue section with dashed "tool coming soon" embed box                              |
-| CommunityForm  | New    | Interest-list form; client-side success state only                                       |
-| Footer         | New    | Dark bar, logo, program summary                                                          |
-| Placeholder    | New    | Shared labeled dashed-border image placeholder (hero, cards, strip, logo)                |
+Every component below resolves to a file under `src/components/`. The column is
+the file rather than a build status so that the list can be checked against the
+tree rather than believed.
+
+| Component          | File                     | Notes                                                                                    |
+| ------------------ | ------------------------ | ---------------------------------------------------------------------------------------- |
+| Nav                | `Nav.tsx`                | Sticky top bar in the document flow: logo placeholder, routed links, yellow pill CTA     |
+| NavLink            | `NavLink.tsx`            | One nav link, at the 44px touch target ADR-0004 sets                                     |
+| HeroViewport       | `HeroViewport.tsx`       | Flex column of Hero + Marquee, `100dvh` less the nav; marquee sits at the bottom edge    |
+| Hero               | `Hero.tsx`               | Purple split layout, italic 900 headline, two CTAs, photo placeholder (hidden on mobile) |
+| Marquee            | `Marquee.tsx`            | Yellow looping text strip; the site's only strip                                         |
+| StripTrack         | `StripTrack.tsx`         | The looping mechanic: duplicated track, pause on hover. One caller, Marquee              |
+| GallerySection     | `GallerySection.tsx`     | Header ("What kids make here.") + GalleryRow, and the tiles' aspect shares               |
+| GalleryRow         | `GalleryRow.tsx`         | Paged row of artwork with prev/next controls; native scroll, snap-x, a named focus stop  |
+| galleryImages      | `galleryImages.ts`       | The nine tile labels and their provisional tall/wide tagging                             |
+| ProgramCards       | `ProgramCards.tsx`       | Two large cards (Art Classes / Tuesday Co-op) with tags, activities grid, CTAs           |
+| Conditions         | `Conditions.tsx`         | Ocean-blue section with a reserved slot for the tool                                     |
+| InterestListTeaser | `InterestListTeaser.tsx` | The landing page's interest-list section, wrapping the form                              |
+| InterestListForm   | `InterestListForm.tsx`   | Interest-list form; client-side success state only                                       |
+| QuoteStats         | `QuoteStats.tsx`         | Parent quotes + K–8 / Charter stat tiles; closes the page                                |
+| SnapSection        | `SnapSection.tsx`        | One stop: owns its height and surface, and the padding its content drops                 |
+| Footer             | `Footer.tsx`             | Dark bar, logo, program summary. Rendered by `layout.tsx`, so it is on every route       |
+| PillLink           | `PillLink.tsx`           | The site's CTA shape, in five closed tones                                               |
+| Placeholder        | `Placeholder.tsx`        | Shared labeled dashed-border stand-in for a future image (hero, cards, tiles, logo)      |
+| ReservedSlot       | `ReservedSlot.tsx`       | Shared labeled stand-in for decided-but-unbuilt content (schedule, booking, conditions)  |
 
 ## Key Interactions
 
-- **Strip motion**: marquee and gallery strip animate leftward continuously via
-  duplicated tracks. They share one pixels-per-second speed — the marquee's 20s
-  half-track loop defines it; the gallery strip's duration is computed from its
-  own track width. Hovering a strip pauses that strip; leaving resumes it.
-  `prefers-reduced-motion: reduce` stops both permanently.
-- **Nav anchors**: links smooth-scroll to `#art`, `#coop`, `#conditions`,
-  `#community`.
+- **Marquee motion**: the marquee animates leftward continuously via a
+  duplicated track, at a fixed pixels-per-second rate computed from the track's
+  own width so the speed holds however wide the content gets. Hovering pauses
+  it; leaving resumes it. `prefers-reduced-motion: reduce` stops it
+  permanently.
+- **Gallery paging**: prev/next controls at the row's edges move it one
+  screenful, and `snap-x mandatory` pulls the result back onto a tile edge, so
+  paging stays aligned without the control knowing how many tiles are visible.
+  The row is a named focus stop, so arrow keys and assistive tech reach it. It
+  never moves on its own.
+- **Nav links**: routed links to `/art`, `/coop`, `/conditions`, `/community`,
+  plus a pill CTA to `/book`. `#community` is the only anchor left on the site;
+  `#art`, `#coop` and `#conditions` were retired with the pages that replaced
+  them.
 - **Card hover**: program cards lift slightly (translateY) on hover.
 - **Form submit**: client-side only — the form hides and the success state
   ("You're in!") appears. No data leaves the page; wiring a destination is a
@@ -93,22 +119,38 @@ the design language.
 
 ## Responsive Behavior
 
-- **Viewport block**: `min-h-dvh`, hero `flex-1` — exactly one window on
-  desktop with the marquee at the fold; allowed to grow taller on small
-  screens so nothing clips.
+- **Snap stops**: the page is six stops on a window at least `lg` wide and
+  39rem (624px) tall, and an ordinary scrolling page below either threshold.
+  A stop is 540px on the machine the site is reviewed on, and every section is
+  built to fit that. The `md`–`lg` band scrolls rather than snapping, because
+  the program cards' two columns are narrow enough there that the CTA pills
+  wrap. See `docs/plans/stop-height-threshold.md`.
+- **Viewport block**: `100dvh` less the nav, hero `flex-1` — one window with
+  the marquee at the fold; a `min-h` rather than a fixed height, so it grows
+  instead of clipping on short screens.
 - **Hero**: photo column hidden ≤768px; text column full-width.
-- **Gallery strip**: same single-row strip at all widths; image tiles shrink.
+- **Gallery row**: below `lg`, one tile at a time at 85% width with the next
+  peeking, swiped or paged. From `lg`, three tiles share a screenful at the
+  0.3/0.3/0.4 shares their aspects normalise to. Its stop's height still grows
+  with viewport width without a cap, which overflows a short window above
+  roughly 1850px — issue #40, open.
 - **Program cards**: two columns → one column ≤768px.
 - **Quote, conditions, community**: two columns → stacked ≤768px.
-- **Nav**: tighter padding and smaller links ≤768px.
+- **Nav**: two rows below `md` — logo and CTA above, links beneath — because
+  four links plus the pill cannot share a 375px row. One row from `md`.
 
 ## Accessibility Requirements
 
-- Both strips stop under `prefers-reduced-motion: reduce`; pause on hover.
+- The marquee stops under `prefers-reduced-motion: reduce` and pauses on hover.
+  The gallery needs neither, having no motion of its own to stop; it carries
+  its own guarantees instead — the row is a named focus stop reachable by
+  arrow keys, and its controls are the affordance.
+- Snapping is itself behind `motion-safe`, so a reader who asked for less
+  motion gets an ordinary scrolling page at every width.
 - Image placeholders carry `role="img"` + `aria-label` describing the future
   image, matching the template's pattern.
-- Marquee/strip duplicate tracks are `aria-hidden` so screen readers hear the
-  content once.
+- The marquee's duplicate track is `aria-hidden` so screen readers hear the
+  content once. The gallery has no duplicate to hide: every tile renders once.
 - Form inputs have visible `<label>`s; success state is announced (rendered in
   DOM, not display-toggled invisibly to AT).
 - Keyboard: all CTAs and links focusable with visible focus rings; smooth
@@ -116,11 +158,21 @@ the design language.
 - Contrast: yellow `#E8FF00` surfaces use near-black `#1A1A00` text; body text
   on purple/ocean stays at the template's tested opacities or better.
 
-## Addendum — 2026-08-13 (what has changed since)
+## Change log
 
-This brief describes the single-page build of 2026-08-11. Four PRs have
-since changed things it still states as current. Recorded here rather than
-rewritten, so the original intent stays readable.
+Everything above states what the site is now. This section is the record of how
+it got there: what each entry describes has already been applied to the body,
+and the entries are kept verbatim — including the claims they supersede — so
+that a review can be matched to the state of the brief it was written against.
+
+Entries are not corrections waiting to be applied. Until 2026-08-15 they were,
+which is what made the body contradict them and got the same drift reported
+twice. See `docs/plans/design-doc-drift.md`.
+
+### 2026-08-13 (what has changed since)
+
+This brief described the single-page build of 2026-08-11. Four PRs had
+since changed things it still stated as current.
 
 - **The landing page snaps.** From `md` up it is six stops, one screen each:
   hero, gallery, program cards, conditions, interest list, quotes + footer.
@@ -150,7 +202,7 @@ rewritten, so the original intent stays readable.
 - **The Calendly `TODO(verify)` is retired** — booking CTAs point at
   `/book`, and the provider decision sits behind that page.
 
-## Addendum — 2026-08-14 (gallery tiles)
+### 2026-08-14 (gallery tiles)
 
 - **Gallery tiles are no longer one shape.** "Gallery strip: same single-row
   strip at all widths; image tiles shrink" now reads: a row is two 4:3 tiles
@@ -169,7 +221,7 @@ rewritten, so the original intent stays readable.
   recorded here because "one screen per section" is a brief-level claim, and
   it is currently false below roughly 780px of usable height.
 
-## Addendum — 2026-08-15 (the stops fit a 555px screen)
+### 2026-08-15 (the stops fit a 555px screen)
 
 - **"One screen per section" is true again, and the sections were changed to
   make it true.** The page is six stops on a window at least `lg` wide and
@@ -208,7 +260,8 @@ rewritten, so the original intent stays readable.
   images is a later content pass.
 - A working form backend — submissions are visual-only until a destination
   (email/sheet/service) is chosen.
-- A real booking URL — the Calendly link is `TODO(verify)`.
-- The conditions tool embed — the dashed placeholder box ships as-is.
-- Dark mode, additional pages, CMS, analytics.
+- A real booking destination — the CTAs point at `/book`, and which provider
+  sits behind that page is a decision that has not been made.
+- The conditions tool embed — the reserved slot ships as-is.
+- Dark mode, CMS, analytics.
 - The template's editorial block and yellow banner — cut, not deferred.

--- a/docs/adr/0007-reader-driven-gallery-over-synced-motion.md
+++ b/docs/adr/0007-reader-driven-gallery-over-synced-motion.md
@@ -1,0 +1,68 @@
+# 0007 — The gallery is driven by the reader, and motion is the marquee alone
+
+Date: 2026-08-15. Status: accepted.
+
+## Context
+
+`DESIGN_BRIEF.md` states three experience principles. The second is "Motion as
+identity, never as obstacle", and it names the mechanism: "the two synced strips
+give the page its pulse, but they pause on hover and stop entirely under
+`prefers-reduced-motion`."
+
+PR #14 removed one of those strips. The gallery became `GalleryRow` — a
+horizontally paged row with prev/next controls at its edges, native scrolling
+with `snap-x mandatory`, and a `tabindex="0"` focus stop so arrow keys reach it.
+It does not move on its own. The marquee still does, and `StripTrack` — the
+looping mechanic built to be shared by both — has had one caller ever since.
+
+That left a question the documents could not answer, and it is why issue #26
+was labelled `needs-human`. Either the principle was superseded and the brief
+owes it an edit, or the principle stood and the code owes it a change: the
+gallery should move again. Nothing in `docs/plans/section-snapping.md` or the
+brief's 2026-08-13 addendum settles which, because both record _what_ changed
+without saying whether the principle survived it.
+
+## Decision
+
+The principle is **restated, not retired**. Motion remains part of the site's
+identity and the marquee carries it. The gallery is driven by the reader.
+
+The brief's principle 2 now reads in terms of one strip rather than two synced
+ones, and the gallery is described as paged wherever the brief and
+`INFORMATION_ARCHITECTURE.md` described it as gliding.
+
+## Consequences
+
+The reason motion is right for the marquee and wrong for the gallery is that
+the two carry different content. The marquee is a band of words the reader
+takes in at a glance and does not need to finish; motion costs them nothing.
+The gallery is nine pieces of children's artwork, which is the page's proof.
+Artwork you want to look at should not slide away, and one you missed should be
+one press back — the reason already written into `GallerySection`'s source.
+"Never as obstacle" was always the second half of the principle; applied to
+content the reader wants to dwell on, it argues against the motion rather than
+for it.
+
+So the principle is narrower than it was, and it now has a stated boundary:
+motion decorates, it does not carry. A future strip of words may loop. A future
+row of things a reader has to study may not.
+
+What this costs is the synced-speed idea, which is genuinely gone. The two
+strips shared one pixels-per-second rate and that was a real compositional
+quality — `DESIGN_REVIEW-2026-08-11.md` credits it under _What Works Well_.
+Nothing replaces it; the page's pulse is now one band rather than a rhythm
+across two. That is a loss taken deliberately in exchange for artwork the
+reader controls, and it is recorded here so the next person to read that review
+does not treat the quality's absence as a regression.
+
+`StripTrack` is now a seam with one caller, which its own doc comment states:
+kept because the looping mechanic is intricate, not because anything varies
+across it, and to be deleted with the marquee rather than to wait for a second
+caller that is not coming. This decision is what makes that permanent — it
+settles that no second caller is expected.
+
+The accessibility obligations survive intact and shrink to one strip: the
+marquee's duplicate track stays `aria-hidden`, hover still pauses it, and
+`prefers-reduced-motion` still stops it. The gallery no longer needs any of
+them, having no motion to stop — it needs its own guarantees instead, and has
+them: the row is a named focus stop and the controls are the affordance.

--- a/docs/plans/design-doc-drift.md
+++ b/docs/plans/design-doc-drift.md
@@ -1,0 +1,114 @@
+# The design docs describe a site that no longer exists
+
+Covers issues #26 (`DESIGN_BRIEF.md`) and #27 (`INFORMATION_ARCHITECTURE.md`).
+One decision applied to two documents; a shared plan is what stops them being
+resolved differently.
+
+## The problem, from the reader's point of view
+
+`DESIGN_BRIEF.md` is the document design reviews are measured against. Someone
+opening it to review the site reads that two synced strips give the page its
+pulse, that the nav is a fixed bar of anchor links, and that the components are
+called `GalleryStrip` and `CommunityForm`. None of that has been true since
+PR #14 and PR #11. They then report the difference as a finding, because that
+is what measuring against a brief means.
+
+`INFORMATION_ARCHITECTURE.md` has the same problem in its Content Hierarchy: it
+lists the sections in an order the page abandoned when the quote moved to the
+close, describes the gallery as auto-scrolling, and names a component that does
+not exist.
+
+## What the issues got wrong, and why it matters
+
+**#26 assumes the drift is unrecorded. It is not.** The brief already carries
+three dated addenda. The 2026-08-13 one records every item #26 lists — the
+gallery no longer moving, the routed nav, the sticky nav, and both component
+renames — and it is dated the same day as the `DESIGN_REVIEW.md` whose finding 8
+raised them. The addendum was the response to that finding.
+
+That changes the diagnosis. The problem is not that nobody wrote the decision
+down. It is that the corrections sit roughly 130 lines below the claims they
+correct, so a reader measuring against the brief meets the stale body first and
+never learns it was superseded. The record exists somewhere that does not
+intercept the reader. That is why finding 8 was raised again after the addendum
+already existed — the addendum pattern failed at the one job the brief has.
+
+**#26's supporting evidence is also wrong in one detail.**
+`DESIGN_REVIEW-2026-08-11.md` has findings 1–6 and no finding 8. What it has is
+a _What Works Well_ section crediting "the synced strips", which the 08-13
+review cites as item 6 _of its own_ finding 8. The issue conflated the two. The
+second-order-cost argument survives regardless: the drift was re-reported, just
+once rather than twice.
+
+## Decisions
+
+**The brief's body states what is true now; the addenda become its change log.**
+The three dated addenda stay verbatim under a heading that says what they are —
+history, not corrections pending application. The body stops contradicting them.
+
+This reverses the brief's own stated preference. The 08-13 addendum says the
+drift was "recorded here rather than rewritten, so the original intent stays
+readable", and that was a deliberate choice. It is overturned because the brief
+has one job — being the yardstick — and a body that must be reconciled against
+three addenda before it can be used does not do that job. The original intent
+stays readable anyway: the addenda quote the superseded claims verbatim, which
+is the whole reason they are kept rather than folded in.
+
+**Experience principle 2 is restated, not retired.** The marquee still carries
+the motion; what was retired is the second synced strip. `docs/adr/0007` records
+it, because restating a stated experience principle outlives this task and an
+ADR is where that is looked for.
+
+**The IA doc is corrected in place, with no addendum.** It has none today —
+issue #25 corrected its routing claims directly — and inventing the pattern for
+one document while retiring it in the other would leave two conventions where
+there is currently one.
+
+### Considered and rejected
+
+- **Signpost the body instead of rewriting it.** Mark each stale claim
+  "superseded — see Addendum 2026-08-13" and change nothing else. Honours the
+  file's stated pattern and is a fraction of the diff. Rejected because the
+  reviewer still has to reconcile a body against three addenda to know what
+  they are measuring against, which is exactly the work that already failed.
+- **Collapse the addenda into a single History section.** Cleanest end state.
+  Rejected because it flattens the dated granularity of what changed when, and
+  the dates are load-bearing: they are what let someone match a review to the
+  state of the brief it was written against.
+- **Treat the brief as a dated record like the reviews and leave it alone.**
+  Rejected because the reviews record what someone saw on a day; the brief
+  records what the site is meant to be. Only the second is a spec, and only a
+  spec has to be current.
+
+## Scope
+
+**In:** `DESIGN_BRIEF.md` (#26), `INFORMATION_ARCHITECTURE.md` (#27), a new ADR.
+
+**Out:**
+
+- `DESIGN_REVIEW.md`, `DESIGN_REVIEW-2026-08-11.md` and `TASKS.md`. Dated
+  records of what was seen and done on a day. Rewriting them to match today's
+  code would destroy the evidence that the drift happened at all.
+- Anything under `src/`. The code is right; the prose is what drifted. The one
+  place this was a live question — whether retiring the gallery's motion
+  violated principle 2 or superseded it — is settled by ADR 0007 as superseded,
+  so no code change follows.
+- The open gallery bugs. Issue #38 (split the grid across two stops) and #40
+  (the stop's height grows with viewport width) are unresolved, and ADR 0005
+  describes a two-stop grid the code does not yet have. The brief must not
+  claim either is done. Where the body would otherwise assert something these
+  contradict, it states what is actually built and leaves the bugs to their
+  issues.
+
+## Verification
+
+No gate reads prose, so the checks are stated and run by hand:
+
+- every component named in either document resolves to a file under
+  `src/components/` or `src/app/`;
+- the Content Hierarchy order matches the order of `SnapSection`s in
+  `src/app/page.tsx`;
+- every claim rewritten in the brief body was checked against the component
+  that implements it, not against another document;
+- `npm run gate` still passes, which for a prose-only change asserts only that
+  nothing was broken in passing — it is not evidence the prose is right.


### PR DESCRIPTION
Closes #26.

The brief's body now states what the site is; its three dated addenda become a
change log. `docs/adr/0007` settles the one item that needed a person.

## The issue's diagnosis was wrong, and it changed the work

#26 assumes the drift is unrecorded. **It is not.** The brief already carries a
2026-08-13 addendum that records every item the issue lists — the gallery no
longer moving, the routed nav, the sticky nav, both component renames — and it
is dated the same day as the `DESIGN_REVIEW.md` whose finding 8 raised them.
The addendum *was* the response to that finding.

The real problem is that those corrections sat ~130 lines below the claims they
correct. A reader measuring against the brief met the stale body and never
learned it was superseded. The record existed somewhere that did not intercept
the reader — which is exactly why the finding came back.

That also means this PR **overturns a deliberate choice**. The addendum says the
drift was "recorded here rather than rewritten, so the original intent stays
readable." Overturned anyway: the brief has one job, and a body that must be
reconciled against three addenda before it can be used does not do it. The
original intent survives in the log, which keeps the superseded claims verbatim.

**One factual correction to the issue.** #26 says *"Findings 8 here and in
`DESIGN_REVIEW-2026-08-11.md` are that already happening."* That review has
findings 1–6 and no finding 8. What it has is a _What Works Well_ section
crediting "the synced strips", which the 08-13 review cites as item 6 of its
*own* finding 8. The issue conflated the two. The second-order-cost argument
survives — the drift was re-reported, just once rather than twice.

## Slices

1. **`82d0324`** — `docs/plans/design-doc-drift.md`, covering #26 and #27. They
   are one decision applied to two documents; a shared plan is what stops them
   being resolved differently.
2. **`83c1297`** — ADR 0007. Principle 2 is **restated, not retired**: motion
   stays part of the identity, the marquee carries it, and the gallery is
   driven by the reader. The boundary the ADR draws — *motion decorates, it
   does not carry* — is what principle 2's own second half already implied:
   "never as obstacle" argues against motion for content someone wants to dwell
   on, and the gallery is the artwork the page offers as proof.
3. **`a0d27a4`** — the brief.

## Scope taken beyond the issue's four items

The decision was "the body states current truth", so stopping at four items
would have left the yardstick broken. Also corrected, each checked against the
component that implements it rather than against another document:

- **Solution** — section order (social proof closes the page now), the gallery
  described as gliding, and the "single page" framing.
- **Responsive Behavior** — the snap-stop thresholds, `min-h-dvh` → `100dvh`
  less the nav, the gallery's actual responsive shape, the two-row nav.
- **Accessibility** — "both strips" → the marquee, plus what the gallery has
  instead (named focus stop, controls as the affordance) and the `motion-safe`
  gate on snapping.
- **Component Inventory** — rebuilt. The `Status: New` column, meaningless for
  a build that shipped, is replaced by the file path, which makes the list
  checkable against the tree rather than believed.
- **Out of Scope** — the retired Calendly `TODO(verify)`, and "additional
  pages" now that the routed pages exist.

## Deliberately not done

- **`Problem` and `Existing Patterns` are untouched.** They describe the
  baseline the work started from, not the site it produced. "Components: none
  exist" is true of the scaffold and is not a claim about today.
- **`DESIGN_REVIEW.md`, `DESIGN_REVIEW-2026-08-11.md`, `TASKS.md` untouched**,
  per the issue. Dated records; rewriting them destroys the evidence the drift
  happened.
- **No `src/` changes.** The one live question — whether retiring the gallery's
  motion violated principle 2 or superseded it — is settled as superseded, so
  no code follows.
- **Open bugs are not papered over.** Issue #40 (the gallery stop's height
  grows with viewport width, uncapped) contradicts a clean "one screen per
  section" claim, so the brief states what is built and names the issue.
- **ADR 0005 vs the code.** ADR 0005 describes the `lg` gallery as a static
  grid split across two snap stops; `GallerySection` renders one `GalleryRow`,
  and issue #38 (split the grid across two stops) is still open. The brief
  describes what is built. Whether ADR 0005 is ahead of the code or drifted
  from it is a separate question and I have not touched it — flagging it rather
  than filing it, since it may be intentional.

## Verification

No gate reads prose, so these were run by hand.

**Every component file named in the brief exists** (20/20):

```
ok    src/components/Conditions.tsx      ok    src/components/NavLink.tsx
ok    src/components/Footer.tsx          ok    src/components/PillLink.tsx
ok    src/components/GalleryRow.tsx      ok    src/components/Placeholder.tsx
ok    src/components/GallerySection.tsx  ok    src/components/ProgramCards.tsx
ok    src/components/Hero.tsx            ok    src/components/QuoteStats.tsx
ok    src/components/HeroViewport.tsx    ok    src/components/ReservedSlot.tsx
ok    src/components/InterestListForm.tsx   ok    src/components/SnapSection.tsx
ok    src/components/InterestListTeaser.tsx ok    src/components/StripTrack.tsx
ok    src/components/Marquee.tsx         ok    src/components/galleryImages.ts
ok    src/components/Nav.tsx             ok    src/app/layout.tsx
```

**And the reverse — no component is missing from the inventory.** Every
non-test file in `src/components/` appears in the table; the check printed
nothing.

**Claims spot-checked against source, not against other docs:** nav CTA →
`/book` (`Nav.tsx`); `/#community` is the only anchor left in `src/`
(`book/page.tsx:27`); `HeroViewport` is `min-h-[calc(100dvh-var(--spacing-nav))]`;
`StripTrack` has one caller; `GalleryRow` is `tabindex="0"` with `snap-x`
paging; snapping is behind `motion-safe`, which the built stylesheet confirms
by emitting `.motion-safe\:stops\:snap-y`.

**`npm run gate`** after `rm -rf .next` — for a prose-only change this asserts
only that nothing was broken in passing, not that the prose is right:

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
