### PR TITLE
Bind all 73 San Diego beaches to their own tide station

### DIFF
--- a/docs/plans/conditions-tool.md
+++ b/docs/plans/conditions-tool.md
@@ -358,3 +358,43 @@ default: it constructed a fresh `ESLint` per assertion, and that construction is
 CPU-bound. `main` at 30 test files is green; 37 turns it red. Fixed as its own
 commit and its own issue rather than folded into the feature, because the number
 was never about the assertion.
+
+### 2026-08-18 — open question 2 is answered, and slice 4 ships without slice 5
+
+**Open question 2 is closed, and the plan underestimated it.** It asked what tide
+station serves the lagoons and Mission Bay, assuming the two stations the source
+repo used. NOAA publishes **nine** tide-prediction stations in the corridor. Eight
+deliver; `TWC0405` Point Loma answers HTTP 200 carrying an error object, which is
+the failure this stack pins its parser against — a join built from the published
+station list without measuring delivery would have bound the middle of the open
+coast to a station that never answers.
+
+Station choice is not cosmetic: for the same low tide on 2026-08-18 the eight
+working stations predicted between 1.442 and 1.700 ft, across 13 minutes.
+
+**The join rule, decided with Cole.** The nearest _delivering_ station whose water
+class matches the beach's, measured from whichever end of the segment is closer.
+The water class of a station is hand-written, because NOAA publishes no such
+field; it has the standing of a join input rather than a joined value, and it is
+what stops an ocean-facing beach near the bay mouth reading a bay tide curve.
+
+**A fourth state exists now, and it is not an outage.** `no-station` is a
+permanent fact about a place; `unavailable` is a transient fact about a feed.
+Telling a reader to try again later about the first would be telling them to wait
+for something that will never arrive.
+
+**Upstream publishes at least one row with transposed coordinates.** "Imperial
+Beach pier area" gives an upper longitude of −117.5866 and a lower latitude of
+32.1327, against neighbouring rows at 32.5866/−117.1327 — a fifty-kilometre
+"beach" running from well offshore to inside Baja California. It is detected and
+refused rather than corrected, because correcting it would be inventing a
+location. Two checks are needed: a bounding box alone misses an endpoint that
+lands in the ocean at a plausible latitude.
+
+**73 beaches, not 82.** The inclusion predicate — Active, PUBLIC, CountAsBeach —
+is a filter over published fields rather than a judgement, and it takes the 82
+San Diego rows down to 73.
+
+**Slice 4 ships without slice 5**, for the same reason slice 3 shipped alone: size.
+`inventoryCaveats()` exists and is tested, and nothing renders it yet — that is
+slice 5, together with the gate row that fails when a caveat reaches no reader.

--- a/scripts/seed-beaches.mjs
+++ b/scripts/seed-beaches.mjs
@@ -1,0 +1,410 @@
+/**
+ * Seed and re-join the beach inventory.
+ *
+ *   node scripts/seed-beaches.mjs           rewrite src/data/beaches.json
+ *   node scripts/seed-beaches.mjs --check   exit 1 if the committed file has moved
+ *
+ * The second mode is the point. A join result nobody can re-run is an assertion;
+ * one that can be re-run and diffed is evidence. `--check` re-fetches, re-joins,
+ * and compares against what is committed, so "fix the join and re-run it" is
+ * something a reviewer can do rather than something a rule asserts.
+ *
+ * It reaches the network, so it is NOT a gate row. Running it on every push would
+ * be both flaky and rude to the publisher.
+ *
+ * WHAT IS PINNED, and asserted on read rather than assumed:
+ *   - the resource id and portal;
+ *   - the column names, including `Beach_ UpperLon`, whose embedded space is
+ *     upstream's own spelling;
+ *   - that the datastore serialises numerics as JSON strings, so coordinates are
+ *     converted once, here, and never by a reader.
+ *
+ * The inclusion predicate is data rather than judgement: County San Diego,
+ * Status Active, BeachAccess PUBLIC, CountAsBeach 1.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { bindTideStation, distanceMetres } from "./tide-join.mjs";
+
+const PORTAL = "https://data.cnra.ca.gov";
+const RESOURCE = "cc674e59-036c-45c3-bec2-5d3d294e0e3d";
+const DATASET =
+  "https://data.cnra.ca.gov/dataset/beach-advisories-postings-and-closures-and-beach-water-quality-monitoring";
+const MIRROR_RESOURCE = "fcbc9250-06e3-437d-b0c6-3cc5ddde93fc";
+
+const BEACHES_PATH = new URL("../src/data/beaches.json", import.meta.url);
+const STATIONS_PATH = new URL(
+  "../src/data/tide-stations.json",
+  import.meta.url,
+);
+
+/** Upstream's own spelling. The space is not a typo here. */
+const LON_UPPER_COLUMN = "Beach_ UpperLon";
+
+const COLUMNS = [
+  "Beach_Name",
+  "BeachType",
+  "WaterBodyType",
+  "WaterBodyName",
+  "BeachAccess",
+  "Status",
+  "CountAsBeach",
+  "NearestCityName",
+  "USEPAID",
+  "Agency_Name",
+  "Beach_UpperLat",
+  LON_UPPER_COLUMN,
+  "Beach_LowerLat",
+  "Beach_LowerLon",
+];
+
+function query() {
+  const columns = COLUMNS.map((c) => `"${c}"`).join(", ");
+  return (
+    `SELECT ${columns} FROM "${RESOURCE}" ` +
+    `WHERE "County" = 'San Diego' AND "Status" = 'Active' ` +
+    `AND "BeachAccess" = 'PUBLIC' AND "CountAsBeach" = '1'`
+  );
+}
+
+async function fetchRows() {
+  const url = `${PORTAL}/api/3/action/datastore_search_sql?sql=${encodeURIComponent(query())}`;
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent":
+        "wild-coast-kids/0.1 (+https://github.com/cweber12/wild-coast-kids) beach-seed",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `${PORTAL} returned HTTP ${response.status} for the beach resource.`,
+    );
+  }
+  const payload = await response.json();
+  if (payload.success !== true) {
+    throw new Error(
+      `${PORTAL} reported failure: ${JSON.stringify(payload.error ?? {})}`,
+    );
+  }
+  const rows = payload.result?.records;
+  if (!Array.isArray(rows) || rows.length === 0) {
+    throw new Error(
+      `${PORTAL} returned no beaches. An empty result is a broken query, not a coastline with no beaches.`,
+    );
+  }
+  return rows;
+}
+
+/** Numerics arrive as strings. Convert once, here, and refuse anything unreadable. */
+function coordinate(row, latColumn, lonColumn) {
+  const lat = Number(row[latColumn]);
+  const lon = Number(row[lonColumn]);
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    throw new Error(
+      `${row.Beach_Name}: ${latColumn}/${lonColumn} did not parse as numbers ` +
+        `(${JSON.stringify(row[latColumn])}, ${JSON.stringify(row[lonColumn])}).`,
+    );
+  }
+  return { lat, lon };
+}
+
+/**
+ * Where a San Diego County beach can plausibly be. Generous on purpose: the
+ * north-west corner has to hold San Onofre at roughly -117.59, so this rejects
+ * only coordinates that are not in the county at all.
+ */
+const COUNTY_BOUNDS = {
+  minLat: 32.5,
+  maxLat: 33.5,
+  minLon: -117.7,
+  maxLon: -117.0,
+};
+
+/**
+ * The longest a single published beach segment can sensibly be. The real ones
+ * top out around 5 km; 25 km is far past any of them and well short of the
+ * distances a transposed coordinate produces.
+ */
+const MAX_SEGMENT_M = 25_000;
+
+/**
+ * Why a segment cannot be used, or null if it can.
+ *
+ * Upstream publishes at least one row whose latitude and longitude fragments are
+ * transposed — "Imperial Beach pier area" on 2026-08-18 gave an upper longitude
+ * of -117.5866 and a lower latitude of 32.1327, against neighbouring rows at
+ * 32.5866/-117.1327 — which describes a fifty-kilometre beach running from well
+ * offshore to inside Baja California. Correcting it here would be inventing
+ * coordinates, so it is detected, refused, and reported instead. Two checks
+ * rather than one: the bounding box alone misses an endpoint that lands in the
+ * ocean at a plausible latitude.
+ */
+export function segmentFault(segment) {
+  for (const [end, point] of Object.entries(segment)) {
+    if (
+      point.lat < COUNTY_BOUNDS.minLat ||
+      point.lat > COUNTY_BOUNDS.maxLat ||
+      point.lon < COUNTY_BOUNDS.minLon ||
+      point.lon > COUNTY_BOUNDS.maxLon
+    ) {
+      return (
+        `the ${end} endpoint published upstream (${point.lat}, ${point.lon}) is outside ` +
+        `San Diego County, so no station can be joined to it`
+      );
+    }
+  }
+
+  const span = distanceMetres(segment.upper, segment.lower);
+  if (span > MAX_SEGMENT_M) {
+    return (
+      `the endpoints published upstream are ${(span / 1000).toFixed(1)} km apart, which is not ` +
+      `a beach, so no station can be joined to them`
+    );
+  }
+
+  return null;
+}
+
+export function slugify(name) {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (slug === "") throw new Error(`${name}: slugified to nothing.`);
+  return slug;
+}
+
+/**
+ * Display grouping only. Never an input to any join — it exists so a reader can
+ * find their beach in a list of seventy-odd, and the bands are latitudes rather
+ * than anyone's idea of where a neighbourhood ends. Bay and inlet sites group
+ * together regardless of latitude, because that is how someone looks for them.
+ */
+export function regionOf(waterClass, meanLat) {
+  if (waterClass === "bay") return "Bays, lagoons and inlets";
+  if (meanLat >= 33.0) return "North County coast";
+  if (meanLat >= 32.8) return "La Jolla and Pacific Beach";
+  if (meanLat >= 32.65) return "Point Loma and Ocean Beach";
+  return "South County coast";
+}
+
+export function build(rows, stations) {
+  const seen = new Map();
+
+  const beaches = rows.map((row) => {
+    for (const column of COLUMNS) {
+      if (!(column in row)) {
+        throw new Error(
+          `${row.Beach_Name ?? "a row"}: column ${JSON.stringify(column)} is missing. ` +
+            `The resource's shape has drifted; refusing to guess.`,
+        );
+      }
+    }
+
+    const segment = {
+      upper: coordinate(row, "Beach_UpperLat", LON_UPPER_COLUMN),
+      lower: coordinate(row, "Beach_LowerLat", "Beach_LowerLon"),
+    };
+
+    const slug = slugify(row.Beach_Name);
+    if (seen.has(slug)) {
+      throw new Error(
+        `slug "${slug}" is claimed by both ${JSON.stringify(seen.get(slug))} and ` +
+          `${JSON.stringify(row.Beach_Name)}. A slug is a primary key; disambiguating one ` +
+          `automatically would make it unstable, so this stops instead.`,
+      );
+    }
+    seen.set(slug, row.Beach_Name);
+
+    const fault = segmentFault(segment);
+    const bound = fault
+      ? { stationId: null, reason: fault }
+      : bindTideStation(
+          { segment, waterBodyType: row.WaterBodyType },
+          stations,
+        );
+
+    const meanLat = (segment.upper.lat + segment.lower.lat) / 2;
+
+    return {
+      slug,
+      name: row.Beach_Name,
+      region: regionOf(bound.stationId ? bound.waterClass : null, meanLat),
+      segment,
+      upstream: {
+        usepa_id: row.USEPAID,
+        agency: row.Agency_Name,
+        water_body_name: row.WaterBodyName,
+        water_body_type: row.WaterBodyType,
+        beach_type: row.BeachType,
+        beach_access: row.BeachAccess,
+        status: row.Status,
+        nearest_city: row.NearestCityName,
+      },
+      tide_station: bound.stationId,
+      tide_station_distance_m: bound.stationId
+        ? Math.round(bound.distanceM)
+        : null,
+      tide_station_from_end: bound.stationId ? bound.fromEnd : null,
+      tide_station_null_reason: bound.stationId ? undefined : bound.reason,
+    };
+  });
+
+  // North to south, then by slug, so the file's order is a property of the data
+  // rather than of the order the portal happened to return rows in.
+  beaches.sort((a, b) => {
+    const aLat = (a.segment.upper.lat + a.segment.lower.lat) / 2;
+    const bLat = (b.segment.upper.lat + b.segment.lower.lat) / 2;
+    return bLat - aLat || a.slug.localeCompare(b.slug);
+  });
+
+  return beaches;
+}
+
+export function document(beaches) {
+  const unbound = beaches.filter((b) => b.tide_station === null);
+  const farthest = beaches
+    .filter((b) => b.tide_station !== null)
+    .reduce((a, b) =>
+      b.tide_station_distance_m > a.tide_station_distance_m ? b : a,
+    );
+
+  return {
+    version: "0.2.0",
+    generated: new Date().toISOString().slice(0, 10),
+    time_zone: "America/Los_Angeles",
+    _provenance:
+      `Seeded from the Beach Detail Information resource of "Beach Advisories (Postings and ` +
+      `Closures) and Beach Water Quality Monitoring", published by the California State Water ` +
+      `Resources Control Board: ${DATASET}, resource ${RESOURCE}. The data.ca.gov copy ` +
+      `(resource ${MIRROR_RESOURCE}) serves identical content and is the mirror. Rebuilt by ` +
+      `scripts/seed-beaches.mjs; re-runnable and diffable with --check. Field values are ` +
+      `reproduced as the resource serves them, including BeachType "UNKNOWN".`,
+    _inclusion:
+      "County San Diego, Status Active, BeachAccess PUBLIC, CountAsBeach 1. A predicate over " +
+      "published fields rather than a judgement about which beaches are worth listing.",
+    _pinned: {
+      field_name_with_a_space:
+        "Upstream names one field 'Beach_ UpperLon', with an embedded space. That is the " +
+        "resource's own spelling, and the seeding script asserts it rather than tolerating " +
+        "its absence.",
+      numerics_are_strings:
+        "The datastore serialises numeric columns as JSON strings. They are converted once, " +
+        "at seed time, and anything that does not parse stops the seed.",
+      a_beach_is_a_segment:
+        "Coordinates arrive as an upper/lower pair, so a beach is a shoreline segment and not " +
+        "a point. tide_station_from_end records which end the join measured from.",
+    },
+    _schema: {
+      slug: "Stable primary key, from the published name. Never change after first write.",
+      name: "Display name, as the resource publishes it.",
+      region:
+        "Display grouping only, derived from water class and mean latitude. Never a join input.",
+      segment:
+        "The shoreline extent, upper and lower endpoints, WGS84 decimal degrees.",
+      upstream: "Fields reproduced from the resource, unmodified.",
+      tide_station:
+        "Joined, never typed: the nearest delivering station of the beach's own water class. " +
+        "Re-runnable with scripts/seed-beaches.mjs --check. null means the join could not " +
+        "bind one, and tide_station_null_reason says why.",
+      tide_station_distance_m:
+        "Great-circle metres from the nearer segment end to the station.",
+      tide_station_from_end:
+        "Which end of the segment supplied the distance, upper or lower.",
+    },
+    beaches,
+    // Written out in full every run, never merged with what is already on disk:
+    // carrying entries forward duplicated them on the second run and made
+    // --check report movement immediately after a seed. A check that cannot say
+    // "unchanged" says nothing.
+    unresolved: [
+      "beach_type is UNKNOWN upstream for most of these beaches. That is a gap in the resource, " +
+        "not a shorthand for sand, and nothing may render it as a description of what the shore " +
+        "is made of.",
+      `The join binds by nearest station of matching water class, and the distances are large ` +
+        `where NOAA publishes no nearby station: the farthest is ${farthest.name} at ` +
+        `${(farthest.tide_station_distance_m / 1000).toFixed(1)} km. See tide-stations.json, ` +
+        `whose own unresolved list records that the one open-coast station between La Jolla and ` +
+        `Imperial Beach does not deliver predictions.`,
+      "A tide prediction is for the station, not for the beach. It is the best published figure " +
+        "for that stretch of shore and it is not a measurement taken there.",
+      ...(unbound.length > 0
+        ? [
+            `${unbound.length} beach(es) could not be bound to a station: ` +
+              unbound
+                .map((b) => `${b.name} (${b.tide_station_null_reason})`)
+                .join("; ") +
+              ". A null station must never render as a reading.",
+          ]
+        : []),
+      "The network module carries no build-time guard against being imported by a browser " +
+        "bundle. The `server-only` package is the intended enforcement and is not installed: " +
+        "importing it breaks the tests under jsdom until vitest is configured with the " +
+        "`react-server` resolve condition. Today the guarantee rests on the module having no " +
+        "client-side importer, which nothing checks.",
+    ],
+  };
+}
+
+/**
+ * The command-line half, kept behind a guard so the pure half above can be
+ * imported and asserted without reaching the network or writing a file. Only the
+ * fetching, the file IO and the exit codes live in here; everything with a rule
+ * in it is exported and tested.
+ */
+async function main() {
+  const checkOnly = process.argv.includes("--check");
+
+  const stations = JSON.parse(readFileSync(STATIONS_PATH, "utf8")).stations;
+  let existing = null;
+  try {
+    existing = JSON.parse(readFileSync(BEACHES_PATH, "utf8"));
+  } catch {
+    existing = null;
+  }
+
+  const rows = await fetchRows();
+  const built = document(build(rows, stations));
+
+  // `generated` is the one field that moves on every run by design, so comparing
+  // it would make every check fail and mean nothing.
+  const comparable = (doc) =>
+    JSON.stringify({ ...doc, generated: null }, null, 2);
+  const next = comparable(built);
+
+  if (checkOnly) {
+    if (existing === null) {
+      console.error("beaches.json is missing. Run without --check to seed it.");
+      process.exit(1);
+    }
+    if (comparable(existing) === next) {
+      console.log(
+        `beaches.json is current: ${built.beaches.length} beaches, join unchanged.`,
+      );
+      process.exit(0);
+    }
+    console.error(
+      "beaches.json has moved. Re-run without --check, read the diff, and say in the commit " +
+        "what moved upstream and why.",
+    );
+    process.exit(1);
+  }
+
+  writeFileSync(
+    BEACHES_PATH,
+    `${JSON.stringify(built, null, 2)}
+`,
+    "utf8",
+  );
+  console.log(
+    `Wrote ${built.beaches.length} beaches to src/data/beaches.json.`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/scripts/seed-beaches.test.mjs
+++ b/scripts/seed-beaches.test.mjs
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import {
+  build,
+  document,
+  regionOf,
+  segmentFault,
+  slugify,
+} from "./seed-beaches.mjs";
+
+const STATIONS = {
+  9410230: {
+    lat: 32.8669,
+    lon: -117.2571,
+    water: "open-coast",
+    delivers: true,
+  },
+  9410170: { lat: 32.7156, lon: -117.1767, water: "bay", delivers: true },
+};
+
+const at = (lat, lon, dLat = 0.01) => ({
+  upper: { lat: lat + dLat, lon },
+  lower: { lat, lon },
+});
+
+function row(overrides = {}) {
+  return {
+    Beach_Name: "Somewhere Beach",
+    BeachType: "UNKNOWN",
+    WaterBodyType: "Open Coast",
+    WaterBodyName: "Pacific Ocean",
+    BeachAccess: "PUBLIC",
+    Status: "Active",
+    CountAsBeach: "1",
+    NearestCityName: "San Diego",
+    USEPAID: "CA000001",
+    Agency_Name: "County of San Diego Department of Environmental Health",
+    Beach_UpperLat: "32.88",
+    "Beach_ UpperLon": "-117.25",
+    Beach_LowerLat: "32.87",
+    Beach_LowerLon: "-117.26",
+    ...overrides,
+  };
+}
+
+describe("segmentFault", () => {
+  it("passes a real beach", () => {
+    expect(segmentFault(at(32.87, -117.25))).toBeNull();
+  });
+
+  it("refuses an endpoint outside the county", () => {
+    // The values upstream published for "Imperial Beach pier area" on
+    // 2026-08-18: latitude and longitude fragments transposed against its
+    // neighbours, putting one end deep into Baja California.
+    const fault = segmentFault({
+      upper: { lat: 32.5804, lon: -117.5866 },
+      lower: { lat: 32.1327, lon: -117.1332 },
+    });
+    expect(fault).toMatch(/outside San Diego County/);
+  });
+
+  it("refuses endpoints too far apart to be one beach", () => {
+    const fault = segmentFault({
+      upper: { lat: 33.4, lon: -117.6 },
+      lower: { lat: 32.55, lon: -117.13 },
+    });
+    expect(fault).toMatch(/is not a beach/);
+  });
+
+  it("needs both checks: an endpoint can be in bounds and still wrong", () => {
+    // 40 km out to sea at a plausible latitude passes the bounding box, and only
+    // the span catches it.
+    const offshore = {
+      upper: { lat: 32.58, lon: -117.5866 },
+      lower: { lat: 32.5783, lon: -117.135 },
+    };
+    expect(segmentFault(offshore)).toMatch(/is not a beach/);
+  });
+});
+
+describe("slugify", () => {
+  it("makes a stable key from a published name", () => {
+    expect(slugify("La Jolla Shores Beach")).toBe("la-jolla-shores-beach");
+    expect(slugify("Coronado Cays (NR)")).toBe("coronado-cays-nr");
+    expect(slugify("north Imperial Beach")).toBe("north-imperial-beach");
+  });
+
+  it("refuses a name that slugifies to nothing", () => {
+    expect(() => slugify("!!!")).toThrow(/slugified to nothing/);
+  });
+});
+
+describe("regionOf", () => {
+  it("groups bays together wherever they are", () => {
+    expect(regionOf("bay", 33.2)).toBe("Bays, lagoons and inlets");
+    expect(regionOf("bay", 32.6)).toBe("Bays, lagoons and inlets");
+  });
+
+  it("bands the open coast by latitude", () => {
+    expect(regionOf("open-coast", 33.2)).toBe("North County coast");
+    expect(regionOf("open-coast", 32.85)).toBe("La Jolla and Pacific Beach");
+    expect(regionOf("open-coast", 32.7)).toBe("Point Loma and Ocean Beach");
+    expect(regionOf("open-coast", 32.58)).toBe("South County coast");
+  });
+});
+
+describe("build", () => {
+  it("binds a beach and records how the join measured it", () => {
+    const [beach] = build([row()], STATIONS);
+
+    expect(beach.slug).toBe("somewhere-beach");
+    expect(beach.tide_station).toBe("9410230");
+    expect(beach.tide_station_distance_m).toBeGreaterThan(0);
+    expect(["upper", "lower"]).toContain(beach.tide_station_from_end);
+  });
+
+  it("refuses a beach whose coordinates cannot be used, and says why", () => {
+    const [beach] = build(
+      [
+        row({
+          Beach_Name: "Imperial Beach pier area",
+          Beach_UpperLat: "32.5804",
+          "Beach_ UpperLon": "-117.5866",
+          Beach_LowerLat: "32.1327",
+          Beach_LowerLon: "-117.1332",
+        }),
+      ],
+      STATIONS,
+    );
+
+    expect(beach.tide_station).toBeNull();
+    expect(beach.tide_station_null_reason).toMatch(/outside San Diego County/);
+  });
+
+  it("stops on a duplicate slug rather than disambiguating one", () => {
+    // A slug is a primary key. Making one unique automatically would make it
+    // unstable, and data accumulates against it.
+    expect(() => build([row(), row()], STATIONS)).toThrow(/is claimed by both/);
+  });
+
+  it("stops when a pinned column is missing", () => {
+    const missing = row();
+    delete missing["Beach_ UpperLon"];
+    expect(() => build([missing], STATIONS)).toThrow(/has drifted/);
+  });
+
+  it("stops when a coordinate does not parse", () => {
+    expect(() =>
+      build([row({ Beach_UpperLat: "north a bit" })], STATIONS),
+    ).toThrow(/did not parse as numbers/);
+  });
+
+  it("orders the inventory north to south", () => {
+    const built = build(
+      [
+        row({
+          Beach_Name: "South one",
+          Beach_UpperLat: "32.61",
+          Beach_LowerLat: "32.6",
+        }),
+        row({
+          Beach_Name: "North one",
+          Beach_UpperLat: "33.21",
+          Beach_LowerLat: "33.2",
+        }),
+      ],
+      STATIONS,
+    );
+    expect(built.map((b) => b.slug)).toEqual(["north-one", "south-one"]);
+  });
+});
+
+describe("document", () => {
+  it("names an unbound beach in the caveats a reader is owed", () => {
+    const built = build(
+      [
+        row(),
+        row({
+          Beach_Name: "Broken coordinates",
+          Beach_LowerLat: "32.1327",
+        }),
+      ],
+      STATIONS,
+    );
+    const doc = document(built);
+
+    expect(doc.unresolved.some((c) => c.includes("Broken coordinates"))).toBe(
+      true,
+    );
+  });
+
+  it("writes its caveats out in full, so two runs agree", () => {
+    // Carrying entries forward from the file duplicated them on the second run,
+    // and made --check report movement immediately after a seed. A check that
+    // cannot say "unchanged" says nothing.
+    const built = build([row()], STATIONS);
+    const first = document(built).unresolved;
+    const second = document(built).unresolved;
+
+    expect(second).toEqual(first);
+    expect(new Set(first).size).toBe(first.length);
+  });
+});

--- a/scripts/tide-join.mjs
+++ b/scripts/tide-join.mjs
@@ -1,0 +1,131 @@
+/**
+ * Binding a beach to a tide station.
+ *
+ * Pure, so the rule can be asserted without a network and the seeding script
+ * next door is left with nothing but fetching and writing.
+ *
+ * THE RULE: the nearest **delivering** station whose water class matches the
+ * beach's, measured from whichever end of the beach's segment is closer to it.
+ *
+ * Each clause is load-bearing.
+ *
+ * *Delivering*, because NOAA's tide-prediction station list includes at least
+ * one station that answers HTTP 200 with an error object instead of predictions.
+ * Choosing from the published list alone would bind beaches to it.
+ *
+ * *Matching water class*, because an ocean-facing beach near a bay mouth is
+ * geometrically closer to a bay station than to any coastal one, and a bay tide
+ * curve at an ocean beach is a wrong number that looks right.
+ *
+ * *From the closer end*, because the state publishes a beach as a shoreline
+ * segment rather than a point. Some are miles long. Measuring from one fixed end
+ * would push the far end of a long beach onto a station that is not its nearest,
+ * and averaging the two would invent a location that is not on the shore at all.
+ *
+ * Nothing here reads a file or a clock. The result is committed by the seeding
+ * script and never recomputed while serving a reader.
+ */
+
+const EARTH_RADIUS_M = 6371008.8;
+
+const toRadians = (degrees) => (degrees * Math.PI) / 180;
+
+/**
+ * Great-circle distance in metres.
+ *
+ * Haversine rather than a projected approximation: the corridor is small enough
+ * that either would do, and this one has no zone to get wrong.
+ *
+ * @param {{lat: number, lon: number}} a
+ * @param {{lat: number, lon: number}} b
+ * @returns {number}
+ */
+export function distanceMetres(a, b) {
+  const dLat = toRadians(b.lat - a.lat);
+  const dLon = toRadians(b.lon - a.lon);
+  const latA = toRadians(a.lat);
+  const latB = toRadians(b.lat);
+
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(latA) * Math.cos(latB) * Math.sin(dLon / 2) ** 2;
+
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(h));
+}
+
+/**
+ * The distance from a beach segment to a point, and which end supplied it.
+ *
+ * @param {{upper: {lat: number, lon: number}, lower: {lat: number, lon: number}}} segment
+ * @param {{lat: number, lon: number}} point
+ * @returns {{metres: number, end: "upper" | "lower"}}
+ */
+export function segmentDistance(segment, point) {
+  const upper = distanceMetres(segment.upper, point);
+  const lower = distanceMetres(segment.lower, point);
+  return upper <= lower
+    ? { metres: upper, end: "upper" }
+    : { metres: lower, end: "lower" };
+}
+
+/**
+ * The water class a beach belongs to, from the value the state publishes.
+ *
+ * Returns null for anything unrecognised rather than defaulting to one class.
+ * A beach whose type cannot be read has no business being bound to a station by
+ * guessing which half of the county it belongs to.
+ *
+ * @param {string} waterBodyType
+ * @returns {"open-coast" | "bay" | null}
+ */
+export function waterClassOf(waterBodyType) {
+  if (waterBodyType === "Open Coast") return "open-coast";
+  if (waterBodyType === "Sound, Bay, or Inlet") return "bay";
+  return null;
+}
+
+/**
+ * Bind one beach to a station.
+ *
+ * @param {{segment: object, waterBodyType: string}} beach
+ * @param {Record<string, {lat: number, lon: number, water: string, delivers: boolean}>} stations
+ * @returns {{stationId: string, distanceM: number, fromEnd: string, waterClass: string}
+ *   | {stationId: null, reason: string}}
+ */
+export function bindTideStation(beach, stations) {
+  const waterClass = waterClassOf(beach.waterBodyType);
+  if (waterClass === null) {
+    return {
+      stationId: null,
+      reason: `water body type ${JSON.stringify(beach.waterBodyType)} is not one this join recognises`,
+    };
+  }
+
+  const candidates = Object.entries(stations).filter(
+    ([, station]) => station.delivers && station.water === waterClass,
+  );
+
+  if (candidates.length === 0) {
+    return {
+      stationId: null,
+      reason: `no delivering ${waterClass} station exists to bind to`,
+    };
+  }
+
+  let best = null;
+  for (const [stationId, station] of candidates) {
+    const { metres, end } = segmentDistance(beach.segment, station);
+    // Ties break on the station id so the join is deterministic: two runs over
+    // the same inputs must produce the same file, or the diff stops meaning
+    // anything.
+    if (
+      best === null ||
+      metres < best.distanceM ||
+      (metres === best.distanceM && stationId < best.stationId)
+    ) {
+      best = { stationId, distanceM: metres, fromEnd: end, waterClass };
+    }
+  }
+
+  return best;
+}

--- a/scripts/tide-join.test.mjs
+++ b/scripts/tide-join.test.mjs
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+  bindTideStation,
+  distanceMetres,
+  segmentDistance,
+  waterClassOf,
+} from "./tide-join.mjs";
+
+/** A cut-down station table with the properties the rule turns on. */
+const STATIONS = {
+  9410230: {
+    lat: 32.8669,
+    lon: -117.2571,
+    water: "open-coast",
+    delivers: true,
+  },
+  9410120: { lat: 32.5783, lon: -117.135, water: "open-coast", delivers: true },
+  9410170: { lat: 32.7156, lon: -117.1767, water: "bay", delivers: true },
+  TWC0405: {
+    lat: 32.6667,
+    lon: -117.2333,
+    water: "open-coast",
+    delivers: false,
+  },
+};
+
+const near = (lat, lon) => ({ upper: { lat, lon }, lower: { lat, lon } });
+
+describe("distanceMetres", () => {
+  it("is zero for a point and itself", () => {
+    expect(
+      distanceMetres({ lat: 32.8, lon: -117.2 }, { lat: 32.8, lon: -117.2 }),
+    ).toBe(0);
+  });
+
+  it("matches a known separation", () => {
+    // La Jolla to Imperial Beach station, about 34 km down the coast.
+    const metres = distanceMetres(
+      { lat: 32.8669, lon: -117.2571 },
+      { lat: 32.5783, lon: -117.135 },
+    );
+    expect(metres).toBeGreaterThan(33_000);
+    expect(metres).toBeLessThan(35_000);
+  });
+
+  it("is symmetric", () => {
+    const a = { lat: 32.8669, lon: -117.2571 };
+    const b = { lat: 32.5783, lon: -117.135 };
+    expect(distanceMetres(a, b)).toBeCloseTo(distanceMetres(b, a), 6);
+  });
+});
+
+describe("segmentDistance", () => {
+  it("measures from whichever end is closer, and says which", () => {
+    const segment = {
+      upper: { lat: 33.2, lon: -117.4 },
+      lower: { lat: 32.87, lon: -117.26 },
+    };
+    const result = segmentDistance(segment, { lat: 32.8669, lon: -117.2571 });
+
+    expect(result.end).toBe("lower");
+    // A long beach must not be pushed onto a distant station by its far end.
+    expect(result.metres).toBeLessThan(1000);
+  });
+
+  it("prefers the upper end when it is the closer one", () => {
+    const segment = {
+      upper: { lat: 32.87, lon: -117.26 },
+      lower: { lat: 32.2, lon: -117.1 },
+    };
+    expect(segmentDistance(segment, { lat: 32.8669, lon: -117.2571 }).end).toBe(
+      "upper",
+    );
+  });
+});
+
+describe("waterClassOf", () => {
+  it("reads the two published values", () => {
+    expect(waterClassOf("Open Coast")).toBe("open-coast");
+    expect(waterClassOf("Sound, Bay, or Inlet")).toBe("bay");
+  });
+
+  it("refuses anything else rather than defaulting to a class", () => {
+    // Defaulting would bind a beach by guessing which half of the county it is in.
+    expect(waterClassOf("Great Lakes")).toBeNull();
+    expect(waterClassOf("")).toBeNull();
+    expect(waterClassOf(undefined)).toBeNull();
+  });
+});
+
+describe("bindTideStation", () => {
+  it("binds an open-coast beach to the nearest open-coast station", () => {
+    const bound = bindTideStation(
+      { segment: near(32.85, -117.27), waterBodyType: "Open Coast" },
+      STATIONS,
+    );
+    expect(bound.stationId).toBe("9410230");
+    expect(bound.waterClass).toBe("open-coast");
+  });
+
+  it("will not put an ocean beach on a bay station, however close it is", () => {
+    // Just outside the bay mouth: the bay station is much nearer than either
+    // coastal one, and is still the wrong tide curve for an ocean shore.
+    const bound = bindTideStation(
+      { segment: near(32.71, -117.18), waterBodyType: "Open Coast" },
+      STATIONS,
+    );
+    expect(bound.stationId).not.toBe("9410170");
+    expect(STATIONS[bound.stationId].water).toBe("open-coast");
+  });
+
+  it("binds a bay beach to the bay station", () => {
+    const bound = bindTideStation(
+      { segment: near(32.72, -117.18), waterBodyType: "Sound, Bay, or Inlet" },
+      STATIONS,
+    );
+    expect(bound.stationId).toBe("9410170");
+  });
+
+  it("never chooses a station that does not deliver", () => {
+    // TWC0405 sits between the two coastal stations and would win on distance
+    // alone. It answers HTTP 200 with an error object instead of predictions.
+    const bound = bindTideStation(
+      { segment: near(32.667, -117.24), waterBodyType: "Open Coast" },
+      STATIONS,
+    );
+    expect(bound.stationId).not.toBe("TWC0405");
+  });
+
+  it("returns a reason rather than a station when the water type is unreadable", () => {
+    const bound = bindTideStation(
+      { segment: near(32.85, -117.27), waterBodyType: "Lagoon" },
+      STATIONS,
+    );
+    expect(bound.stationId).toBeNull();
+    expect(bound.reason).toMatch(/not one this join recognises/);
+  });
+
+  it("returns a reason when no delivering station of that class exists", () => {
+    const bound = bindTideStation(
+      { segment: near(32.85, -117.27), waterBodyType: "Open Coast" },
+      { TWC0405: STATIONS.TWC0405 },
+    );
+    expect(bound.stationId).toBeNull();
+    expect(bound.reason).toMatch(/no delivering open-coast station/);
+  });
+
+  it("is deterministic when two stations tie", () => {
+    const tied = {
+      bbb: { lat: 32.8, lon: -117.2, water: "bay", delivers: true },
+      aaa: { lat: 32.8, lon: -117.2, water: "bay", delivers: true },
+    };
+    const bound = bindTideStation(
+      { segment: near(32.8, -117.2), waterBodyType: "Sound, Bay, or Inlet" },
+      tied,
+    );
+    // Two runs over the same inputs must produce the same file, or the diff the
+    // re-join prints stops meaning anything.
+    expect(bound.stationId).toBe("aaa");
+  });
+});

--- a/src/app/conditions/[slug]/page.test.tsx
+++ b/src/app/conditions/[slug]/page.test.tsx
@@ -1,0 +1,63 @@
+import { expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/components/TidePanel", () => ({
+  TidePanel: ({ slug }: { slug: string }) => <p>panel for {slug}</p>,
+}));
+
+const notFound = vi.fn(() => {
+  throw new Error("NEXT_NOT_FOUND");
+});
+vi.mock("next/navigation", () => ({
+  notFound,
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+const {
+  default: BeachConditions,
+  generateMetadata,
+  generateStaticParams,
+  revalidate,
+} = await import("./page");
+
+const params = (slug: string) => ({ params: Promise.resolve({ slug }) });
+
+test("renders the beach named in the route", async () => {
+  render(await BeachConditions(params("harbor-beach")));
+
+  expect(screen.getByRole("main")).toBeDefined();
+  expect(screen.getByText("panel for harbor-beach")).toBeDefined();
+});
+
+test("a slug outside the inventory is a 404, not an apology page", async () => {
+  await expect(BeachConditions(params("no-such-beach"))).rejects.toThrow(
+    "NEXT_NOT_FOUND",
+  );
+  expect(notFound).toHaveBeenCalled();
+});
+
+test("the title names the beach, so a shared link says where it is about", async () => {
+  const metadata = await generateMetadata(params("harbor-beach"));
+  expect(metadata.title).toBe("Harbor Beach conditions");
+  expect(String(metadata.description)).toContain("Harbor Beach");
+});
+
+test("metadata for an unknown slug falls back rather than throwing", async () => {
+  // generateMetadata runs before the page body, so it must not be the thing that
+  // decides a 404.
+  expect((await generateMetadata(params("no-such-beach"))).title).toBe(
+    "Conditions",
+  );
+});
+
+test("nothing is prerendered at build, so upstream load follows real readers", () => {
+  // 73 beaches times a NOAA request each, on every build, for pages nobody has
+  // looked at.
+  expect(generateStaticParams()).toEqual([]);
+});
+
+test("it revalidates on the same clock as /conditions", () => {
+  // The two routes render one section; which URL a reader arrived at must not
+  // decide how fresh their answer is.
+  expect(revalidate).toBe(900);
+});

--- a/src/app/conditions/[slug]/page.tsx
+++ b/src/app/conditions/[slug]/page.tsx
@@ -1,0 +1,57 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { ConditionsSection } from "@/components/ConditionsSection";
+import { beachBySlug } from "@/lib/beaches";
+
+/**
+ * Fifteen minutes, for the calendar rather than the tide. See
+ * `../page.tsx`, which carries the reasoning; the two must agree, because the
+ * same section is rendered by both and a reader should not get a fresher answer
+ * depending on which URL they arrived at.
+ */
+export const revalidate = 900;
+
+/**
+ * Nothing prerendered at build, and every beach reachable.
+ *
+ * Seventy-three beaches times a NOAA request each, on every build, would ask the
+ * publisher for a great deal that nobody has looked at. Returning none means a
+ * beach is fetched the first time somebody actually chooses it and is served
+ * from the cache after that, so upstream load follows real readers.
+ */
+export function generateStaticParams() {
+  return [];
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const beach = beachBySlug(slug);
+  if (!beach) return { title: "Conditions" };
+
+  return {
+    title: `${beach.name} conditions`,
+    description: `Today's lowest tide at ${beach.name}, from NOAA Tides & Currents — for families planning tidepool visits and beach days in San Diego.`,
+  };
+}
+
+export default async function BeachConditions({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  // A slug outside the inventory is a 404 rather than a page apologising about a
+  // beach that does not exist. The chooser cannot produce one; a stale link can.
+  if (!beachBySlug(slug)) notFound();
+
+  return (
+    <main className="flex-1">
+      <ConditionsSection slug={slug} />
+    </main>
+  );
+}

--- a/src/app/conditions/page.test.tsx
+++ b/src/app/conditions/page.test.tsx
@@ -7,8 +7,10 @@ import { render, screen } from "@testing-library/react";
 vi.mock("@/components/TidePanel", () => ({
   TidePanel: ({ slug }: { slug: string }) => <p>panel for {slug}</p>,
 }));
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 const { default: Conditions, revalidate } = await import("./page");
+const { DEFAULT_BEACH_SLUG } = await import("@/lib/beaches");
 
 test("the conditions page exposes its landmark and heading", () => {
   render(<Conditions />);
@@ -19,11 +21,20 @@ test("the conditions page exposes its landmark and heading", () => {
   expect(heading.textContent).toContain("conditions");
 });
 
-test("the reserved slot is gone, replaced by the tide panel", () => {
+test("it opens on the named default beach", () => {
   render(<Conditions />);
 
   expect(screen.queryByText(/conditions tool coming soon/i)).toBeNull();
-  expect(screen.getByText("panel for la-jolla-shores")).toBeDefined();
+  expect(screen.getByText(`panel for ${DEFAULT_BEACH_SLUG}`)).toBeDefined();
+});
+
+test("a reader can choose another beach from here", () => {
+  render(<Conditions />);
+
+  const select = screen.getByLabelText("Choose a beach") as HTMLSelectElement;
+  expect(select.value).toBe(DEFAULT_BEACH_SLUG);
+  // Every beach in the inventory is offered, not a curated subset.
+  expect(select.querySelectorAll("option").length).toBe(73);
 });
 
 test("the page revalidates often enough that 'today' does not go stale", () => {

--- a/src/app/conditions/page.tsx
+++ b/src/app/conditions/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
-import { Suspense } from "react";
-import { TidePanel } from "@/components/TidePanel";
+import { ConditionsSection } from "@/components/ConditionsSection";
+import { DEFAULT_BEACH_SLUG, defaultBeach } from "@/lib/beaches";
 
 export const metadata: Metadata = {
   title: "Conditions",
@@ -25,39 +25,21 @@ export const metadata: Metadata = {
  * override every fetch to `no-store` and reach NOAA on every request.
  *
  * The value must be statically analyzable, so it is a literal: 900, not 15 * 60.
+ * `[slug]/page.tsx` carries the same number for the same reason, and they must
+ * agree: the two routes render one section, and which URL a reader arrived at
+ * should not decide how fresh their answer is.
  */
 export const revalidate = 900;
 
 export default function Conditions() {
+  // Asserts the named default is still in the inventory, which a script rewrites
+  // from an upstream resource. A rename upstream should stop a build rather than
+  // render a page about nothing.
+  defaultBeach();
+
   return (
     <main className="flex-1">
-      <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
-        <p className="mb-7 text-2xs font-extrabold tracking-widest text-ocean uppercase">
-          Surf · Tide · Wind · Visibility
-        </p>
-        <h1 className="text-title leading-display mb-4 font-black italic">
-          Check <span className="text-ocean">conditions</span> first.
-        </h1>
-        <p className="leading-relaxed mb-9 max-w-130 text-base text-fog">
-          Real-time surf, tide, wind and visibility for San Diego&apos;s coast —
-          built by a local, for families planning tidepool visits and hikes.
-          Know before you go.
-        </p>
-        {/*
-          The slot this page used to carry is gone, because there is now something
-          to put in its place. The landing-page teaser keeps its slot until the
-          slice that fills it.
-        */}
-        <Suspense
-          fallback={
-            <p className="text-base text-fog">
-              Reading today&apos;s tide from NOAA…
-            </p>
-          }
-        >
-          <TidePanel slug="la-jolla-shores" />
-        </Suspense>
-      </section>
+      <ConditionsSection slug={DEFAULT_BEACH_SLUG} />
     </main>
   );
 }

--- a/src/components/BeachSelector.test.tsx
+++ b/src/components/BeachSelector.test.tsx
@@ -1,0 +1,73 @@
+import { expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { BeachSelector } from "./BeachSelector";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }));
+
+const GROUPS = [
+  {
+    region: "North County coast",
+    beaches: [
+      { slug: "san-onofre-state-beach", name: "San Onofre State Beach" },
+      { slug: "harbor-beach", name: "Harbor Beach" },
+    ],
+  },
+  {
+    region: "Bays, lagoons and inlets",
+    beaches: [{ slug: "agua-hedionda-lagoon", name: "Agua Hedionda Lagoon" }],
+  },
+];
+
+test("the chooser is labelled, so it is reachable without sight of it", () => {
+  render(<BeachSelector groups={GROUPS} current="harbor-beach" />);
+
+  const select = screen.getByLabelText("Choose a beach");
+  expect(select).toBeDefined();
+  expect((select as HTMLSelectElement).value).toBe("harbor-beach");
+});
+
+test("beaches are grouped by region rather than listed flat", () => {
+  const { container } = render(
+    <BeachSelector groups={GROUPS} current="harbor-beach" />,
+  );
+
+  const labels = [...container.querySelectorAll("optgroup")].map((group) =>
+    group.getAttribute("label"),
+  );
+  // Seventy-three entries is too many to scan as one list.
+  expect(labels).toEqual(["North County coast", "Bays, lagoons and inlets"]);
+});
+
+test("every beach given is offered exactly once", () => {
+  const { container } = render(
+    <BeachSelector groups={GROUPS} current="harbor-beach" />,
+  );
+
+  const values = [...container.querySelectorAll("option")].map(
+    (option) => (option as HTMLOptionElement).value,
+  );
+  expect(values).toEqual([
+    "san-onofre-state-beach",
+    "harbor-beach",
+    "agua-hedionda-lagoon",
+  ]);
+});
+
+test("a beach without scripting is still reachable, as a link", () => {
+  // Asserted against server-rendered markup, because that is where a `noscript`
+  // does its job: the client renderer never parses its contents, and a family on
+  // a phone with a blocked script only ever sees the HTML the server sent.
+  const markup = renderToStaticMarkup(
+    <BeachSelector groups={GROUPS} current="harbor-beach" />,
+  );
+
+  expect(markup).toContain("<noscript>");
+  expect(markup).toContain("San Onofre State Beach");
+  expect(markup).toContain("/conditions/agua-hedionda-lagoon");
+  // Two-sided: markup containing every beach twice would pass the lines above
+  // whether or not the fallback exists, so the links must be inside it.
+  const fallback = markup.slice(markup.indexOf("<noscript>"));
+  expect(fallback).toContain("/conditions/san-onofre-state-beach");
+});

--- a/src/components/BeachSelector.tsx
+++ b/src/components/BeachSelector.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+/**
+ * Choosing which beach the conditions view is about.
+ *
+ * Seventy-three entries is too many to scan flat, so they are grouped by region
+ * — a display grouping the inventory derives from water class and latitude, and
+ * never a join input. Bays, lagoons and inlets group together regardless of
+ * where they are, because that is how someone looks for them.
+ *
+ * The `noscript` list is not decoration. Selecting with a `select` needs
+ * JavaScript to navigate, and a family checking the tide on a phone with a
+ * blocked script would otherwise get a control that silently does nothing. The
+ * fallback is the same inventory as plain links, so the page works either way.
+ */
+
+export interface SelectableBeach {
+  slug: string;
+  name: string;
+}
+
+export interface BeachGroup {
+  region: string;
+  beaches: readonly SelectableBeach[];
+}
+
+export function BeachSelector({
+  groups,
+  current,
+}: {
+  groups: readonly BeachGroup[];
+  current: string;
+}) {
+  const router = useRouter();
+
+  return (
+    <div className="mb-9">
+      <label className="leading-relaxed text-base text-fog" htmlFor="beach">
+        Choose a beach
+      </label>
+      <select
+        id="beach"
+        name="beach"
+        className="rounded-pill mt-2 block w-full max-w-130 border-2 border-lavender bg-white px-5 py-3 text-base"
+        defaultValue={current}
+        onChange={(event) => router.push(`/conditions/${event.target.value}`)}
+      >
+        {groups.map((group) => (
+          <optgroup key={group.region} label={group.region}>
+            {group.beaches.map((beach) => (
+              <option key={beach.slug} value={beach.slug}>
+                {beach.name}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </select>
+
+      <noscript>
+        {groups.map((group) => (
+          <div key={group.region} className="mt-4">
+            <p className="text-2xs font-extrabold tracking-widest text-ocean uppercase">
+              {group.region}
+            </p>
+            <ul className="leading-relaxed text-base text-fog">
+              {group.beaches.map((beach) => (
+                <li key={beach.slug}>
+                  <a href={`/conditions/${beach.slug}`}>{beach.name}</a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </noscript>
+    </div>
+  );
+}

--- a/src/components/ConditionsSection.tsx
+++ b/src/components/ConditionsSection.tsx
@@ -1,0 +1,52 @@
+/**
+ * The conditions view: the same section whether it is reached at /conditions or
+ * at /conditions/<beach>.
+ *
+ * It exists so the two routes cannot drift apart. The default route is the
+ * inventory's first entry that has a station, so the page always opens on
+ * something that can answer rather than on whichever beach happens to sort
+ * first.
+ */
+
+import { Suspense } from "react";
+import { beachesByRegion } from "@/lib/beaches";
+import { BeachSelector } from "./BeachSelector";
+import { TidePanel } from "./TidePanel";
+
+export function ConditionsSection({ slug }: { slug: string }) {
+  const groups = beachesByRegion().map((group) => ({
+    region: group.region,
+    beaches: group.beaches.map((beach) => ({
+      slug: beach.slug,
+      name: beach.name,
+    })),
+  }));
+
+  return (
+    <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
+      <p className="mb-7 text-2xs font-extrabold tracking-widest text-ocean uppercase">
+        Surf · Tide · Wind · Visibility
+      </p>
+      <h1 className="text-title leading-display mb-4 font-black italic">
+        Check <span className="text-ocean">conditions</span> first.
+      </h1>
+      <p className="leading-relaxed mb-9 max-w-130 text-base text-fog">
+        Real-time surf, tide, wind and visibility for San Diego&apos;s coast —
+        built by a local, for families planning tidepool visits and hikes. Know
+        before you go.
+      </p>
+
+      <BeachSelector groups={groups} current={slug} />
+
+      <Suspense
+        fallback={
+          <p className="text-base text-fog">
+            Reading today&apos;s tide from NOAA…
+          </p>
+        }
+      >
+        <TidePanel slug={slug} />
+      </Suspense>
+    </section>
+  );
+}

--- a/src/components/TidePanel.test.tsx
+++ b/src/components/TidePanel.test.tsx
@@ -8,8 +8,11 @@ const { TidePanel } = await import("./TidePanel");
 
 const BINDING = {
   beachName: "La Jolla Shores Beach",
-  stationName: "La Jolla (Scripps Pier)",
-  stationRole: "open coast",
+  station: {
+    name: "La Jolla (Scripps Institution Wharf)",
+    water: "open-coast",
+    distanceM: 1369,
+  },
 };
 
 beforeEach(() => {
@@ -22,9 +25,9 @@ test("asks for the slug it was given and renders the reading", async () => {
     state: { kind: "reading", timeLabel: "6:24 AM", feet: 1.368 },
   });
 
-  render(await TidePanel({ slug: "la-jolla-shores" }));
+  render(await TidePanel({ slug: "la-jolla-shores-beach" }));
 
-  expect(readTodaysLowestLow).toHaveBeenCalledWith("la-jolla-shores");
+  expect(readTodaysLowestLow).toHaveBeenCalledWith("la-jolla-shores-beach");
   expect(screen.getByText("6:24 AM")).toBeDefined();
   expect(screen.getByText(/1\.4 ft above the average low tide/)).toBeDefined();
 });
@@ -39,12 +42,27 @@ test("an unavailable reading reaches the reader as words, not a blank", async ()
     },
   });
 
-  render(await TidePanel({ slug: "la-jolla-shores" }));
+  render(await TidePanel({ slug: "la-jolla-shores-beach" }));
 
   expect(screen.getByText(/Nothing is wrong with the beach/)).toBeDefined();
   expect(
     screen.getByText("NOAA returned HTTP 503 for station 9410230."),
   ).toBeDefined();
+});
+
+test("a beach with no station renders its own state, not an outage", async () => {
+  readTodaysLowestLow.mockResolvedValue({
+    beachName: "Imperial Beach pier area",
+    station: null,
+    state: { kind: "no-station", reason: "upstream coordinates are unusable" },
+  });
+
+  render(await TidePanel({ slug: "imperial-beach-pier-area" }));
+
+  expect(
+    screen.getByText(/No tide station could be matched to it/),
+  ).toBeDefined();
+  expect(screen.queryByText(/try again shortly/)).toBeNull();
 });
 
 test("a failure to resolve the beach is not swallowed into a rendered nothing", async () => {

--- a/src/components/TideToday.test.tsx
+++ b/src/components/TideToday.test.tsx
@@ -2,16 +2,23 @@ import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { TideToday } from "./TideToday";
 
-const BINDING = {
-  beachName: "La Jolla Shores Beach",
-  stationName: "La Jolla (Scripps Pier)",
-  stationRole: "open coast",
+const NEAR_STATION = {
+  name: "La Jolla (Scripps Institution Wharf)",
+  water: "open-coast",
+  distanceM: 1369,
+};
+
+const FAR_STATION = {
+  name: "La Jolla (Scripps Institution Wharf)",
+  water: "open-coast",
+  distanceM: 56_557,
 };
 
 test("a reading leads with the time and names the beach", () => {
   render(
     <TideToday
-      {...BINDING}
+      beachName="La Jolla Shores Beach"
+      station={NEAR_STATION}
       state={{ kind: "reading", timeLabel: "6:24 AM", feet: 1.368 }}
     />,
   );
@@ -25,7 +32,8 @@ test("a reading leads with the time and names the beach", () => {
 test("a positive height is described against the average low", () => {
   render(
     <TideToday
-      {...BINDING}
+      beachName="La Jolla Shores Beach"
+      station={NEAR_STATION}
       state={{ kind: "reading", timeLabel: "6:24 AM", feet: 1.368 }}
     />,
   );
@@ -35,7 +43,8 @@ test("a positive height is described against the average low", () => {
 test("a negative height explains its own minus sign", () => {
   render(
     <TideToday
-      {...BINDING}
+      beachName="Cabrillo"
+      station={NEAR_STATION}
       state={{ kind: "reading", timeLabel: "3:12 PM", feet: -0.4 }}
     />,
   );
@@ -44,35 +53,87 @@ test("a negative height explains its own minus sign", () => {
   expect(
     screen.getByText(/-0\.4 ft — the water drops below the average low/),
   ).toBeDefined();
-  expect(
-    screen.getByText(/more of the sand and reef is uncovered/),
-  ).toBeDefined();
 });
 
 test("the datum is named once, and predictions are not offered as a safety call", () => {
   render(
     <TideToday
-      {...BINDING}
+      beachName="La Jolla Shores Beach"
+      station={NEAR_STATION}
       state={{ kind: "reading", timeLabel: "6:24 AM", feet: 1.368 }}
     />,
   );
   expect(screen.getByText(/mean lower low water/)).toBeDefined();
   expect(screen.getByText(/not a safety assessment/)).toBeDefined();
-  expect(screen.getByText(/La Jolla \(Scripps Pier\)/)).toBeDefined();
+});
+
+test("a nearby station is credited without a distance", () => {
+  render(
+    <TideToday
+      beachName="La Jolla Shores Beach"
+      station={NEAR_STATION}
+      state={{ kind: "reading", timeLabel: "6:24 AM", feet: 1.368 }}
+    />,
+  );
+  expect(screen.queryByText(/km away/)).toBeNull();
+});
+
+test("a distant station discloses how far away it is", () => {
+  render(
+    <TideToday
+      beachName="San Onofre State Beach"
+      station={FAR_STATION}
+      state={{ kind: "reading", timeLabel: "6:24 AM", feet: 1.368 }}
+    />,
+  );
+  // 57 km up the coast is the difference between a prediction for this shore and
+  // the nearest one anybody publishes, so it is said where the number is given.
+  expect(screen.getByText(/57 km away/)).toBeDefined();
+  expect(
+    screen.getByText(/nearest open-coast station publishing predictions/),
+  ).toBeDefined();
 });
 
 test("no low in the window says so, and says it is not a calm sea", () => {
-  render(<TideToday {...BINDING} state={{ kind: "no-low-today" }} />);
+  render(
+    <TideToday
+      beachName="La Jolla Shores Beach"
+      station={NEAR_STATION}
+      state={{ kind: "no-low-today" }}
+    />,
+  );
   expect(
     screen.getByText(/gap in our request rather than a calm sea/),
   ).toBeDefined();
-  expect(screen.getByText(/the tide still goes out/)).toBeDefined();
+});
+
+test("a beach with no station says so permanently, and credits no station", () => {
+  render(
+    <TideToday
+      beachName="Imperial Beach pier area"
+      station={null}
+      state={{
+        kind: "no-station",
+        reason:
+          "the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County",
+      }}
+    />,
+  );
+
+  expect(
+    screen.getByText(/No tide station could be matched to it/),
+  ).toBeDefined();
+  // Not an outage: nothing here invites the reader to try again later.
+  expect(screen.queryByText(/try again shortly/)).toBeNull();
+  expect(screen.queryByText(/NOAA Tides/)).toBeNull();
+  expect(screen.getByText(/outside San Diego County/)).toBeDefined();
 });
 
 test("an unavailable reading is a sentence, with the upstream reason behind a disclosure", () => {
   render(
     <TideToday
-      {...BINDING}
+      beachName="La Jolla Shores Beach"
+      station={NEAR_STATION}
       state={{
         kind: "unavailable",
         detail: "NOAA returned HTTP 503 for station 9410230.",
@@ -84,19 +145,19 @@ test("an unavailable reading is a sentence, with the upstream reason behind a di
   expect(
     screen.getByText(/could not get today's tide prediction/),
   ).toBeDefined();
-  // The reader gets a sentence; the exact reason is available without being in the way.
   expect(screen.getByText("What went wrong")).toBeDefined();
   expect(
     screen.getByText("NOAA returned HTTP 503 for station 9410230."),
   ).toBeDefined();
-  // Nothing anywhere renders a number, which is the point: no blank, no zero.
+  // No blank and no zero: nothing here can be read as a calm sea.
   expect(screen.queryByText(/ft above the average low/)).toBeNull();
 });
 
 test("drift is called out as a bug here rather than a problem at the station", () => {
   render(
     <TideToday
-      {...BINDING}
+      beachName="La Jolla Shores Beach"
+      station={NEAR_STATION}
       state={{
         kind: "unavailable",
         detail:

--- a/src/components/TideToday.tsx
+++ b/src/components/TideToday.tsx
@@ -4,7 +4,7 @@
  * Presentational and pure: it takes a state and renders it, so every branch is
  * assertable without a network. The panel next door does the fetching.
  *
- * Three decisions in the markup are deliberate.
+ * Four decisions in the markup are deliberate.
  *
  * **Timing first, height second.** A parent plans around when to leave the
  * house. The height is what distinguishes a good tidepooling day from an
@@ -18,12 +18,24 @@
  *
  * **An absent reading is a sentence, not a blank.** A missing number renders as
  * an explanation a reader can act on, with the upstream detail behind a
- * disclosure. A blank or a zero would read as a calm, flat sea.
+ * disclosure. A blank or a zero would read as a calm, flat sea. The four states
+ * stay distinct, and the two that look alike are the ones most worth separating:
+ * no station will ever exist for this beach, against a station that could not be
+ * reached just now.
+ *
+ * **A distant station says so.** NOAA publishes no delivering tide station on the
+ * open coast between La Jolla and Imperial Beach, so some beaches read one tens
+ * of kilometres away. That is disclosed where the number is given rather than
+ * buried, because it is the difference between a prediction for this shore and
+ * the nearest one anybody publishes.
  */
 
 import type { TideTodayView } from "@/lib/conditions";
 
 export type TideTodayProps = TideTodayView;
+
+/** Past this, the station is far enough away that the reader is owed the number. */
+const DISTANT_STATION_M = 5000;
 
 function heightSentence(feet: number): string {
   const magnitude = Math.abs(feet).toFixed(1);
@@ -32,12 +44,13 @@ function heightSentence(feet: number): string {
     : `${magnitude} ft above the average low tide.`;
 }
 
-export function TideToday({
-  beachName,
-  stationName,
-  stationRole,
-  state,
-}: TideTodayProps) {
+export function TideToday({ beachName, station, state }: TideTodayProps) {
+  const distanceM = station?.distanceM ?? null;
+  const distantKm =
+    distanceM !== null && distanceM > DISTANT_STATION_M
+      ? (distanceM / 1000).toFixed(0)
+      : null;
+
   return (
     <section aria-labelledby="tide-today-heading" className="max-w-130">
       <h2
@@ -66,6 +79,20 @@ export function TideToday({
         </p>
       )}
 
+      {state.kind === "no-station" && (
+        <>
+          <p className="leading-relaxed mb-4 text-base text-fog">
+            We cannot give a tide time for this beach. No tide station could be
+            matched to it, so there is nothing to predict from — the tide here
+            is not different, we simply have no published figure for it.
+          </p>
+          <details className="mb-4 text-sm text-fog">
+            <summary>Why not</summary>
+            <p className="mt-2">{state.reason}</p>
+          </details>
+        </>
+      )}
+
       {state.kind === "unavailable" && (
         <>
           <p className="leading-relaxed mb-4 text-base text-fog">
@@ -86,12 +113,17 @@ export function TideToday({
         </>
       )}
 
-      <p className="text-2xs leading-relaxed text-fog">
-        Predicted for {stationName} ({stationRole}), NOAA Tides &amp; Currents.
-        Heights are feet above mean lower low water, the average of the lower
-        low tide each day. Predictions are astronomy, not a measurement of the
-        water on the day, and they are not a safety assessment.
-      </p>
+      {station !== null && (
+        <p className="text-2xs leading-relaxed text-fog">
+          Predicted for {station.name}, NOAA Tides &amp; Currents
+          {distantKm !== null
+            ? ` — the nearest ${station.water === "bay" ? "bay" : "open-coast"} station publishing predictions, about ${distantKm} km away`
+            : ""}
+          . Heights are feet above mean lower low water, the average of the
+          lower low tide each day. Predictions are astronomy, not a measurement
+          of the water on the day, and they are not a safety assessment.
+        </p>
+      )}
     </section>
   );
 }

--- a/src/data/beaches.json
+++ b/src/data/beaches.json
@@ -1,35 +1,645 @@
 {
-  "version": "0.1.0",
-  "generated": "2026-08-17",
+  "version": "0.2.0",
+  "generated": "2026-08-18",
   "time_zone": "America/Los_Angeles",
-  "_provenance": "Seeded from the Beach Detail Information resource of 'Beach Advisories (Postings and Closures) and Beach Water Quality Monitoring', published by the California State Water Resources Control Board on the CNRA portal: https://data.cnra.ca.gov/dataset/beach-advisories-postings-and-closures-and-beach-water-quality-monitoring, resource cc674e59-036c-45c3-bec2-5d3d294e0e3d, read 2026-08-17. The data.ca.gov copy (resource fcbc9250-06e3-437d-b0c6-3cc5ddde93fc) serves identical content and is the mirror. Field values are reproduced as the resource serves them, including BeachType 'UNKNOWN'. This file is machine-formatted on purpose: a generator may rewrite it, which is why no two keys share a line.",
+  "_provenance": "Seeded from the Beach Detail Information resource of \"Beach Advisories (Postings and Closures) and Beach Water Quality Monitoring\", published by the California State Water Resources Control Board: https://data.cnra.ca.gov/dataset/beach-advisories-postings-and-closures-and-beach-water-quality-monitoring, resource cc674e59-036c-45c3-bec2-5d3d294e0e3d. The data.ca.gov copy (resource fcbc9250-06e3-437d-b0c6-3cc5ddde93fc) serves identical content and is the mirror. Rebuilt by scripts/seed-beaches.mjs; re-runnable and diffable with --check. Field values are reproduced as the resource serves them, including BeachType \"UNKNOWN\".",
+  "_inclusion": "County San Diego, Status Active, BeachAccess PUBLIC, CountAsBeach 1. A predicate over published fields rather than a judgement about which beaches are worth listing.",
   "_pinned": {
-    "field_name_with_a_space": "Upstream names one field 'Beach_ UpperLon', with an embedded space. That is the resource's own spelling, and any reader must quote it exactly.",
-    "numerics_are_strings": "The datastore serialises numeric columns as JSON strings -- '32.883647', '1'. Coordinates here are converted to numbers once, at seed time, and the conversion is the seed script's job rather than a reader's.",
-    "a_beach_is_a_segment": "Coordinates arrive as an upper/lower pair, so a beach is a shoreline segment and not a point. Every join must say which end it joined from, and a marine protected area test is a segment-versus-polygon question: a segment can straddle a boundary."
+    "field_name_with_a_space": "Upstream names one field 'Beach_ UpperLon', with an embedded space. That is the resource's own spelling, and the seeding script asserts it rather than tolerating its absence.",
+    "numerics_are_strings": "The datastore serialises numeric columns as JSON strings. They are converted once, at seed time, and anything that does not parse stops the seed.",
+    "a_beach_is_a_segment": "Coordinates arrive as an upper/lower pair, so a beach is a shoreline segment and not a point. tide_station_from_end records which end the join measured from."
   },
   "_schema": {
-    "slug": "Stable primary key. Never change after first write.",
+    "slug": "Stable primary key, from the published name. Never change after first write.",
     "name": "Display name, as the resource publishes it.",
-    "segment": "The shoreline extent, upper and lower endpoints, in WGS84 decimal degrees.",
-    "upstream": "Fields reproduced from the resource, unmodified. beach_type 'UNKNOWN' is upstream's own value and must not be rendered as a fact about the beach.",
-    "tide_station": "NOAA CO-OPS station id whose predictions this beach reads.",
-    "tide_station_basis": "Why that station, and by what method it was chosen. Recorded because slice 3 has one beach and no join script: this is a stated basis, not a join result, and it says so."
-  },
-  "tide_stations": {
-    "9410230": {
-      "name": "La Jolla (Scripps Pier)",
-      "role": "open coast"
-    },
-    "9410170": {
-      "name": "San Diego Bay",
-      "role": "bay side only"
-    }
+    "region": "Display grouping only, derived from water class and mean latitude. Never a join input.",
+    "segment": "The shoreline extent, upper and lower endpoints, WGS84 decimal degrees.",
+    "upstream": "Fields reproduced from the resource, unmodified.",
+    "tide_station": "Joined, never typed: the nearest delivering station of the beach's own water class. Re-runnable with scripts/seed-beaches.mjs --check. null means the join could not bind one, and tide_station_null_reason says why.",
+    "tide_station_distance_m": "Great-circle metres from the nearer segment end to the station.",
+    "tide_station_from_end": "Which end of the segment supplied the distance, upper or lower."
   },
   "beaches": [
     {
-      "slug": "la-jolla-shores",
+      "slug": "san-onofre-state-beach",
+      "name": "San Onofre State Beach",
+      "region": "North County coast",
+      "segment": {
+        "upper": {
+          "lat": 33.38685,
+          "lon": -117.59623
+        },
+        "lower": {
+          "lat": 33.331617,
+          "lon": -117.503883
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA981113",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "USMC Camp Pendleton"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 56557,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "oceanside-harbor",
+      "name": "Oceanside Harbor",
+      "region": "North County coast",
+      "segment": {
+        "upper": {
+          "lat": 33.208892,
+          "lon": -117.397348
+        },
+        "lower": {
+          "lat": 33.207721,
+          "lon": -117.396431
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA359747",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Oceanside"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 40061,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "harbor-beach",
+      "name": "Harbor Beach",
+      "region": "North County coast",
+      "segment": {
+        "upper": {
+          "lat": 33.206959,
+          "lon": -117.398525
+        },
+        "lower": {
+          "lat": 33.202442,
+          "lon": -117.392907
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA624767",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Oceanside"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 39400,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "oceanside-municipal-beach-other",
+      "name": "Oceanside municipal beach, other",
+      "region": "North County coast",
+      "segment": {
+        "upper": {
+          "lat": 33.206959,
+          "lon": -117.398525
+        },
+        "lower": {
+          "lat": 33.165153,
+          "lon": -117.359478
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA333308",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Oceanside"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 34511,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "buccaneer-beach",
+      "name": "Buccaneer Beach",
+      "region": "North County coast",
+      "segment": {
+        "upper": {
+          "lat": 33.176962,
+          "lon": -117.370063
+        },
+        "lower": {
+          "lat": 33.17577,
+          "lon": -117.368925
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA976061",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Oceanside"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 35892,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "carlsbad-municipal-beach",
+      "name": "Carlsbad municipal beach",
+      "region": "North County coast",
+      "segment": {
+        "upper": {
+          "lat": 33.1651,
+          "lon": -117.3594
+        },
+        "lower": {
+          "lat": 33.1559,
+          "lon": -117.3526
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA789152",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Carlsbad"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 33346,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "carlsbad-state-beach",
+      "name": "Carlsbad State Beach",
+      "region": "North County coast",
+      "segment": {
+        "upper": {
+          "lat": 33.1559,
+          "lon": -117.3526
+        },
+        "lower": {
+          "lat": 33.1338,
+          "lon": -117.3375
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA009204",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Carlsbad"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 30610,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "agua-hedionda-lagoon",
+      "name": "Agua Hedionda Lagoon",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 33.147393,
+          "lon": -117.333249
+        },
+        "lower": {
+          "lat": 33.141831,
+          "lon": -117.319977
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA953023",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Del Mar"
+      },
+      "tide_station": "9410196",
+      "tide_station_distance_m": 39737,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "south-carlsbad-state-beach",
+      "name": "South Carlsbad State Beach",
+      "region": "North County coast",
+      "segment": {
+        "upper": {
+          "lat": 33.1285,
+          "lon": -117.3338
+        },
+        "lower": {
+          "lat": 33.0815,
+          "lon": -117.3115
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA606869",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Carlsbad"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 24396,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "leucadia",
+      "name": "Leucadia",
+      "region": "North County coast",
+      "segment": {
+        "upper": {
+          "lat": 33.0817,
+          "lon": -117.3114
+        },
+        "lower": {
+          "lat": 33.0482,
+          "lon": -117.2986
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA331931",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Encinitas"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 20528,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "encinitas-city-beaches",
+      "name": "Encinitas City Beaches",
+      "region": "North County coast",
+      "segment": {
+        "upper": {
+          "lat": 33.086824,
+          "lon": -117.313045
+        },
+        "lower": {
+          "lat": 33.031856,
+          "lon": -117.290849
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA121276",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Encinitas"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 18611,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "moonlight-beach",
+      "name": "Moonlight Beach",
+      "region": "North County coast",
+      "segment": {
+        "upper": {
+          "lat": 33.04831,
+          "lon": -117.299051
+        },
+        "lower": {
+          "lat": 33.0438,
+          "lon": -117.2925
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA326620",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Encinitas"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 19946,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "swami-s-park",
+      "name": "Swami's Park",
+      "region": "North County coast",
+      "segment": {
+        "upper": {
+          "lat": 33.034763,
+          "lon": -117.293736
+        },
+        "lower": {
+          "lat": 33.031856,
+          "lon": -117.290849
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA789562",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Encinitas"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 18611,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "san-elijo-state-beach",
+      "name": "San Elijo State Beach",
+      "region": "North County coast",
+      "segment": {
+        "upper": {
+          "lat": 33.031855,
+          "lon": -117.290849
+        },
+        "lower": {
+          "lat": 33.016626,
+          "lon": -117.282485
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA059339",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Del Mar"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 16816,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "cardiff-state-beach",
+      "name": "Cardiff State Beach",
+      "region": "North County coast",
+      "segment": {
+        "upper": {
+          "lat": 33.01556,
+          "lon": -117.281346
+        },
+        "lower": {
+          "lat": 32.99947,
+          "lon": -117.277931
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA152716",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Del Mar"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 14869,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "solana-beach-city-beaches",
+      "name": "Solana Beach City Beaches",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.99947,
+          "lon": -117.277931
+        },
+        "lower": {
+          "lat": 32.980308,
+          "lon": -117.272381
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA505182",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Solana Beach"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 12691,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "seascape-beach-park",
+      "name": "Seascape Beach Park",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.982363,
+          "lon": -117.273475
+        },
+        "lower": {
+          "lat": 32.980308,
+          "lon": -117.272381
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA723256",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Solana Beach"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 12691,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "san-dieguito-river-beach",
+      "name": "San Dieguito River Beach",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.976558,
+          "lon": -117.270906
+        },
+        "lower": {
+          "lat": 32.974609,
+          "lon": -117.27033
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA531242",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Del Mar"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 12040,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "del-mar-city-beach",
+      "name": "Del Mar City Beach",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.980308,
+          "lon": -117.272381
+        },
+        "lower": {
+          "lat": 32.948992,
+          "lon": -117.265203
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA593616",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Del Mar"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 9160,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "powerhouse-park-15th-street",
+      "name": "Powerhouse Park 15th Street",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.961524,
+          "lon": -117.268705
+        },
+        "lower": {
+          "lat": 32.959689,
+          "lon": -117.268595
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA650180",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Del Mar"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 10373,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "torrey-pines-state-beach",
+      "name": "Torrey Pines State Beach",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.948992,
+          "lon": -117.265203
+        },
+        "lower": {
+          "lat": 32.895772,
+          "lon": -117.253408
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA785240",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Del Mar"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 3229,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "torrey-pines-city-beach",
+      "name": "Torrey Pines City Beach",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.895772,
+          "lon": -117.253408
+        },
+        "lower": {
+          "lat": 32.883647,
+          "lon": -117.252681
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA922367",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 1907,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "la-jolla-shores-beach",
       "name": "La Jolla Shores Beach",
+      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.883647,
@@ -51,12 +661,1416 @@
         "nearest_city": "San Diego"
       },
       "tide_station": "9410230",
-      "tide_station_basis": "Open coast, so the open-coast station rather than the bay-side one. Confirmed against an independent product rather than assumed: the National Weather Service surf zone forecast for San Diego County Coastal (CAZ043), issued 12:41 PM PDT 2026-08-17, quotes La Jolla tides of 3.4 ft at 01:29 AM, 2.0 ft at 06:47 AM and 4.9 ft at 01:41 PM for 2026-08-18, and station 9410230's own predictions for those instants are 3.447, 2.006 and 4.938 ft. Three values agreeing to the rounding is what establishes that this station is the one NWS means by 'La Jolla'."
+      "tide_station_distance_m": 1369,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "la-jolla-cove",
+      "name": "La Jolla Cove",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.850235,
+          "lon": -117.272347
+        },
+        "lower": {
+          "lat": 32.850825,
+          "lon": -117.273034
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA997086",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 2326,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "shell-beach",
+      "name": "Shell Beach",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.850043,
+          "lon": -117.274805
+        },
+        "lower": {
+          "lat": 32.849578,
+          "lon": -117.27544
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA310313",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 2500,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "childrens-pool",
+      "name": "Childrens Pool",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.8478,
+          "lon": -117.2787
+        },
+        "lower": {
+          "lat": 32.8474,
+          "lon": -117.2782
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA499806",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": null,
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "La Jolla"
+      },
+      "tide_station": "9410196",
+      "tide_station_distance_m": 7842,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "south-casa-beach-s-d",
+      "name": "South Casa Beach S.D.",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.847306,
+          "lon": -117.278886
+        },
+        "lower": {
+          "lat": 32.845896,
+          "lon": -117.279105
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA273334",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 2981,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "whispering-sands-nicholson-pt",
+      "name": "Whispering Sands  Nicholson Pt.",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.845887,
+          "lon": -117.278994
+        },
+        "lower": {
+          "lat": 32.836703,
+          "lon": -117.281569
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA549566",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 3105,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "marine-street-beach",
+      "name": "Marine Street Beach",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.839494,
+          "lon": -117.282322
+        },
+        "lower": {
+          "lat": 32.836703,
+          "lon": -117.281569
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA982426",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 3852,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "la-jolla-community-beach",
+      "name": "La Jolla Community Beach",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.854717,
+          "lon": -117.259183
+        },
+        "lower": {
+          "lat": 32.809867,
+          "lon": -117.269317
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA211756",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 1369,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "windansea-beach",
+      "name": "WindanSea Beach",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.836703,
+          "lon": -117.281569
+        },
+        "lower": {
+          "lat": 32.824588,
+          "lon": -117.28006
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA499735",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 4062,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "bird-rock-nr",
+      "name": "Bird Rock (NR)",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.815476,
+          "lon": -117.273951
+        },
+        "lower": {
+          "lat": 32.809867,
+          "lon": -117.269317
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA479103",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 5931,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "tourmaline-surfing-park",
+      "name": "Tourmaline Surfing Park",
+      "region": "La Jolla and Pacific Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.8079,
+          "lon": -117.2662
+        },
+        "lower": {
+          "lat": 32.8008,
+          "lon": -117.2594
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA748587",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 6615,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "pacific-beach",
+      "name": "Pacific Beach",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.8008,
+          "lon": -117.2594
+        },
+        "lower": {
+          "lat": 32.7933,
+          "lon": -117.2561
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA631432",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 7353,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "mission-bay-campland-on-the-bay",
+      "name": "Mission Bay, Campland On The Bay",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.794406,
+          "lon": -117.22355
+        },
+        "lower": {
+          "lat": 32.795784,
+          "lon": -117.220812
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA397227",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410196",
+      "tide_station_distance_m": 82,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "mission-bay-de-anza-cove",
+      "name": "Mission Bay, De Anza Cove",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.794,
+          "lon": -117.2116
+        },
+        "lower": {
+          "lat": 32.7935,
+          "lon": -117.2093
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA895390",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410196",
+      "tide_station_distance_m": 1141,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "mission-bay-visitor-s-center",
+      "name": "Mission Bay, Visitor's Center",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.7932,
+          "lon": -117.209522
+        },
+        "lower": {
+          "lat": 32.788497,
+          "lon": -117.209584
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA891580",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410196",
+      "tide_station_distance_m": 1336,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "mission-bay-fanuel-park",
+      "name": "Mission Bay, Fanuel Park",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.7913,
+          "lon": -117.248952
+        },
+        "lower": {
+          "lat": 32.785963,
+          "lon": -117.240459
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA377016",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410196",
+      "tide_station_distance_m": 1779,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "mission-bay-leisure-lagoon",
+      "name": "Mission Bay, Leisure Lagoon",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.7868,
+          "lon": -117.2089
+        },
+        "lower": {
+          "lat": 32.784023,
+          "lon": -117.2112
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA246103",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410196",
+      "tide_station_distance_m": 1590,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "mission-bay-crown-point-shores",
+      "name": "Mission Bay, Crown Point Shores",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.788545,
+          "lon": -117.231675
+        },
+        "lower": {
+          "lat": 32.779582,
+          "lon": -117.23593
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA373657",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410196",
+      "tide_station_distance_m": 933,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "mission-bay-riviera-shores",
+      "name": "Mission Bay, Riviera Shores",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.78596,
+          "lon": -117.240459
+        },
+        "lower": {
+          "lat": 32.779445,
+          "lon": -117.236301
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA153271",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0413",
+      "tide_station_distance_m": 1445,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "mission-bay-north-pacific-passage",
+      "name": "Mission Bay, north pacific passage",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.784023,
+          "lon": -117.21121
+        },
+        "lower": {
+          "lat": 32.777328,
+          "lon": -117.211393
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA414803",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410196",
+      "tide_station_distance_m": 1595,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "mission-bay-san-juan-cove",
+      "name": "Mission Bay, San Juan Cove",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.781296,
+          "lon": -117.24875
+        },
+        "lower": {
+          "lat": 32.779968,
+          "lon": -117.24838
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA160930",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0413",
+      "tide_station_distance_m": 2041,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "mission-bay-sail-bay",
+      "name": "Mission Bay, Sail Bay",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.7799,
+          "lon": -117.2483
+        },
+        "lower": {
+          "lat": 32.7775,
+          "lon": -117.2473
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA424988",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0413",
+      "tide_station_distance_m": 1776,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "mission-bay-santa-barbara-cove",
+      "name": "Mission Bay, Santa Barbara Cove",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.777576,
+          "lon": -117.247327
+        },
+        "lower": {
+          "lat": 32.775961,
+          "lon": -117.246786
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA260791",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0413",
+      "tide_station_distance_m": 1628,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "mission-beach",
+      "name": "Mission Beach",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.793314,
+          "lon": -117.256197
+        },
+        "lower": {
+          "lat": 32.759253,
+          "lon": -117.254047
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA208646",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 8183,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "tecolote-shores",
+      "name": "Tecolote Shores",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.777317,
+          "lon": -117.211315
+        },
+        "lower": {
+          "lat": 32.771283,
+          "lon": -117.20965
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA801852",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410196",
+      "tide_station_distance_m": 2164,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "mission-bay-bahia-point",
+      "name": "Mission Bay, Bahia Point",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.7759,
+          "lon": -117.2467
+        },
+        "lower": {
+          "lat": 32.7724,
+          "lon": -117.2455
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA954630",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0413",
+      "tide_station_distance_m": 1305,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "mission-bay-vacation-isle",
+      "name": "Mission Bay, Vacation Isle",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.7737,
+          "lon": -117.2402
+        },
+        "lower": {
+          "lat": 32.7737,
+          "lon": -117.2402
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA211999",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0413",
+      "tide_station_distance_m": 1011,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "mission-bay-ventura-cove",
+      "name": "Mission Bay, Ventura Cove",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.773704,
+          "lon": -117.244602
+        },
+        "lower": {
+          "lat": 32.770928,
+          "lon": -117.243216
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA289877",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0413",
+      "tide_station_distance_m": 1040,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "fiesta-island",
+      "name": "Fiesta Island",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.7694,
+          "lon": -117.2111
+        },
+        "lower": {
+          "lat": 32.769,
+          "lon": -117.2109
+        }
+      },
+      "upstream": {
+        "usepa_id": null,
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": null,
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 11663,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "mission-bay-sea-world",
+      "name": "Mission Bay, Sea World",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.769509,
+          "lon": -117.233724
+        },
+        "lower": {
+          "lat": 32.766121,
+          "lon": -117.221506
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA108339",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0413",
+      "tide_station_distance_m": 315,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "mission-bay-mariners-basin",
+      "name": "Mission Bay, Mariners Basin",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.762084,
+          "lon": -117.245973
+        },
+        "lower": {
+          "lat": 32.764278,
+          "lon": -117.246744
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA192160",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0413",
+      "tide_station_distance_m": 1286,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "mission-bay-quivera-basin",
+      "name": "Mission Bay, Quivera Basin",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.763274,
+          "lon": -117.241533
+        },
+        "lower": {
+          "lat": 32.76194,
+          "lon": -117.241338
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA712752",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0413",
+      "tide_station_distance_m": 859,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "mission-bay",
+      "name": "Mission Bay",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.760031,
+          "lon": -117.247919
+        },
+        "lower": {
+          "lat": 32.761722,
+          "lon": -117.241383
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA108339",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0413",
+      "tide_station_distance_m": 937,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "dog-beach-o-b",
+      "name": "Dog Beach, O.B.",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.75617,
+          "lon": -117.252734
+        },
+        "lower": {
+          "lat": 32.747069,
+          "lon": -117.254253
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA316627",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 12319,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "ocean-beach",
+      "name": "Ocean Beach",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.756524,
+          "lon": -117.251911
+        },
+        "lower": {
+          "lat": 32.735192,
+          "lon": -117.255806
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA799523",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 12283,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "spanish-landing-park",
+      "name": "Spanish Landing Park",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.728278,
+          "lon": -117.213857
+        },
+        "lower": {
+          "lat": 32.728458,
+          "lon": -117.199202
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA769604",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410170",
+      "tide_station_distance_m": 2545,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "sunset-cliffs-park",
+      "name": "Sunset Cliffs Park",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.735192,
+          "lon": -117.255806
+        },
+        "lower": {
+          "lat": 32.713183,
+          "lon": -117.256222
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA628494",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410230",
+      "tide_station_distance_m": 14646,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "shoreline-park",
+      "name": "Shoreline Park",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.708872,
+          "lon": -117.234734
+        },
+        "lower": {
+          "lat": 32.719678,
+          "lon": -117.220187
+        }
+      },
+      "upstream": {
+        "usepa_id": null,
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": null,
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410166",
+      "tide_station_distance_m": 620,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "san-diego-bay",
+      "name": "San Diego Bay",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.707794,
+          "lon": -117.237025
+        },
+        "lower": {
+          "lat": 32.703083,
+          "lon": -117.180908
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA506450",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410166",
+      "tide_station_distance_m": 534,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "tide-beach-park",
+      "name": "Tide Beach Park",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.692502,
+          "lon": -117.16396
+        },
+        "lower": {
+          "lat": 32.688449,
+          "lon": -117.163634
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA654912",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Solana Beach"
+      },
+      "tide_station": "9410120",
+      "tide_station_distance_m": 12538,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "coronado-north-beach",
+      "name": "Coronado north beach",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.683267,
+          "lon": -117.223496
+        },
+        "lower": {
+          "lat": 32.6864,
+          "lon": -117.194
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA604254",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410120",
+      "tide_station_distance_m": 13229,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "coronado-central-beach",
+      "name": "Coronado, Central beach",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.684744,
+          "lon": -117.19049
+        },
+        "lower": {
+          "lat": 32.680392,
+          "lon": -117.18199
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA594160",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Coronado"
+      },
+      "tide_station": "9410120",
+      "tide_station_distance_m": 12175,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "coronado-city-beaches",
+      "name": "Coronado City beaches",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.6867,
+          "lon": -117.1976
+        },
+        "lower": {
+          "lat": 32.6739,
+          "lon": -117.1721
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA204955",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Coronado"
+      },
+      "tide_station": "9410120",
+      "tide_station_distance_m": 11184,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "coronado-cays-nr",
+      "name": "Coronado Cays (NR)",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.637678,
+          "lon": -117.138767
+        },
+        "lower": {
+          "lat": 32.630722,
+          "lon": -117.138047
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA125172",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Coronado"
+      },
+      "tide_station": "9410135",
+      "tide_station_distance_m": 2838,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "silver-strand-state-beach",
+      "name": "Silver Strand State Beach",
+      "region": "South County coast",
+      "segment": {
+        "upper": {
+          "lat": 32.636836,
+          "lon": -117.144303
+        },
+        "lower": {
+          "lat": 32.608936,
+          "lon": -117.134783
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA801475",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410120",
+      "tide_station_distance_m": 3407,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "north-imperial-beach",
+      "name": "north Imperial Beach",
+      "region": "South County coast",
+      "segment": {
+        "upper": {
+          "lat": 32.6089,
+          "lon": -117.1347
+        },
+        "lower": {
+          "lat": 32.5866,
+          "lon": -117.1327
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA134387",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Imperial Beach"
+      },
+      "tide_station": "9410120",
+      "tide_station_distance_m": 948,
+      "tide_station_from_end": "lower"
+    },
+    {
+      "slug": "imperial-beach-municipal-beach-other",
+      "name": "Imperial Beach municipal beach, other",
+      "region": "South County coast",
+      "segment": {
+        "upper": {
+          "lat": 32.587527,
+          "lon": -117.132598
+        },
+        "lower": {
+          "lat": 32.566219,
+          "lon": -117.133006
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA068221",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Imperial Beach"
+      },
+      "tide_station": "9410120",
+      "tide_station_distance_m": 1050,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "tijuana-slough-national-wildlife-refuge",
+      "name": "Tijuana Slough National Wildlife Refuge",
+      "region": "Bays, lagoons and inlets",
+      "segment": {
+        "upper": {
+          "lat": 32.5662,
+          "lon": -117.133
+        },
+        "lower": {
+          "lat": 32.5529,
+          "lon": -117.1276
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA104746",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Sound, Bay, or Inlet",
+        "beach_type": "ROCKY",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410135",
+      "tide_station_distance_m": 7382,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "tijana-river",
+      "name": "Tijana River",
+      "region": "South County coast",
+      "segment": {
+        "upper": {
+          "lat": 32.55358,
+          "lon": -117.06321
+        },
+        "lower": {
+          "lat": 32.54168,
+          "lon": -117.04485
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA630931",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Chula Vista"
+      },
+      "tide_station": "9410120",
+      "tide_station_distance_m": 7267,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "border-field-state-park",
+      "name": "Border Field State Park",
+      "region": "South County coast",
+      "segment": {
+        "upper": {
+          "lat": 32.55282,
+          "lon": -117.127708
+        },
+        "lower": {
+          "lat": 32.534367,
+          "lon": -117.124197
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA809706",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410120",
+      "tide_station_distance_m": 2914,
+      "tide_station_from_end": "upper"
+    },
+    {
+      "slug": "imperial-beach-pier-area",
+      "name": "Imperial Beach pier area",
+      "region": "South County coast",
+      "segment": {
+        "upper": {
+          "lat": 32.5804,
+          "lon": -117.5866
+        },
+        "lower": {
+          "lat": 32.1327,
+          "lon": -117.1332
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA432983",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Imperial Beach"
+      },
+      "tide_station": null,
+      "tide_station_distance_m": null,
+      "tide_station_from_end": null,
+      "tide_station_null_reason": "the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it"
     }
   ],
   "unresolved": [
-    "There is no tide-station join script yet. This beach's station is a stated basis checked against one independent product, which is weaker than a re-runnable join and is the whole reason slice 4 exists. Until it lands, a second beach must not be added to this file by hand.",
-    "beach_type is 'UNKNOWN' upstream for this beach. That is a gap in the resource, not a shorthand for sand, and nothing may render it as a description of what the shore is made of.",
-    "The network module carries no build-time guard against being imported by a browser bundle. The `server-only` package is the intended enforcement and is not installed: importing it breaks these tests under jsdom until vitest is configured with the `react-server` resolve condition. Today the guarantee rests on the module having no client-side importer, which nothing checks."
+    "beach_type is UNKNOWN upstream for most of these beaches. That is a gap in the resource, not a shorthand for sand, and nothing may render it as a description of what the shore is made of.",
+    "The join binds by nearest station of matching water class, and the distances are large where NOAA publishes no nearby station: the farthest is San Onofre State Beach at 56.6 km. See tide-stations.json, whose own unresolved list records that the one open-coast station between La Jolla and Imperial Beach does not deliver predictions.",
+    "A tide prediction is for the station, not for the beach. It is the best published figure for that stretch of shore and it is not a measurement taken there.",
+    "1 beach(es) could not be bound to a station: Imperial Beach pier area (the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it). A null station must never render as a reading.",
+    "The network module carries no build-time guard against being imported by a browser bundle. The `server-only` package is the intended enforcement and is not installed: importing it breaks the tests under jsdom until vitest is configured with the `react-server` resolve condition. Today the guarantee rests on the module having no client-side importer, which nothing checks."
   ]
 }

--- a/src/data/tide-stations.json
+++ b/src/data/tide-stations.json
@@ -1,0 +1,95 @@
+{
+  "version": "0.1.0",
+  "generated": "2026-08-18",
+  "_provenance": "Station ids, names and coordinates read from NOAA CO-OPS metadata, https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?type=tidepredictions, filtered to 32.5-33.4N and -117.5 to -117.0E, on 2026-08-18. Nine stations answered. Delivery was then measured one station at a time against the same predictions endpoint this site reads, rather than inferred from the station list: eight serve predictions and one does not.",
+  "_water_is_an_input_not_a_result": "The `water` field is hand-written, and that is deliberate in a file whose values otherwise come from upstream. NOAA publishes no open-coast/bay classification, so no authority can state it, and a join has to be told which stations are candidates for which beaches. It has the same standing as the scope field on a join rather than the standing of a joined value. What it prevents is concrete: an ocean-facing beach near the bay mouth is geometrically closer to a bay station than to any coastal one, and a bay tide curve at an ocean beach is a wrong number that looks entirely right.",
+  "_measured_spread": "Station choice is not cosmetic. For the low tide around 02:4x GMT on 2026-08-18 the eight working stations predicted between 1.442 and 1.700 ft, across 13 minutes of timing. A quarter of a foot is the difference between a reef being out and not.",
+  "_schema": {
+    "name": "NOAA's own station name.",
+    "lat": "Decimal degrees north, from NOAA station metadata.",
+    "lon": "Decimal degrees east, negative for west.",
+    "kind": "NOAA's station type: R is a reference station with harmonic predictions, S is subordinate, derived by offset from a reference. Recorded because it is published, not because this site treats them differently -- both were measured to deliver.",
+    "water": "open-coast or bay. Hand-written join input; see above.",
+    "delivers": "Whether the predictions endpoint actually answers for this station, measured rather than assumed. A station that does not deliver is kept and marked, never deleted.",
+    "dead_note": "Present only when delivers is false. What the station did when asked."
+  },
+  "stations": {
+    "9410230": {
+      "name": "La Jolla (Scripps Institution Wharf)",
+      "lat": 32.8669,
+      "lon": -117.2571,
+      "kind": "R",
+      "water": "open-coast",
+      "delivers": true
+    },
+    "9410196": {
+      "name": "Mission Bay, Campland",
+      "lat": 32.7937,
+      "lon": -117.2238,
+      "kind": "R",
+      "water": "bay",
+      "delivers": true
+    },
+    "TWC0413": {
+      "name": "Quivira Basin, Mission Bay",
+      "lat": 32.7667,
+      "lon": -117.2333,
+      "kind": "S",
+      "water": "bay",
+      "delivers": true
+    },
+    "9410170": {
+      "name": "San Diego (Broadway)",
+      "lat": 32.7156,
+      "lon": -117.1767,
+      "kind": "R",
+      "water": "bay",
+      "delivers": true
+    },
+    "9410166": {
+      "name": "San Diego, Quarantine Station",
+      "lat": 32.7033,
+      "lon": -117.235,
+      "kind": "S",
+      "water": "bay",
+      "delivers": true
+    },
+    "9410152": {
+      "name": "National City, San Diego Bay",
+      "lat": 32.665,
+      "lon": -117.118,
+      "kind": "S",
+      "water": "bay",
+      "delivers": true
+    },
+    "9410135": {
+      "name": "South San Diego Bay",
+      "lat": 32.6291,
+      "lon": -117.1078,
+      "kind": "R",
+      "water": "bay",
+      "delivers": true
+    },
+    "9410120": {
+      "name": "Imperial Beach",
+      "lat": 32.5783,
+      "lon": -117.135,
+      "kind": "S",
+      "water": "open-coast",
+      "delivers": true
+    },
+    "TWC0405": {
+      "name": "Point Loma",
+      "lat": 32.6667,
+      "lon": -117.2333,
+      "kind": "S",
+      "water": "open-coast",
+      "delivers": false,
+      "dead_note": "Asked for hilo predictions on 2026-08-18 it answered HTTP 200 carrying {\"error\":{\"message\":\"No Predictions data was found. Please make sure the Datum input is valid.\"}} -- a dead response wearing a success code, which is the failure this stack pins the parser against. It is listed in NOAA's tide-prediction station metadata all the same, so a join built from that list without measuring delivery would have bound the middle of the open coast to a station that never answers. Kept and marked rather than deleted: if it starts answering, that is a change a human should see."
+    }
+  },
+  "unresolved": [
+    "TWC0405 Point Loma is the only tide-prediction station on the open coast between La Jolla and Imperial Beach, and it does not deliver. So every open-coast beach from Point Loma through Ocean Beach and Pacific Beach binds to a station some distance away, and the join records that distance rather than hiding it. This is a gap in NOAA's published predictions, not one this site can close.",
+    "The open-coast/bay classification of each station is an author judgement, written by hand because no upstream authority publishes one. It has not been checked against a tidal-datum study, and the case it most affects is the bay mouth, where the two classes are closest together."
+  ]
+}

--- a/src/lib/beaches.test.ts
+++ b/src/lib/beaches.test.ts
@@ -1,60 +1,155 @@
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import {
   allBeaches,
   beachBySlug,
+  beachesByRegion,
+  DEFAULT_BEACH_SLUG,
+  defaultBeach,
   inventoryCaveats,
   tideStationFor,
 } from "./beaches";
 
-test("the inventory holds the seeded beach", () => {
-  const beaches = allBeaches();
-  expect(beaches).toHaveLength(1);
-  expect(beaches[0].slug).toBe("la-jolla-shores");
-  expect(beaches[0].name).toBe("La Jolla Shores Beach");
+describe("the inventory", () => {
+  test("holds every public, active San Diego beach the state publishes", () => {
+    expect(allBeaches()).toHaveLength(73);
+  });
+
+  test("is ordered north to south", () => {
+    const meanLat = (b: (typeof beaches)[number]) =>
+      (b.segment.upper.lat + b.segment.lower.lat) / 2;
+    const beaches = allBeaches();
+    for (let i = 1; i < beaches.length; i += 1) {
+      expect(meanLat(beaches[i - 1])).toBeGreaterThanOrEqual(
+        meanLat(beaches[i]),
+      );
+    }
+  });
+
+  test("every slug is unique, since it is the primary key", () => {
+    const slugs = allBeaches().map((beach) => beach.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  test("an unknown slug is null rather than a throw", () => {
+    expect(beachBySlug("no-such-beach")).toBeNull();
+  });
 });
 
-test("a beach is a segment, so both endpoints are present and distinct", () => {
-  const beach = beachBySlug("la-jolla-shores")!;
-  expect(beach.segment.upper).not.toEqual(beach.segment.lower);
-  for (const end of [beach.segment.upper, beach.segment.lower]) {
-    expect(typeof end.lat).toBe("number");
-    expect(typeof end.lon).toBe("number");
-    expect(end.lon).toBeLessThan(0);
-  }
+describe("a beach", () => {
+  test("is a segment, so both endpoints are present", () => {
+    for (const beach of allBeaches()) {
+      for (const end of [beach.segment.upper, beach.segment.lower]) {
+        expect(Number.isFinite(end.lat)).toBe(true);
+        expect(Number.isFinite(end.lon)).toBe(true);
+        expect(end.lon).toBeLessThan(0);
+      }
+    }
+  });
+
+  test("reproduces upstream's values, including the unknown one", () => {
+    const beach = beachBySlug(DEFAULT_BEACH_SLUG)!;
+    expect(beach.upstream.usepa_id).toBe("CA876094");
+    expect(beach.upstream.water_body_type).toBe("Open Coast");
+    expect(beach.upstream.beach_access).toBe("PUBLIC");
+    // Upstream publishes UNKNOWN. Kept as published, so a gap in the resource
+    // can never be rendered as a claim about the shore.
+    expect(beach.upstream.beach_type).toBe("UNKNOWN");
+  });
 });
 
-test("upstream values are reproduced, including the unknown one", () => {
-  const beach = beachBySlug("la-jolla-shores")!;
-  expect(beach.upstream.usepa_id).toBe("CA876094");
-  expect(beach.upstream.water_body_type).toBe("Open Coast");
-  expect(beach.upstream.beach_access).toBe("PUBLIC");
-  // Upstream publishes UNKNOWN here. It is kept as published so that nothing can
-  // quietly turn a gap in the resource into a claim about the shore.
-  expect(beach.upstream.beach_type).toBe("UNKNOWN");
+describe("the tide station binding", () => {
+  test("resolves with its water class and the distance the join measured", () => {
+    const beach = beachBySlug(DEFAULT_BEACH_SLUG)!;
+    const station = tideStationFor(beach)!;
+
+    expect(station.id).toBe("9410230");
+    expect(station.water).toBe("open-coast");
+    expect(station.delivers).toBe(true);
+    expect(beach.tide_station_distance_m).toBeLessThan(2000);
+    expect(["upper", "lower"]).toContain(beach.tide_station_from_end);
+  });
+
+  test("never binds an open-coast beach to a bay station, or the reverse", () => {
+    for (const beach of allBeaches()) {
+      const station = tideStationFor(beach);
+      if (station === null) continue;
+      const expected =
+        beach.upstream.water_body_type === "Open Coast" ? "open-coast" : "bay";
+      expect(station.water).toBe(expected);
+    }
+  });
+
+  test("never binds to a station that does not deliver", () => {
+    for (const beach of allBeaches()) {
+      expect(tideStationFor(beach)?.delivers ?? true).toBe(true);
+    }
+  });
+
+  test("a beach the join could not bind is null with a stated reason", () => {
+    const unbound = allBeaches().filter((beach) => beach.tide_station === null);
+
+    // Upstream publishes one row whose coordinates are transposed; it is refused
+    // rather than corrected here, because correcting it would be inventing a
+    // location. If this count changes, upstream changed.
+    expect(unbound).toHaveLength(1);
+    for (const beach of unbound) {
+      expect(beach.tide_station_null_reason).toBeTruthy();
+      expect(tideStationFor(beach)).toBeNull();
+      expect(beach.tide_station_distance_m).toBeNull();
+    }
+  });
+
+  test("a beach naming an undescribed station is a broken data file, and says so", () => {
+    const beach = {
+      ...beachBySlug(DEFAULT_BEACH_SLUG)!,
+      tide_station: "9999999",
+    };
+    expect(() => tideStationFor(beach)).toThrow(
+      /no entry in tide-stations.json/,
+    );
+  });
 });
 
-test("an unknown slug is null rather than a throw", () => {
-  expect(beachBySlug("no-such-beach")).toBeNull();
+describe("grouping for a chooser", () => {
+  test("covers every beach exactly once", () => {
+    const grouped = beachesByRegion().flatMap((group) => group.beaches);
+    expect(grouped).toHaveLength(allBeaches().length);
+    expect(new Set(grouped.map((b) => b.slug)).size).toBe(allBeaches().length);
+  });
+
+  test("names no empty region", () => {
+    for (const group of beachesByRegion()) {
+      expect(group.region).not.toBe("");
+      expect(group.beaches.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("puts bays and inlets in one group regardless of latitude", () => {
+    const bays = beachesByRegion().find((g) => g.region.startsWith("Bays"))!;
+    for (const beach of bays.beaches) {
+      expect(beach.upstream.water_body_type).toBe("Sound, Bay, or Inlet");
+    }
+  });
 });
 
-test("the tide station resolves with its role", () => {
-  const station = tideStationFor(beachBySlug("la-jolla-shores")!);
-  expect(station.id).toBe("9410230");
-  expect(station.name).toContain("La Jolla");
-  // An open-coast beach must not be reading the bay-side station.
-  expect(station.role).toBe("open coast");
+describe("the default beach", () => {
+  test("is in the inventory and has a station", () => {
+    const beach = defaultBeach();
+    expect(beach.slug).toBe(DEFAULT_BEACH_SLUG);
+    expect(tideStationFor(beach)).not.toBeNull();
+  });
 });
 
-test("a beach naming an undescribed station is a broken data file, and says so", () => {
-  const beach = { ...beachBySlug("la-jolla-shores")!, tide_station: "9999999" };
-  expect(() => tideStationFor(beach)).toThrow(/no entry under tide_stations/);
-});
-
-test("the inventory's caveats are readable, so they can be rendered", () => {
-  const caveats = inventoryCaveats();
-  expect(caveats.length).toBeGreaterThan(0);
-  for (const caveat of caveats) {
-    expect(typeof caveat).toBe("string");
-    expect(caveat.length).toBeGreaterThan(0);
-  }
+describe("caveats", () => {
+  test("carry both data files' unresolved entries", () => {
+    const caveats = inventoryCaveats();
+    expect(caveats.length).toBeGreaterThan(2);
+    for (const caveat of caveats) {
+      expect(typeof caveat).toBe("string");
+      expect(caveat.length).toBeGreaterThan(0);
+    }
+    // The station file's own caveat about the gap on the open coast must reach a
+    // reader, not just the inventory's.
+    expect(caveats.some((c) => c.includes("TWC0405"))).toBe(true);
+  });
 });

--- a/src/lib/beaches.ts
+++ b/src/lib/beaches.ts
@@ -1,17 +1,18 @@
 /**
- * The beach inventory, typed.
+ * The beach inventory and the tide stations it binds to, typed.
  *
- * `src/data/beaches.json` is the record; this is the only way to read it, so a
- * caller cannot reach past the types into a raw shape. The JSON is
- * machine-formatted on purpose -- a generator may rewrite it -- and the types
- * here are hand-written until a generator exists to emit them.
+ * `src/data/beaches.json` is written by `scripts/seed-beaches.mjs` and is never
+ * edited by hand: every station binding there is a join result, re-runnable and
+ * diffable with `--check`. `src/data/tide-stations.json` is its counterpart, and
+ * holds the one field that is written by hand — a station's water class, which
+ * no upstream authority publishes and which the join needs as an input.
  *
- * Nothing in this module fetches anything. A beach's bindings are values
- * resolved against upstream authorities and committed; reading them is a file
- * read, and that is the point.
+ * Nothing here fetches anything. Reading a binding is a file read, and that is
+ * the point: the join ran offline, and a reader is served its committed result.
  */
 
 import inventory from "@/data/beaches.json";
+import stationTable from "@/data/tide-stations.json";
 
 export interface Coordinate {
   lat: number;
@@ -19,9 +20,8 @@ export interface Coordinate {
 }
 
 /**
- * A beach is a shoreline **segment**, upper and lower endpoints, because that is
- * how the state publishes it. It is not a point, and code that needs one has to
- * say which end it took and why.
+ * A beach is a shoreline **segment**, because that is how the state publishes
+ * it. Code that needs a single point has to say which end it took and why.
  */
 export interface BeachSegment {
   upper: Coordinate;
@@ -31,40 +31,75 @@ export interface BeachSegment {
 export interface Beach {
   slug: string;
   name: string;
+  /** Display grouping only. Never an input to any join. */
+  region: string;
   segment: BeachSegment;
-  /** Fields reproduced from the upstream resource, unmodified. */
   upstream: {
     usepa_id: string;
     agency: string;
     water_body_name: string;
     water_body_type: string;
-    /**
-     * Upstream's own value, which is `UNKNOWN` for some beaches. That is a gap in
-     * the resource and must never be rendered as a description of the shore.
-     */
+    /** Upstream's own value, `UNKNOWN` for most beaches. Never a description of the shore. */
     beach_type: string;
     beach_access: string;
     status: string;
     nearest_city: string;
   };
-  tide_station: string;
-  tide_station_basis: string;
+  /** Joined, never typed. null means the join could not bind one. */
+  tide_station: string | null;
+  tide_station_distance_m: number | null;
+  tide_station_from_end: string | null;
+  /** Present exactly when tide_station is null, and required then. */
+  tide_station_null_reason?: string;
 }
 
 export interface TideStation {
   name: string;
-  /** `open coast` or `bay side only`. Reading a bay station for an open-coast beach yields a wrong curve. */
-  role: string;
+  lat: number;
+  lon: number;
+  kind: string;
+  /** `open-coast` or `bay`. The join input; see tide-stations.json. */
+  water: string;
+  /** Measured, not assumed. A station that does not deliver is kept and marked. */
+  delivers: boolean;
+  dead_note?: string;
 }
 
 const BEACHES = inventory.beaches as readonly Beach[];
-const TIDE_STATIONS = inventory.tide_stations as Readonly<
-  Record<string, TideStation>
->;
+const STATIONS = stationTable.stations as Readonly<Record<string, TideStation>>;
 
-/** Every beach in the inventory, in file order. */
+/**
+ * The beach the conditions view opens on when no other is asked for.
+ *
+ * Named rather than derived. "First in the inventory" would be San Onofre, at
+ * the county's northern edge and 57 km from the nearest station that publishes
+ * predictions, which is the worst-supported reading on the site. This one is
+ * central, sits 1.4 km from its station, and is the beach the National Weather
+ * Service means when its surf zone forecast says "La Jolla".
+ */
+export const DEFAULT_BEACH_SLUG = "la-jolla-shores-beach";
+
+/** Every beach, north to south. */
 export function allBeaches(): readonly Beach[] {
   return BEACHES;
+}
+
+/**
+ * The default beach, or a loud failure.
+ *
+ * The inventory is rewritten by a script from an upstream resource, so a rename
+ * upstream could take the default slug with it. That must stop a build rather
+ * than render an empty page.
+ */
+export function defaultBeach(): Beach {
+  const beach = beachBySlug(DEFAULT_BEACH_SLUG);
+  if (!beach) {
+    throw new Error(
+      `beaches.json no longer contains ${DEFAULT_BEACH_SLUG}, which the conditions view ` +
+        `opens on. Upstream may have renamed it; pick a new default deliberately.`,
+    );
+  }
+  return beach;
 }
 
 /** One beach by slug, or null. Null means the slug is not in the inventory. */
@@ -73,24 +108,49 @@ export function beachBySlug(slug: string): Beach | null {
 }
 
 /**
- * The tide station a beach reads, with its role.
- *
- * Throws when a beach names a station the inventory does not describe. That is a
- * broken data file rather than a missing reading, and it should stop a build
- * rather than render an unlabelled number.
+ * Beaches grouped for a chooser, in inventory order within each group and with
+ * the groups in the order they first appear — which, the inventory being sorted
+ * north to south, runs down the coast.
  */
-export function tideStationFor(beach: Beach): TideStation & { id: string } {
-  const station = TIDE_STATIONS[beach.tide_station];
+export function beachesByRegion(): {
+  region: string;
+  beaches: readonly Beach[];
+}[] {
+  const groups = new Map<string, Beach[]>();
+  for (const beach of BEACHES) {
+    const existing = groups.get(beach.region);
+    if (existing) existing.push(beach);
+    else groups.set(beach.region, [beach]);
+  }
+  return [...groups].map(([region, beaches]) => ({ region, beaches }));
+}
+
+/**
+ * The station a beach reads, or null when the join could not bind one.
+ *
+ * Throws when a beach names a station the table does not describe. That is a
+ * broken pair of data files rather than a missing reading, and it should stop a
+ * build rather than render an unlabelled number.
+ */
+export function tideStationFor(
+  beach: Beach,
+): (TideStation & { id: string }) | null {
+  if (beach.tide_station === null) return null;
+
+  const station = STATIONS[beach.tide_station];
   if (!station) {
     throw new Error(
       `beaches.json: ${beach.slug} names tide station ${beach.tide_station}, ` +
-        `which has no entry under tide_stations.`,
+        `which has no entry in tide-stations.json.`,
     );
   }
   return { id: beach.tide_station, ...station };
 }
 
-/** Caveats carried by the inventory. Every one of these owes the reader a rendering. */
+/** Caveats carried by both data files. Every one owes the reader a rendering. */
 export function inventoryCaveats(): readonly string[] {
-  return inventory.unresolved as readonly string[];
+  return [
+    ...(inventory.unresolved as readonly string[]),
+    ...(stationTable.unresolved as readonly string[]),
+  ];
 }

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -5,6 +5,11 @@ vi.mock("./upstream", () => ({ fetchTideExtremes }));
 
 const { readTodaysLowestLow } = await import("./conditions");
 
+const BEACH = "la-jolla-shores-beach";
+
+/** The one beach the join refuses, because upstream's coordinates are transposed. */
+const UNBOUND_BEACH = "imperial-beach-pier-area";
+
 /**
  * Noon Pacific on 2026-08-17. The clock is injected rather than faked, which is
  * the reason `readTodaysLowestLow` takes it as an argument at all.
@@ -28,7 +33,7 @@ function ok(extremes: { atMs: number; feet: number; kind: "low" | "high" }[]) {
 
 test("asks for a window either side of today, because a Pacific day spans two GMT dates", async () => {
   ok([]);
-  await readTodaysLowestLow("la-jolla-shores", NOON_PACIFIC_20260817);
+  await readTodaysLowestLow(BEACH, NOON_PACIFIC_20260817);
 
   expect(fetchTideExtremes).toHaveBeenCalledWith({
     stationId: "9410230",
@@ -42,7 +47,7 @@ test("the window is anchored to the Pacific date, not the UTC one", async () => 
   // 00:30 Pacific on the 17th is already 07:30 UTC on the 17th, so a UTC-anchored
   // window would ask for the 16th-18th by accident and be right for the wrong
   // reason. Anchoring on the local date makes it right on purpose.
-  await readTodaysLowestLow("la-jolla-shores", JUST_AFTER_MIDNIGHT_20260817);
+  await readTodaysLowestLow(BEACH, JUST_AFTER_MIDNIGHT_20260817);
 
   expect(fetchTideExtremes).toHaveBeenCalledWith({
     stationId: "9410230",
@@ -51,16 +56,14 @@ test("the window is anchored to the Pacific date, not the UTC one", async () => 
   });
 });
 
-test("carries the beach and station bindings through to the view", async () => {
+test("carries the beach and station bindings, including how far the station is", async () => {
   ok([]);
-  const view = await readTodaysLowestLow(
-    "la-jolla-shores",
-    NOON_PACIFIC_20260817,
-  );
+  const view = await readTodaysLowestLow(BEACH, NOON_PACIFIC_20260817);
 
   expect(view.beachName).toBe("La Jolla Shores Beach");
-  expect(view.stationName).toContain("La Jolla");
-  expect(view.stationRole).toBe("open coast");
+  expect(view.station?.name).toContain("La Jolla");
+  expect(view.station?.water).toBe("open-coast");
+  expect(view.station?.distanceM).toBeGreaterThan(0);
 });
 
 test("picks the day's deeper low and renders it as Pacific wall-clock time", async () => {
@@ -71,10 +74,7 @@ test("picks the day's deeper low and renders it as Pacific wall-clock time", asy
     { atMs: Date.UTC(2026, 7, 18, 2, 46), feet: 1.51, kind: "low" },
   ]);
 
-  const view = await readTodaysLowestLow(
-    "la-jolla-shores",
-    NOON_PACIFIC_20260817,
-  );
+  const view = await readTodaysLowestLow(BEACH, NOON_PACIFIC_20260817);
 
   expect(view.state).toEqual({
     kind: "reading",
@@ -86,10 +86,7 @@ test("picks the day's deeper low and renders it as Pacific wall-clock time", asy
 test("a window with no low for today is its own state, never a reading", async () => {
   ok([{ atMs: Date.UTC(2026, 7, 20, 13, 24), feet: 1.1, kind: "low" }]);
 
-  const view = await readTodaysLowestLow(
-    "la-jolla-shores",
-    NOON_PACIFIC_20260817,
-  );
+  const view = await readTodaysLowestLow(BEACH, NOON_PACIFIC_20260817);
 
   expect(view.state).toEqual({ kind: "no-low-today" });
 });
@@ -102,10 +99,7 @@ test("an unavailable upstream carries its reason through, unswallowed", async ()
     url: "https://example.invalid",
   });
 
-  const view = await readTodaysLowestLow(
-    "la-jolla-shores",
-    NOON_PACIFIC_20260817,
-  );
+  const view = await readTodaysLowestLow(BEACH, NOON_PACIFIC_20260817);
 
   expect(view.state).toEqual({
     kind: "unavailable",
@@ -126,12 +120,24 @@ test("drift is carried as drift rather than folded into a quiet failure", async 
     url: "https://example.invalid",
   });
 
-  const view = await readTodaysLowestLow(
-    "la-jolla-shores",
-    NOON_PACIFIC_20260817,
-  );
+  const view = await readTodaysLowestLow(BEACH, NOON_PACIFIC_20260817);
 
   expect(view.state).toMatchObject({ kind: "unavailable", drift: true });
+});
+
+test("a beach with no station never reaches upstream, and is not an outage", async () => {
+  const view = await readTodaysLowestLow(UNBOUND_BEACH, NOON_PACIFIC_20260817);
+
+  // A permanent fact about the place, kept apart from a feed having a bad day:
+  // telling this reader to try again later would be telling them to wait for
+  // something that will never arrive.
+  expect(view.state.kind).toBe("no-station");
+  expect(view.station).toBeNull();
+  expect(fetchTideExtremes).not.toHaveBeenCalled();
+
+  if (view.state.kind === "no-station") {
+    expect(view.state.reason).toMatch(/outside San Diego County/);
+  }
 });
 
 test("a slug outside the inventory is a coding error, and nothing is fetched", async () => {

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -17,16 +17,23 @@ import { lowestLowOn } from "./tide-day";
 import { fetchTideExtremes } from "./upstream";
 
 /**
- * What the view renders. Three states, kept distinct on purpose: a reading, a
- * window that held no low for the day, and nothing available. Collapsing any two
- * of them would let one render as another, and the dangerous direction is an
- * absent reading reading as a calm sea.
+ * What the view renders. Four states, kept distinct on purpose, because the
+ * dangerous direction is any of the last three reading as a calm sea:
+ *
+ *   reading        a predicted low for today
+ *   no-low-today   the window held none, which is a gap in our request
+ *   no-station     the join bound no station to this beach at all
+ *   unavailable    a station exists and upstream could not answer
+ *
+ * `no-station` is a permanent fact about the place; `unavailable` is a transient
+ * fact about the feed. Collapsing them would tell a reader to try again later
+ * about something that will never work, or the reverse.
  */
 export type TideTodayState =
   | { kind: "reading"; timeLabel: string; feet: number }
   | { kind: "no-low-today" }
+  | { kind: "no-station"; reason: string }
   | {
-      /** Upstream could not answer. The wording shown to a reader belongs to the view. */
       kind: "unavailable";
       /** The exact upstream reason, for the disclosure. */
       detail: string;
@@ -36,8 +43,8 @@ export type TideTodayState =
 
 export interface TideTodayView {
   beachName: string;
-  stationName: string;
-  stationRole: string;
+  /** null exactly when the state is `no-station`. */
+  station: { name: string; water: string; distanceM: number | null } | null;
   state: TideTodayState;
 }
 
@@ -57,8 +64,8 @@ function compact(localDate: string): string {
  * low off the end.
  *
  * Throws only when the slug is not in the inventory, which is a coding error
- * rather than a quiet feed. Everything an upstream can do wrong arrives as the
- * `unavailable` state instead.
+ * rather than a quiet feed. Everything an upstream can do wrong, and every beach
+ * the join could not bind, arrives as a state instead.
  */
 export async function readTodaysLowestLow(
   slug: string,
@@ -70,19 +77,35 @@ export async function readTodaysLowestLow(
       `readTodaysLowestLow: no beach in the inventory with slug "${slug}".`,
     );
   }
+
   const station = tideStationFor(beach);
+  if (station === null) {
+    return {
+      beachName: beach.name,
+      station: null,
+      state: {
+        kind: "no-station",
+        reason:
+          beach.tide_station_null_reason ??
+          "the join bound no tide station to this beach, and recorded no reason",
+      },
+    };
+  }
+
+  const binding = {
+    beachName: beach.name,
+    station: {
+      name: station.name,
+      water: station.water,
+      distanceM: beach.tide_station_distance_m,
+    },
+  };
 
   const result = await fetchTideExtremes({
     stationId: station.id,
     beginDate: compact(localDateOf(nowMs - ONE_DAY_MS)),
     endDate: compact(localDateOf(nowMs + ONE_DAY_MS)),
   });
-
-  const binding = {
-    beachName: beach.name,
-    stationName: station.name,
-    stationRole: station.role,
-  };
 
   if (result.kind === "unavailable") {
     return {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -34,10 +34,10 @@ export default defineConfig({
       // run-vitest.mjs and check-built-css.mjs sit at 0% on purpose, and all
       // three drag these figures down in plain sight rather than quietly.
       thresholds: {
-        statements: 82.56,
-        branches: 85.5,
-        functions: 90.32,
-        lines: 82.77,
+        statements: 80.71,
+        branches: 82.25,
+        functions: 87.78,
+        lines: 80.17,
       },
     },
   },


### PR DESCRIPTION
Slice 4 of `docs/plans/conditions-tool.md`. Part of
https://github.com/cweber12/wild-coast-kids/issues/50 — slice 5 is not here, so
that issue stays open.

`/conditions` was one beach. It is now every public, active beach the state
publishes — **73** of them — each reading the station a join gave it, chosen from
a region-grouped list, with `/conditions/<beach>` as a shareable URL.

## Open question 2 is answered, and it was bigger than the plan assumed

The plan asked what tide station serves the lagoons and Mission Bay, assuming the
two stations the source repo used. NOAA publishes **nine** in the corridor.
**Eight deliver.**

`TWC0405` Point Loma answers **HTTP 200 carrying an error object** instead of
predictions — the exact failure this stack pins its parser against. A join built
from the published station list without measuring delivery would have bound the
middle of the open coast to a station that never answers. It is kept and marked
dead rather than deleted.

Station choice is not cosmetic. For the same low tide on 2026-08-18 the eight
working stations predicted **1.442 to 1.700 ft, across 13 minutes**.

## The join rule

Nearest **delivering** station whose **water class matches** the beach's, measured
**from whichever end of the segment is closer**. Each clause earns its place:

- *delivering*, because of `TWC0405`;
- *matching class*, because an ocean-facing beach near the bay mouth is
  geometrically closer to a bay station than to any coastal one, and a bay curve
  at an ocean beach is a wrong number that looks right;
- *from the closer end*, because the state publishes a beach as a segment, and a
  fixed end would push a long beach onto a station that is not its nearest.

A station's water class is **hand-written**, in a file whose values otherwise come
from upstream. NOAA publishes no such field, so no authority can state it; it has
the standing of a join input rather than a joined value, and `tide-stations.json`
says so at length.

## Upstream publishes a row with transposed coordinates

`Imperial Beach pier area` gives an upper longitude of **−117.5866** and a lower
latitude of **32.1327**, against neighbouring rows at 32.5866 / −117.1327. As
published it is a fifty-kilometre beach running from well offshore to inside Baja
California.

It is **detected and refused, not corrected** — correcting it would be inventing a
location. Two checks are needed: a bounding box alone misses an endpoint that
lands in the ocean at a plausible latitude; the span catches that.

That produced a fourth render state. **`no-station` is a permanent fact about a
place; `unavailable` is a transient fact about a feed.** Telling this reader to
try again later would be telling them to wait for something that will never
arrive.

## Re-runnable and diffable

```
$ node scripts/seed-beaches.mjs --check
beaches.json is current: 73 beaches, join unchanged.
```

It re-fetches, re-joins and exits 1 when a match moves, so "fix the join and
re-run it" is something a reviewer can do. It reaches the network, so it is **not**
a gate row. Its pure half — the join, the coordinate checks, the slug and region
rules — is exported and tested offline; only fetching, file IO and exit codes sit
behind the CLI guard.

## Verification

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

Exit code 0, 254 tests.

Against the running site, live NOAA, three beaches:

```
/conditions
  Lowest tide today · La Jolla Shores Beach — 6:24 AM — 1.4 ft above the average
  low tide. Predicted for La Jolla (Scripps Institution Wharf).

/conditions/san-onofre-state-beach
  … Predicted for La Jolla (Scripps Institution Wharf) — the nearest open-coast
  station publishing predictions, about 57 km away.

/conditions/imperial-beach-pier-area
  We cannot give a tide time for this beach. No tide station could be matched to
  it … the lower endpoint published upstream (32.1327, -117.1332) is outside San
  Diego County.
```

## Coverage floor lowered, and why

To **80.71 / 82.25 / 87.78 / 80.17** from 82.56 / 85.5 / 90.32 / 82.77. This is
reason 1 in `vitest.config.mts`: the denominator grew with deliberately-untested
entry plumbing. The uncovered statements are `seed-beaches.mjs`'s `fetchRows` and
`main` — network, file writes and exit codes — and `upstream.ts`, the one module
that touches the network while serving.

Worth saying plainly: the first attempt scored **68.4**. Rather than accept that
or exclude the file (which that config forbids), the script's rules were made
importable and tested, which is where 80.71 came from.

## What I did not do, and what is worth arguing with

- **Slice 5 is not here.** `inventoryCaveats()` exists and is tested; nothing
  renders it yet. That, plus the gate row that fails when a caveat reaches no
  reader, is the next PR.
- **The bay class lumps lagoons with San Diego Bay.** Agua Hedionda Lagoon in
  Carlsbad binds to Mission Bay Campland 40 km south, because those are the
  published bay stations. It is the honest nearest match and it is not a good
  tidal analogue; recorded as a caveat rather than fixed.
- **The `noscript` fallback is the only no-JS path.** The `select` needs
  JavaScript to navigate, so the fallback lists every beach as a plain link. Its
  test renders server markup, because the client renderer never parses `noscript`
  contents.
- **The region bands are latitude, not local knowledge.** "Point Loma and Ocean
  Beach" is a band from 32.65 to 32.8, not a neighbourhood boundary anyone in San
  Diego would draw. It is display-only and never a join input, but a local will
  find an entry in the wrong group eventually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
