### PR TITLE
Park the two-stop gallery grid and record what it leaves behind

### DIFF
--- a/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
+++ b/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
@@ -131,9 +131,11 @@ tree rather than believed.
 - **Hero**: photo column hidden ≤768px; text column full-width.
 - **Gallery row**: below `lg`, one tile at a time at 85% width with the next
   peeking, swiped or paged. From `lg`, three tiles share a screenful at the
-  0.3/0.3/0.4 shares their aspects normalise to. Its stop's height still grows
-  with viewport width without a cap, which overflows a short window above
-  roughly 1850px — issue #40, open.
+  0.3/0.3/0.4 shares their aspects normalise to. This is the shape the gallery
+  keeps; the static grid once planned for it is parked, not pending. Its stop's
+  height grows with viewport width without a cap, which overflows a window
+  wider than about 1836px and short for its width — a stated exception, not a
+  scheduled fix. Issue #38.
 - **Program cards**: two columns → one column ≤768px.
 - **Quote, conditions, community**: two columns → stacked ≤768px.
 - **Nav**: two rows below `md` — logo and CTA above, links beneath — because
@@ -253,6 +255,36 @@ since changed things it still stated as current.
   short window it overflows above about 1850px wide. "Gallery strip: same
   single-row strip at all widths" is what does it. Issue #40; the fix is the
   `gallery-fit` cap already designed for issue #38.
+
+### 2026-08-17 (the gallery row stays)
+
+- **The paged row is the gallery's final shape, not an interim one.** The owner
+  asked for it to be kept as it is. Every previous entry describing the gallery
+  did so against a planned static grid that would replace it at `lg`; that grid
+  is parked, and the brief no longer treats the row as a stage on the way to
+  something else.
+
+- **The grid is parked rather than cancelled.** Its design is kept in full in
+  `docs/plans/gallery-aspect-rhythm.md` — the 30/30/40 shares, the 16:9 choice,
+  the height-derived cap and the alternatives that were rejected. What changed
+  is that it has no scheduled build and no blocker that could clear: a capped
+  grid gives a 322px tile against the 417px the row already ships, and parity
+  needs a stop about 697px tall on a display whose ceiling is 639.
+
+- **The overflow above is a stated exception now, not a pending fix.** The entry
+  above promises "the `gallery-fit` cap already designed for issue #38". That
+  promise does not hold: the cap was derived for a second stop carrying rows and
+  no heading, and the stop that shipped carries the heading too, so applying it
+  needs a measured constant for the heading block. Nothing is scheduled. The
+  condition is written into `CONTEXT.md`'s **Stop** entry, and the window it
+  needs — wider than about 1836px and short for its width — is one no display
+  the site is reviewed on can produce.
+
+- **Issues #38 and #40 are one issue.** #40 folded into #38, which carries both
+  halves under `needs-triage`. Of #40's three claims only the width-driven
+  overflow survived review; the `md`–`lg` band it described has had no stops
+  since 2026-08-15, and the two-up step it called a regression was a deliberate
+  choice recorded in the plan before the code was written.
 
 ## Out of Scope
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,6 +57,13 @@ it. Content that does not is a bug in the section: the budget is the constraint
 sections are designed against, not a number to raise.
 `docs/plans/stop-height-threshold.md` has the measurements and the reason the
 threshold cannot go above 39rem.
+
+The gallery is a stated exception, and the only one. Its tiles are a share of
+the row with a fixed aspect, so its height follows the window's _width_ rather
+than sitting under a budget: it exceeds its stop when `viewportHeight` is under
+`0.225 × viewportWidth + 211`, which takes a window wider than about 1836px and
+short for its width. Recorded rather than fixed — issue #38 — because no
+display the site is reviewed on is wide enough to produce one.
 _Avoid_: slide, panel, screen (a section is the content; the stop is the screen
 it fills)
 

--- a/docs/adr/0005-breakpoint-divergent-layouts.md
+++ b/docs/adr/0005-breakpoint-divergent-layouts.md
@@ -2,6 +2,24 @@
 
 Date: 2026-08-14. Status: accepted.
 
+> **Note, 2026-08-17.** The gallery grid this was written for never shipped. It
+> was descoped the day after this ADR was accepted and is now parked on issue
+> #38, so **the rule below has no instance in the code**: the gallery renders
+> nine tiles once, in one paged row, at every width.
+>
+> The Context therefore describes a layout in the present tense that has never
+> existed. That sentence is left as written, because this is a dated record of a
+> decision taken on 2026-08-14 and rewriting it would hide that the decision
+> outlived the thing that prompted it. Read it as the case that was made, not as
+> a description of the tree.
+>
+> The decision itself stands. It is a rule about when duplication is allowed,
+> not a claim that anything currently duplicates, and the next layout that
+> genuinely diverges in DOM structure is entitled to it — with the three
+> obligations attached. The `display: contents` finding below is the part most
+> worth keeping: it is the reason nobody should attempt to reparent a snap stop
+> with CSS again. See `docs/plans/gallery-aspect-rhythm.md`.
+
 ## Context
 
 The gallery shows the same nine images two ways. Below `lg` it is one

--- a/docs/plans/gallery-aspect-rhythm.md
+++ b/docs/plans/gallery-aspect-rhythm.md
@@ -243,6 +243,110 @@ Slices 3 and 4 above are therefore superseded: 3 is not built, and 4 becomes
 slice 3 of this branch. The rest of this file records what was decided for the
 grid, and stands as the design for the issue that will build it.
 
+## Addendum — 2026-08-17: the row stays, and the grid is parked
+
+The owner asked for the gallery row to be kept as it is. The grid is not
+withdrawn: the design above stands, and the point of this addendum is that
+nobody has to derive it a second time. What changes is its standing in the
+tracker. Issues #38 and #40 are consolidated into one `needs-triage` PRD on
+**#38**, so there is one place to look rather than two that each hold half the
+story.
+
+**Parked, not blocked.** The 2026-08-14 addendum filed #38 as blocked on #37, on
+the premise that fixing the stop's height would unblock it. #37 landed and did
+not. It made the stops fit 555px by trimming three sections rather than by
+giving them more room, so a stop is still 555px on the machine the site is
+reviewed from, and none of the grid's arithmetic moved. A capped grid gives a
+4:3 tile of `0.667 × (stopHeight − 72)` — the 322px the last addendum measured.
+Reaching parity with the **417px** tile the paged row already ships needs a
+**697px** stop, which is a 781px viewport, and `stop-height-threshold.md`'s own
+addendum established that this display cannot exceed 639. So the blocker was
+never #37. It is the display, and no issue in this repo can close it.
+
+That is why the label is `needs-triage` rather than `ready-for-agent` or
+`needs-human`: there is nothing to implement and nobody to unblock. There is a
+decision to re-evaluate if the circumstances change.
+
+### What survived of issue #40
+
+Three claims were made there. Checked against the tree on 2026-08-17:
+
+| claim                                                           | verdict                                                      |
+| --------------------------------------------------------------- | ------------------------------------------------------------ |
+| The stop's height grows 543 → 734 between `md` and `lg`         | **Dead.** #37 moved `stops` to `lg`; that band has no stops. |
+| It is a regression from `f4c3408` dropping the two-up `md` step | **Wrong.** The change was deliberate — see below.            |
+| Above `lg` the height grows with width without limit            | **Live.** Recorded below rather than fixed.                  |
+
+The regression claim is the one worth writing down, because the evidence for it
+was a commit message and the evidence against it is this plan. `f4c3408` did
+drop `md:w-[calc((100%-1rem)/2)]`, and its message did say "Below lg nothing
+changes shape", which is false for the `md`–`lg` band. But the body of this plan
+chose that shape before the code existed: "Tablets keep the swipe row, where a
+tile at 768 is 571 wide." 571 is `0.85 × (768 − 96)`, computed for the new
+behaviour, not inherited from the old. The plan is the record; the commit
+message was imprecise about a decision it had already taken.
+
+### The width-driven overflow is recorded, not fixed
+
+The live half is real. Fitted to the three measured points (473 at 1536, 559 at
+1920, 703 at 2560), the section's content height is `0.225 × W + 127`, so it
+exceeds its stop when
+
+```
+viewportHeight < 0.225 × viewportWidth + 211
+```
+
+A stop only exists from 39rem tall, so triggering it needs a window **wider than
+about 1836px and short for its width**. Worked through the maximised-window
+arithmetic in `stop-height-threshold.md` — display height less the taskbar and
+the browser's furniture — **no 16:9 or 16:10 display reaches it at any
+scaling**, and the reason is the threshold itself: such a window has to be
+shorter than about 727 CSS pixels of display to overflow, and it stops having
+stops at all at 849. It runs out of stop before it runs out of room. Wider
+ratios can: a 32:9 panel (5120×1440, 3840×1080) overflows, and a 21:9 does in a
+narrow band of scalings. So can any window sized by hand to be wide and short.
+
+The review machine cannot produce it at all, for a different reason than usual.
+Its 639px viewport would overflow above about 1902px of width, but its display
+is only 1536 CSS pixels wide, so no window on it is ever wide enough. This is
+the mirror image of the two-stop grid's problem: that one is blocked by a screen
+too short, and this one is hidden by a screen too narrow.
+
+**The `gallery-fit` cap designed above does not transfer to it.** That cap
+worked because stop B carried two rows and no heading, so the arithmetic had
+only rows to budget. In the single-stop row that shipped, the heading and the
+row share one stop, so a cap has to subtract the heading block — 160px measured
+at 1536, being the 473 total less the 313 tile. That is a constant standing in
+for something nobody measured on purpose, which is the failure `CLAUDE.md` names
+as fixing a symptom with a constant. Deriving it instead means restructuring the
+section so the row takes the leftover height, and that is a layout change, which
+is the thing this addendum exists to decline.
+
+So the overflow is stated as an exception rather than left implied: `CONTEXT.md`
+says a stop is 540px and every section is built to fit it, and one section does
+not.
+
+### What follows from this
+
+- `docs/adr/0005-breakpoint-divergent-layouts.md` gains a dated note that its
+  rule has no instance in the code, since the grid it was written for never
+  shipped. The body is left alone — it is a dated record, and the
+  `display: contents` finding in it is the reason nobody should try reparenting
+  again.
+- `CONTEXT.md`'s **Stop** entry names the gallery as the one section that does
+  not fit at every width, with the condition above.
+- `DESIGN_BRIEF.md` gains a dated addendum. Its 2026-08-15 entry promises "the
+  fix is the `gallery-fit` cap already designed for issue #38", and that promise
+  is now wrong twice over — the cap does not transfer, and no fix is scheduled.
+- `galleryImages.ts` and its test keep every composition invariant and change
+  their reasons. Rows of three, two tall and one wide, and the alternating side
+  are all still load-bearing, but not for the grid's flush edges: three tiles
+  and their two gaps total exactly one content width, which is what makes
+  `scrollBy(clientWidth)` land a whole page of three. Verified arithmetically at
+  1024, 1536 and 1900 — a press overshoots the stride by the gutter and
+  `snap-mandatory` pulls back to the correct tile. Mistag one image and a page
+  comes up short.
+
 ## Out of scope
 
 Real photography, and the final decision about which images are wide. Renaming

--- a/src/components/galleryImages.test.ts
+++ b/src/components/galleryImages.test.ts
@@ -5,9 +5,10 @@ const ROW_LENGTH = 3;
 
 /* The rows are chunks of the list rather than a structure in it, so the
    chunking lives here with the assertions that need it. Nothing in the app
-   asks for rows yet — the paged row shows three at a time because the tiles
-   are sized to fill it — so a helper in the module would be a seam with no
-   caller. */
+   asks for rows — the paged row shows three at a time because the tiles are
+   sized to fill it — so a helper in the module would be a seam with no caller.
+   The static grid that would have asked for them is parked, so this is the
+   arrangement to write against rather than an interim one. */
 function rows(): GalleryImage[][] {
   const chunks: GalleryImage[][] = [];
 
@@ -19,15 +20,17 @@ function rows(): GalleryImage[][] {
 }
 
 test("the gallery divides into whole rows of three", () => {
-  // A tenth image does not make a longer gallery, it makes a row of one
-  // against an edge the other rows do not share.
+  // A tenth image does not make a longer gallery, it makes a final page
+  // holding one tile against a screenful of empty row.
   expect(GALLERY_IMAGES.length % ROW_LENGTH).toBe(0);
 });
 
 test("every row is two tall tiles and one wide one", () => {
-  // The row's total width is what keeps the grid's edges flush, and it is only
-  // constant while every row holds the same set of ratios. Mistag one image
-  // and one row gets narrower than the others.
+  // Three tiles and their two gaps total exactly one content width only while
+  // every row holds the same set of ratios, and that total is what makes
+  // GalleryRow's scrollBy(clientWidth) land a whole page of three. Mistag one
+  // image and its page is short by the difference, so every press after it
+  // leaves the row starting mid-tile.
   for (const row of rows()) {
     expect(row.filter((image) => image.aspect === "tall")).toHaveLength(2);
     expect(row.filter((image) => image.aspect === "wide")).toHaveLength(1);
@@ -37,7 +40,9 @@ test("every row is two tall tiles and one wide one", () => {
 test("the wide tile alternates side down the rows", () => {
   // Right, left, right. This is the rhythm the issue asked for, and the only
   // place the rule is written down — the data satisfies it, the layout reads
-  // the data, and neither states it.
+  // the data, and neither states it. The reader meets it as three successive
+  // pages rather than as three stacked rows, which is a weaker reading of the
+  // same rule but still the variation the gallery was asked for.
   rows().forEach((row, index) => {
     const expected = index % 2 === 0 ? ROW_LENGTH - 1 : 0;
 

--- a/src/components/galleryImages.ts
+++ b/src/components/galleryImages.ts
@@ -3,10 +3,20 @@
  *
  * A row of the gallery is three of these — two `tall` and one `wide`, sharing
  * one height, so the wide one is the wider tile rather than the shorter one.
- * The wide slot alternates right, left, right down the rows, which is what
- * gives the gallery its print-zine rhythm without ragging its edges: every row
- * holds the same set of ratios, so every row totals the same width whatever
- * the order. See docs/plans/gallery-aspect-rhythm.md.
+ * The wide slot alternates right, left, right, which is the print-zine rhythm
+ * the gallery was asked for. From `lg` the reader meets those rows one at a
+ * time, as successive pages of the paged row.
+ *
+ * Every row holding the same set of ratios is load-bearing rather than tidy.
+ * The 0.3/0.3/0.4 shares make three tiles and their two gaps total exactly one
+ * content width, which is what lets `GalleryRow`'s scrollBy(clientWidth) land a
+ * whole page of three on every press. Mistag one image and its page is short by
+ * the difference, and every page after it starts mid-tile.
+ *
+ * That reason is not the original one. The composition was designed for a
+ * static grid, where a constant row width kept the grid's outer edges flush;
+ * the grid is parked and the rule outlived it. See
+ * docs/plans/gallery-aspect-rhythm.md.
  *
  * The aspect belongs to the image rather than to its position. Deriving it
  * from the index cannot break, but it silently re-crops the gallery whenever


### PR DESCRIPTION
Closes #40.

The owner asked for the gallery row to be kept as it is. Nothing in the rendered
page changes: this is the paperwork that makes the tree say so, plus the
adjudication of issue #40 before it folds into #38.

## What was decided

**The grid is parked, not cancelled.** Issue #38 was filed as blocked on #37, on
the premise that fixing the stop's height would unblock it. #37 landed by
trimming three sections to fit 555px rather than by finding more room, so the
stop is the same size and none of the grid's arithmetic moved. A capped grid
gives a 4:3 tile of `0.667 × (stopHeight − 72)` — 322px — against the **417px**
the paged row already ships. Parity needs a **697px** stop, a 781px viewport,
and `stop-height-threshold.md` established that the review display cannot exceed
639. The blocker was never #37; it is the display, and no issue here can close
it.

So the design in `docs/plans/gallery-aspect-rhythm.md` is left standing rather
than withdrawn, and #38 becomes one `needs-triage` PRD carrying both halves.

**Issue #40's three claims, checked against the tree:**

| claim | verdict |
| --- | --- |
| Stop height grows 543 → 734 between `md` and `lg` | **Dead** — #37 moved `stops` to `lg`; that band has no stops |
| A regression from `f4c3408` dropping the two-up `md` step | **Wrong** — chosen deliberately, see below |
| Above `lg` the height grows with width without limit | **Live** — recorded, not fixed |

The regression claim is worth stating because its evidence was a commit message
and the evidence against it is the plan. `f4c3408` did drop
`md:w-[calc((100%-1rem)/2)]`, and its message did say "Below lg nothing changes
shape", which is false for that band. But `gallery-aspect-rhythm.md` chose the
shape before the code existed: *"Tablets keep the swipe row, where a tile at 768
is 571 wide."* 571 is `0.85 × (768 − 96)` — computed for the new behaviour, not
inherited from the old.

**The live overflow is recorded rather than fixed.** Fitted to the three
measured points (473 at 1536, 559 at 1920, 703 at 2560) the section's content
height is `0.225 × W + 127`, so it exceeds its stop when
`viewportHeight < 0.225 × viewportWidth + 211`. With a stop needing 39rem, that
takes a window wider than ~1836px and short for its width. No 16:9 or 16:10
display reaches it at any scaling — such a window stops having stops at 849 CSS
pixels of display height and would need to be under 727 to overflow. It takes a
32:9 panel or a hand-sized window, and the review machine cannot produce one at
any width because its display is 1536 CSS pixels wide.

The `gallery-fit` cap the docs promised does not transfer: it was derived for a
second stop carrying two rows and no heading, and the stop that shipped carries
the heading too, so applying it needs a measured 160px constant standing in for
the heading block.

## Slices

1. `cef8ea1` — Record that the gallery row stays and the grid is parked
   (`docs/plans/gallery-aspect-rhythm.md`, second dated addendum)
2. `6bd840b` — Note that ADR-0005's rule has no instance in the code
   (dated note; body untouched, because it is a dated record)
3. `72d611d` — State the gallery's stop overflow as an exception, not a pending
   fix (`CONTEXT.md` in place; `DESIGN_BRIEF.md` body corrected and a dated
   change-log entry added, per the convention #26 established)
4. `cd3898a` — Give the gallery's composition invariants their real reason
   (comments only in `galleryImages.ts` / `.test.ts`)

## Gate

Run at `cd3898a`, after `rm -rf .next`:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

## What I did not do

- **No fix for the width-driven overflow.** Decided above; it is recorded on
  #38 instead.
- **No change to `src/` behaviour.** Slice 4 is comments only — verified by
  filtering the staged diff to non-comment lines, which came back empty.
- **The #38 rewrite is not in this PR.** Retitling it, rewriting the body to
  pointer form and swapping `needs-human` for `needs-triage` are tracker
  operations, done after merge so the issue can link docs on `main`.
- **`GalleryRow`'s snap gutter is untouched and unverified.** While checking the
  paging arithmetic I noticed the row sets `px-gutter-sm md:px-gutter` and
  `snap-mandatory` with no matching `scroll-padding`, so `scrollLeft: 0` is not
  a snap position and the container may rest past its own gutter. It predates
  #19, is nowhere in #40, and I have not confirmed it in a browser. Filed
  separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
