### PR TITLE
Show the reader what this data is unsure about

### DIFF
--- a/docs/plans/conditions-tool.md
+++ b/docs/plans/conditions-tool.md
@@ -398,3 +398,42 @@ San Diego rows down to 73.
 **Slice 4 ships without slice 5**, for the same reason slice 3 shipped alone: size.
 `inventoryCaveats()` exists and is tested, and nothing renders it yet — that is
 slice 5, together with the gate row that fails when a caveat reaches no reader.
+
+### 2026-08-18 — slice 5 lands, and the "gate row" is two tests
+
+Slice 5 said a gate row that fails when an `unresolved` entry has no path to a
+reader. It is **two tests under the existing `test` row** instead, and the
+distinction is worth stating because it is a deviation from the plan.
+
+Half the check has to render React to know whether a caveat reached a reader, and
+the test runner already does that. A separate row would have had to stand up its
+own renderer to assert the same thing, so the row would have been a second way of
+running the suite rather than a second check. `test` is a gate row; the guarantee
+is unchanged.
+
+The two halves are deliberately in different files, because they guard different
+seams:
+
+- `src/lib/caveats.test.ts` walks `src/data/` and asserts nothing is dropped
+  between the **files and the loader**. It walks rather than reading a list, so a
+  data file added later is discovered instead of forgotten.
+- `src/components/ConditionsSection.test.tsx` asserts nothing is dropped between
+  the **loader and the reader**.
+
+Both are two-sided. The walk asserts it found files and entries at all, since a
+discovery that found nothing would satisfy every other assertion while checking
+nothing; and the loader is asserted to show nothing the data files do not carry,
+so a caveat cannot be invented in code.
+
+**Demonstrated rather than assumed.** A `src/data/probe-unwired.json` carrying one
+caveat and imported by nothing was added; the suite failed with
+`probe-unwired.json carries a caveat that nothing loads, so no reader will ever
+see it`. Removing the file returned it to green. A check that has never failed is
+not yet evidence.
+
+Seven caveats render on `/conditions` today, from two data files.
+
+**This completes the plan's slices 3 to 5.** Slices 6 onwards — waves and water
+temp, wind and visibility, the forward panel, the safety layer, water quality,
+the education layer, the weekly probe, and the landing-page teaser — are
+unstarted.

--- a/src/components/Caveats.test.tsx
+++ b/src/components/Caveats.test.tsx
@@ -1,0 +1,32 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Caveats } from "./Caveats";
+
+const ENTRIES = [
+  "beach_type is UNKNOWN upstream for most of these beaches.",
+  "TWC0405 Point Loma does not deliver predictions.",
+];
+
+test("every caveat given is rendered, not a summary of them", () => {
+  render(<Caveats entries={ENTRIES} />);
+
+  for (const entry of ENTRIES) {
+    expect(screen.getByText(entry)).toBeDefined();
+  }
+});
+
+test("they sit behind a disclosure, so the tide time is not buried", () => {
+  const { container } = render(<Caveats entries={ENTRIES} />);
+
+  expect(container.querySelector("details")).not.toBeNull();
+  expect(
+    screen.getByText("What we are unsure about in this data"),
+  ).toBeDefined();
+});
+
+test("nothing is rendered when there is nothing to disclose", () => {
+  // An empty disclosure inviting a reader to open it and find nothing is worse
+  // than no disclosure.
+  const { container } = render(<Caveats entries={[]} />);
+  expect(container.firstChild).toBeNull();
+});

--- a/src/components/Caveats.tsx
+++ b/src/components/Caveats.tsx
@@ -1,0 +1,35 @@
+/**
+ * What this site does not know, on the page where it matters.
+ *
+ * The data files carry `unresolved` arrays: a station whose water class is an
+ * author's judgement, a beach whose coordinates upstream published wrong, a gap
+ * in NOAA's own predictions. Those entries exist to be read by the person acting
+ * on the number, not by whoever maintains the repo — a caveat that reaches only a
+ * maintainer is a caveat nobody was warned by.
+ *
+ * They sit behind a disclosure rather than on the page, because the reader came
+ * for a tide time and a wall of qualifications would bury it. The disclosure is
+ * the compromise that lets the list be comprehensive and the page stay readable:
+ * a beach whose water-quality station is unresolved can still ship, because the
+ * page says it is unresolved.
+ *
+ * The gate asserts that every entry in every data file arrives here, so a caveat
+ * cannot be added to a file and quietly reach no reader.
+ */
+
+export function Caveats({ entries }: { entries: readonly string[] }) {
+  if (entries.length === 0) return null;
+
+  return (
+    <details className="mt-9 max-w-130 text-sm text-fog">
+      <summary>What we are unsure about in this data</summary>
+      <ul className="leading-relaxed mt-3">
+        {entries.map((entry) => (
+          <li key={entry} className="mb-3">
+            {entry}
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}

--- a/src/components/ConditionsSection.test.tsx
+++ b/src/components/ConditionsSection.test.tsx
@@ -1,0 +1,31 @@
+import { expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/components/TidePanel", () => ({
+  TidePanel: ({ slug }: { slug: string }) => <p>panel for {slug}</p>,
+}));
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+const { ConditionsSection } = await import("./ConditionsSection");
+const { inventoryCaveats, DEFAULT_BEACH_SLUG } = await import("@/lib/beaches");
+
+test("the view carries the chooser, the reading and the caveats", () => {
+  render(<ConditionsSection slug={DEFAULT_BEACH_SLUG} />);
+
+  expect(screen.getByLabelText("Choose a beach")).toBeDefined();
+  expect(screen.getByText(`panel for ${DEFAULT_BEACH_SLUG}`)).toBeDefined();
+  expect(
+    screen.getByText("What we are unsure about in this data"),
+  ).toBeDefined();
+});
+
+test("every caveat the data files carry reaches this page", () => {
+  render(<ConditionsSection slug={DEFAULT_BEACH_SLUG} />);
+
+  // The other half of the check in src/lib/caveats.test.ts: that one asserts
+  // nothing is dropped between the files and the loader, this one asserts
+  // nothing is dropped between the loader and the reader.
+  for (const caveat of inventoryCaveats()) {
+    expect(screen.getByText(caveat)).toBeDefined();
+  }
+});

--- a/src/components/ConditionsSection.tsx
+++ b/src/components/ConditionsSection.tsx
@@ -9,8 +9,9 @@
  */
 
 import { Suspense } from "react";
-import { beachesByRegion } from "@/lib/beaches";
+import { beachesByRegion, inventoryCaveats } from "@/lib/beaches";
 import { BeachSelector } from "./BeachSelector";
+import { Caveats } from "./Caveats";
 import { TidePanel } from "./TidePanel";
 
 export function ConditionsSection({ slug }: { slug: string }) {
@@ -47,6 +48,8 @@ export function ConditionsSection({ slug }: { slug: string }) {
       >
         <TidePanel slug={slug} />
       </Suspense>
+
+      <Caveats entries={inventoryCaveats()} />
     </section>
   );
 }

--- a/src/lib/caveats.test.ts
+++ b/src/lib/caveats.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import { inventoryCaveats } from "./beaches";
+
+/**
+ * The gate that stops a caveat reaching nobody.
+ *
+ * Every data file may carry an `unresolved` array. The entries are written for
+ * the person acting on the number, so one that only a maintainer ever sees has
+ * failed at its whole purpose. These assertions walk the data directory rather
+ * than a list, so a file added later is discovered instead of forgotten — the
+ * failure mode being guarded against is a new file whose caveats nothing loads,
+ * which no amount of care prevents and a walk does.
+ *
+ * The path is resolved from the working directory rather than `import.meta.url`,
+ * which is not a `file:` URL under this test environment.
+ */
+const DATA_DIRECTORY = join(process.cwd(), "src", "data");
+
+function dataFiles(): string[] {
+  return readdirSync(DATA_DIRECTORY).filter((name) => name.endsWith(".json"));
+}
+
+function unresolvedIn(file: string): string[] {
+  const parsed = JSON.parse(readFileSync(join(DATA_DIRECTORY, file), "utf8"));
+  const entries = parsed.unresolved;
+  if (entries === undefined) return [];
+  expect(Array.isArray(entries), `${file}: unresolved must be an array`).toBe(
+    true,
+  );
+  return entries;
+}
+
+describe("every data file's caveats", () => {
+  test("the walk finds files to check, so a green run is not an empty one", () => {
+    // Two-sided: a discovery that found nothing would satisfy every assertion
+    // below and assert nothing at all.
+    const files = dataFiles();
+    expect(files.length).toBeGreaterThan(0);
+    expect(files.flatMap(unresolvedIn).length).toBeGreaterThan(0);
+  });
+
+  test("are all loaded, whichever file they are in", () => {
+    const loaded = new Set(inventoryCaveats());
+
+    for (const file of dataFiles()) {
+      for (const entry of unresolvedIn(file)) {
+        expect(
+          loaded.has(entry),
+          `${file} carries a caveat that nothing loads, so no reader will ever see it:\n  ${entry}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  test("are non-empty strings, since an empty one warns nobody", () => {
+    for (const file of dataFiles()) {
+      for (const entry of unresolvedIn(file)) {
+        expect(typeof entry).toBe("string");
+        expect(entry.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("carry nothing the data files do not, so none is invented in code", () => {
+    const onDisk = new Set(dataFiles().flatMap(unresolvedIn));
+    for (const entry of inventoryCaveats()) {
+      expect(
+        onDisk.has(entry),
+        `a caveat is being shown that no data file carries:\n  ${entry}`,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes #50

Slice 5, and the last of the plan's slices 3 to 5.

The data files have carried `unresolved` arrays since slice 3 — a station whose
water class is an author's judgement, a beach whose coordinates upstream published
wrong, a gap in NOAA's own predictions — and `inventoryCaveats()` was wired to
nothing. A caveat that reaches only a maintainer is a caveat nobody was warned by.

Seven entries from two data files now render on `/conditions`, behind a disclosure
rather than on the page. The reader came for a tide time; a wall of qualifications
in front of it would bury the thing they came for. The disclosure is what lets the
list be comprehensive and the page stay readable — a beach whose station is
unresolved can still ship, **because the page says it is unresolved.**

## The plan said a gate row; this is two tests under the existing `test` row

Worth flagging as a deviation. Half the check has to render React to know whether
a caveat reached a reader, and the test runner already does that — a separate row
would have stood up its own renderer to assert the same thing, making it a second
way of running the suite rather than a second check. `test` is a gate row; the
guarantee is unchanged.

The halves guard different seams, so they live in different files:

- `src/lib/caveats.test.ts` walks `src/data/` and asserts nothing is dropped
  between the **files and the loader**;
- `src/components/ConditionsSection.test.tsx` asserts nothing is dropped between
  the **loader and the reader**.

It walks the directory rather than reading a list, because the failure being
guarded against is a data file added later whose caveats nothing loads — which no
amount of care prevents and a walk does.

Both are two-sided: the walk asserts it found files and entries at all (a
discovery that found nothing would satisfy every other assertion while checking
nothing), and the loader is asserted to show nothing the data files do not carry,
so a caveat cannot be invented in code.

## Demonstrated, not assumed

A check that has never failed is not yet evidence, so I made it fail. Adding
`src/data/probe-unwired.json` with one caveat and no importer:

```
× are all loaded, whichever file they are in
AssertionError: probe-unwired.json carries a caveat that nothing loads, so no
reader will ever see it:
  A caveat in a file nothing imports. No reader will ever see it.
      Tests  1 failed | 3 passed (4)
```

Removing the file:

```
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

## Verification

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

Exit code 0.

Against the running site, `/conditions` serves the disclosure and seven caveat
items, including:

```
What we are unsure about in this data
  TWC0405 Point Loma is the only tide-prediction station on the open coast
  between La Jolla and Imperial Beach, and it does not deliver…
  beach_type is UNKNOWN upstream for most of these beaches…
```

## What this does not do

- **The caveats are inventory-wide, not per-beach.** Every beach shows all seven,
  including the one about a beach whose coordinates are unusable — which is only
  true of one of the 73. Narrowing them to the beach in view is a real
  improvement and is not here; it needs the entries to carry a scope, which is a
  data-shape change rather than a rendering one.
- **Slices 6 onward are unstarted** — waves and water temp, wind and visibility,
  the forward panel, the safety layer, water quality, the education layer, the
  weekly probe, and the landing-page teaser. `docs/plans/conditions-tool.md` is
  current as of this PR.
- **No gate reads whether a caveat is well written.** It asserts every entry
  reaches the page. Whether these seven say the right thing to a parent is a
  judgement, and it is the part worth arguing with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
