### PR TITLE
Address the conditions teaser's copy to a visitor

### DIFF
--- a/src/components/Conditions.test.tsx
+++ b/src/components/Conditions.test.tsx
@@ -2,12 +2,25 @@ import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { Conditions } from "./Conditions";
 
-test("the conditions teaser renders its heading and embed slot", () => {
+test("the conditions teaser renders its heading and reserved slot", () => {
   render(<Conditions />);
 
   const heading = screen.getByRole("heading", { level: 2 });
   expect(heading.textContent).toContain("conditions");
-  expect(screen.getByText(/conditions tool coming soon/i)).toBeDefined();
+  expect(screen.getByText(/today's low tide is live/i)).toBeDefined();
+  expect(
+    screen.getByText(/surf, wind and visibility are still to come/i),
+  ).toBeDefined();
+});
+
+test("the slot's copy is addressed to a visitor, not to whoever builds the site", () => {
+  render(<Conditions />);
+
+  // It read "Drop the URL and it embeds here automatically" until #59: an
+  // instruction to a builder, describing an embed ADR-0009 retired, on the copy
+  // a parent actually reads.
+  expect(screen.queryByText(/drop the url/i)).toBeNull();
+  expect(screen.queryByText(/embed/i)).toBeNull();
 });
 
 test("the section teases the full conditions page", () => {

--- a/src/components/Conditions.tsx
+++ b/src/components/Conditions.tsx
@@ -20,10 +20,18 @@ export function Conditions() {
           Learn more →
         </PillLink>
       </div>
+      {/*
+        The slot stays until the teaser has conditions of its own to show. What
+        changed is who the copy is addressed to: it read "Drop the URL and it
+        embeds here automatically" — an instruction to whoever builds the site,
+        describing an embed ADR-0009 retired — three lines above a pill leading
+        to a page that now shows a real reading. It says nothing about how many
+        beaches or how many slices, so adding beaches does not make it false.
+      */}
       <ReservedSlot
         emoji="🌊"
-        headline="Conditions tool coming soon."
-        detail="Drop the URL and it embeds here automatically."
+        headline="Today's low tide is live."
+        detail="Surf, wind and visibility are still to come."
         tone="ocean"
       />
     </section>


### PR DESCRIPTION
Closes #59

Decision taken with Cole from the three readings the issue lays out: **keep the
reserved slot, fix the copy.**

## What changed

```diff
- headline="Conditions tool coming soon."
- detail="Drop the URL and it embeds here automatically."
+ headline="Today's low tide is live."
+ detail="Surf, wind and visibility are still to come."
```

Both halves of the old copy were wrong by the time a parent read them. The detail
was an instruction to whoever builds the site, describing an embed ADR-0009
retired. The headline was half false: PR #56 shipped the first reading, and the
slot sat three lines above a "Learn more →" pill pointing at the page that has it.

The new copy names neither a beach count nor a slice, so adding the remaining
beaches in slice 4 will not make it false.

## Why the slot stays

The teaser has nothing of its own to show yet, and retiring the box would
re-stale the two design-doc sentences PR #61 corrected on 2026-08-18, which say
the teaser's dashed box still waits.

`ReservedSlot` is untouched and keeps its five callers. Worth noting for anyone
scanning for the word: `/book`'s slot still reads "The scheduler embeds here once
a booking provider is chosen" — a real third-party embed, and not what ADR-0009
is about.

## Verification

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

Exit code 0.

A second test asserts the builder-facing wording stays gone, so the phrasing
cannot drift back without failing:

```js
expect(screen.queryByText(/drop the url/i)).toBeNull();
expect(screen.queryByText(/embed/i)).toBeNull();
```

## Not done here

- **The glossary count is #60**, open as https://github.com/cweber12/wild-coast-kids/pull/63.
  Independent file, independent branch; neither PR needs the other.
- **No gate reads whether the copy is *good*.** It asserts the words are present
  and the old ones are gone. Whether "Today's low tide is live" is the right
  register for the landing page is a judgement, and it is the part of this worth
  arguing with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
