### PR TITLE
Rest the gallery row on its gutter and take the controls off the artwork

### DIFF
--- a/.design/wild-coast-kids-landing/DESIGN_REVIEW.md
+++ b/.design/wild-coast-kids-landing/DESIGN_REVIEW.md
@@ -86,6 +86,21 @@ is a separate, straightforwardly unfinished piece of interaction design.
    right edges; size tiles so a fixed 3–4 are visible and scale them with
    the available width._
 
+   > **Note, 2026-08-17.** Three of these four fixes stand. The fourth —
+   > "move the controls onto the row's left and right edges" — is
+   > **superseded**, and the controls now sit above the row instead. PR #14
+   > did as this asked, and issue #45 then measured what it produced: a 44px
+   > control (ADR-0004) overhung the gutter by 20px at `md`+ and 32px below
+   > it, and below `md` no offset exists that would fit it, the gutter being
+   > 24px. A scroll container's padding is also empty space only at the
+   > scroll extremes, so an overlaid control covers artwork at some scroll
+   > position whatever the padding is.
+   >
+   > The finding was right about what it saw. Controls sitting below-left of
+   > a row with a visible scrollbar and per-item paging were unfinished, and
+   > the row's edges were the only home available to a row that had no other.
+   > See `docs/adr/0008-gallery-controls-outside-the-artwork.md`.
+
 5. **The row's smooth scroll ignores `prefers-reduced-motion`.**
    `src/components/GalleryRow.tsx` uses bare `scroll-smooth`. Everywhere else
    in this repo motion is gated — `motion-safe:scroll-smooth` on `html`,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,6 +41,21 @@ left: the gallery was a strip until PR #14 gave it controls and stopped it
 moving, and a row the reader drives is not a strip.
 _Avoid_: carousel, ticker, marquee (the marquee is one strip, not the concept)
 
+**Row**:
+The gallery's nine tiles in one horizontal scroller the reader pages through a
+screenful at a time. What a strip stopped being: it holds still until someone
+moves it (ADR-0007). It keeps the page's gutter on both sides, and its snap
+positions are offset to match — without that it comes to rest one gutter in,
+having eaten its own inset.
+_Avoid_: carousel, slider, gallery strip
+
+**Pager**:
+The row's prev/next pair. It sits above the row rather than on its edges,
+because a control overlaid on a scroller covers artwork at some scroll position
+whatever the padding is (ADR-0008). It names what it drives with
+`aria-controls`, the row having stopped being its neighbour.
+_Avoid_: arrows, nav buttons, controls (unqualified — the nav has controls too)
+
 **Stop**:
 One screen of the landing page, which the viewport comes to rest on. The page
 is six of them. A stop owns its height and its surface, and the content inside

--- a/docs/adr/0008-gallery-controls-outside-the-artwork.md
+++ b/docs/adr/0008-gallery-controls-outside-the-artwork.md
@@ -1,0 +1,85 @@
+# 0008 — The gallery's paging controls sit outside the artwork
+
+Date: 2026-08-17. Status: accepted.
+
+## Context
+
+Finding 4 of `DESIGN_REVIEW.md` called the gallery row "unfinished as an
+interaction" and prescribed four fixes: page by the row's width, hide the
+scrollbar, size the tiles so 3–4 are visible, and **move the controls onto the
+row's left and right edges**. PR #14 did all four. The controls became `size-11`
+circles, absolutely positioned at `left-3 md:left-6` and `right-3 md:right-6`,
+overlaying the row.
+
+Issue #45 then read the code and predicted the row rests past its own gutter.
+Measuring confirmed it, and turned up a second fault the issue did not name: the
+control's footprint is wider than the gutter it sits in. At `md`+ the gutter is
+48px and the control occupies 24 + 44 = 68, overhanging the artwork by 20px;
+below `md` it is 24 against 12 + 44 = 56, overhanging by 32.
+
+Two measurements make this a design question rather than a tuning one.
+
+**A 44px control cannot fit a 24px gutter.** ADR-0004 requires 44px below `md`
+and `--spacing-gutter-sm` is 24px. No offset exists that puts the control in the
+gutter on a phone. The only ways to make it fit are to shrink the control below
+`md` — which ADR-0004 forbids — or to inset the row past the page gutter, which
+costs the phone about 20% of its tile width.
+
+**Padding is empty space only at the scroll extremes.** Mid-scroll, artwork
+slides through the padding band. So an overlaid control sits on artwork at some
+scroll position regardless of what the padding is, and `scroll-padding` — the
+fix #45 proposes — cannot change that. The alternative that does, ending the
+scrollport at the gutter, was measured and removes the partial tile at the
+row's trailing edge: the share arithmetic in `galleryImages.ts` makes three
+tiles fill the scrollport exactly. With the scrollbar already hidden, that
+partial tile is the only thing on screen saying nine images exist.
+
+## Decision
+
+**A row whose content the reader is meant to study puts its paging controls
+outside the artwork.** For the gallery that means the section's heading block,
+above the row, rather than overlaid on its edges.
+
+Finding 4's placement instruction is **superseded**. Its other three fixes
+stand, and the finding as a whole was right about what it saw: controls sitting
+below-left of a row with a visible scrollbar and per-item paging were
+unfinished. Moving them onto the row's edges was the fix available at the time
+for a row that had no other home for them.
+
+## Consequences
+
+The controls keep 44px at every width. Once they are out of the gutter there is
+nothing to fit them into, so ADR-0004 needs no argument and the control's size
+gains no breakpoint variation — the "second, invisible axis of variation" that
+ADR-0004 says it wrote itself as a breakpoint rule to avoid.
+
+`scroll-padding` becomes sufficient rather than partial, so the row keeps its
+padding and keeps bleeding off-screen, and the partial tile at the trailing edge
+survives. That partial tile is load-bearing: it is the row's only remaining
+scrollability cue, and this decision is what lets it stay.
+
+The controls' relationship to the row stops being positional, so it is stated:
+the row takes an `id` and the buttons take `aria-controls`. Tab order changes —
+the controls now come before the region they drive, which is the ordinary
+reading order for a header control.
+
+This has a boundary, and it is the same one ADR-0007 drew for motion. That
+decision said motion decorates and does not carry, so a strip of words may loop
+while a row of artwork may not. The same distinction applies here: an overlaid
+control is a reasonable pattern for a dense row of thumbnails, where the
+covered pixels are the edge of something nobody is studying. It is wrong for
+nine pieces of children's artwork, which ADR-0007 already established is the
+page's proof. This licenses moving controls off content the reader dwells on;
+it is not a general rule against overlaid controls.
+
+**The gate cannot check this.** jsdom applies no stylesheets (ADR-0001), so no
+test can measure whether a control overlaps a tile. The class contract can
+assert the pager is not absolutely positioned and that `aria-controls` names the
+row, which catches the arrangement being undone; it cannot confirm that nothing
+overlaps at a given width. That stays a browser measurement, recorded in
+`docs/plans/gallery-row-gutter.md`.
+
+What this costs is proximity on a phone. Below `md` the controls sit above the
+row rather than on it, further from the thing they move, and the compensation is
+that a phone reader swipes rather than pressing them. That is a trade taken
+knowingly, and it is the part most likely to be re-litigated.

--- a/docs/plans/gallery-row-gutter.md
+++ b/docs/plans/gallery-row-gutter.md
@@ -1,0 +1,248 @@
+# The gallery row's gutter, and where its controls belong
+
+Issue #45. Branch `issue-45-gallery-row-gutter`.
+
+Confirms and widens the code reading filed as #45: the row does rest past its
+own gutter, and the controls have a second, independent problem that the
+proposed fix does not touch.
+
+## Problem, from the reader's point of view
+
+On every load, at every width, the gallery's leftmost artwork sits flush against
+the edge of the screen and the `←` control sits on top of it. Nothing else on
+the page does this — the `What kids make here.` heading directly above the row,
+and the program cards below it, both keep the page's `--spacing-gutter` inset.
+The gallery alone loses it, and the reader's first sight of the artwork is a
+tile with a button parked over its corner.
+
+Scrolling does not clear it. At the far end of the row the `→` control overlaps
+the last tile too, by less — which is the tell that there are two faults here,
+not one.
+
+## What is actually wrong, measured
+
+Measured in Chrome against the dev server, reading the live DOM before any
+interaction. Numbers below are at 1536x639 — Cole's review window — and at 375
+wide.
+
+**Fault A: the row rests past its own gutter.** A scroll container's snapport is
+its scrollport reduced by `scroll-padding`, which is unset here. `snap-start`
+therefore aligns a tile's left edge with the _padding box_ start, so the first
+tile's snap position is `scrollLeft: padding-left` — not `0`. Under
+`scroll-snap-type: x mandatory` the container must rest on a snap position, so
+it comes to rest one whole gutter in, having consumed its own left padding:
+
+|      | `scrollLeft` at rest | `scroll-padding-left` | tile 1 left | `h2` left |
+| ---- | -------------------- | --------------------- | ----------- | --------- |
+| 1536 | **48**               | `auto`                | **0**       | 48        |
+| 375  | **24**               | `auto`                | **0**       | 24        |
+
+This is exactly the reading in #45, confirmed.
+
+**Fault B: the controls are wider than the gutter they sit in.** Independent of
+A, and not fixed by it. `CONTROL_CLASSES` is `size-11` — 44px, per ADR-0004 —
+offset by `left-3 md:left-6`. The control's inner edge therefore lands past the
+content edge:
+
+|            | gutter | control footprint | overhang into the artwork |
+| ---------- | ------ | ----------------- | ------------------------- |
+| `md`+      | 48     | 24 + 44 = 68      | **20px**                  |
+| below `md` | 24     | 12 + 44 = 56      | **32px**                  |
+
+The 20px figure is measurable today at the scroll end, where the padding _is_
+honoured and fault A is out of the way. It matches the screenshot on #45
+captioned "rightmost image slightly overlaps control".
+
+**Fault B cannot be fixed by moving the control into the gutter.** Below `md`
+the gutter is 24px and ADR-0004 requires 44px, so a 44px control will never fit
+a 24px band. That is not a tuning problem; it is arithmetic.
+
+**And padding is not empty space except at the extremes.** `scroll-padding`
+alone was measured: it fixes the resting state (`scrollLeft: 0`, tile 1 at 48)
+and nothing else. Mid-scroll, artwork slides _through_ the padding band, so the
+control is over a tile again on page 2. Padding reserves space at the scroll
+extremes only.
+
+## Solution
+
+Two changes, neither of which fights the other:
+
+1. **`scroll-pl-gutter-sm md:scroll-pl-gutter` on the row**, matching its
+   padding. The snapport now starts where the gutter ends, so the first tile's
+   snap position is `0` and the row rests on its own inset. This is the fix #45
+   proposes, and with change 2 in place it is sufficient rather than partial.
+2. **The controls move out of the artwork band** into the heading block's
+   right-hand column, above the paragraph.
+
+Change 2 is what makes change 1 enough: `scroll-padding` was only ever
+insufficient because the controls were inside the band the artwork scrolls
+through. Take them out and the mid-scroll case stops mattering.
+
+### What this costs, measured
+
+Nothing that shows. The controls take no horizontal space in their new home, so
+the tiles are untouched, and they fit in vertical space that is already empty:
+
+|            | tall tile | wide tile | tile height | whole tiles | peek   |
+| ---------- | --------- | --------- | ----------- | ----------- | ------ |
+| 1536 today | 413.1     | 550.8     | 309.8       | 3           | 72px   |
+| 1536 after | 413.1     | 550.8     | 309.8       | 3           | 72px   |
+| 375 today  | 265.2     | —         | 198.9       | 1           | 70.8px |
+| 375 after  | 265.2     | —         | 198.9       | 1           | 70.8px |
+
+The vertical budget at 1536x639: the gallery stop is 555px and its section
+content 473px, so there is 82px of slack. It is not needed. The heading block is
+123.2px tall because the `h2` runs to two lines, while the paragraph beside it
+is 40.8px and bottom-aligned by `md:items-end` — leaving **82.4px of empty
+height above the paragraph**, in a column 134px wide. Two 44px controls and a
+`gap-3` come to 100px. The pair fits in space the layout is already spending, at
+zero added height.
+
+Below `md` there is no height cost to worry about either: the `stops` variant
+requires `min-width: 64rem`, so a phone is an ordinary scrolling page.
+
+## Implementation decisions
+
+**The controls keep 44px at every width.** Moving them out of the gutter removes
+the only reason to shrink them, so ADR-0004 needs no argument and
+`CONTROL_CLASSES` keeps `size-11`.
+
+**The padding stays; the row keeps bleeding off-screen.** The alternative —
+margin instead of padding, so the scrollport ends at the gutter — was measured
+and rejected. See below.
+
+**`GalleryRow` keeps the paging mechanic; `GallerySection` places the
+controls.** The controls need the scroller's `clientWidth`, so separating them
+in the DOM means publishing a seam. The mechanic moves into a
+`useGalleryPaging()` hook returning `{ rowRef, page }`; `GalleryRow` renders the
+scroller and takes `rowRef`; a `GalleryPager` renders the two buttons and takes
+`page`. `GallerySection` composes both, which is where the composition already
+lives — it owns tile geometry today for the same reason, and says so in a
+comment.
+
+The hook is kept as a named seam for the reason `StripTrack`'s doc comment
+gives about the looping mechanic: the interesting part is intricate and worth
+one home, not because anything varies across it. `scrollBy(clientWidth)` and
+its dependence on `snap-x mandatory` to correct the landing is that intricate
+part, and the reasoning currently written into `GalleryRow`'s doc comment moves
+with it.
+
+**The buttons gain `aria-controls`, and the row gains an `id`.** Today the
+buttons sit next to the row in the DOM and their relationship to it is
+positional. Once they are in the heading block that is gone, so it gets stated
+instead. This is an addition the current layout should arguably have had; it is
+in scope here because the move is what removes the implicit version.
+
+**Tab order changes, and that is accepted.** The controls come before the row in
+the DOM after this. A control announced before the region it drives is the
+ordinary reading order for a header control, and `aria-controls` names the
+target.
+
+## Test seams
+
+Class contract, per the `StripTrack.test.tsx` precedent that jsdom applies no
+stylesheets — and per #45's own observation that the class contract is the only
+seam jsdom can reach for this:
+
+- **`GalleryRow.test.tsx`:** the row carries `scroll-pl-gutter-sm` and
+  `md:scroll-pl-gutter`. This is the regression test for fault A and must fail
+  before the fix.
+- **`GalleryRow.test.tsx`:** the existing "the controls sit on the row's edges"
+  test is replaced, not deleted. It asserts `absolute`/`left-3`/`right-3`, which
+  is precisely the arrangement being removed; its replacement asserts the pager
+  is not absolutely positioned and the row has no control overlaid on it.
+- **`GalleryRow.test.tsx`:** paging still calls `scrollBy` with one
+  `clientWidth`, in both directions. This is the existing pair of tests and they
+  must survive the hook extraction unchanged in meaning — they are the evidence
+  the refactor preserved behaviour.
+- **`GallerySection.test.tsx`:** the pager renders inside the heading block, and
+  its buttons' `aria-controls` matches the row's `id`.
+
+**`built-css.mjs` gains `REQUIRED` rows for `scroll-pl-gutter-sm` and
+`md:scroll-pl-gutter`.** A Tailwind utility that resolves to nothing still
+appears in the markup, so the class-contract test above passes either way. The
+gate row is what proves the declaration is emitted. It does **not** prove the
+value is right; that stays a browser measurement, recorded above.
+
+**Outside the gate, needs a human in a browser:** that the row rests on its
+gutter at load, that no control overlaps artwork at any scroll position, and
+that the controls read as belonging to the row from their new position. ADR-0001
+and ADR-0004 both already record this gap. The measurements above were taken at
+1536x639 and 375 only — **768 and 1024 are unverified**, and checking them is
+part of slice 2's verification, not an assumption of it.
+
+## Slices
+
+1. This plan, and ADR-0008.
+2. **Rest the row on its own gutter.** `scroll-pl-gutter-sm
+md:scroll-pl-gutter`, its failing-first class-contract test, and the two
+   built-CSS rows. Independently shippable and independently good: it takes the
+   left-hand overlap from 68px to 20px and restores the inset at load, without
+   depending on slice 3.
+3. **Move the paging controls out of the artwork.** The `useGalleryPaging`
+   extraction, `GalleryPager`, the heading-block placement, `aria-controls`, and
+   the test changes above. Takes the overlap to zero at every width and every
+   scroll position.
+4. **Catch the docs up.** `CONTEXT.md`'s gallery entry, and an addendum on
+   `DESIGN_REVIEW.md` finding 4 recording that its "move the controls onto the
+   row's left and right edges" instruction is superseded and why.
+
+Slice 3 depends on slice 2 only for tidiness of review; they touch the same file
+but not the same lines. Slice 4 depends on both.
+
+## Considered and rejected
+
+**Margin instead of padding, so the scrollport ends at the gutter.** This was
+the strongest alternative and was measured across four scroll states. It works:
+artwork under the controls goes to 0px at rest, page 2, page 3 and the end, the
+leading tile lands on exactly 48 every time, and fault A disappears as a side
+effect because there is no padding left to consume. It was rejected for one
+measured reason: **it kills the peek.** The 0.3/0.3/0.4 share arithmetic
+recorded in `galleryImages.ts` makes three tiles and two gaps equal exactly one
+content width, so when the scrollport equals the content box, three tiles fill
+it precisely and no partial tile remains — measured at 1536, `whole=3
+partial=0 peek=0`. With the scrollbar already hidden by `no-scrollbar`, the
+partial tile is the only thing on screen saying there are nine images. Trading a
+discoverability affordance for an alignment fix is the wrong direction, and it
+would have been invisible in review because the row still looks finished.
+
+**Pulling the controls into the gutter** (`md:left-1`, control flush at 48).
+Fixes `md`+ only. Below `md` a 44px control cannot fit a 24px gutter, so phones
+keep a 32px overlap — the worst case of the two, on the narrowest artwork. Also
+cramped: a 44px circle in a 48px band leaves 2px either side.
+
+**Shrinking the controls at `md`+ to fit the gutter** (`md:size-9` at
+`md:left-1.5`, measured at 0px overlap). Permitted by ADR-0004, which requires
+only 24px above `md` and names these very controls as the site's 44px instance.
+Rejected because it buys at `md`+ what the move buys everywhere, while adding a
+breakpoint divergence in the control's size — the "second, invisible axis of
+variation" ADR-0004 says it wrote itself as a breakpoint rule to avoid.
+
+**Insetting the row far enough below `md` to host a 44px control** (`mx-14`,
+56px; measured at 0px overlap at 375). Costs the phone about 20% of its tile
+width, taking the scrollport from 312 to 248, and puts the gallery's inset out
+of step with the page gutter on exactly the screens where space is scarcest.
+
+**`scroll-padding` alone**, as #45 proposes. Sufficient only in combination with
+slice 3; on its own it fixes the load state and leaves both screenshots that
+show a scrolled row unchanged. Recorded here because the issue proposes it and a
+reader should not conclude it was overlooked.
+
+## Out of scope
+
+- **The controls are dead at the row's ends and do not say so.** Measured: at
+  rest `scrollLeft` is already at minimum so `←` does nothing, and after two
+  `→` presses the row pins at `maxScroll` and further presses do nothing. Both
+  controls stay enabled and styled as active throughout. This is a real defect
+  and a separate one — it predates this work and is not caused by it. To be
+  filed as its own issue.
+- **A scrim or gradient behind the controls**, which is the overlay pattern's
+  own fix. Moot once they are out of the artwork.
+- **Position indicators** (dots, or a progress bar for the three pages). A
+  genuine option for a nine-item row with three visible, and unrelated to
+  either fault here.
+- **The hidden scrollbar.** `no-scrollbar` removes a visible affordance and a
+  mouse drag target; that is a live question, raised by the peek finding above,
+  but it is a separate decision.
+- **Verifying anything in Firefox or Safari.** Every measurement here is Chrome.
+- **The gallery grid**, still parked on issue #38.

--- a/docs/plans/gallery-row-gutter.md
+++ b/docs/plans/gallery-row-gutter.md
@@ -246,3 +246,35 @@ reader should not conclude it was overlooked.
   but it is a separate decision.
 - **Verifying anything in Firefox or Safari.** Every measurement here is Chrome.
 - **The gallery grid**, still parked on issue #38.
+
+## Addendum — 2026-08-17: what implementing it changed
+
+Four things the plan above did not say, recorded rather than edited in.
+
+**`GallerySection` is now a client component.** It holds the paging seam the
+row and the pager share, so it holds the hook, so it carries `"use client"`.
+The plan said "`GallerySection` composes both" without noticing that follows.
+Its own content is static; what hydrates is the wiring between the two. The
+alternative — a client wrapper owning the heading block so the section could
+stay a server component — was not taken, because it would put the section's
+heading layout inside a component named for the row.
+
+**The built-CSS row is `scroll-pl-gutter`, not `md:scroll-pl-gutter`.** The
+variant form does not match: the built selector escapes the colon, so
+`rulesFor` reads `.md\:scroll-pl-gutter` and a table entry written with a bare
+colon finds nothing. This is the case `min-h-footer`'s comment already
+documents. The trailing `(?![\w-])` boundary in that matcher is what keeps the
+bare form off `scroll-pl-gutter-sm`'s rule, so the two rows do not alias.
+
+**768 and 1024 are now verified**, which the Test seams section listed as an
+open obligation. At rest, all four widths: `scrollLeft` 0, first tile on the
+gutter. Across four scroll states each — rest, two pages, and the end — the
+artwork covered by either control is **0px at every width and every state**,
+measured as true rect intersection clipped to the scrollport, and a partial
+tile survives in every one.
+
+**Below `md` the section grows by 56px** — the control's 44px plus a `gap-3`.
+The plan said there was no height cost to worry about there, which was right
+about the consequence and silent about the number. At 1536x639 the stop is
+still 555 and the section still 473, unchanged, so the claim that the move is
+free holds where a stop exists.

--- a/scripts/built-css.mjs
+++ b/scripts/built-css.mjs
@@ -82,6 +82,14 @@ export const REQUIRED = [
     utility: "scroll-pt-nav-sm",
     why: "the root element offsets every snap stop by the nav height with it",
   },
+  {
+    utility: "scroll-pl-gutter-sm",
+    why: "GalleryRow keeps its snapport off its own gutter with it; resolving to nothing puts the row back to resting one gutter in, which the class contract cannot see because the class name stays in the markup either way",
+  },
+  {
+    utility: "scroll-pl-gutter",
+    why: "the same, at the width where the gutter is 48px. Written in src/ only as md:scroll-pl-gutter, so this is the bare form for the reason min-h-footer above is — the built selector escapes the variant into the class name. The trailing boundary is what keeps it off scroll-pl-gutter-sm's rule",
+  },
 ];
 
 /** A rule body counts as emitting CSS only if it holds a declaration. */

--- a/src/components/GalleryPager.test.tsx
+++ b/src/components/GalleryPager.test.tsx
@@ -1,0 +1,47 @@
+import { expect, test, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { GalleryPager } from "./GalleryPager";
+
+function renderPager() {
+  const page = vi.fn();
+
+  render(<GalleryPager controls="gallery-row" page={page} />);
+
+  return {
+    page,
+    previous: screen.getByRole("button", { name: /previous artwork/i }),
+    next: screen.getByRole("button", { name: /next artwork/i }),
+  };
+}
+
+test("each control names the row it pages", () => {
+  const { previous, next } = renderPager();
+
+  // The pair no longer sits on the row, so nothing about their position says
+  // what they drive. Without this the relationship is not stated anywhere.
+  expect(previous.getAttribute("aria-controls")).toBe("gallery-row");
+  expect(next.getAttribute("aria-controls")).toBe("gallery-row");
+});
+
+test("next pages forward and previous pages back", () => {
+  const { page, previous, next } = renderPager();
+
+  fireEvent.click(next);
+  expect(page).toHaveBeenCalledWith(1);
+
+  fireEvent.click(previous);
+  expect(page).toHaveBeenCalledWith(-1);
+});
+
+test("the controls sit in flow rather than overlaid on the artwork", () => {
+  const { previous, next } = renderPager();
+
+  // jsdom applies no stylesheets, so the class contract is the seam. This is
+  // the assertion that keeps ADR-0008 from being undone by a stray absolute:
+  // the pair used to be positioned onto the row's left and right edges, where
+  // a 44px control overhung the gutter by 20px at md+ and 32px below it.
+  for (const control of [previous, next]) {
+    expect(control.className).not.toContain("absolute");
+    expect(control.className).toContain("size-11");
+  }
+});

--- a/src/components/GalleryPager.tsx
+++ b/src/components/GalleryPager.tsx
@@ -1,0 +1,46 @@
+type GalleryPagerProps = {
+  /** The `id` of the row these controls page, named for assistive tech. */
+  controls: string;
+  /** From `useGalleryPaging`, which owns the row this pages. */
+  page: (direction: 1 | -1) => void;
+};
+
+const CONTROL_CLASSES =
+  "rounded-pill shadow-card flex size-11 cursor-pointer items-center justify-center border-2 border-lavender bg-cream text-base font-black text-dark transition-colors duration-fast hover:border-purple hover:text-purple";
+
+/**
+ * The gallery row's prev/next pair.
+ *
+ * In normal flow rather than overlaid on the row's edges. A 44px control
+ * (ADR-0004) does not fit a 24px gutter below `md` at any offset, and a
+ * scroll container's padding is empty space only at the scroll extremes — so
+ * an overlaid control covers artwork at some scroll position whatever the
+ * padding is. See `docs/adr/0008-gallery-controls-outside-the-artwork.md`.
+ *
+ * Sitting apart from the row costs the pair the relationship the old position
+ * implied, so `aria-controls` states it instead.
+ */
+export function GalleryPager({ controls, page }: GalleryPagerProps) {
+  return (
+    <div className="flex gap-3">
+      <button
+        type="button"
+        aria-label="Previous artwork"
+        aria-controls={controls}
+        className={CONTROL_CLASSES}
+        onClick={() => page(-1)}
+      >
+        <span aria-hidden="true">←</span>
+      </button>
+      <button
+        type="button"
+        aria-label="Next artwork"
+        aria-controls={controls}
+        className={CONTROL_CLASSES}
+        onClick={() => page(1)}
+      >
+        <span aria-hidden="true">→</span>
+      </button>
+    </div>
+  );
+}

--- a/src/components/GalleryRow.test.tsx
+++ b/src/components/GalleryRow.test.tsx
@@ -1,25 +1,19 @@
-import { expect, test, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { createRef } from "react";
+import { render, screen } from "@testing-library/react";
 import { GalleryRow } from "./GalleryRow";
 
 function renderRow() {
+  const rowRef = createRef<HTMLDivElement>();
+
   render(
-    <GalleryRow label="Artwork">
+    <GalleryRow id="gallery-row" label="Artwork" rowRef={rowRef}>
       <div>first</div>
       <div>second</div>
     </GalleryRow>,
   );
 
-  const row = screen.getByRole("group", { name: "Artwork" });
-
-  // jsdom has no layout, so the row cannot really scroll and measures zero.
-  // Stubbing both is what lets the assertion be about the distance asked for
-  // rather than about jsdom.
-  const scrollBy = vi.fn();
-  row.scrollBy = scrollBy;
-  Object.defineProperty(row, "clientWidth", { value: 900, configurable: true });
-
-  return { row, scrollBy };
+  return { row: screen.getByRole("group", { name: "Artwork" }), rowRef };
 }
 
 test("the row is reachable and named for a keyboard or screen reader", () => {
@@ -31,23 +25,20 @@ test("the row is reachable and named for a keyboard or screen reader", () => {
   expect(row.getAttribute("aria-label")).toBe("Artwork");
 });
 
-test("next pages forward by a screenful", () => {
-  const { scrollBy } = renderRow();
+test("the row carries the id its pager points at", () => {
+  const { row } = renderRow();
 
-  fireEvent.click(screen.getByRole("button", { name: /next artwork/i }));
-
-  // A screenful, not one item: how many items that is changes with the
-  // width, and snap-mandatory pulls the result back onto an item edge, so
-  // the control never has to know the count.
-  expect(scrollBy).toHaveBeenCalledWith({ left: 900 });
+  // The pager sits outside the row now, so aria-controls is the only thing
+  // tying the two together — and it can only name an id that is really here.
+  expect(row.id).toBe("gallery-row");
 });
 
-test("previous pages back by a screenful", () => {
-  const { scrollBy } = renderRow();
+test("the row hands itself to the paging mechanic", () => {
+  const { row, rowRef } = renderRow();
 
-  fireEvent.click(screen.getByRole("button", { name: /previous artwork/i }));
-
-  expect(scrollBy).toHaveBeenCalledWith({ left: -900 });
+  // page() measures clientWidth off this element. A ref pointed anywhere else
+  // scrolls nothing, silently.
+  expect(rowRef.current).toBe(row);
 });
 
 test("the row snaps horizontally without moving on its own", () => {
@@ -58,22 +49,6 @@ test("the row snaps horizontally without moving on its own", () => {
   expect(row.className).toContain("overflow-x-auto");
   expect(row.className).toContain("snap-x");
   expect(row.className).not.toContain("animate-strip");
-});
-
-test("the scrollbar is hidden, because the controls are the affordance", () => {
-  const { row } = renderRow();
-
-  expect(row.className).toContain("no-scrollbar");
-});
-
-test("the controls do not animate for a reader who asked for less motion", () => {
-  const { row } = renderRow();
-
-  // Every other piece of motion here is gated — motion-safe:scroll-smooth on
-  // html, motion-reduce:animate-none on the marquee, motion-safe on snapping
-  // itself. A bare scroll-smooth would animate every press regardless.
-  expect(row.className).toContain("motion-safe:scroll-smooth");
-  expect(row.className).not.toMatch(/(^|\s)scroll-smooth/);
 });
 
 test("the row's snap positions account for its own gutter", () => {
@@ -89,16 +64,30 @@ test("the row's snap positions account for its own gutter", () => {
   expect(row.className).toContain("md:scroll-pl-gutter");
 });
 
-test("the controls sit on the row's edges", () => {
-  renderRow();
+test("the scrollbar is hidden, because the controls are the affordance", () => {
+  const { row } = renderRow();
 
-  // Overlaid left and right rather than stacked beneath, so the row reads as
-  // one paged surface instead of a scroller with buttons parked under it.
-  const previous = screen.getByRole("button", { name: /previous artwork/i });
-  const next = screen.getByRole("button", { name: /next artwork/i });
+  expect(row.className).toContain("no-scrollbar");
+});
 
-  expect(previous.className).toContain("absolute");
-  expect(previous.className).toContain("left-3");
-  expect(next.className).toContain("absolute");
-  expect(next.className).toContain("right-3");
+test("the row does not animate for a reader who asked for less motion", () => {
+  const { row } = renderRow();
+
+  // Every other piece of motion here is gated — motion-safe:scroll-smooth on
+  // html, motion-reduce:animate-none on the marquee, motion-safe on snapping
+  // itself. A bare scroll-smooth would animate every press regardless.
+  expect(row.className).toContain("motion-safe:scroll-smooth");
+  expect(row.className).not.toMatch(/(^|\s)scroll-smooth/);
+});
+
+test("the row carries no control of its own", () => {
+  const { row } = renderRow();
+
+  // This replaces an assertion that the controls sat absolutely positioned on
+  // the row's left and right edges. That arrangement is what ADR-0008 removed:
+  // a 44px control does not fit a 24px gutter below md, and padding is empty
+  // space only at the scroll extremes, so an overlaid control covers artwork
+  // at some scroll position whatever the padding is.
+  expect(row.querySelector("button")).toBeNull();
+  expect(row.className).not.toContain("relative");
 });

--- a/src/components/GalleryRow.test.tsx
+++ b/src/components/GalleryRow.test.tsx
@@ -76,6 +76,19 @@ test("the controls do not animate for a reader who asked for less motion", () =>
   expect(row.className).not.toMatch(/(^|\s)scroll-smooth/);
 });
 
+test("the row's snap positions account for its own gutter", () => {
+  const { row } = renderRow();
+
+  // A snapport is the scrollport reduced by scroll-padding. With none, and
+  // snap-start on the tiles, the first tile's snap position is the padding box
+  // start — so under snap-mandatory the row rests at scrollLeft: padding-left,
+  // one whole gutter in, with the artwork flush to the screen edge and the
+  // gutter consumed. Measured at 48 (1536) and 24 (375) before this matched;
+  // see docs/plans/gallery-row-gutter.md.
+  expect(row.className).toContain("scroll-pl-gutter-sm");
+  expect(row.className).toContain("md:scroll-pl-gutter");
+});
+
 test("the controls sit on the row's edges", () => {
   renderRow();
 

--- a/src/components/GalleryRow.tsx
+++ b/src/components/GalleryRow.tsx
@@ -24,6 +24,11 @@ const CONTROL_CLASSES =
  * having to know how many items are visible at the current width. The
  * scrollbar is hidden because the controls are the affordance.
  *
+ * The scroll padding matches the padding because a snapport is the scrollport
+ * reduced by it. Left unset, `snap-start` would align the first tile with the
+ * padding box rather than the inset, and mandatory snapping would rest the row
+ * one whole gutter in — losing the inset the rest of the page keeps.
+ *
  * The row is a focus stop (`tabindex="0"`) so arrow keys scroll it — a
  * scrollable region with no way in is unreachable for anyone not using a
  * pointer, and the controls alone would not give it a name.
@@ -44,7 +49,7 @@ export function GalleryRow({ label, children }: GalleryRowProps) {
         tabIndex={0}
         role="group"
         aria-label={label}
-        className="no-scrollbar flex snap-x snap-mandatory gap-6 overflow-x-auto px-gutter-sm motion-safe:scroll-smooth md:px-gutter"
+        className="no-scrollbar flex snap-x snap-mandatory gap-6 overflow-x-auto px-gutter-sm scroll-pl-gutter-sm motion-safe:scroll-smooth md:px-gutter md:scroll-pl-gutter"
       >
         {children}
       </div>

--- a/src/components/GalleryRow.tsx
+++ b/src/components/GalleryRow.tsx
@@ -1,74 +1,43 @@
-"use client";
-
-import { useRef, type ReactNode } from "react";
+import type { ReactNode, RefObject } from "react";
 
 type GalleryRowProps = {
+  /** What the pager's `aria-controls` names. */
+  id: string;
   /** Names the row for assistive tech, since it is a focus stop. */
   label: string;
+  /** From `useGalleryPaging`, whose `page` measures and scrolls this element. */
+  rowRef: RefObject<HTMLDivElement | null>;
   children: ReactNode;
 };
 
-const CONTROL_CLASSES =
-  "rounded-pill shadow-card absolute top-1/2 z-10 flex size-11 -translate-y-1/2 cursor-pointer items-center justify-center border-2 border-lavender bg-cream text-base font-black text-dark transition-colors duration-fast hover:border-purple hover:text-purple";
-
 /**
- * A horizontally paged row of artwork, driven by controls at its edges.
+ * A horizontally paged row of artwork.
  *
- * Native scrolling rather than a transform and an index: touch fling,
- * trackpad, arrow keys and screen-reader navigation all work without being
- * reimplemented, and there is no index to fall out of step with reality when
- * a resize changes how many items fit.
+ * The scroller alone: `useGalleryPaging` owns the mechanic that moves it and
+ * `GalleryPager` owns the controls that drive it, because the controls sit
+ * outside the artwork rather than on this row's edges (ADR-0008). The
+ * scrollbar is hidden because those controls are the affordance.
  *
- * A press moves one screenful, not one item, and `snap-x mandatory` pulls the
- * result back onto an item edge — so paging stays aligned without the button
- * having to know how many items are visible at the current width. The
- * scrollbar is hidden because the controls are the affordance.
+ * The row is a focus stop (`tabindex="0"`) so arrow keys scroll it — a
+ * scrollable region with no way in is unreachable for anyone not using a
+ * pointer, and the controls alone would not give it a name.
  *
  * The scroll padding matches the padding because a snapport is the scrollport
  * reduced by it. Left unset, `snap-start` would align the first tile with the
  * padding box rather than the inset, and mandatory snapping would rest the row
  * one whole gutter in — losing the inset the rest of the page keeps.
- *
- * The row is a focus stop (`tabindex="0"`) so arrow keys scroll it — a
- * scrollable region with no way in is unreachable for anyone not using a
- * pointer, and the controls alone would not give it a name.
  */
-export function GalleryRow({ label, children }: GalleryRowProps) {
-  const rowRef = useRef<HTMLDivElement>(null);
-
-  const page = (direction: 1 | -1) => {
-    const row = rowRef.current;
-    if (!row) return;
-    row.scrollBy({ left: row.clientWidth * direction });
-  };
-
+export function GalleryRow({ id, label, rowRef, children }: GalleryRowProps) {
   return (
-    <div className="relative">
-      <div
-        ref={rowRef}
-        tabIndex={0}
-        role="group"
-        aria-label={label}
-        className="no-scrollbar flex snap-x snap-mandatory gap-6 overflow-x-auto px-gutter-sm scroll-pl-gutter-sm motion-safe:scroll-smooth md:px-gutter md:scroll-pl-gutter"
-      >
-        {children}
-      </div>
-      <button
-        type="button"
-        aria-label="Previous artwork"
-        className={`${CONTROL_CLASSES} left-3 md:left-6`}
-        onClick={() => page(-1)}
-      >
-        <span aria-hidden="true">←</span>
-      </button>
-      <button
-        type="button"
-        aria-label="Next artwork"
-        className={`${CONTROL_CLASSES} right-3 md:right-6`}
-        onClick={() => page(1)}
-      >
-        <span aria-hidden="true">→</span>
-      </button>
+    <div
+      id={id}
+      ref={rowRef}
+      tabIndex={0}
+      role="group"
+      aria-label={label}
+      className="no-scrollbar flex snap-x snap-mandatory gap-6 overflow-x-auto px-gutter-sm scroll-pl-gutter-sm motion-safe:scroll-smooth md:px-gutter md:scroll-pl-gutter"
+    >
+      {children}
     </div>
   );
 }

--- a/src/components/GallerySection.test.tsx
+++ b/src/components/GallerySection.test.tsx
@@ -60,6 +60,41 @@ test("the reader drives the row", () => {
   expect(screen.getByRole("button", { name: /next artwork/i })).toBeDefined();
 });
 
+test("the controls sit in the heading block, not on the artwork", () => {
+  render(<GallerySection />);
+
+  // Where the pair sits is the whole of ADR-0008, and it is the one part of
+  // that decision jsdom can see: the heading block is a different element from
+  // the row, so containment is a real assertion even without a stylesheet.
+  const headingBlock = screen.getByRole("heading", { level: 2 }).parentElement;
+  const row = screen.getByRole("group", {
+    name: /artwork from wild coast kids/i,
+  });
+
+  for (const name of [/previous artwork/i, /next artwork/i]) {
+    const control = screen.getByRole("button", { name });
+    expect(headingBlock?.contains(control)).toBe(true);
+    expect(row.contains(control)).toBe(false);
+  }
+});
+
+test("the controls name the row they page", () => {
+  render(<GallerySection />);
+
+  // Wired here rather than in either component, so a row and a pager that
+  // disagree about the id fail rather than quietly controlling nothing.
+  const row = screen.getByRole("group", {
+    name: /artwork from wild coast kids/i,
+  });
+
+  expect(row.id).not.toBe("");
+  expect(
+    screen
+      .getByRole("button", { name: /previous artwork/i })
+      .getAttribute("aria-controls"),
+  ).toBe(row.id);
+});
+
 test("the section puts its own padding back where there is no stop", () => {
   const { container } = render(<GallerySection />);
 

--- a/src/components/GallerySection.tsx
+++ b/src/components/GallerySection.tsx
@@ -1,5 +1,9 @@
+"use client";
+
+import { GalleryPager } from "./GalleryPager";
 import { GalleryRow } from "./GalleryRow";
 import { Placeholder } from "./Placeholder";
+import { useGalleryPaging } from "./useGalleryPaging";
 import { GALLERY_IMAGES, type GalleryAspect } from "./galleryImages";
 
 /* What a tile's aspect costs it in width. Two 4:3 tiles and one 16:9 share a
@@ -17,7 +21,16 @@ const TILE_ASPECT_CLASSES: Record<GalleryAspect, string> = {
   wide: "aspect-video lg:w-[calc((100%-3rem)*0.4)]",
 };
 
+/* Ties the pager to the row it drives. The two no longer sit together in the
+   DOM, so the relationship is stated rather than positional. */
+const GALLERY_ROW_ID = "gallery-row";
+
 export function GallerySection() {
+  /* The section is a client component because it holds the paging seam the
+     row and the pager share. Its own content is static; what is hydrated is
+     the wiring between the two. */
+  const { rowRef, page } = useGalleryPaging();
+
   return (
     // Surface lives on the SnapSection wrapping this, so it fills the stop
     // rather than only the height of the content.
@@ -28,16 +41,27 @@ export function GallerySection() {
           <br />
           make here.
         </h2>
-        <p className="leading-normal text-sm text-fog md:max-w-50 md:text-right">
-          Every class is different.
-          <br />
-          Every kid surprises us.
-        </p>
+        {/* Reversed below md so the controls sit nearest the row they drive.
+            From md the heading runs to two lines while this column's paragraph
+            is one, and the controls take the height that leaves empty — which
+            is why moving them off the row costs the stop nothing. */}
+        <div className="flex flex-col-reverse gap-3 md:flex-col md:items-end">
+          <GalleryPager controls={GALLERY_ROW_ID} page={page} />
+          <p className="leading-normal text-sm text-fog md:max-w-50 md:text-right">
+            Every class is different.
+            <br />
+            Every kid surprises us.
+          </p>
+        </div>
       </div>
       {/* The row is driven by the reader, not by a clock: a piece of artwork
           you want to look at should not slide away, and one you missed
           should be one press back. */}
-      <GalleryRow label="Artwork from Wild Coast Kids classes">
+      <GalleryRow
+        id={GALLERY_ROW_ID}
+        label="Artwork from Wild Coast Kids classes"
+        rowRef={rowRef}
+      >
         {GALLERY_IMAGES.map(({ label, aspect }) => (
           <Placeholder
             key={label}

--- a/src/components/useGalleryPaging.test.tsx
+++ b/src/components/useGalleryPaging.test.tsx
@@ -1,0 +1,64 @@
+import { expect, test, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useGalleryPaging } from "./useGalleryPaging";
+
+/** The smallest thing that uses the hook the way the gallery does. */
+function Harness({ attach = true }: { attach?: boolean }) {
+  const { rowRef, page } = useGalleryPaging();
+
+  return (
+    <>
+      {attach && <div ref={rowRef} data-testid="row" />}
+      <button type="button" onClick={() => page(-1)}>
+        back
+      </button>
+      <button type="button" onClick={() => page(1)}>
+        forward
+      </button>
+    </>
+  );
+}
+
+function renderHarness() {
+  render(<Harness />);
+
+  const row = screen.getByTestId("row");
+
+  // jsdom has no layout, so the row cannot really scroll and measures zero.
+  // Stubbing both is what lets the assertion be about the distance asked for
+  // rather than about jsdom.
+  const scrollBy = vi.fn();
+  row.scrollBy = scrollBy;
+  Object.defineProperty(row, "clientWidth", { value: 900, configurable: true });
+
+  return { scrollBy };
+}
+
+test("next pages forward by a screenful", () => {
+  const { scrollBy } = renderHarness();
+
+  fireEvent.click(screen.getByRole("button", { name: "forward" }));
+
+  // A screenful, not one item: how many items that is changes with the
+  // width, and snap-mandatory pulls the result back onto an item edge, so
+  // the control never has to know the count.
+  expect(scrollBy).toHaveBeenCalledWith({ left: 900 });
+});
+
+test("previous pages back by a screenful", () => {
+  const { scrollBy } = renderHarness();
+
+  fireEvent.click(screen.getByRole("button", { name: "back" }));
+
+  expect(scrollBy).toHaveBeenCalledWith({ left: -900 });
+});
+
+test("paging a row that is not mounted does nothing rather than throwing", () => {
+  render(<Harness attach={false} />);
+
+  // The controls render before the row in the DOM now, so an unattached ref
+  // is reachable in a way it was not when they were siblings of the scroller.
+  expect(() =>
+    fireEvent.click(screen.getByRole("button", { name: "forward" })),
+  ).not.toThrow();
+});

--- a/src/components/useGalleryPaging.ts
+++ b/src/components/useGalleryPaging.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useRef } from "react";
+
+/**
+ * The gallery row's paging mechanic: a ref to the scroller, and a press that
+ * moves it one screenful.
+ *
+ * Native scrolling rather than a transform and an index: touch fling,
+ * trackpad, arrow keys and screen-reader navigation all work without being
+ * reimplemented, and there is no index to fall out of step with reality when
+ * a resize changes how many items fit.
+ *
+ * A press moves one screenful, not one item, and `snap-x mandatory` on the row
+ * pulls the result back onto an item edge — so paging stays aligned without
+ * the button having to know how many items are visible at the current width.
+ *
+ * It lives in its own module because the row and the controls no longer sit
+ * together in the DOM (ADR-0008), so the two need something to share. That is
+ * the same reason `StripTrack` is kept as a seam with one caller: the mechanic
+ * is the intricate part and is worth one home, not because anything varies
+ * across it.
+ */
+export function useGalleryPaging() {
+  const rowRef = useRef<HTMLDivElement>(null);
+
+  const page = (direction: 1 | -1) => {
+    const row = rowRef.current;
+    if (!row) return;
+    row.scrollBy({ left: row.clientWidth * direction });
+  };
+
+  return { rowRef, page };
+}


### PR DESCRIPTION
Closes #45.

#45 read the code and predicted the row rests past its own gutter. Measuring
confirmed it and found a second fault the issue does not name, which is why
this is more than the one-line fix it proposes.

## What was wrong

**Fault A — the row rests past its own gutter.** A snapport is the scrollport
reduced by `scroll-padding`, which was unset. With `snap-start` on the tiles,
the first tile's snap position was the padding box start, so mandatory snapping
rested the row at `scrollLeft: padding-left` — the leftmost artwork flush to the
screen edge while the heading above it kept the inset.

**Fault B — the controls were wider than the gutter they sat in.** `size-11`
(44px, ADR-0004) at `left-3 md:left-6` occupies 68px at `md`+ against a 48px
gutter, and 56px below `md` against 24px. Independent of A, and not fixed by it:
the 20px figure was measurable at the scroll end, where the padding is honoured.

Two measurements made this a design question rather than a tuning one. Below
`md` a 44px target cannot fit a 24px gutter at any offset. And padding is empty
space only at the scroll extremes — mid-scroll the artwork slides through it, so
an overlaid control covers artwork at some scroll position whatever the padding
is. `scroll-padding` alone was measured and fixes the load state only.

## What changed

- `scroll-pl-gutter-sm md:scroll-pl-gutter` on the row, matching its padding.
- The prev/next pair moves into the heading block's right column, above the
  paragraph, where the two-line heading already leaves the height empty.
- The mechanic they now share moves to `useGalleryPaging`; `GalleryRow` becomes
  the scroller and `GalleryPager` the controls. Their relationship stops being
  positional, so the row takes an `id` and the controls take `aria-controls`.
- ADR-0008 records the decision, since it supersedes `DESIGN_REVIEW.md` finding
  4's "move the controls onto the row's left and right edges".

## Measured, in Chrome against the dev server

At rest, untouched, before and after:

| width | `scrollLeft` before | after | first tile before | after |
| --- | --- | --- | --- | --- |
| 1536 | 48 | **0** | 0 | **48** |
| 1024 | 48 | **0** | 0 | **48** |
| 768 | 48 | **0** | 0 | **48** |
| 375 | 24 | **0** | 0 | **24** |

Artwork covered by a control, as true rect intersection clipped to the
scrollport, across four scroll states at each width — rest, two pages, and the
end: **0px in all sixteen**. A partial trailing tile survives in every one,
which matters because `no-scrollbar` means it is the row's only remaining
scrollability cue.

Tile sizes are untouched (413.1 / 550.8 / 309.8 at 1536, unchanged), and at
1536x639 the stop is still 555 with the section still 473 — the move bought no
height. Below `md` the section grows 56px, which is free because the `stops`
variant needs `min-width: 64rem`.

## Gate

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

The regression test for fault A was confirmed red first:

```
 FAIL  src/components/GalleryRow.test.tsx > the row's snap positions account for its own gutter
AssertionError: expected 'no-scrollbar flex snap-x snap-mandato…' to contain 'scroll-pl-gutter-sm'
```

## Not done

- **The controls are dead at both ends and do not say so.** At rest `←` does
  nothing; after two `→` presses the row pins at `maxScroll`. Both stay enabled
  and styled active. Real defect, predates this work, not caused by it — wants
  its own issue.
- **Firefox and Safari.** Every measurement here is Chrome.
- **Position indicators**, a scrim behind the controls, and the hidden
  scrollbar question — all recorded in the plan's Out of scope.

## Worth a look

- `GallerySection` becomes a client component, because it now holds the paging
  seam. The plan did not anticipate that; it is recorded in a dated addendum
  rather than edited in.
- 724 insertions sounds past the reviewable guide, but ~430 of it is prose — the
  plan, ADR-0008 and the doc catch-up. The code surface is ~300 lines including
  four test files. Splitting at a dependency boundary would separate the docs
  from the code they describe, so I left it whole; say if you would rather it
  were two PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
