### PR TITLE
Stop three specs calling the conditions tool an embed

### DIFF
--- a/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
+++ b/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
@@ -294,6 +294,8 @@ since changed things it still stated as current.
   (email/sheet/service) is chosen.
 - A real booking destination — the CTAs point at `/book`, and which provider
   sits behind that page is a decision that has not been made.
-- The conditions tool embed — the reserved slot ships as-is.
+- The conditions tool — built in this repo rather than embedded from elsewhere
+  (ADR-0009), under its own plan (`docs/plans/conditions-tool.md`) rather than
+  this brief. The landing teaser's reserved slot ships as-is.
 - Dark mode, CMS, analytics.
 - The template's editorial block and yellow banner — cut, not deferred.

--- a/.design/wild-coast-kids-landing/DESIGN_TOKENS.css
+++ b/.design/wild-coast-kids-landing/DESIGN_TOKENS.css
@@ -71,7 +71,7 @@
   /* ---- Radii ------------------------------------------------------------ */
   --radius-tile: 12px; /* co-op activity tiles, inputs */
   --radius-thumb: 16px; /* gallery images, stat tiles */
-  --radius-box: 20px; /* conditions embed box */
+  --radius-box: 20px; /* reserved slots, routed-page gallery boxes */
   --radius-card: 24px; /* program cards, form card */
   --radius-pill: 99px; /* every button */
 

--- a/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
+++ b/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
@@ -132,7 +132,11 @@ lands on `/art` first; that page's CTA is "Book a class →" → `/book`.
   against an empty row. Adding photos is a data change _and_ a composition
   decision; what it is not is a layout one.
 - **Programs**: the grid accepts a third card if an offering is added.
-- **Conditions**: the dashed box is the reserved slot for the future embed.
+- **Conditions**: the teaser's dashed box is the reserved slot for the
+  conditions tool, which is built in this repo rather than embedded from
+  elsewhere (ADR-0009). `/conditions` has already dropped its own slot for a
+  first reading; the teaser keeps its box until a slice has something to put in
+  it. `docs/plans/conditions-tool.md` is where that state is recorded, not here.
 - **A new program area** is a route beside the existing five, plus a teaser
   section on `/` that links to it. That path is established; adding one
   decides nothing new.

--- a/docs/plans/design-doc-drift.md
+++ b/docs/plans/design-doc-drift.md
@@ -190,3 +190,42 @@ and `<PillLink` returns eleven. #47 adds no new check.
 `Placeholder`'s own docstring says "gallery strip", and `globals.css` claims
 the gallery still runs the marquee animation — a claim `GalleryRow.test.tsx`
 asserts against. Both are filed as #54 rather than fixed here.
+
+## Addendum — 2026-08-18: #53 corrects two "embed" sentences, and the reader-facing copy splits off
+
+#54 has merged. #53 corrects the last two places in these two documents that
+still describe the conditions tool as an embed, a plan ADR-0009 retired. It
+belongs to this plan for the same reason #47 did: the same two documents, under
+the same decision that each is corrected in place. Nothing in _Decisions_ or
+_Scope_ changes.
+
+**The scope is two sentences, and the third candidate became its own issue.**
+The issue named a third target — the reserved slots' own copy, "Drop the URL and
+it embeds here automatically" — and left to triage whether it belonged here or
+to the first conditions slice. It belongs to neither, and is now #59. Two
+reasons. It is copy a visitor reads rather than a note for the team, so no gate
+and no plan can settle it: what it should say is a content decision, and
+`docs/plans/conditions-tool.md` has slices 4 and 5 open, which makes "how
+finished is the tool" a live question rather than a settled one. And #50 already
+removed the `/conditions` half of it, so what remains is one line in one file
+with a different owner.
+
+**What the sentences must not do is claim the tool is unbuilt.** ADR-0009 says
+built here; #50 shipped the first reading, so `/conditions` names today's lowest
+tide at La Jolla Shores today. But the landing teaser still carries its reserved
+slot, and slices 4 and 5 are open. So the corrected sentences say three things
+and no more: the tool is built here rather than embedded, the teaser's dashed box
+still waits, and `docs/plans/conditions-tool.md` is where its state is recorded.
+Naming a slice count or a completion state here would put this plan's prose in
+the business of tracking another plan's progress, which is how both go stale.
+
+**The brief's bullet stays an _Out of Scope_ bullet.** It is tempting to delete
+it now that the tool is real, but this brief is the landing page's, and the
+conditions tool is genuinely not part of it — it is built under its own plan.
+What was wrong was the word for the thing excluded, not the exclusion.
+
+**A third drift was found and filed, not folded in.** `CONTEXT.md:102` says the
+teaser and `/conditions` "both currently carry a reserved slot". #50 made that
+false. It is #60 rather than a third slice here, because the cause differs — a
+count broken by #50, not the word retired by ADR-0009 — and because `CONTEXT.md`
+is the glossary rather than one of this plan's two documents.

--- a/docs/plans/design-doc-drift.md
+++ b/docs/plans/design-doc-drift.md
@@ -229,3 +229,27 @@ teaser and `/conditions` "both currently carry a reserved slot". #50 made that
 false. It is #60 rather than a third slice here, because the cause differs — a
 count broken by #50, not the word retired by ADR-0009 — and because `CONTEXT.md`
 is the glossary rather than one of this plan's two documents.
+
+### Amended 2026-08-18: #53 is three specs, not two
+
+Confirmed with Cole mid-branch rather than expanded quietly. #53 reasons that
+"three design docs were not [amended], and two of them are specs rather than
+dated records", and counts `INFORMATION_ARCHITECTURE.md`, `DESIGN_BRIEF.md` and
+`TASKS.md`. It missed a fourth file, and that file is a third spec:
+`DESIGN_TOKENS.css:74` reads `--radius-box: 20px; /* conditions embed box */`.
+
+It qualifies on the issue's own test. Its header says the block "replaces the
+scaffold tokens in `src/app/globals.css`" during the build, so it is the
+authoritative source for the tokens rather than a record of what they once were
+— the same standing as the brief and the IA doc, and the opposite of `TASKS.md`.
+
+The comment is wrong twice, and only one half is this plan's drift. `embed` is
+ADR-0009's, and it is what brings the line into scope. The other half is that
+`rounded-box` is no longer the conditions box alone: `ReservedSlot` uses it for
+all five slots and the three routed pages use it for their gallery boxes. Both
+are corrected in one line, because a comment naming the wrong thing for the
+wrong reason cannot be half-fixed — and the sibling tokens already list their
+callers this way (`co-op activity tiles, inputs`), so the shape was set.
+
+This does not reopen the `src/`-stays-out decision. `globals.css:110` carries the
+same token with no comment on it, so there is nothing there to correct.


### PR DESCRIPTION
Closes #53.

Three specs still described the conditions tool as an embed, a plan ADR-0009
retired. Prose only — nothing under `src/` changed.

## Slices

**1. `19a7c26` Record #53's two sentences, and why the teaser copy left.** A
dated addendum to `docs/plans/design-doc-drift.md`, which governs both of these
documents and is how #27, #47 and this were worked.

**2. `3c9bcc9` Stop the growth plan calling the conditions tool an embed.**
`INFORMATION_ARCHITECTURE.md:135` is in the Content Growth Plan — the section a
reader consults to find out what is coming — so it was the worst place on the
page to still promise an embed. It also read as though nothing existed yet, which
stopped being true when #50 shipped the first reading.

**3. `537a946` Name the right thing in the brief's conditions exclusion.**
`DESIGN_BRIEF.md:297` excluded "the conditions tool embed". The exclusion is
still true — this is the landing page's brief, and the tool is built under its
own plan — so the bullet stays a bullet and points at that plan. Deleting it was
the tempting move and would have lost a true statement about this brief's
boundary.

**4. `47558f3` + 5. `a029790` — scope widened once, confirmed first.**
`DESIGN_TOKENS.css:74` read `--radius-box: 20px; /* conditions embed box */`.
That file is a spec, not a dated record: its header says the block "replaces the
scaffold tokens in `src/app/globals.css`" during the build. So it qualifies on
#53's own test — the issue reasoned "three design docs were not [amended], and
two of them are specs", counted `IA`, `BRIEF` and `TASKS.md`, and missed a
fourth file that is a third spec.

Confirmed with Cole before touching it rather than folded in quietly, since it
widens a scope that had been deliberately narrowed one triage decision ago. The
plan amendment is its own commit, ahead of the fix, matching slices 1–3.

The comment was wrong twice and only one half is this plan's drift: `embed` is
ADR-0009's and is what brought the line into scope, while `rounded-box` had also
stopped being the conditions box alone. Both are fixed in one line, in the shape
the sibling radii already use (`co-op activity tiles, inputs`).

## Triage decision recorded on the issue

#53's body left one question open — whether the reserved slots' own copy belonged
here or to the first conditions slice. **Neither: it is now #59**, `needs-human`.
It is copy a visitor reads rather than a note for the team, and what it should
say is a content decision no gate can settle — `docs/plans/conditions-tool.md`
still has slices 4 and 5 open, so "how finished is the tool" is live rather than
settled. #50 had already removed the `/conditions` half of it.

Relabelled `needs-triage` → `autonomous` before starting.

## Verification

No gate reads prose, so the checks were run by hand.

**Every `embed` left in the three specs, verbatim:**

```
$ grep -rni "embed" INFORMATION_ARCHITECTURE.md DESIGN_BRIEF.md DESIGN_TOKENS.css
INFORMATION_ARCHITECTURE.md:136:  conditions tool, which is built in this repo rather than embedded from
DESIGN_BRIEF.md:297:- The conditions tool — built in this repo rather than embedded from elsewhere
```

Two hits, both inside the negation that is the correction itself.
`DESIGN_TOKENS.css` has none.

**The new token comment matches its callers:**

```
$ grep -rn "rounded-box" src/ --include=*.tsx | grep -v "\.test\."
src/app/art/page.tsx:42, src/app/community/page.tsx:36, src/app/coop/page.tsx:42
src/components/ReservedSlot.tsx:41

$ grep -rn "<ReservedSlot" src/ --include=*.tsx | grep -vc "\.test\."
5
```

`ReservedSlot` (five callers) plus three routed-page gallery boxes — which is
"reserved slots, routed-page gallery boxes".

**Left alone deliberately, and checked rather than assumed:** every other
`embed` under `docs/` and `.design/` is either an ADR or a plan describing the
retired decision — `docs/adr/0009` and `docs/plans/conditions-tool.md` argue
against embedding, so the word has to appear — or `TASKS.md:58`, which #53
excludes as a dated record. `docs/plans/nav-pages-scaffolding.md`,
`shared-module-deepening.md` and `wild-coast-kids-landing.md` are plan records
superseded by ADR-0009 rather than specs to correct.

`npm run gate` on `a029790`:

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

For a prose-only change this asserts only that nothing broke in passing; the
greps above are the actual evidence.

## One flake to report

On slice 1 — a commit touching **only** a markdown file under `docs/plans/` —
the `test` row failed once: `Test Files 1 failed | 36 passed`, `Tests 1 failed |
203 passed`. It has passed **five times since** on the same tree (two `npm run
gate`, three `npm test`, 204/204 each).

**I did not capture which test.** I tailed the gate output and lost the name,
which is my error, not the gate's — it does print the failing row's output. I
could not reproduce it to recover the name.

What the evidence does say: the failing run's `environment` was 147.33s against
118.16 / 126.63 / 122.32s for three clean runs, so that run was ~20% more
loaded. And the edit provably cannot have caused it — every reference to
`docs/` in the test files is a comment pointing at a plan, not a read; nothing
parses `docs/plans/`. Checked with
`grep -rln "docs/plans\|\.design\|docs/adr" src/ scripts/ --include=*.test.* --include=*.mjs`.

This is adjacent to #9 (closed not-reproducible), but not the same failure: that
one was `gate-scope.test.mjs`'s 5s default, and both suspects there are now on
60s budgets with the reasoning in-file. Every gate run after this was captured
to a log so a recurrence is diagnosable.

## Not done, and why

- **`src/components/Conditions.tsx:26` untouched** — #59, by your decision.
- **`CONTEXT.md:102`** says the teaser and `/conditions` "both currently carry a
  reserved slot"; #50 made that false. Filed as **#60**, not folded in: the
  cause differs (a count broken by #50, not the word retired by ADR-0009) and
  `CONTEXT.md` is the glossary rather than one of this plan's documents.
- **`src/` stays out.** `globals.css:110` carries `--radius-box` with no comment
  on it, so there was nothing there to correct — verified, not assumed.
- **No tests added.** Nothing here changes behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
