### PR TITLE
Catch the IA doc up to the snap-section reorder

### DIFF
--- a/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
+++ b/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
@@ -38,8 +38,12 @@ page. See _URL Strategy_ for the anchors that were retired.
 
 1. **Viewport block: Hero + Marquee** — identity and both CTAs in one composed
    window; the marquee pinned at the fold is the visual signature.
-2. **Gallery section (header + film strip)** — proof before pitch: kids' actual
-   work scrolls by, synced with the marquee it sits beneath.
+2. **Gallery section (header + paged row)** — proof before pitch: kids' actual
+   work holds still until the reader moves it, a screenful at a time
+   (ADR-0007). The header carries the prev/next pager as well as the heading,
+   because a control overlaid on the row covers artwork at some scroll
+   position whatever its padding is (ADR-0008). The marquee it sits beneath is
+   the only thing on the page that still moves on its own.
 3. **Programs (prog-grid)** — the two offerings, each with its own CTA. This is
    the conversion core; everything above earns attention for it.
 4. **Conditions** — differentiator teaser; placeholder until the tool exists.
@@ -120,8 +124,13 @@ lands on `/art` first; that page's CTA is "Book a class →" → `/book`.
 
 ## Content Growth Plan
 
-- **Gallery strip**: designed to take any number of images — the strip loops
-  whatever list it is given; adding photos is a data change, not a layout one.
+- **Gallery row**: photos arrive in composed threes. The row pages a screenful
+  at a time, and from `lg` a page is three tiles — two 4:3 and one 16:9, the
+  wide one alternating side down the list — so the nine grow by whole pages or
+  not at all. `galleryImages.test.ts` asserts all three rules, so a tenth image
+  fails the gate rather than quietly leaving a final page holding one tile
+  against an empty row. Adding photos is a data change _and_ a composition
+  decision; what it is not is a layout one.
 - **Programs**: the grid accepts a third card if an offering is added.
 - **Conditions**: the dashed box is the reserved slot for the future embed.
 - **A new program area** is a route beside the existing five, plus a teaser

--- a/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
+++ b/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
@@ -115,12 +115,12 @@ lands on `/art` first; that page's CTA is "Book a class →" → `/book`.
 
 ## Component Reuse Map
 
-| Component     | Used on                                       | Behavior differences                                                                   |
-| ------------- | --------------------------------------------- | -------------------------------------------------------------------------------------- |
-| Placeholder   | Nav logo, hero photo, card backgrounds, strip | Label size varies; backgrounds drop the border                                         |
-| Pill button   | Nav CTA, hero CTAs, card CTAs, form submit    | Yellow/ghost/purple variants                                                           |
-| Looping track | Marquee, GalleryStrip                         | Shared duplicated-track + pause-on-hover mechanic; content and speed derivation differ |
-| Section shell | Gallery, quote, conditions, community         | Shared gutter/padding rhythm, varying backgrounds                                      |
+| Component     | Used on                                             | Behavior differences                                                                                              |
+| ------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Placeholder   | Nav logo, hero photo, card backgrounds, strip       | Label size varies; backgrounds drop the border                                                                    |
+| Pill button   | Nav CTA, hero CTAs, card CTAs, form submit          | Yellow/ghost/purple variants                                                                                      |
+| Looping track | Marquee                                             | `StripTrack`, and the marquee is its only caller — `GalleryRow` does not use it (ADR-0007)                        |
+| Section shell | All six sections of `/`, hero and programs included | `SnapSection` shares a height, a surface tone and `snap-start`; children drop their own vertical padding under it |
 
 ## Content Growth Plan
 

--- a/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
+++ b/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
@@ -42,11 +42,20 @@ page. See _URL Strategy_ for the anchors that were retired.
    work scrolls by, synced with the marquee it sits beneath.
 3. **Programs (prog-grid)** — the two offerings, each with its own CTA. This is
    the conversion core; everything above earns attention for it.
-4. **Quote + stats** — social proof and the two facts parents filter on
-   (K–8, charter eligible).
-5. **Conditions** — differentiator teaser; placeholder until the tool exists.
-6. **Community form** — the catch-all conversion for anyone not ready to book.
-7. **Footer** — recap and identity close.
+4. **Conditions** — differentiator teaser; placeholder until the tool exists.
+5. **Community form** — the catch-all conversion for anyone not ready to book.
+6. **Quote + stats** — social proof and the two facts parents filter on
+   (K–8, charter eligible). It closes the page by decision, not by leftover
+   ordering: it was fourth until the sections became snap stops
+   (`docs/plans/section-snapping.md`).
+
+Six items, and they are the six `SnapSection`s of `src/app/page.tsx` in order.
+
+**The footer is not one of them.** It lives in `src/app/layout.tsx`, so it
+closes every route rather than the landing page. It still shares the quote's
+screen — that stop is `screen-less-footer`, the window less the nav less the
+footer — but it is not a stop of its own and nothing above it on this list
+applies to it.
 
 Cut from the template: editorial block ("Real kids…") and the yellow
 wordmark banner. Decided in the brief; not deferred.

--- a/docs/plans/design-doc-drift.md
+++ b/docs/plans/design-doc-drift.md
@@ -112,3 +112,41 @@ No gate reads prose, so the checks are stated and run by hand:
   that implements it, not against another document;
 - `npm run gate` still passes, which for a prose-only change asserts only that
   nothing was broken in passing — it is not evidence the prose is right.
+
+## Addendum — 2026-08-17: #27 is five items, and the gallery bugs have moved
+
+#26 has merged. This records what changed under #27 between the plan being
+written and the branch starting. Nothing in _Decisions_ changes: the IA doc is
+still corrected in place, with no addendum of its own.
+
+**#27 is five items, not three.** The plan above describes it as the three
+errors in the doc's Content Hierarchy and Component Reuse Map — the section
+order, the auto-scrolling gallery, and `GalleryStrip`. Re-checking the document
+against the code on 2026-08-17 found two more with the same cause and in
+sections the first three do not reach: the Content Growth Plan's **Gallery
+strip** bullet, which repeats the looping claim and adds that "adding photos is
+a data change, not a layout one"; and the Component Reuse Map's **Section
+shell** row, which predates `SnapSection`. A fix scoped to items 1–3 would have
+left both behind, in one case one table row below a row it corrected.
+
+The count is no longer free, which is why the growth-plan bullet is wrong
+twice. `src/components/galleryImages.test.ts` asserts the list divides into
+whole rows of three, that each row is two `tall` tiles and one `wide` one, and
+that the wide tile alternates side. Photos arrive in composed threes or the
+gate fails.
+
+**#40 is closed, so the _Out of scope_ bullet naming it is one issue stale.**
+It folded into #38 (PR #44): its `md`–`lg` claim died when #37 moved the `stops`
+variant to `lg` × 39rem, so that band has no stops left to overflow, and the
+width-driven growth above `lg` is recorded on #38 as a stated exception rather
+than a scheduled fix. What the bullet _decides_ is unchanged and still binding:
+**#38 is open and the two-stop grid is still parked** (`galleryImages.ts`,
+`docs/plans/gallery-aspect-rhythm.md`), so the prose states what is built — one
+paged row, three tiles to a page from `lg` — and describes no grid.
+
+**#45 closed and ADR-0008 landed, so the pager is part of what the prose must
+match.** When this plan was written the gallery's controls were overlaid on the
+row's left and right edges. They now sit in the section's heading block, above
+the artwork, and the row keeps the page's gutter with its snap positions offset
+to match. That makes item 2's "header + film strip" stale in both halves rather
+than one: the strip is a paged row, and the header is where the pager lives.


### PR DESCRIPTION
Closes #27

`INFORMATION_ARCHITECTURE.md` described the landing page as it was before the
section-snapping reorder. Five claims, one cause, corrected in place — the doc
has no addendum pattern and #25 corrected its routing claims directly.

## The slices

1. **Dated addendum to `docs/plans/design-doc-drift.md`** — the plan described
   #27 as three items and listed #40 as an open gallery bug. It is five items;
   #40 folded into #38 and #37 and #45 closed under it, so ADR-0008 and the
   row's gutter are part of what the prose must match. #38 is still open and
   the two-stop grid is still parked. Amended, not rewritten.
2. **Content Hierarchy in render order** — Quote + stats moves from fourth to
   sixth, where `page.tsx` puts it and where `docs/plans/section-snapping.md`
   says it belongs. Footer comes off the list: it is in `layout.tsx`, so it
   closes every route. Called out rather than deleted, since it does still
   share the quote stop's screen (`screen-less-footer`).
3. **The gallery as reader-driven, in both places it is described** — the
   Content Hierarchy item and the Content Growth Plan bullet. "Scrolls by,
   synced with the marquee" and "the strip loops whatever list it is given"
   both go; the header is now where the pager lives (ADR-0008), and photos
   arrive in composed threes because `galleryImages.test.ts` asserts whole
   rows of three, two tall and one wide, alternating side.
4. **Component Reuse Map** — `GalleryStrip` (never a file) → `GalleryRow`,
   which does not use `StripTrack` at all; the marquee is that mechanic's only
   caller. The Section shell row now says `SnapSection` on all six sections,
   sharing a height, a surface tone and `snap-start` — and children *dropping*
   their own vertical padding under `stops`, which is the opposite of the
   "shared padding rhythm" it claimed.

## Verification

The gate does not read prose. These were run by hand:

**Every component named in the document resolves to a file.** `GalleryRow`,
`SnapSection`, `StripTrack`, `Marquee`, `Placeholder`, `Hero`, `Footer` and
`galleryImages.test.ts` all resolve under `src/components/`; `GalleryStrip` and
`CommunityForm` no longer appear anywhere in the file.

**The Content Hierarchy order matches `src/app/page.tsx`.** Both read
HeroViewport, GallerySection, ProgramCards, Conditions, InterestListTeaser,
QuoteStats — six `SnapSection`s, six list items.

**`grep -rn 'id=' src/`** (tests excluded) returns seven lines:

```
src/app/page.tsx:24:      <SnapSection id="community">
src/components/GalleryRow.tsx:33:      id={id}
src/components/GallerySection.tsx:61:        id={GALLERY_ROW_ID}
src/components/InterestListForm.tsx:70:              id="community-name"
src/components/InterestListForm.tsx:86:              id="community-email"
src/components/InterestListForm.tsx:102:              id="community-ages"
src/components/SnapSection.tsx:69:      id={id}
```

Of the ids that reach the DOM, only **`community`** is an anchor target.
`gallery-row` exists for the pager's `aria-controls`, and `community-name`,
`community-email` and `community-ages` are form-field ids for their labels —
nothing links to any of the four. The two `id={id}` lines are the props that
carry the first two. Confirmed from the other end too: the only anchor hrefs in
`src/` are `#community` (`ProgramCards.tsx:120`) and `/#community`
(`book/page.tsx:27`, `coop/page.tsx:28`). So URL Strategy's "one anchor id
remains" still holds, and the next reader running #25's grep should expect the
extras.

**`npm run gate`** — on a prose-only change this asserts only that nothing
broke in passing; it is not evidence the prose is right.

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

One earlier run in this session failed on `gate-scope.test.mjs > "ignores agent
worktrees"` — the known flake where an `ESLint().isPathIgnored` assertion
exceeds the 5s timeout while jsdom workers boot in parallel (closed as #9,
wontfix). Three subsequent runs, including the one above on the rebased branch,
passed. Reported rather than buried, but it is not this branch's doing: nothing
here is executable.

## Not done

- **The `Placeholder` and `Pill button` rows keep their wording** — they are
  #47, which is blocked on this. Their cell *padding* moves anyway, because
  prettier aligns a table to its widest cell and slice 4 widens two columns.
- **`DESIGN_BRIEF.md` still says the gallery's controls sit "at the row's
  edges"** (line 106), which ADR-0008 superseded. Different document, different
  drift, and #26 has merged — filed separately.
- **The Content Growth Plan still calls the conditions slot "the reserved slot
  for the future embed."** ADR-0009 landed on `main` today and decides the tool
  is built in this repo rather than embedded. That drift postdates this issue
  and has a different cause — filed separately.
- Nothing under `src/`, and no other `.design/` document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
