### PR TITLE
Correct the glossary's reserved-slot count

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -99,7 +99,7 @@ program card)
 **Conditions**:
 The real-time surf, tide, wind and visibility tool for San Diego's coast, built
 in this repo (ADR-0009). Has a teaser on the landing page and a page of its own;
-both currently carry a reserved slot, which comes out in the slice that has
+the teaser still carries a reserved slot, which comes out in the slice that has
 something to put in its place. It shows readings and forecasts relayed from
 public sources, attributed and timestamped — never a judgement this site makes
 about whether conditions are safe.


### PR DESCRIPTION
Closes #60

One clause. `CONTEXT.md`'s **Conditions** entry said the teaser and `/conditions`
"both currently carry a reserved slot"; PR #56 removed the `/conditions` one and
put `TidePanel` in its place.

Only the false clause is touched, as the issue asks. "Built in this repo
(ADR-0009)" is correct, and "comes out in the slice that has something to put in
its place" is the sentence `/conditions` has just demonstrated.

## Verification

No gate reads prose, so the check is stated and was run by hand. `ReservedSlot`
has five callers under `src/` excluding tests:

```
src/app/art/page.tsx
src/app/book/page.tsx
src/app/community/page.tsx
src/app/coop/page.tsx
src/components/Conditions.tsx
```

`src/app/conditions/page.tsx` is not among them, and the entry now agrees with
that list.

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

Exit code 0.

**One thing to flag honestly:** an earlier run of the gate on this same tree
reported one failed test out of 204, and I truncated its output before reading
which. That run was under heavy machine load — 557s of environment time against a
normal ~140s. The immediately following run was green on all six rows, and this
change is one word in a prose file that no test reads. I could not reproduce it,
so I am recording it rather than claiming a diagnosis. If CI shows the same, the
suite has a second load-sensitive test beyond the one fixed in #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
