### PR TITLE
Warm eslint's resolver in the hook that has the budget

### DIFF
--- a/scripts/gate-scope.test.mjs
+++ b/scripts/gate-scope.test.mjs
@@ -180,21 +180,33 @@ describe("vitest", () => {
 });
 
 describe("eslint", () => {
-  // One resolver for all three assertions, constructed in a hook with room to do
-  // it. Constructing an ESLint resolves the entire flat-config chain --
-  // eslint-config-next and every plugin it pulls -- which is CPU-bound and takes
-  // seconds from cold. Doing that once per assertion did it three times, and the
-  // first one alone outgrew vitest's 5s default as soon as the suite had enough
-  // files to compete for the processor: measured at ~3.1s with this file run on
-  // its own and ~6.0s in a 37-file run, on the same machine minutes apart. So the
-  // number was never about this assertion, which is why raising its timeout would
-  // have been the wrong repair -- the work moves into a hook that is allowed to
-  // take as long as it takes, the way the vitest row above already is, and the
-  // three assertions then cost nothing each.
+  // One resolver for all three assertions, warmed here where the budget is.
+  //
+  // THE COST IS NOT IN THE CONSTRUCTOR, which an earlier repair assumed and this
+  // comment used to assert. Measured in this repo on an idle machine:
+  // `new ESLint()` returns in 1ms, the FIRST `isPathIgnored` pays 1708ms
+  // resolving the whole flat-config chain -- eslint-config-next and every plugin
+  // it pulls -- and every call after that is cached and costs ~0ms. Resolution is
+  // lazy, so moving only the constructor into this hook wrapped a 1ms operation
+  // in a 60s budget and kept the seconds inside the first assertion, where
+  // vitest's 5s default still applied. It then timed out at 6072ms on main under
+  // parallel load while the other two assertions passed -- the signature of
+  // exactly that.
+  //
+  // 1708ms idle against a 5s limit is 3x headroom, which a 37-file run competing
+  // for the processor erases. So the resolution is done here, in a hook allowed
+  // to take as long as the work takes, the way the vitest row above already is,
+  // and the three assertions then cost nothing each. Raising an assertion's
+  // timeout would still be the wrong repair: the number was never about the
+  // assertion.
+  //
+  // Warming with IN_THIS_CHECKOUT weakens nothing. The third assertion asks for
+  // that same path again, from cache, and still requires it to be false.
   let eslint;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     eslint = new ESLint();
+    await eslint.isPathIgnored(IN_THIS_CHECKOUT);
   }, 60_000);
 
   // Asked of eslint's own resolver rather than by running it: `npm run lint`


### PR DESCRIPTION
Closes #62

The issue is right, and it corrects my own fix for #55. That fix moved
`new ESLint()` into a `beforeAll` with a 60s budget and asserted that
construction resolves the flat-config chain. **The premise was false** — ESLint
resolves lazily — so the hook wrapped a 1ms operation and the seconds stayed
inside the first assertion, still on vitest's 5s default.

I re-measured rather than taking the issue's numbers, on this machine, in this
repo:

```
new ESLint():      1ms
1st isPathIgnored: 1708ms -> true
2nd isPathIgnored: 0ms -> true
3rd isPathIgnored: 45ms -> false
```

The first call pays for the whole chain; the rest are cached. That is exactly the
failure signature #62 reports from `main`: assertion one at 6072ms, the other two
passing.

## The fix

The hook makes the first `isPathIgnored` call as well, so the resolution lands
where the budget already is.

Per-test durations, `--reporter=verbose`:

```
✓ scripts/gate-scope.test.mjs > eslint > ignores agent worktrees 1ms
✓ scripts/gate-scope.test.mjs > eslint > ignores the coverage report the gate produces 0ms
✓ scripts/gate-scope.test.mjs > eslint > does not ignore this checkout's own source 0ms
```

Against 6072ms for the first of those before.

Warming with `IN_THIS_CHECKOUT` weakens nothing: the third assertion asks for that
same path again, from cache, and still requires `false`. The three assertions are
unchanged and still two-sided.

The comment is corrected in the same commit, as the issue asks. It is
load-bearing documentation, and it taught the wrong model of where the cost
is — which is how the wrong line came to be repaired.

## Verification

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

Exit code 0.

## What I got wrong, plainly

Two claims of mine need withdrawing:

1. **PR #56 said the #55 fix worked.** It did not address the cost. The gate runs
   I pasted as evidence were green because of machine load, not because the
   contention was removed. I also reported one transient failure on PR #63 that I
   could not name — this is very likely what it was.
2. **The reasoning that survived was the part I kept.** "The number was never
   about the assertion, so raising its timeout is the wrong repair" is still
   right, and is why this PR does not raise a timeout either.

## What this does not fix

`#62` notes the wider cost: a gate failing ~1 run in 6 under load cannot
distinguish a regression from noise. This removes the one measured cause. Whether
any other test in the suite sits inside similar headroom is not something I
checked, and a sweep for tests near their timeout under load would be its own
issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
