### PR TITLE
Plan the conditions tool, and record that it is built here

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -98,6 +98,9 @@ program card)
 
 **Conditions**:
 The real-time surf, tide, wind and visibility tool for San Diego's coast, built
-separately and embedded here. Has a teaser on the landing page and a page of
-its own; both currently carry a reserved slot for it.
+in this repo (ADR-0009). Has a teaser on the landing page and a page of its own;
+both currently carry a reserved slot, which comes out in the slice that has
+something to put in its place. It shows readings and forecasts relayed from
+public sources, attributed and timestamped — never a judgement this site makes
+about whether conditions are safe.
 _Avoid_: weather, forecast, surf report

--- a/docs/adr/0009-conditions-is-native-not-embedded.md
+++ b/docs/adr/0009-conditions-is-native-not-embedded.md
@@ -1,0 +1,114 @@
+# 0009 — The conditions tool is built here, not embedded
+
+Date: 2026-08-17. Status: accepted.
+
+## Context
+
+`CONTEXT.md` defines **Conditions** as "the real-time surf, tide, wind and
+visibility tool for San Diego's coast, built separately and embedded here", and
+both reserved slots — in `src/components/Conditions.tsx` and
+`src/app/conditions/page.tsx` — say _"Drop the URL and it embeds here
+automatically."_ The slot has been waiting for a URL that does not exist.
+
+Two things have changed since that was written.
+
+**There is a body of verified upstream work to draw on.**
+`cweber12/socal-coastal-data` holds request contracts measured against live
+endpoints, parsers pinned to specific column headers and unit strings, and a set
+of data-integrity rules each of which was written after something went wrong: a
+buoy serving HTTP 200 on its station page while its data feed 404s; a feed whose
+timestamps carry no offset, so asking for local time and tagging it UTC ages
+every reading by 7–8 hours; the same river published in cubic metres per second
+by one agency and cubic feet per second by another. That is transferable as
+contracts and rules without being transferable as a service — its corridor,
+its audience and its computed verdicts are all wrong for this site.
+
+**The content this site needs is not what a general surf tool shows.** The
+audience is co-op groups taking K–8 children to the coast: tidepoolers,
+swimmers and snorkellers, surfers, and beach-goers. What they need includes
+things a surf report does not carry — whether take is permitted where a child
+picks something up, how often a beach is posted, what the tide does at 3 pm on
+Tuesday — and excludes the thing a surf report leads with, a judgement about
+whether conditions are good.
+
+The decision then is where the tool is built, and the constraints are the ones
+this repo already documents.
+
+**An iframe cannot inherit a stop.** A stop is 540px and content that does not
+fit is a bug in the section. An embedded document sizes itself; the host page
+can give it a box but cannot make its contents obey the budget, and the height
+negotiation is exactly the class of problem the stop rule exists to prevent.
+
+**An iframe cannot be vouched for.** The safety framing this content needs — a
+standing notice that these are instrument readings and not a safety assessment,
+and that lifeguards and posted signs are the authority on the day — has to sit
+around the readings. Inside a frame, the host page is asserting something it
+does not control; outside it, the notice describes content the page cannot see.
+
+**Nothing in an iframe reaches the design system.** Tailwind's source detection
+here is opt-in and scoped to `src/`, which is what makes "the class is in the
+built stylesheet" evidence that a component uses it (ADR-0006). An embed is
+outside that boundary entirely: no tokens, no pill, no gutter, no touch-target
+floor from ADR-0004, and no gate can see any of it.
+
+## Decision
+
+**The conditions tool is built in this repo, natively.** `CONTEXT.md`'s
+**Conditions** entry is amended to drop "built separately and embedded here".
+
+The two `ReservedSlot` usages stay for now. They come out in the slice that has
+something to put in their place — a slot removed before its replacement exists
+would leave the page promising less than it did.
+
+The plan is `docs/plans/conditions-tool.md`, and two decisions in it are
+load-bearing enough to name here:
+
+**Published judgements are relayed; inferred ones are not computed.** The
+National Weather Service publishes a rip current risk for San Diego County
+Coastal — "Moderate", measured 2026-08-17 — and that is a forecaster's judgement
+this site quotes verbatim and attributes. "Safe for kids today" would be this
+site's own judgement, and the only numbers available to found it on are author
+estimates: the source repo's swell ceiling is a single uncalibrated figure
+standing in for reefs of differing exposure, and its own file says so. Facts get
+described in plain language; the only computed value is the low-tide window,
+whose input is an astronomical prediction rather than an estimate.
+
+**Resolved values come from joins, never from typing.** Beach coordinates, tide
+station, buoy, water-quality station and marine protected area are joined against
+upstream authorities and committed with enough provenance to re-run, with one
+re-join script per binding that exits nonzero when a match moves. The location
+list is seeded from the state's Beach Detail Information resource — 82 beaches
+with `County = 'San Diego'`, which the county's own map corroborates as
+"approximately 80 beaches from Camp Pendleton to the US/Mexico border" — rather
+than typed off a map.
+
+## Consequences
+
+The tool inherits the stops, the tokens, the pill, the touch-target floor and
+the gate. Its readings are testable by the same seams as everything else here,
+and its parsers are pure and offline against committed fixtures, so a pinned
+column header or unit string is asserted without a network.
+
+The safety notice becomes ordinary page content, which is the only arrangement
+where it is true.
+
+`/conditions` gains real routes and real data, so this repo acquires an outbound
+network dependency it did not have — and with it a failure surface. The policy
+is stated rather than discovered: fetching, caching and what a failure means live
+in one module; a missing reading degrades to a named unavailable state with its
+reason on the page; and three states stay visibly distinct — a fresh reading, a
+station gone quiet, and no station covering this beach at all. That third state
+is the common one, and rendering it as a blank would let a reader read it as calm.
+
+**This repo now owns data that rots.** A decommissioned buoy, a retired dataset,
+a re-gridded forecast point and a renamed column are all things that happen
+without notice and none of them break a build. A weekly probe and the re-join
+scripts are how that becomes a notification rather than a wrong number on a
+landing page, and they are slices in the plan rather than aspirations here.
+
+What this costs is scope. An embed would have been one `iframe` and a URL; this
+is thirteen slices, eleven upstream products and a location inventory with
+provenance per entry. The trade is taken knowingly: the embed was cheap because
+it moved every hard decision somewhere else, and there was nowhere else. That is
+the part most likely to be re-litigated, and the answer to "why not just embed
+something" is that after this decision there is nothing to embed.

--- a/docs/plans/conditions-tool.md
+++ b/docs/plans/conditions-tool.md
@@ -1,0 +1,302 @@
+# The conditions tool, built in this repo (issue #48)
+
+Date: 2026-08-17.
+
+## Problem, from the reader's point of view
+
+A parent leading a co-op outing decides on Thursday where to take eight children
+on Tuesday. They want to know whether the tide will be low enough for the
+tidepools, whether the surf is small enough for kids in the water, how cold the
+water is, and whether anything is posted at that beach. Today they assemble that
+from a surf app, a tide table and a county web app, none of which agree on units
+or on how old their numbers are.
+
+`/conditions` and the landing-page teaser both carry a reserved slot promising a
+tool. `CONTEXT.md` says it is "built separately and embedded here", and the slot
+says _"Drop the URL and it embeds here automatically."_ There is no URL to drop.
+
+The naive fix is to render whatever a weather API returns for a beach name. That
+produces plausible-looking wrong numbers, and the audience is people taking
+children into the ocean. The upstream discipline in this plan is ported from
+`cweber12/socal-coastal-data`, which exists because coastal feeds rot quietly:
+NDBC 46235 serves HTTP 200 on its station page and 404 on its data feed, having
+stopped publishing on 2026-05-03; asking NOAA CO-OPS for local time and tagging
+the result UTC ages every reading by 7–8 hours; the Tijuana River is published in
+m³/s by one agency and ft³/s by another.
+
+## Solution
+
+A native conditions view. The reader picks a beach; the page shows what is
+actually known about it now, plus a forward panel built only from products that
+genuinely forecast. Every figure carries its observation time. Nothing computes a
+verdict about safety.
+
+The tool is built **in this repo**, not embedded — see
+`docs/adr/0009-conditions-is-native-not-embedded.md`.
+
+## Implementation decisions
+
+### Extent and the location list
+
+**82 beaches**, seeded from an authority rather than typed by hand. The statewide
+Beach Detail Information resource names 82 with `County = 'San Diego'`, which the
+county's own beach map corroborates as "approximately 80 beaches from Camp
+Pendleton to the US/Mexico border". It carries `Beach_Name`, `BeachType`,
+`WaterBodyType`, `WaterShedName`, `BeachAccess`, `NearestCityName`,
+`AttendanceSummer`, `USEPAID` and `Status`, so the inclusion predicate is data
+rather than judgement: public access, active, counted as a beach.
+
+Read it from the CNRA portal, which names the State Water Resources Control
+Board as publisher:
+`https://data.cnra.ca.gov/dataset/beach-advisories-postings-and-closures-and-beach-water-quality-monitoring`,
+resource `cc674e59-036c-45c3-bec2-5d3d294e0e3d`. The data.ca.gov copy
+(`fcbc9250-06e3-437d-b0c6-3cc5ddde93fc`) is byte-identical in content and is
+recorded as the mirror.
+
+Two things about this source are pinned because they will bite otherwise:
+
+- **A beach is a segment, not a point.** Coordinates arrive as
+  `Beach_UpperLat`/`Beach_UpperLon` and `Beach_LowerLat`/`Beach_LowerLon`. Every
+  nearest-station join must state which end it joined from, and the marine
+  protected area test becomes a segment-versus-polygon question — a beach can
+  straddle a boundary, which a point cannot.
+- **One field is named `Beach_ UpperLon`, with an embedded space.** That is
+  upstream's, reproduced verbatim, and asserted on read.
+
+### Bindings are joined, never hand-populated
+
+Every resolved value comes from a join against an upstream authority and is
+committed with enough provenance to re-run it: tide station (carrying the
+open-coast versus bay-side role — 9410230 serves the open coast, 9410170 is bay
+only, and confusing them yields a wrong tide curve), buoy primary and fallback,
+water-quality station with its distance in metres and a suspect flag past 1000 m,
+marine protected area with type and CCR section, and the NWS grid and zones. One
+re-join script per binding, each exiting nonzero when a match moves.
+
+The one field written by hand is the join's own scope, because no upstream
+authority can state which beaches this repo chose to ask about.
+
+### What is fetched, and its contract
+
+| Product                              | Serves                             | Horizon         | Contract facts, measured                                                                                                                                                                                                                                         |
+| ------------------------------------ | ---------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CO-OPS predictions                   | tides                              | years           | `time_zone=gmt`, `units=english`, `datum=MLLW`. Returned timestamps carry no offset. Serves `{"error":{...}}` under HTTP 200 — a dead response, not a payload.                                                                                                   |
+| NDBC `realtime2`                     | waves, water temp                  | now             | 19-column pinned header. Wave height in metres, `WTMP` in °C. On 46254, `WDIR`, `WSPD`, `GST`, `ATMP`, `VIS` are all `MM` — so wave and water temp yes, **wind and visibility no**. A reading older than 180 minutes is reported unknown.                        |
+| NWS `/points` → `/gridpoints`        | wind, visibility, air temp, sky    | 7 d             | Resolve `gridId`/`gridX`/`gridY` once per beach and commit it, so an NWS re-grid appears as a diff. Self-identifying User-Agent required.                                                                                                                        |
+| NWS active alerts                    | hazards                            | now             | An empty `features` array is a valid empty response, not a failure.                                                                                                                                                                                              |
+| NWS surf zone forecast, SGX          | rip current risk, surf, water temp | ~3 d            | Two zones cover the whole extent: `CAZ043` San Diego County Coastal and `CAZ552` Orange County Coastal. Measured 2026-08-17: rip current risk "Moderate", surf 2 to 4 feet, water temperature "65 to 73 degrees", tides quoted at La Jolla. Already °F and feet. |
+| CO-OPS `water_temperature` @ 9410230 | swimmers                           | now             | `&date=latest`. A real station reading where the SRF gives a county range.                                                                                                                                                                                       |
+| SCCOOS ERDDAP                        | water science                      | trailing weekly | Columns are `time,Temp,Salinity,Avg_Chloro,Pseudo_nitzschia_seriata_group` — capitalised `Temp`; `temperature` exists on no SCCOOS dataset. A 404 carrying "no matching results" means the query was valid and the window empty.                                 |
+| iNaturalist                          | education                          | trailing 14 d   | One request per beach on its own coordinates and radius, never a corridor bbox: the bbox needs ~12 pages and ~144 MB and still misses coastal sites, where per-beach requests total ~142 kB. HTTP 422 is a rejected query, not an empty one.                     |
+| CDFW ds582 marine protected areas    | tidepoolers                        | dated snapshot  | Content date 2019-01-01, layer last edit 2024-01-09 — both recorded. `Type` is a join result, never string-matched off the name. Publisher disclaimer: "not intended for navigational use or defining legal boundaries."                                         |
+| Beach advisories archive             | water quality                      | historical only | See below.                                                                                                                                                                                                                                                       |
+| Daylight                             | all                                | any             | Computed in-repo. There is no sun API here and there should not be.                                                                                                                                                                                              |
+
+**The surf zone forecast is zone-level.** Its values render identically at all 82
+beaches, so it is presented as what the county forecast says, never as a reading
+at this beach. Zone forecast and station reading are different provenance and are
+never blended into one figure.
+
+### There is no live beach advisory feed, and the plan says so
+
+Measured on 2026-08-17, by calling each source:
+
+| Source                                     | State                                                                                              |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| Statewide advisories, CNRA and data.ca.gov | Machine-readable, San Diego covered — 4,353 rows, **newest 2026-03-03**                            |
+| Statewide bacteria results                 | 385,313 San Diego rows, **newest 2025-09-09**                                                      |
+| County open-data portal                    | Three beach assets, data last updated 2020-02-19, 2020-04-09 and 2023-03-23                        |
+| County public ArcGIS, `DEH` folder         | One GPServer, **no advisory layer**                                                                |
+| `sdbeachinfo`                              | An OutSystems app; internal `screenservices` endpoints, no public API, 403 to programmatic clients |
+| EPA BEACON 2.0                             | Oracle APEX app, no documented API, and fed by the state anyway                                    |
+
+Every county in the statewide archive tops out in early March 2026, so the
+167-day lag belongs to the dataset rather than to one portal — two independent
+portals serving identical rows is the evidence.
+
+So the water-quality panel **states that live advisory status is not available
+here, links to the county as the authority, and shows one dated historical fact**:
+how often this beach was posted between 2010 and 2026-03-03, with the window
+named. A beach posted forty times is not the same place as one posted twice, and
+that is a fact about the beach rather than about today.
+
+The two portals serialise the same column differently —
+`2026-03-03T00:00:00` on CNRA, `3/3/2026 12:00:00 AM` on data.ca.gov. The format
+is pinned per portal and asserted, not assumed.
+
+### Judgements are relayed, never computed
+
+Rip current risk is a forecaster's published judgement, quoted verbatim and
+attributed. "Safe for kids today" would be this site's judgement, and the only
+numbers available to found it on are author estimates: the source repo's swell
+ceiling is one uncalibrated figure standing in for reefs of differing exposure.
+Facts are described in plain language; the sole computed value is the low-tide
+window, whose input is an astronomical prediction rather than an estimate.
+
+### Presentation
+
+Tide **timing first, height second**, with the datum explained once in plain
+words — a minus sign in front of a tide height reads as an error to a reader who
+has not met MLLW. Feet, °F, mph, 12-hour local time. The dropdown groups the 82
+beaches by region rather than listing them flat.
+
+An unavailable reading gets one plain sentence for the reader and the exact
+upstream reason behind a disclosure. Three states stay visibly distinct: a fresh
+reading, a station that has gone quiet, and no station covering this beach at
+all — which will be the common case, and which must never render as a blank a
+reader can read as calm.
+
+Above the readings, a standing notice: these are readings from public
+instruments, not a safety assessment, and lifeguards and posted signs on the day
+are the authority.
+
+### The landing page is a teaser, not the tool
+
+A stop is 540px and content that does not fit is a bug in the section. The
+teaser keeps its heading, its copy and its pill to `/conditions`, and gains at
+most the beach selector and a headline reading. The tool lives on its own page.
+
+### Caveats reach the reader, enforced
+
+Data files carry an `unresolved` array and a gate row fails when an entry has no
+path to a reader. This is what lets the list be comprehensive and honest at the
+same time: a beach whose water-quality station is unresolved can still ship,
+because the page says it is unresolved.
+
+## Test seams
+
+- **Parsers are pure and offline.** One per upstream product, taking bytes and a
+  request contract, returning typed values or raising. Tested against captured
+  payloads committed as fixtures — evidence, not source. This is the seam that
+  makes unit strings, timezone labels and column headers assertable without a
+  network.
+- **Fetching, caching and failure policy sit in one module** above the parsers,
+  so a parser cannot know about retries and a component cannot make a request.
+- **Joins are scripts with committed outputs**, so the seam is a diff: perturb a
+  match and the re-join exits nonzero.
+- **The zone-versus-station provenance distinction is a type**, not a convention,
+  so blending a county forecast into a station reading fails to compile.
+- Rendering is asserted the way this repo already asserts it: the reading is
+  reachable and labelled, and an unavailable reading renders its sentence rather
+  than an empty node.
+
+## Slices
+
+In order, with dependencies. Grouped into pull requests at dependency
+boundaries, because five slices or ~400 lines is the reviewable limit.
+
+**PR A — the decision record (this issue, #48)**
+
+1. This plan file, as its own first commit.
+2. ADR 0009 and the `CONTEXT.md` amendment: the glossary stops describing an
+   embed. The reserved slots are not touched — they come out when there is
+   something to put in their place.
+
+**PR B — the tracer bullet**
+
+3. One beach, one reading, end to end: a locations file with a single entry, the
+   CO-OPS parser, the fetch module, and `/conditions` showing today's low-tide
+   time. This slice is where Next 16.3's caching API is read out of
+   `node_modules/next/dist/docs/` and pinned; until then, every revalidate
+   figure in this plan is `TODO(verify)`.
+4. The full inventory and a chooser: 82 beaches seeded with provenance, tide
+   station joined, region-grouped selector.
+5. Caveats reach the reader, with its gate row. Lands here because slice 4 is
+   where the first unresolved binding appears.
+
+**PR C — the readings the site already promises**
+
+6. Waves and water temp from NDBC: buoy binding with fallback, the 180-minute
+   limit, substitution disclosed, and the "no water temp at this buoy" state,
+   which is measured rather than hypothetical.
+7. Wind, visibility, air temp and sky from NWS gridpoint. Until this lands, two
+   of the four words in "Surf · Tide · Wind · Visibility" have nothing behind
+   them.
+
+**PR D — planning and safety**
+
+8. The forward panel: tide predictions, NWS forecast and daylight, labelled
+   forecast, with observed-only products absent rather than blank.
+9. Safety layer: active alerts, the surf zone forecast relayed verbatim and
+   attributed, and the standing notice.
+
+**PR E–G — the rest**
+
+10. Water quality: the statement, the link, and the historical posting count.
+11. Marine protected area rules with the CDFW disclaimer attached, then
+    iNaturalist sightings, text only.
+12. The weekly probe, the re-join scripts, and the dead/revived registry.
+13. The landing-page teaser inside its stop budget.
+
+Each data-integrity rule lands in `CLAUDE.md`'s project invariants **in the slice
+that earns it**, with what it cost, rather than as a documentation slice at the
+end that nobody reads.
+
+## Considered and rejected
+
+**Embedding an externally hosted tool**, as the reserved slots describe. Rejected
+in ADR 0009; the short form is that an iframe cannot inherit the stop budget or
+the tokens, and the safety notice has to live in the page rather than inside the
+frame.
+
+**Embedding `socal-coastal-data` itself.** Cheapest path to something on the
+page. It renders a different corridor against a tidepool-and-surf framing, and it
+ships the computed verdicts this audience is the reason to avoid.
+
+**A computed verdict per audience** — a green, amber or red badge for tidepooling
+or swimming. The best user experience by a distance, and the thing a parent
+actually wants. It would make an uncalibrated author estimate into a green light
+for children in the water at 82 beaches nobody here has stood at. If this is ever
+wanted, calibration comes first and the thresholds come after.
+
+**Scraping `sdbeachinfo` for live advisory status.** The only route to a live
+posting. Undocumented POST endpoints on a low-code platform that already refuses
+generic clients, with no stability contract, on a public-health datum where a
+plausible-looking wrong answer is the worst available failure.
+
+**Hand-typing the location list from a map.** Faster than a seeded join, and the
+error bar and origin of every coordinate would then be unknown and untraceable.
+
+**A Google Sheet or a CMS for the locations.** The friendliest editing surface,
+and it puts values that upstream authorities own somewhere with no join, no
+diff, no check and no provenance.
+
+**Hiding unavailable sections** for a cleaner page. A missing section reads as
+nothing-to-report, which turns "no water-quality data for this beach" into
+"water quality is fine".
+
+## Out of scope
+
+- Any beach outside San Diego County. Crossing the county line changes the health
+  agency, and eventually the NWS office.
+- Computed safety verdicts, per above.
+- iNaturalist photos: per-image licensing, revisited after the text layer ships.
+- The tidepool floor elevations and the calibration pipeline from the source
+  repo. Those rest on lidar work with no counterpart here.
+- Accounts, saved beaches, notifications.
+- Replacing the reserved slots, which belongs to the slices that fill them.
+
+## Verification
+
+Verification means calling the endpoint. For each product: capture the real
+payload as a committed fixture, parse it offline in a test, and record the
+measured freshness, the unit strings and the timezone label. For each binding:
+run the join, commit the result with its distance and flags, and confirm the
+re-join exits nonzero when a match is perturbed. Per-station coverage is measured
+rather than assumed — 46254's empty wind and visibility columns were found by
+reading a captured row, and the same check applies to every buoy bound to any of
+the 82 beaches.
+
+## Open questions
+
+1. **Which buoys serve the northern county and the bays, and which of them
+   populate wave height?** The source repo's inventory ends at Oceanside
+   Offshore, and its southern spots already fall back roughly 15 miles across
+   differing exposure because 46235 is dead.
+2. **What tide station serves the lagoons and Mission Bay?** 9410230 is open
+   coast, 9410170 is bay only, and the lagoons are neither.
+3. **Does SCCOOS still cover anything in San Diego County beyond Scripps Pier?**
+   If not, the water-science panel is one location's data and must say so rather
+   than render blank elsewhere.
+4. **Next 16.3's caching API.** Every revalidate interval here is provisional
+   until slice 3 reads the shipped documentation.


### PR DESCRIPTION
Closes #48

Docs only. No fetching, no UI, no change to the reserved slots.

## Slices

**1 — `docs/plans/conditions-tool.md`** (commit `736020b`). The plan, as its own
first commit: problem from the reader's point of view, implementation decisions,
test seams, thirteen slices in dependency order grouped into pull requests,
considered-and-rejected, out of scope, verification approach, and four open
questions.

**2 — ADR 0009 and the glossary amendment** (commit `ad9ebfd`).
`docs/adr/0009-conditions-is-native-not-embedded.md` plus the **Conditions**
entry in `CONTEXT.md`, which said "built separately and embedded here".

## Why native rather than embedded

Argued from constraints this repo already documents, not from preference:

- **A stop is 540px and content that does not fit is a bug in the section.** An
  embedded document sizes itself; the host can give it a box and cannot make its
  contents obey the budget.
- **The safety notice has to sit around the readings.** Inside a frame, the page
  would be asserting something it does not control.
- **Tailwind source detection is opt-in and scoped to `src/` (ADR-0006)**, which
  is what makes a class in the built stylesheet evidence that a component uses
  it. An embed is outside that boundary: no tokens, no pill, no touch-target
  floor from ADR-0004, and no gate can see any of it.

## What was measured rather than assumed

Each of these was found by calling the endpoint, and each changes a slice.

**There is no live machine-readable San Diego beach advisory feed.**

| Source | State |
| --- | --- |
| Statewide advisories (CNRA and data.ca.gov, identical rows) | 4,353 San Diego rows, newest **2026-03-03** |
| Statewide bacteria results | 385,313 San Diego rows, newest **2025-09-09** |
| County open-data portal | Three beach assets, data last updated 2020-02-19, 2020-04-09, 2023-03-23 |
| County public ArcGIS `DEH` folder | One GPServer, no advisory layer |
| `sdbeachinfo` | OutSystems app, internal `screenservices` endpoints, no public API, 403 to programmatic clients |
| EPA BEACON 2.0 | Oracle APEX, no documented API, and fed by the state anyway |

Every county in the archive tops out in early March 2026, and two independent
portals serve identical rows, so the 167-day lag belongs to the dataset rather
than to one mirror. The water-quality panel therefore states that live status is
not available here, links to the county, and shows a dated historical posting
count.

**The SGX surf zone forecast covers the whole extent in one product** — zones
`CAZ043` San Diego County Coastal and `CAZ552` Orange County Coastal. Measured
2026-08-17: rip current risk "Moderate", surf 2 to 4 feet, water temperature "65
to 73 degrees", tides quoted at La Jolla, ~3-day horizon, already in °F and feet.
That is a published judgement to relay verbatim, and a county-wide water-temp
fallback for the many beaches with no station. It is zone-level, so it renders
identically at all 82 beaches and is presented as what the county forecast says
rather than as a reading at that beach.

**The state names 82 San Diego beaches** with public-access flags, beach type,
water body type, watershed and EPA id — corroborated by the county map's own
"approximately 80 beaches from Camp Pendleton to the US/Mexico border". That is
the location seed. Two properties are pinned: coordinates arrive as upper/lower
pairs, so **a beach is a segment rather than a point** and can straddle a marine
protected area boundary; and one field is named `Beach_ UpperLon`, with the space
upstream's own.

**A CDIP-relayed nearshore buoy leaves wind and visibility empty.** On 46254,
`WDIR`, `WSPD`, `GST`, `ATMP` and `VIS` are all `MM` while `WVHT`, `DPD` and
`WTMP` carry values. Both "wind" and "visibility" are promised in this site's
committed copy, so they must come from the NWS gridpoint forecast — slice 7 in
the plan.

## Gate output

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

Exit code 0.

## What this does not do, and what I am unsure about

- **The reserved slots stay.** Removing one before its replacement exists would
  leave the page promising less than it does today.
- **No revalidate interval in the plan is verified.** This is Next 16.3 and its
  own `AGENTS.md` block warns that APIs differ from training data. Every caching
  figure in the plan is marked `TODO(verify)` against
  `node_modules/next/dist/docs/`, to be resolved in slice 3 — the tracer bullet
  exists partly to force that.
- **Three open questions remain unanswered** and are recorded as such: which
  buoys serve the northern county and the bays and which of them populate wave
  height; what tide station serves the lagoons and Mission Bay, given 9410230 is
  open coast and 9410170 is bay only; and whether SCCOOS still covers anything in
  the county beyond Scripps Pier.
- **The 82-beach figure is the seed, not the final count.** The inclusion
  predicate — public access, active, counted as a beach — has not been run yet,
  so the dropdown will hold some number at or below 82.
- **The most re-litigable decision is the refusal to compute a verdict.** A
  green/amber/red badge per audience is what a parent actually wants, and the
  plan declines it because the only numbers available to found it on are
  uncalibrated author estimates. That trade is stated in both the plan and the
  ADR so it can be argued with directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
