### PR TITLE
Show waves and water temperature, from the buoy the join picked

### DIFF
--- a/docs/plans/conditions-tool.md
+++ b/docs/plans/conditions-tool.md
@@ -437,3 +437,45 @@ Seven caveats render on `/conditions` today, from two data files.
 temp, wind and visibility, the forward panel, the safety layer, water quality,
 the education layer, the weekly probe, and the landing-page teaser — are
 unstarted.
+
+### 2026-08-18 — slice 6, and wind stops being optional
+
+**Ten delivering wave buoys**, measured one at a time against `realtime2` rather
+than read off `activestations.xml`, which lists nineteen stations in the box.
+Every delivering one publishes `WVHT`, `DPD`, `MWD` **and `WTMP`**, so waves and
+water temperature arrive in a single fetch.
+
+**No nearshore buoy publishes wind or visibility — none of the ten.** Slice 3 saw
+this on 46254 and recorded it as one station's quirk; across the corridor it is
+categorical. The only station in the box with wind, 46086, is twenty-seven
+nautical miles offshore and publishes no waves. So slice 7 is not an enhancement:
+two of the four words in the site's own "Surf · Tide · Wind · Visibility" can only
+ever come from the National Weather Service gridpoint forecast.
+
+**Two more listed-but-dead stations.** 46273 Torrey Pines Inner and 46235 Imperial
+Beach both 404 while listed active — 46235 independently confirming what
+`socal-coastal-data` recorded. That is the third time the pattern has appeared,
+after `TWC0405` in the tide join, and it is why every station table in this repo
+carries a measured `delivers` rather than an inherited one.
+
+**Bay beaches get no wave reading at all**, decided with Cole. The wave join is
+deliberately asymmetric with the tide join: the tide has two classes and binds to
+the matching one, while every wave buoy is open-coast, so a bay, lagoon or inlet
+binds to nothing. 27 of the 73 beaches have no wave height, and their pages say
+why. Their water temperature is missing for the same reason and waits for the
+surf zone forecast's county-wide range in slice 9.
+
+**The geometry moved out of the tide join first**, into `scripts/geo.mjs`, as its
+own commit. Two joins need great-circle distance now, and geometry filed under
+either would be found by whoever was not looking for it.
+
+**The parser reads its own units.** Unusually, `realtime2` states them on its
+second header line, so `m` and `degC` are asserted rather than assumed — an
+upstream switch to feet would otherwise be invisible and would read as a very
+calm day.
+
+**Coverage rose to 86.14 / 86.87 / 90.9 / 86.06** and the floor was raised to
+match. The new fetch policy is tested by stubbing `fetch` rather than left as
+plumbing: what a 404 means, when a reading is too old to be called current, and
+which failures are drift are rules, not wiring, and none of them can be asserted
+against a live buoy that is having a good day.

--- a/scripts/geo.mjs
+++ b/scripts/geo.mjs
@@ -1,0 +1,49 @@
+/**
+ * Distances along a coastline, for the joins next door.
+ *
+ * Pure geometry and nothing else. It lives on its own because two joins need it
+ * now -- a beach to a tide station, and a beach to a wave buoy -- and geometry
+ * filed under either of them would be found by whoever was not looking for it.
+ */
+
+const EARTH_RADIUS_M = 6371008.8;
+
+const toRadians = (degrees) => (degrees * Math.PI) / 180;
+
+/**
+ * Great-circle distance in metres.
+ *
+ * Haversine rather than a projected approximation: the corridor is small enough
+ * that either would do, and this one has no zone to get wrong.
+ *
+ * @param {{lat: number, lon: number}} a
+ * @param {{lat: number, lon: number}} b
+ * @returns {number}
+ */
+export function distanceMetres(a, b) {
+  const dLat = toRadians(b.lat - a.lat);
+  const dLon = toRadians(b.lon - a.lon);
+  const latA = toRadians(a.lat);
+  const latB = toRadians(b.lat);
+
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(latA) * Math.cos(latB) * Math.sin(dLon / 2) ** 2;
+
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(h));
+}
+
+/**
+ * The distance from a beach segment to a point, and which end supplied it.
+ *
+ * @param {{upper: {lat: number, lon: number}, lower: {lat: number, lon: number}}} segment
+ * @param {{lat: number, lon: number}} point
+ * @returns {{metres: number, end: "upper" | "lower"}}
+ */
+export function segmentDistance(segment, point) {
+  const upper = distanceMetres(segment.upper, point);
+  const lower = distanceMetres(segment.lower, point);
+  return upper <= lower
+    ? { metres: upper, end: "upper" }
+    : { metres: lower, end: "lower" };
+}

--- a/scripts/geo.test.mjs
+++ b/scripts/geo.test.mjs
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { distanceMetres, segmentDistance } from "./geo.mjs";
+
+describe("distanceMetres", () => {
+  it("is zero for a point and itself", () => {
+    expect(
+      distanceMetres({ lat: 32.8, lon: -117.2 }, { lat: 32.8, lon: -117.2 }),
+    ).toBe(0);
+  });
+
+  it("matches a known separation", () => {
+    // La Jolla to Imperial Beach station, about 34 km down the coast.
+    const metres = distanceMetres(
+      { lat: 32.8669, lon: -117.2571 },
+      { lat: 32.5783, lon: -117.135 },
+    );
+    expect(metres).toBeGreaterThan(33_000);
+    expect(metres).toBeLessThan(35_000);
+  });
+
+  it("is symmetric", () => {
+    const a = { lat: 32.8669, lon: -117.2571 };
+    const b = { lat: 32.5783, lon: -117.135 };
+    expect(distanceMetres(a, b)).toBeCloseTo(distanceMetres(b, a), 6);
+  });
+});
+
+describe("segmentDistance", () => {
+  it("measures from whichever end is closer, and says which", () => {
+    const segment = {
+      upper: { lat: 33.2, lon: -117.4 },
+      lower: { lat: 32.87, lon: -117.26 },
+    };
+    const result = segmentDistance(segment, { lat: 32.8669, lon: -117.2571 });
+
+    expect(result.end).toBe("lower");
+    // A long beach must not be pushed onto a distant station by its far end.
+    expect(result.metres).toBeLessThan(1000);
+  });
+
+  it("prefers the upper end when it is the closer one", () => {
+    const segment = {
+      upper: { lat: 32.87, lon: -117.26 },
+      lower: { lat: 32.2, lon: -117.1 },
+    };
+    expect(segmentDistance(segment, { lat: 32.8669, lon: -117.2571 }).end).toBe(
+      "upper",
+    );
+  });
+});

--- a/scripts/seed-beaches.mjs
+++ b/scripts/seed-beaches.mjs
@@ -27,6 +27,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { distanceMetres } from "./geo.mjs";
 import { bindTideStation } from "./tide-join.mjs";
+import { bindWaveBuoy } from "./wave-join.mjs";
 
 const PORTAL = "https://data.cnra.ca.gov";
 const RESOURCE = "cc674e59-036c-45c3-bec2-5d3d294e0e3d";
@@ -35,6 +36,7 @@ const DATASET =
 const MIRROR_RESOURCE = "fcbc9250-06e3-437d-b0c6-3cc5ddde93fc";
 
 const BEACHES_PATH = new URL("../src/data/beaches.json", import.meta.url);
+const BUOYS_PATH = new URL("../src/data/wave-buoys.json", import.meta.url);
 const STATIONS_PATH = new URL(
   "../src/data/tide-stations.json",
   import.meta.url,
@@ -190,7 +192,7 @@ export function regionOf(waterClass, meanLat) {
   return "South County coast";
 }
 
-export function build(rows, stations) {
+export function build(rows, stations, buoys) {
   const seen = new Map();
 
   const beaches = rows.map((row) => {
@@ -225,6 +227,9 @@ export function build(rows, stations) {
           { segment, waterBodyType: row.WaterBodyType },
           stations,
         );
+    const wave = fault
+      ? { buoyId: null, reason: fault }
+      : bindWaveBuoy({ segment, waterBodyType: row.WaterBodyType }, buoys);
 
     const meanLat = (segment.upper.lat + segment.lower.lat) / 2;
 
@@ -249,6 +254,10 @@ export function build(rows, stations) {
         : null,
       tide_station_from_end: bound.stationId ? bound.fromEnd : null,
       tide_station_null_reason: bound.stationId ? undefined : bound.reason,
+      wave_buoy: wave.buoyId,
+      wave_buoy_distance_m: wave.buoyId ? Math.round(wave.distanceM) : null,
+      wave_buoy_from_end: wave.buoyId ? wave.fromEnd : null,
+      wave_buoy_null_reason: wave.buoyId ? undefined : wave.reason,
     };
   });
 
@@ -328,6 +337,10 @@ export function document(beaches) {
         `${(farthest.tide_station_distance_m / 1000).toFixed(1)} km. See tide-stations.json, ` +
         `whose own unresolved list records that the one open-coast station between La Jolla and ` +
         `Imperial Beach does not deliver predictions.`,
+      `${beaches.filter((b) => b.wave_buoy === null).length} of these beaches get no wave height at all. ` +
+        `Every NDBC wave buoy sits on the open coast, and ocean swell does not reach into a bay or ` +
+        `lagoon, so binding one to the nearest buoy would put an open-ocean number on enclosed water. ` +
+        `Their water temperature is missing for the same reason and is not yet filled from another source.`,
       "A tide prediction is for the station, not for the beach. It is the best published figure " +
         "for that stretch of shore and it is not a measurement taken there.",
       ...(unbound.length > 0
@@ -358,6 +371,7 @@ async function main() {
   const checkOnly = process.argv.includes("--check");
 
   const stations = JSON.parse(readFileSync(STATIONS_PATH, "utf8")).stations;
+  const buoys = JSON.parse(readFileSync(BUOYS_PATH, "utf8")).buoys;
   let existing = null;
   try {
     existing = JSON.parse(readFileSync(BEACHES_PATH, "utf8"));
@@ -366,7 +380,7 @@ async function main() {
   }
 
   const rows = await fetchRows();
-  const built = document(build(rows, stations));
+  const built = document(build(rows, stations, buoys));
 
   // `generated` is the one field that moves on every run by design, so comparing
   // it would make every check fail and mean nothing.

--- a/scripts/seed-beaches.mjs
+++ b/scripts/seed-beaches.mjs
@@ -25,7 +25,8 @@
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
-import { bindTideStation, distanceMetres } from "./tide-join.mjs";
+import { distanceMetres } from "./geo.mjs";
+import { bindTideStation } from "./tide-join.mjs";
 
 const PORTAL = "https://data.cnra.ca.gov";
 const RESOURCE = "cc674e59-036c-45c3-bec2-5d3d294e0e3d";

--- a/scripts/seed-beaches.test.mjs
+++ b/scripts/seed-beaches.test.mjs
@@ -7,6 +7,21 @@ import {
   slugify,
 } from "./seed-beaches.mjs";
 
+const BUOYS = {
+  46254: {
+    lat: 32.868,
+    lon: -117.267,
+    delivers: true,
+    publishes_waves: true,
+  },
+  46235: {
+    lat: 32.57,
+    lon: -117.169,
+    delivers: false,
+    publishes_waves: false,
+  },
+};
+
 const STATIONS = {
   9410230: {
     lat: 32.8669,
@@ -105,12 +120,30 @@ describe("regionOf", () => {
 
 describe("build", () => {
   it("binds a beach and records how the join measured it", () => {
-    const [beach] = build([row()], STATIONS);
+    const [beach] = build([row()], STATIONS, BUOYS);
 
     expect(beach.slug).toBe("somewhere-beach");
     expect(beach.tide_station).toBe("9410230");
     expect(beach.tide_station_distance_m).toBeGreaterThan(0);
     expect(["upper", "lower"]).toContain(beach.tide_station_from_end);
+
+    // The wave binding rides along on the same walk, and an open-coast beach
+    // gets one.
+    expect(beach.wave_buoy).toBe("46254");
+    expect(beach.wave_buoy_distance_m).toBeGreaterThan(0);
+  });
+
+  it("gives a bay beach a tide station and no wave buoy", () => {
+    const [beach] = build(
+      [row({ WaterBodyType: "Sound, Bay, or Inlet" })],
+      STATIONS,
+      BUOYS,
+    );
+
+    // Swell does not reach into a bay, and the tide certainly does.
+    expect(beach.tide_station).toBe("9410170");
+    expect(beach.wave_buoy).toBeNull();
+    expect(beach.wave_buoy_null_reason).toMatch(/does not reach into a bay/);
   });
 
   it("refuses a beach whose coordinates cannot be used, and says why", () => {
@@ -125,6 +158,7 @@ describe("build", () => {
         }),
       ],
       STATIONS,
+      BUOYS,
     );
 
     expect(beach.tide_station).toBeNull();
@@ -134,18 +168,20 @@ describe("build", () => {
   it("stops on a duplicate slug rather than disambiguating one", () => {
     // A slug is a primary key. Making one unique automatically would make it
     // unstable, and data accumulates against it.
-    expect(() => build([row(), row()], STATIONS)).toThrow(/is claimed by both/);
+    expect(() => build([row(), row()], STATIONS, BUOYS)).toThrow(
+      /is claimed by both/,
+    );
   });
 
   it("stops when a pinned column is missing", () => {
     const missing = row();
     delete missing["Beach_ UpperLon"];
-    expect(() => build([missing], STATIONS)).toThrow(/has drifted/);
+    expect(() => build([missing], STATIONS, BUOYS)).toThrow(/has drifted/);
   });
 
   it("stops when a coordinate does not parse", () => {
     expect(() =>
-      build([row({ Beach_UpperLat: "north a bit" })], STATIONS),
+      build([row({ Beach_UpperLat: "north a bit" })], STATIONS, BUOYS),
     ).toThrow(/did not parse as numbers/);
   });
 
@@ -164,6 +200,7 @@ describe("build", () => {
         }),
       ],
       STATIONS,
+      BUOYS,
     );
     expect(built.map((b) => b.slug)).toEqual(["north-one", "south-one"]);
   });
@@ -180,6 +217,7 @@ describe("document", () => {
         }),
       ],
       STATIONS,
+      BUOYS,
     );
     const doc = document(built);
 
@@ -192,7 +230,7 @@ describe("document", () => {
     // Carrying entries forward from the file duplicated them on the second run,
     // and made --check report movement immediately after a seed. A check that
     // cannot say "unchanged" says nothing.
-    const built = build([row()], STATIONS);
+    const built = build([row()], STATIONS, BUOYS);
     const first = document(built).unresolved;
     const second = document(built).unresolved;
 

--- a/scripts/tide-join.mjs
+++ b/scripts/tide-join.mjs
@@ -26,47 +26,7 @@
  * script and never recomputed while serving a reader.
  */
 
-const EARTH_RADIUS_M = 6371008.8;
-
-const toRadians = (degrees) => (degrees * Math.PI) / 180;
-
-/**
- * Great-circle distance in metres.
- *
- * Haversine rather than a projected approximation: the corridor is small enough
- * that either would do, and this one has no zone to get wrong.
- *
- * @param {{lat: number, lon: number}} a
- * @param {{lat: number, lon: number}} b
- * @returns {number}
- */
-export function distanceMetres(a, b) {
-  const dLat = toRadians(b.lat - a.lat);
-  const dLon = toRadians(b.lon - a.lon);
-  const latA = toRadians(a.lat);
-  const latB = toRadians(b.lat);
-
-  const h =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos(latA) * Math.cos(latB) * Math.sin(dLon / 2) ** 2;
-
-  return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(h));
-}
-
-/**
- * The distance from a beach segment to a point, and which end supplied it.
- *
- * @param {{upper: {lat: number, lon: number}, lower: {lat: number, lon: number}}} segment
- * @param {{lat: number, lon: number}} point
- * @returns {{metres: number, end: "upper" | "lower"}}
- */
-export function segmentDistance(segment, point) {
-  const upper = distanceMetres(segment.upper, point);
-  const lower = distanceMetres(segment.lower, point);
-  return upper <= lower
-    ? { metres: upper, end: "upper" }
-    : { metres: lower, end: "lower" };
-}
+import { segmentDistance } from "./geo.mjs";
 
 /**
  * The water class a beach belongs to, from the value the state publishes.

--- a/scripts/tide-join.test.mjs
+++ b/scripts/tide-join.test.mjs
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  bindTideStation,
-  distanceMetres,
-  segmentDistance,
-  waterClassOf,
-} from "./tide-join.mjs";
+import { bindTideStation, waterClassOf } from "./tide-join.mjs";
 
 /** A cut-down station table with the properties the rule turns on. */
 const STATIONS = {
@@ -25,54 +20,6 @@ const STATIONS = {
 };
 
 const near = (lat, lon) => ({ upper: { lat, lon }, lower: { lat, lon } });
-
-describe("distanceMetres", () => {
-  it("is zero for a point and itself", () => {
-    expect(
-      distanceMetres({ lat: 32.8, lon: -117.2 }, { lat: 32.8, lon: -117.2 }),
-    ).toBe(0);
-  });
-
-  it("matches a known separation", () => {
-    // La Jolla to Imperial Beach station, about 34 km down the coast.
-    const metres = distanceMetres(
-      { lat: 32.8669, lon: -117.2571 },
-      { lat: 32.5783, lon: -117.135 },
-    );
-    expect(metres).toBeGreaterThan(33_000);
-    expect(metres).toBeLessThan(35_000);
-  });
-
-  it("is symmetric", () => {
-    const a = { lat: 32.8669, lon: -117.2571 };
-    const b = { lat: 32.5783, lon: -117.135 };
-    expect(distanceMetres(a, b)).toBeCloseTo(distanceMetres(b, a), 6);
-  });
-});
-
-describe("segmentDistance", () => {
-  it("measures from whichever end is closer, and says which", () => {
-    const segment = {
-      upper: { lat: 33.2, lon: -117.4 },
-      lower: { lat: 32.87, lon: -117.26 },
-    };
-    const result = segmentDistance(segment, { lat: 32.8669, lon: -117.2571 });
-
-    expect(result.end).toBe("lower");
-    // A long beach must not be pushed onto a distant station by its far end.
-    expect(result.metres).toBeLessThan(1000);
-  });
-
-  it("prefers the upper end when it is the closer one", () => {
-    const segment = {
-      upper: { lat: 32.87, lon: -117.26 },
-      lower: { lat: 32.2, lon: -117.1 },
-    };
-    expect(segmentDistance(segment, { lat: 32.8669, lon: -117.2571 }).end).toBe(
-      "upper",
-    );
-  });
-});
 
 describe("waterClassOf", () => {
   it("reads the two published values", () => {

--- a/scripts/wave-join.mjs
+++ b/scripts/wave-join.mjs
@@ -1,0 +1,76 @@
+/**
+ * Binding a beach to a wave buoy.
+ *
+ * Pure, like the tide join beside it, and the same shape: nearest **delivering**
+ * candidate, measured from whichever end of the beach's segment is closer.
+ *
+ * WHAT DIFFERS IS THE CLASS RULE, AND IT IS NOT SYMMETRIC. The tide join has two
+ * classes and binds a beach to the matching one. Here there is one class of
+ * candidate, because every wave buoy sits on the open coast, and a bay or inlet
+ * beach is therefore bound to **nothing**. Ocean swell does not propagate into a
+ * bay or a lagoon, so the nearest buoy's height would describe different water:
+ * a parent reading three feet before a paddle with children would be told
+ * something false about the place they are going. A missing number they can see
+ * is better than a confident wrong one.
+ *
+ * `publishes_waves` is checked separately from `delivers` because one station in
+ * the table answers perfectly and carries no wave height at all.
+ */
+
+import { segmentDistance } from "./geo.mjs";
+import { waterClassOf } from "./tide-join.mjs";
+
+/**
+ * Bind one beach to a wave buoy.
+ *
+ * @param {{segment: object, waterBodyType: string}} beach
+ * @param {Record<string, {lat: number, lon: number, delivers: boolean, publishes_waves: boolean}>} buoys
+ * @returns {{buoyId: string, distanceM: number, fromEnd: string}
+ *   | {buoyId: null, reason: string}}
+ */
+export function bindWaveBuoy(beach, buoys) {
+  const waterClass = waterClassOf(beach.waterBodyType);
+
+  if (waterClass === null) {
+    return {
+      buoyId: null,
+      reason: `water body type ${JSON.stringify(beach.waterBodyType)} is not one this join recognises`,
+    };
+  }
+
+  if (waterClass !== "open-coast") {
+    return {
+      buoyId: null,
+      reason:
+        "every wave buoy sits on the open coast, and ocean swell does not reach into a bay " +
+        "or lagoon, so no buoy describes the water here",
+    };
+  }
+
+  const candidates = Object.entries(buoys).filter(
+    ([, buoy]) => buoy.delivers && buoy.publishes_waves,
+  );
+
+  if (candidates.length === 0) {
+    return {
+      buoyId: null,
+      reason: "no delivering wave buoy exists to bind to",
+    };
+  }
+
+  let best = null;
+  for (const [buoyId, buoy] of candidates) {
+    const { metres, end } = segmentDistance(beach.segment, buoy);
+    // Ties break on the id, so two runs over the same inputs produce the same
+    // file and the re-join's diff keeps meaning something.
+    if (
+      best === null ||
+      metres < best.distanceM ||
+      (metres === best.distanceM && buoyId < best.buoyId)
+    ) {
+      best = { buoyId, distanceM: metres, fromEnd: end };
+    }
+  }
+
+  return best;
+}

--- a/scripts/wave-join.test.mjs
+++ b/scripts/wave-join.test.mjs
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { bindWaveBuoy } from "./wave-join.mjs";
+
+const BUOYS = {
+  46254: { lat: 32.868, lon: -117.267, delivers: true, publishes_waves: true },
+  46232: { lat: 32.517, lon: -117.425, delivers: true, publishes_waves: true },
+  46235: { lat: 32.57, lon: -117.169, delivers: false, publishes_waves: false },
+  46086: { lat: 32.504, lon: -118.029, delivers: true, publishes_waves: false },
+};
+
+const at = (lat, lon) => ({ upper: { lat, lon }, lower: { lat, lon } });
+
+describe("bindWaveBuoy", () => {
+  it("binds an open-coast beach to the nearest delivering buoy", () => {
+    const bound = bindWaveBuoy(
+      { segment: at(32.87, -117.26), waterBodyType: "Open Coast" },
+      BUOYS,
+    );
+    expect(bound.buoyId).toBe("46254");
+    expect(bound.distanceM).toBeGreaterThan(0);
+    expect(["upper", "lower"]).toContain(bound.fromEnd);
+  });
+
+  it("gives a bay beach no buoy at all, and says why", () => {
+    // The nearest buoy is a few hundred metres away and still describes water
+    // the swell never reaches.
+    const bound = bindWaveBuoy(
+      { segment: at(32.868, -117.266), waterBodyType: "Sound, Bay, or Inlet" },
+      BUOYS,
+    );
+    expect(bound.buoyId).toBeNull();
+    expect(bound.reason).toMatch(/does not reach into a bay/);
+  });
+
+  it("never chooses a buoy that does not deliver", () => {
+    // 46235 is the closest thing to the south county and answers 404.
+    const bound = bindWaveBuoy(
+      { segment: at(32.575, -117.17), waterBodyType: "Open Coast" },
+      BUOYS,
+    );
+    expect(bound.buoyId).not.toBe("46235");
+    expect(bound.buoyId).toBe("46232");
+  });
+
+  it("never chooses a delivering station that carries no wave height", () => {
+    // 46086 answers with rows, and none of them has WVHT in it.
+    const bound = bindWaveBuoy(
+      { segment: at(32.5, -117.9), waterBodyType: "Open Coast" },
+      BUOYS,
+    );
+    expect(bound.buoyId).not.toBe("46086");
+  });
+
+  it("refuses an unreadable water body type rather than guessing", () => {
+    const bound = bindWaveBuoy(
+      { segment: at(32.87, -117.26), waterBodyType: "Estuarine" },
+      BUOYS,
+    );
+    expect(bound.buoyId).toBeNull();
+    expect(bound.reason).toMatch(/not one this join recognises/);
+  });
+
+  it("says so when no delivering buoy exists at all", () => {
+    const bound = bindWaveBuoy(
+      { segment: at(32.87, -117.26), waterBodyType: "Open Coast" },
+      { 46235: BUOYS["46235"] },
+    );
+    expect(bound.buoyId).toBeNull();
+    expect(bound.reason).toMatch(/no delivering wave buoy/);
+  });
+
+  it("is deterministic when two buoys tie", () => {
+    const tied = {
+      bbb: { lat: 32.8, lon: -117.2, delivers: true, publishes_waves: true },
+      aaa: { lat: 32.8, lon: -117.2, delivers: true, publishes_waves: true },
+    };
+    const bound = bindWaveBuoy(
+      { segment: at(32.8, -117.2), waterBodyType: "Open Coast" },
+      tied,
+    );
+    expect(bound.buoyId).toBe("aaa");
+  });
+});

--- a/src/app/conditions/[slug]/page.test.tsx
+++ b/src/app/conditions/[slug]/page.test.tsx
@@ -4,6 +4,9 @@ import { render, screen } from "@testing-library/react";
 vi.mock("@/components/TidePanel", () => ({
   TidePanel: ({ slug }: { slug: string }) => <p>panel for {slug}</p>,
 }));
+vi.mock("@/components/WavePanel", () => ({
+  WavePanel: ({ slug }: { slug: string }) => <p>waves for {slug}</p>,
+}));
 
 const notFound = vi.fn(() => {
   throw new Error("NEXT_NOT_FOUND");

--- a/src/app/conditions/page.test.tsx
+++ b/src/app/conditions/page.test.tsx
@@ -7,6 +7,9 @@ import { render, screen } from "@testing-library/react";
 vi.mock("@/components/TidePanel", () => ({
   TidePanel: ({ slug }: { slug: string }) => <p>panel for {slug}</p>,
 }));
+vi.mock("@/components/WavePanel", () => ({
+  WavePanel: ({ slug }: { slug: string }) => <p>waves for {slug}</p>,
+}));
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 const { default: Conditions, revalidate } = await import("./page");

--- a/src/components/ConditionsSection.test.tsx
+++ b/src/components/ConditionsSection.test.tsx
@@ -4,6 +4,9 @@ import { render, screen } from "@testing-library/react";
 vi.mock("@/components/TidePanel", () => ({
   TidePanel: ({ slug }: { slug: string }) => <p>panel for {slug}</p>,
 }));
+vi.mock("@/components/WavePanel", () => ({
+  WavePanel: ({ slug }: { slug: string }) => <p>waves for {slug}</p>,
+}));
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 const { ConditionsSection } = await import("./ConditionsSection");
@@ -14,6 +17,7 @@ test("the view carries the chooser, the reading and the caveats", () => {
 
   expect(screen.getByLabelText("Choose a beach")).toBeDefined();
   expect(screen.getByText(`panel for ${DEFAULT_BEACH_SLUG}`)).toBeDefined();
+  expect(screen.getByText(`waves for ${DEFAULT_BEACH_SLUG}`)).toBeDefined();
   expect(
     screen.getByText("What we are unsure about in this data"),
   ).toBeDefined();

--- a/src/components/ConditionsSection.tsx
+++ b/src/components/ConditionsSection.tsx
@@ -13,6 +13,7 @@ import { beachesByRegion, inventoryCaveats } from "@/lib/beaches";
 import { BeachSelector } from "./BeachSelector";
 import { Caveats } from "./Caveats";
 import { TidePanel } from "./TidePanel";
+import { WavePanel } from "./WavePanel";
 
 export function ConditionsSection({ slug }: { slug: string }) {
   const groups = beachesByRegion().map((group) => ({
@@ -47,6 +48,16 @@ export function ConditionsSection({ slug }: { slug: string }) {
         }
       >
         <TidePanel slug={slug} />
+      </Suspense>
+
+      {/*
+        Its own boundary, so a slow buoy cannot hold up the tide time. The two
+        readings come from different agencies and fail independently.
+      */}
+      <Suspense
+        fallback={<p className="mt-9 text-base text-fog">Reading the buoy…</p>}
+      >
+        <WavePanel slug={slug} />
       </Suspense>
 
       <Caveats entries={inventoryCaveats()} />

--- a/src/components/WavePanel.test.tsx
+++ b/src/components/WavePanel.test.tsx
@@ -1,0 +1,42 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const readLatestWaves = vi.fn();
+vi.mock("@/lib/conditions", () => ({ readLatestWaves }));
+
+const { WavePanel } = await import("./WavePanel");
+
+beforeEach(() => {
+  readLatestWaves.mockReset();
+});
+
+test("asks for the slug it was given and renders the reading", async () => {
+  readLatestWaves.mockResolvedValue({
+    beachName: "La Jolla Shores Beach",
+    buoy: { name: "Scripps Nearshore", distanceM: 1400 },
+    state: {
+      kind: "reading",
+      heightFt: 2.62,
+      periodS: 5,
+      directionDegT: 278,
+      waterTempF: 69.98,
+    },
+  });
+
+  render(await WavePanel({ slug: "la-jolla-shores-beach" }));
+
+  expect(readLatestWaves).toHaveBeenCalledWith("la-jolla-shores-beach");
+  expect(screen.getByText("2.6 ft")).toBeDefined();
+});
+
+test("a bay beach renders its own state, not an outage", async () => {
+  readLatestWaves.mockResolvedValue({
+    beachName: "Agua Hedionda Lagoon",
+    buoy: null,
+    state: { kind: "no-buoy", reason: "swell does not reach here" },
+  });
+
+  render(await WavePanel({ slug: "agua-hedionda-lagoon" }));
+
+  expect(screen.getByText(/what we expect rather than a fault/)).toBeDefined();
+});

--- a/src/components/WavePanel.tsx
+++ b/src/components/WavePanel.tsx
@@ -1,0 +1,12 @@
+/**
+ * The seam between the network and the wave markup, kept as thin as the tide
+ * panel: read, render.
+ */
+
+import { readLatestWaves } from "@/lib/conditions";
+import { WavesToday } from "./WavesToday";
+
+export async function WavePanel({ slug }: { slug: string }) {
+  const view = await readLatestWaves(slug);
+  return <WavesToday {...view} />;
+}

--- a/src/components/WavesToday.test.tsx
+++ b/src/components/WavesToday.test.tsx
@@ -1,0 +1,157 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { WavesToday } from "./WavesToday";
+
+const NEAR = { name: "Scripps Nearshore", distanceM: 1400 };
+const FAR = { name: "Point Loma South", distanceM: 34_159 };
+
+test("a reading leads with the height and puts it in plain words", () => {
+  render(
+    <WavesToday
+      beachName="La Jolla Shores Beach"
+      buoy={NEAR}
+      state={{
+        kind: "reading",
+        heightFt: 2.62,
+        periodS: 5,
+        directionDegT: 278,
+        waterTempF: 69.98,
+      }}
+    />,
+  );
+
+  expect(screen.getByText("2.6 ft")).toBeDefined();
+  // A height alone tells a surfer what they need and a parent very little.
+  expect(screen.getByText(/about waist high, 5 seconds apart/)).toBeDefined();
+});
+
+test("water temperature comes from the same reading, rounded", () => {
+  render(
+    <WavesToday
+      beachName="La Jolla Shores Beach"
+      buoy={NEAR}
+      state={{
+        kind: "reading",
+        heightFt: 2.62,
+        periodS: 5,
+        directionDegT: 278,
+        waterTempF: 69.98,
+      }}
+    />,
+  );
+  expect(screen.getByText(/The water is 70°F/)).toBeDefined();
+});
+
+test("a buoy reporting no water temperature says so rather than omitting it", () => {
+  render(
+    <WavesToday
+      beachName="La Jolla Shores Beach"
+      buoy={NEAR}
+      state={{
+        kind: "reading",
+        heightFt: 2.62,
+        periodS: null,
+        directionDegT: null,
+        waterTempF: null,
+      }}
+    />,
+  );
+  expect(screen.getByText(/reported no water temperature/)).toBeDefined();
+});
+
+test("the reading is attributed as open water, not as the breaking wave", () => {
+  render(
+    <WavesToday
+      beachName="La Jolla Shores Beach"
+      buoy={NEAR}
+      state={{
+        kind: "reading",
+        heightFt: 2.62,
+        periodS: 5,
+        directionDegT: 278,
+        waterTempF: 69.98,
+      }}
+    />,
+  );
+  expect(
+    screen.getByText(/not the height of the wave breaking at the shore/),
+  ).toBeDefined();
+  expect(screen.queryByText(/km from this beach/)).toBeNull();
+});
+
+test("a distant buoy discloses how far away it is", () => {
+  render(
+    <WavesToday
+      beachName="Tijana River"
+      buoy={FAR}
+      state={{
+        kind: "reading",
+        heightFt: 3.1,
+        periodS: 9,
+        directionDegT: 270,
+        waterTempF: 68,
+      }}
+    />,
+  );
+  // 34 km up the coast, because the only buoy south of Point Loma is dead.
+  expect(screen.getByText(/about 34 km from this beach/)).toBeDefined();
+});
+
+test("a bay beach is told this is expected, not a fault", () => {
+  render(
+    <WavesToday
+      beachName="Agua Hedionda Lagoon"
+      buoy={null}
+      state={{
+        kind: "no-buoy",
+        reason:
+          "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      }}
+    />,
+  );
+
+  expect(
+    screen.getByText(/that is what we expect rather than a fault/),
+  ).toBeDefined();
+  // Not an outage: nothing invites the reader to try again.
+  expect(screen.queryByText(/Try again shortly/)).toBeNull();
+  expect(screen.queryByText(/Measured at NDBC buoy/)).toBeNull();
+  expect(screen.getByText(/does not reach into a bay or lagoon/)).toBeDefined();
+});
+
+test("an unavailable buoy is a sentence with the reason behind a disclosure", () => {
+  render(
+    <WavesToday
+      beachName="La Jolla Shores Beach"
+      buoy={NEAR}
+      state={{
+        kind: "unavailable",
+        detail:
+          "NDBC 46254's newest observation is 214 minutes old, past the 180 minute limit.",
+        drift: false,
+      }}
+    />,
+  );
+
+  expect(screen.getByText(/could not get a wave reading/)).toBeDefined();
+  expect(screen.getByText(/past the 180 minute limit/)).toBeDefined();
+  // No number anywhere that could read as a calm sea.
+  expect(screen.queryByText(/ft$/)).toBeNull();
+});
+
+test("drift is named as a bug here rather than a problem at the buoy", () => {
+  render(
+    <WavesToday
+      beachName="La Jolla Shores Beach"
+      buoy={NEAR}
+      state={{
+        kind: "unavailable",
+        detail: "NDBC 46254: the column layout has drifted.",
+        drift: true,
+      }}
+    />,
+  );
+  expect(
+    screen.getByText(/a bug here rather than a problem at the buoy/),
+  ).toBeDefined();
+});

--- a/src/components/WavesToday.tsx
+++ b/src/components/WavesToday.tsx
@@ -1,0 +1,112 @@
+/**
+ * The newest wave observation, and the water temperature that comes with it.
+ *
+ * Presentational and pure, like the tide panel beside it.
+ *
+ * **One fetch, two readings.** Every delivering buoy in this corridor publishes
+ * wave height, period, direction and water temperature in the same row, so the
+ * surfer's number and the swimmer's number arrive together.
+ *
+ * **Height is described, not just stated.** "2.6 ft" tells a surfer what they
+ * need and tells a parent of an eight-year-old very little, so the figure is
+ * given a plain-language companion. The bands are this site's own wording for
+ * published measurements, not a judgement about whether anyone should go in.
+ *
+ * **A buoy is offshore, and says so.** These are open-water measurements taken
+ * some distance out, not the height of the wave breaking at the shore, and no
+ * shoaling transform is applied. Where the buoy is far away the distance is
+ * given, for the same reason the tide panel gives it.
+ */
+
+import type { WavesView } from "@/lib/conditions";
+
+/** Past this, the buoy is far enough away that the reader is owed the number. */
+const DISTANT_BUOY_M = 10_000;
+
+/**
+ * Plain words for a published height. Deliberately descriptive rather than
+ * advisory: this site relays measurements and does not decide whether the water
+ * is suitable for anybody.
+ */
+function heightWords(feet: number): string {
+  if (feet < 1) return "close to flat";
+  if (feet < 2) return "about knee to thigh high";
+  if (feet < 3) return "about waist high";
+  if (feet < 5) return "overhead for a child";
+  return "large";
+}
+
+export function WavesToday({ beachName, buoy, state }: WavesView) {
+  const distanceM = buoy?.distanceM ?? null;
+  const distantKm =
+    distanceM !== null && distanceM > DISTANT_BUOY_M
+      ? (distanceM / 1000).toFixed(0)
+      : null;
+
+  return (
+    <section aria-labelledby="waves-today-heading" className="mt-9 max-w-130">
+      <h2
+        id="waves-today-heading"
+        className="text-2xs mb-3 font-extrabold tracking-widest text-ocean uppercase"
+      >
+        Waves and water · {beachName}
+      </h2>
+
+      {state.kind === "reading" && (
+        <>
+          <p className="leading-tight mb-2 text-4xl font-black italic">
+            {state.heightFt.toFixed(1)} ft
+          </p>
+          <p className="leading-relaxed mb-4 text-base text-fog">
+            {heightWords(state.heightFt)}
+            {state.periodS !== null ? `, ${state.periodS} seconds apart` : ""}.
+            {state.waterTempF !== null
+              ? ` The water is ${Math.round(state.waterTempF)}°F.`
+              : " The buoy reported no water temperature."}
+          </p>
+        </>
+      )}
+
+      {state.kind === "no-buoy" && (
+        <>
+          <p className="leading-relaxed mb-4 text-base text-fog">
+            We cannot give a wave height here, and that is what we expect rather
+            than a fault. Every wave buoy sits out on the open coast.
+          </p>
+          <details className="mb-4 text-sm text-fog">
+            <summary>Why not</summary>
+            <p className="mt-2">{state.reason}</p>
+          </details>
+        </>
+      )}
+
+      {state.kind === "unavailable" && (
+        <>
+          <p className="leading-relaxed mb-4 text-base text-fog">
+            We could not get a wave reading from the buoy just now. Try again
+            shortly.
+          </p>
+          <details className="mb-4 text-sm text-fog">
+            <summary>What went wrong</summary>
+            <p className="mt-2">{state.detail}</p>
+            {state.drift && (
+              <p className="mt-2">
+                NDBC&apos;s payload was not the shape this site pins, which is a
+                bug here rather than a problem at the buoy.
+              </p>
+            )}
+          </details>
+        </>
+      )}
+
+      {buoy !== null && (
+        <p className="text-2xs leading-relaxed text-fog">
+          Measured at NDBC buoy {buoy.name}
+          {distantKm !== null ? `, about ${distantKm} km from this beach` : ""}.
+          That is the height of the swell in open water, not the height of the
+          wave breaking at the shore, and it is not a safety assessment.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/data/beaches.json
+++ b/src/data/beaches.json
@@ -46,7 +46,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 56557,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46275",
+      "wave_buoy_distance_m": 4524,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "oceanside-harbor",
@@ -74,7 +77,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 40061,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46224",
+      "wave_buoy_distance_m": 7749,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "harbor-beach",
@@ -102,7 +108,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 39400,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46224",
+      "wave_buoy_distance_m": 7557,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "oceanside-municipal-beach-other",
@@ -130,7 +139,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 34511,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46224",
+      "wave_buoy_distance_m": 7557,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "buccaneer-beach",
@@ -158,7 +170,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 35892,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46224",
+      "wave_buoy_distance_m": 9488,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "carlsbad-municipal-beach",
@@ -186,7 +201,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 33346,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46224",
+      "wave_buoy_distance_m": 10578,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "carlsbad-state-beach",
@@ -214,7 +232,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 30610,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46274",
+      "wave_buoy_distance_m": 8278,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "agua-hedionda-lagoon",
@@ -242,7 +263,11 @@
       },
       "tide_station": "9410196",
       "tide_station_distance_m": 39737,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "south-carlsbad-state-beach",
@@ -270,7 +295,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 24396,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46274",
+      "wave_buoy_distance_m": 2181,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "leucadia",
@@ -298,7 +326,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 20528,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46274",
+      "wave_buoy_distance_m": 2101,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "encinitas-city-beaches",
@@ -326,7 +357,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 18611,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46274",
+      "wave_buoy_distance_m": 2762,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "moonlight-beach",
@@ -354,7 +388,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 19946,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46274",
+      "wave_buoy_distance_m": 2064,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "swami-s-park",
@@ -382,7 +419,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 18611,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46274",
+      "wave_buoy_distance_m": 3569,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "san-elijo-state-beach",
@@ -410,7 +450,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 16816,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46274",
+      "wave_buoy_distance_m": 3986,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "cardiff-state-beach",
@@ -438,7 +481,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 14869,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46266",
+      "wave_buoy_distance_m": 4724,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "solana-beach-city-beaches",
@@ -466,7 +512,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 12691,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46266",
+      "wave_buoy_distance_m": 2664,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "seascape-beach-park",
@@ -494,7 +543,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 12691,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46266",
+      "wave_buoy_distance_m": 2664,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "san-dieguito-river-beach",
@@ -522,7 +574,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 12040,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46266",
+      "wave_buoy_distance_m": 2119,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "del-mar-city-beach",
@@ -550,7 +605,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 9160,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46266",
+      "wave_buoy_distance_m": 1565,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "powerhouse-park-15th-street",
@@ -578,7 +636,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 10373,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46266",
+      "wave_buoy_distance_m": 1016,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "torrey-pines-state-beach",
@@ -606,7 +667,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 3229,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46266",
+      "wave_buoy_distance_m": 1565,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "torrey-pines-city-beach",
@@ -634,7 +698,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 1907,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 2194,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "la-jolla-shores-beach",
@@ -662,7 +729,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 1369,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 1648,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "la-jolla-cove",
@@ -690,7 +760,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 2326,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 1991,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "shell-beach",
@@ -718,7 +791,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 2500,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 2126,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "childrens-pool",
@@ -746,7 +822,11 @@
       },
       "tide_station": "9410196",
       "tide_station_distance_m": 7842,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "south-casa-beach-s-d",
@@ -774,7 +854,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 2981,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 2555,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "whispering-sands-nicholson-pt",
@@ -802,7 +885,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 3105,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 2702,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "marine-street-beach",
@@ -830,7 +916,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 3852,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 3478,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "la-jolla-community-beach",
@@ -858,7 +947,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 1369,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 1648,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "windansea-beach",
@@ -886,7 +978,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 4062,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 3737,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "bird-rock-nr",
@@ -914,7 +1009,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 5931,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 5876,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "tourmaline-surfing-park",
@@ -942,7 +1040,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 6615,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 6683,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "pacific-beach",
@@ -970,7 +1071,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 7353,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 7506,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "mission-bay-campland-on-the-bay",
@@ -998,7 +1102,11 @@
       },
       "tide_station": "9410196",
       "tide_station_distance_m": 82,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-de-anza-cove",
@@ -1026,7 +1134,11 @@
       },
       "tide_station": "9410196",
       "tide_station_distance_m": 1141,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-visitor-s-center",
@@ -1054,7 +1166,11 @@
       },
       "tide_station": "9410196",
       "tide_station_distance_m": 1336,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-fanuel-park",
@@ -1082,7 +1198,11 @@
       },
       "tide_station": "9410196",
       "tide_station_distance_m": 1779,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-leisure-lagoon",
@@ -1110,7 +1230,11 @@
       },
       "tide_station": "9410196",
       "tide_station_distance_m": 1590,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-crown-point-shores",
@@ -1138,7 +1262,11 @@
       },
       "tide_station": "9410196",
       "tide_station_distance_m": 933,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-riviera-shores",
@@ -1166,7 +1294,11 @@
       },
       "tide_station": "TWC0413",
       "tide_station_distance_m": 1445,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-north-pacific-passage",
@@ -1194,7 +1326,11 @@
       },
       "tide_station": "9410196",
       "tide_station_distance_m": 1595,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-san-juan-cove",
@@ -1222,7 +1358,11 @@
       },
       "tide_station": "TWC0413",
       "tide_station_distance_m": 2041,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-sail-bay",
@@ -1250,7 +1390,11 @@
       },
       "tide_station": "TWC0413",
       "tide_station_distance_m": 1776,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-santa-barbara-cove",
@@ -1278,7 +1422,11 @@
       },
       "tide_station": "TWC0413",
       "tide_station_distance_m": 1628,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-beach",
@@ -1306,7 +1454,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 8183,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 8366,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "tecolote-shores",
@@ -1334,7 +1485,11 @@
       },
       "tide_station": "9410196",
       "tide_station_distance_m": 2164,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-bahia-point",
@@ -1362,7 +1517,11 @@
       },
       "tide_station": "TWC0413",
       "tide_station_distance_m": 1305,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-vacation-isle",
@@ -1390,7 +1549,11 @@
       },
       "tide_station": "TWC0413",
       "tide_station_distance_m": 1011,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-ventura-cove",
@@ -1418,7 +1581,11 @@
       },
       "tide_station": "TWC0413",
       "tide_station_distance_m": 1040,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "fiesta-island",
@@ -1446,7 +1613,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 11663,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 12145,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "mission-bay-sea-world",
@@ -1474,7 +1644,11 @@
       },
       "tide_station": "TWC0413",
       "tide_station_distance_m": 315,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-mariners-basin",
@@ -1502,7 +1676,11 @@
       },
       "tide_station": "TWC0413",
       "tide_station_distance_m": 1286,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay-quivera-basin",
@@ -1530,7 +1708,11 @@
       },
       "tide_station": "TWC0413",
       "tide_station_distance_m": 859,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "mission-bay",
@@ -1558,7 +1740,11 @@
       },
       "tide_station": "TWC0413",
       "tide_station_distance_m": 937,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "dog-beach-o-b",
@@ -1586,7 +1772,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 12319,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 12506,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "ocean-beach",
@@ -1614,7 +1803,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 12283,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 12476,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "spanish-landing-park",
@@ -1642,7 +1834,11 @@
       },
       "tide_station": "9410170",
       "tide_station_distance_m": 2545,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "sunset-cliffs-park",
@@ -1670,7 +1866,10 @@
       },
       "tide_station": "9410230",
       "tide_station_distance_m": 14646,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 14805,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "shoreline-park",
@@ -1698,7 +1897,11 @@
       },
       "tide_station": "9410166",
       "tide_station_distance_m": 620,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "san-diego-bay",
@@ -1726,7 +1929,11 @@
       },
       "tide_station": "9410166",
       "tide_station_distance_m": 534,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "tide-beach-park",
@@ -1754,7 +1961,10 @@
       },
       "tide_station": "9410120",
       "tide_station_distance_m": 12538,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 21763,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "coronado-north-beach",
@@ -1782,7 +1992,10 @@
       },
       "tide_station": "9410120",
       "tide_station_distance_m": 13229,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 20940,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "coronado-central-beach",
@@ -1810,7 +2023,10 @@
       },
       "tide_station": "9410120",
       "tide_station_distance_m": 12175,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 21596,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "coronado-city-beaches",
@@ -1838,7 +2054,10 @@
       },
       "tide_station": "9410120",
       "tide_station_distance_m": 11184,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 21178,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "coronado-cays-nr",
@@ -1866,7 +2085,11 @@
       },
       "tide_station": "9410135",
       "tide_station_distance_m": 2838,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "silver-strand-state-beach",
@@ -1894,7 +2117,10 @@
       },
       "tide_station": "9410120",
       "tide_station_distance_m": 3407,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46254",
+      "wave_buoy_distance_m": 28149,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "north-imperial-beach",
@@ -1922,7 +2148,10 @@
       },
       "tide_station": "9410120",
       "tide_station_distance_m": 948,
-      "tide_station_from_end": "lower"
+      "tide_station_from_end": "lower",
+      "wave_buoy": "46232",
+      "wave_buoy_distance_m": 28469,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "imperial-beach-municipal-beach-other",
@@ -1950,7 +2179,10 @@
       },
       "tide_station": "9410120",
       "tide_station_distance_m": 1050,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46232",
+      "wave_buoy_distance_m": 27913,
+      "wave_buoy_from_end": "lower"
     },
     {
       "slug": "tijuana-slough-national-wildlife-refuge",
@@ -1978,7 +2210,11 @@
       },
       "tide_station": "9410135",
       "tide_station_distance_m": 7382,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
     },
     {
       "slug": "tijana-river",
@@ -2006,7 +2242,10 @@
       },
       "tide_station": "9410120",
       "tide_station_distance_m": 7267,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46232",
+      "wave_buoy_distance_m": 34159,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "border-field-state-park",
@@ -2034,7 +2273,10 @@
       },
       "tide_station": "9410120",
       "tide_station_distance_m": 2914,
-      "tide_station_from_end": "upper"
+      "tide_station_from_end": "upper",
+      "wave_buoy": "46232",
+      "wave_buoy_distance_m": 28153,
+      "wave_buoy_from_end": "upper"
     },
     {
       "slug": "imperial-beach-pier-area",
@@ -2063,12 +2305,17 @@
       "tide_station": null,
       "tide_station_distance_m": null,
       "tide_station_from_end": null,
-      "tide_station_null_reason": "the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it"
+      "tide_station_null_reason": "the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it"
     }
   ],
   "unresolved": [
     "beach_type is UNKNOWN upstream for most of these beaches. That is a gap in the resource, not a shorthand for sand, and nothing may render it as a description of what the shore is made of.",
     "The join binds by nearest station of matching water class, and the distances are large where NOAA publishes no nearby station: the farthest is San Onofre State Beach at 56.6 km. See tide-stations.json, whose own unresolved list records that the one open-coast station between La Jolla and Imperial Beach does not deliver predictions.",
+    "27 of these beaches get no wave height at all. Every NDBC wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so binding one to the nearest buoy would put an open-ocean number on enclosed water. Their water temperature is missing for the same reason and is not yet filled from another source.",
     "A tide prediction is for the station, not for the beach. It is the best published figure for that stretch of shore and it is not a measurement taken there.",
     "1 beach(es) could not be bound to a station: Imperial Beach pier area (the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it). A null station must never render as a reading.",
     "The network module carries no build-time guard against being imported by a browser bundle. The `server-only` package is the intended enforcement and is not installed: importing it breaks the tests under jsdom until vitest is configured with the `react-server` resolve condition. Today the guarantee rests on the module having no client-side importer, which nothing checks."

--- a/src/data/wave-buoys.json
+++ b/src/data/wave-buoys.json
@@ -1,0 +1,129 @@
+{
+  "version": "0.1.0",
+  "generated": "2026-08-18",
+  "_provenance": "Station ids, names and coordinates read from NOAA NDBC's active station list, https://www.ndbc.noaa.gov/activestations.xml, filtered to 32.4-33.5N and -118.2 to -117.0E, on 2026-08-18. Nineteen stations were listed. Delivery was then measured one station at a time against https://www.ndbc.noaa.gov/data/realtime2/<id>.txt, the same endpoint this site reads, rather than inferred from the list.",
+  "_what_was_measured": "Every delivering buoy publishes WVHT, DPD, MWD and WTMP. NOT ONE publishes WDIR, WSPD or VIS -- ten out of ten leave them MM. Slice 3 saw this on 46254 and recorded it as one station's quirk; it is categorical. The only station in the box with wind is 46086, twenty-seven nautical miles offshore in the San Clemente Basin, and it publishes no waves at all. That is why this site's wind and visibility must come from the National Weather Service gridpoint forecast and can never come from a buoy.",
+  "_schema": {
+    "name": "NDBC's own station name.",
+    "cdip": "The CDIP station number NDBC prints in parentheses after the name, where it prints one. Recorded because it is published, and because the relay is what makes these nearshore buoys wave-only.",
+    "lat": "Decimal degrees north, from the NDBC station list.",
+    "lon": "Decimal degrees east, negative for west.",
+    "delivers": "Whether realtime2 actually answers with data rows, measured rather than assumed. A station that does not deliver is kept and marked, never deleted.",
+    "publishes_waves": "Whether the delivering station's rows carry WVHT. Recorded separately from `delivers` because one station does neither the same way.",
+    "dead_note": "Present only when delivers is false. What the station did when asked."
+  },
+  "buoys": {
+    "46285": {
+      "name": "Capistrano Beach Nearshore",
+      "cdip": "284",
+      "lat": 33.445,
+      "lon": -117.68,
+      "delivers": true,
+      "publishes_waves": true
+    },
+    "46277": {
+      "name": "Green Beach Offshore",
+      "cdip": "271",
+      "lat": 33.336,
+      "lon": -117.659,
+      "delivers": true,
+      "publishes_waves": true
+    },
+    "46275": {
+      "name": "Red Beach Nearshore",
+      "cdip": "264",
+      "lat": 33.291,
+      "lon": -117.501,
+      "delivers": true,
+      "publishes_waves": true
+    },
+    "46224": {
+      "name": "Oceanside Offshore",
+      "cdip": "045",
+      "lat": 33.178,
+      "lon": -117.472,
+      "delivers": true,
+      "publishes_waves": true
+    },
+    "46274": {
+      "name": "Leucadia Nearshore",
+      "cdip": "262",
+      "lat": 33.062,
+      "lon": -117.314,
+      "delivers": true,
+      "publishes_waves": true
+    },
+    "46266": {
+      "name": "Del Mar Nearshore",
+      "cdip": "153",
+      "lat": 32.957,
+      "lon": -117.279,
+      "delivers": true,
+      "publishes_waves": true
+    },
+    "46225": {
+      "name": "Torrey Pines Outer",
+      "cdip": "100",
+      "lat": 32.933,
+      "lon": -117.391,
+      "delivers": true,
+      "publishes_waves": true
+    },
+    "46254": {
+      "name": "Scripps Nearshore",
+      "cdip": "201",
+      "lat": 32.868,
+      "lon": -117.267,
+      "delivers": true,
+      "publishes_waves": true
+    },
+    "46258": {
+      "name": "Mission Bay West",
+      "cdip": "220",
+      "lat": 32.749,
+      "lon": -117.502,
+      "delivers": true,
+      "publishes_waves": true
+    },
+    "46232": {
+      "name": "Point Loma South",
+      "cdip": "191",
+      "lat": 32.517,
+      "lon": -117.425,
+      "delivers": true,
+      "publishes_waves": true
+    },
+    "46273": {
+      "name": "Torrey Pines Inner",
+      "cdip": "101",
+      "lat": 32.93,
+      "lon": -117.274,
+      "delivers": false,
+      "publishes_waves": false,
+      "dead_note": "Listed in NDBC's active station list on 2026-08-18 and answered 404 on realtime2 the same day. Its entry carries met=n. Listed but not delivering is the same trap TWC0405 sets in the tide join, and the reason delivery is measured here rather than read off the list."
+    },
+    "46235": {
+      "name": "Imperial Beach Nearshore",
+      "cdip": "155",
+      "lat": 32.57,
+      "lon": -117.169,
+      "delivers": false,
+      "publishes_waves": false,
+      "dead_note": "Answered 404 on realtime2 on 2026-08-18. Independently confirms cweber12/socal-coastal-data, which recorded it as dead since 2026-05-03 with the death date read from CDIP archive deployment 155p1_d14. It is the only buoy south of Point Loma, so its absence is why south-county beaches reach a long way for a wave height."
+    },
+    "46086": {
+      "name": "San Clemente Basin",
+      "cdip": null,
+      "lat": 32.504,
+      "lon": -118.029,
+      "delivers": true,
+      "publishes_waves": false,
+      "dead_note": null
+    }
+  },
+  "unresolved": [
+    "46235 Imperial Beach Nearshore is the only buoy south of Point Loma and it does not deliver, so every south-county beach reads a buoy well to its north-west across water of different exposure. The join records the distance rather than hiding it. This is a gap in what NDBC publishes, not one this site can close.",
+    "A buoy's significant wave height is not the height of the wave breaking at the shore. No shoaling or refraction transform is applied, and none is planned: the number shown is what the buoy reported, which is the only thing actually measured.",
+    "46086 San Clemente Basin delivers wind and water temp but no waves, and sits twenty-seven nautical miles offshore outside the county. It is recorded here because it is the only station in the box with wind, and it is bound to no beach."
+  ]
+}

--- a/src/lib/__fixtures__/ndbc-46254-realtime2.txt
+++ b/src/lib/__fixtures__/ndbc-46254-realtime2.txt
@@ -1,0 +1,8 @@
+#YY  MM DD hh mm WDIR WSPD GST  WVHT   DPD   APD MWD   PRES  ATMP  WTMP  DEWP  VIS PTDY  TIDE
+#yr  mo dy hr mn degT m/s  m/s     m   sec   sec degT   hPa  degC  degC  degC  nmi  hPa    ft
+2026 08 18 03 26  MM   MM   MM   0.8     5   4.6 278     MM    MM  21.1    MM   MM   MM    MM
+2026 08 18 02 56  MM   MM   MM   0.8     5   4.8 275     MM    MM  21.1    MM   MM   MM    MM
+2026 08 18 02 26  MM   MM   MM   0.8     4   4.6 273     MM    MM  21.2    MM   MM   MM    MM
+2026 08 18 01 56  MM   MM   MM   0.7     5   4.7 282     MM    MM  21.4    MM   MM   MM    MM
+2026 08 18 01 26  MM   MM   MM   0.7     6   4.6 294     MM    MM  21.5    MM   MM   MM    MM
+2026 08 18 00 56  MM   MM   MM   0.7     6   4.7 288     MM    MM  21.6    MM   MM   MM    MM

--- a/src/lib/beaches.test.ts
+++ b/src/lib/beaches.test.ts
@@ -7,6 +7,7 @@ import {
   defaultBeach,
   inventoryCaveats,
   tideStationFor,
+  waveBuoyFor,
 } from "./beaches";
 
 describe("the inventory", () => {
@@ -151,5 +152,42 @@ describe("caveats", () => {
     // The station file's own caveat about the gap on the open coast must reach a
     // reader, not just the inventory's.
     expect(caveats.some((c) => c.includes("TWC0405"))).toBe(true);
+  });
+});
+
+describe("the wave buoy binding", () => {
+  test("open-coast beaches get a delivering buoy that publishes waves", () => {
+    const bound = allBeaches().filter((beach) => beach.wave_buoy !== null);
+    expect(bound.length).toBeGreaterThan(0);
+
+    for (const beach of bound) {
+      const buoy = waveBuoyFor(beach)!;
+      expect(buoy.delivers).toBe(true);
+      expect(buoy.publishes_waves).toBe(true);
+      expect(beach.upstream.water_body_type).toBe("Open Coast");
+    }
+  });
+
+  test("no bay, lagoon or inlet is bound to a buoy", () => {
+    // Swell does not reach them, so the nearest buoy would describe different
+    // water. The reason travels with the null.
+    for (const beach of allBeaches()) {
+      if (beach.upstream.water_body_type === "Open Coast") continue;
+      expect(beach.wave_buoy).toBeNull();
+      expect(beach.wave_buoy_null_reason).toBeTruthy();
+      expect(waveBuoyFor(beach)).toBeNull();
+    }
+  });
+
+  test("a beach naming an undescribed buoy is a broken data file, and says so", () => {
+    const beach = { ...defaultBeach(), wave_buoy: "99999" };
+    expect(() => waveBuoyFor(beach)).toThrow(/no entry in wave-buoys.json/);
+  });
+
+  test("the dead buoys are kept and marked, not deleted", () => {
+    // 46235 is the only buoy south of Point Loma and it 404s; deleting it would
+    // erase the reason south-county beaches reach so far for a height.
+    const caveats = inventoryCaveats();
+    expect(caveats.some((c) => c.includes("46235"))).toBe(true);
   });
 });

--- a/src/lib/beaches.ts
+++ b/src/lib/beaches.ts
@@ -13,6 +13,7 @@
 
 import inventory from "@/data/beaches.json";
 import stationTable from "@/data/tide-stations.json";
+import buoyTable from "@/data/wave-buoys.json";
 
 export interface Coordinate {
   lat: number;
@@ -51,6 +52,24 @@ export interface Beach {
   tide_station_from_end: string | null;
   /** Present exactly when tide_station is null, and required then. */
   tide_station_null_reason?: string;
+  /** Joined, never typed. null for every bay, lagoon and inlet. */
+  wave_buoy: string | null;
+  wave_buoy_distance_m: number | null;
+  wave_buoy_from_end: string | null;
+  /** Present exactly when wave_buoy is null, and required then. */
+  wave_buoy_null_reason?: string;
+}
+
+export interface WaveBuoy {
+  name: string;
+  cdip: string | null;
+  lat: number;
+  lon: number;
+  /** Measured, not assumed. A buoy that does not deliver is kept and marked. */
+  delivers: boolean;
+  /** One delivering station carries no wave height at all, so this is separate. */
+  publishes_waves: boolean;
+  dead_note?: string | null;
 }
 
 export interface TideStation {
@@ -67,6 +86,7 @@ export interface TideStation {
 
 const BEACHES = inventory.beaches as readonly Beach[];
 const STATIONS = stationTable.stations as Readonly<Record<string, TideStation>>;
+const BUOYS = buoyTable.buoys as Readonly<Record<string, WaveBuoy>>;
 
 /**
  * The beach the conditions view opens on when no other is asked for.
@@ -147,10 +167,31 @@ export function tideStationFor(
   return { id: beach.tide_station, ...station };
 }
 
-/** Caveats carried by both data files. Every one owes the reader a rendering. */
+/**
+ * The wave buoy a beach reads, or null when the join bound none.
+ *
+ * Throws when a beach names a buoy the table does not describe -- a broken pair
+ * of data files, which should stop a build rather than render an unlabelled
+ * number.
+ */
+export function waveBuoyFor(beach: Beach): (WaveBuoy & { id: string }) | null {
+  if (beach.wave_buoy === null) return null;
+
+  const buoy = BUOYS[beach.wave_buoy];
+  if (!buoy) {
+    throw new Error(
+      `beaches.json: ${beach.slug} names wave buoy ${beach.wave_buoy}, ` +
+        `which has no entry in wave-buoys.json.`,
+    );
+  }
+  return { id: beach.wave_buoy, ...buoy };
+}
+
+/** Caveats carried by every data file. Every one owes the reader a rendering. */
 export function inventoryCaveats(): readonly string[] {
   return [
     ...(inventory.unresolved as readonly string[]),
     ...(stationTable.unresolved as readonly string[]),
+    ...(buoyTable.unresolved as readonly string[]),
   ];
 }

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, expect, test, vi } from "vitest";
 
 const fetchTideExtremes = vi.fn();
-vi.mock("./upstream", () => ({ fetchTideExtremes }));
+const fetchLatestWave = vi.fn();
+vi.mock("./upstream", () => ({ fetchTideExtremes, fetchLatestWave }));
 
-const { readTodaysLowestLow } = await import("./conditions");
+const { readTodaysLowestLow, readLatestWaves } = await import("./conditions");
 
 const BEACH = "la-jolla-shores-beach";
 
@@ -21,6 +22,7 @@ const JUST_AFTER_MIDNIGHT_20260817 = Date.UTC(2026, 7, 17, 7, 30);
 
 beforeEach(() => {
   fetchTideExtremes.mockReset();
+  fetchLatestWave.mockReset();
 });
 
 function ok(extremes: { atMs: number; feet: number; kind: "low" | "high" }[]) {
@@ -145,4 +147,83 @@ test("a slug outside the inventory is a coding error, and nothing is fetched", a
     readTodaysLowestLow("no-such-beach", NOON_PACIFIC_20260817),
   ).rejects.toThrow(/no beach in the inventory/);
   expect(fetchTideExtremes).not.toHaveBeenCalled();
+});
+
+/* ===========================================================================
+ * Waves
+ * ========================================================================= */
+
+/** A bay beach, which the join deliberately binds to no buoy. */
+const BAY_BEACH = "agua-hedionda-lagoon";
+
+test("a wave reading carries the buoy, its distance and the water temperature", async () => {
+  fetchLatestWave.mockResolvedValue({
+    kind: "ok",
+    observation: {
+      atMs: NOON_PACIFIC_20260817,
+      heightFt: 2.62,
+      periodS: 5,
+      directionDegT: 278,
+      waterTempF: 69.98,
+    },
+    ageMinutes: 12,
+    url: "https://example.invalid",
+  });
+
+  const view = await readLatestWaves(
+    "la-jolla-shores-beach",
+    NOON_PACIFIC_20260817,
+  );
+
+  expect(view.buoy?.name).toBe("Scripps Nearshore");
+  expect(view.buoy?.distanceM).toBeGreaterThan(0);
+  expect(view.state).toMatchObject({
+    kind: "reading",
+    heightFt: 2.62,
+    waterTempF: 69.98,
+  });
+});
+
+test("a bay beach is never asked about, because there is nothing to ask", async () => {
+  const view = await readLatestWaves(BAY_BEACH, NOON_PACIFIC_20260817);
+
+  expect(view.state.kind).toBe("no-buoy");
+  expect(view.buoy).toBeNull();
+  expect(fetchLatestWave).not.toHaveBeenCalled();
+  if (view.state.kind === "no-buoy") {
+    expect(view.state.reason).toMatch(/does not reach into a bay/);
+  }
+});
+
+test("an unavailable buoy carries its reason through", async () => {
+  fetchLatestWave.mockResolvedValue({
+    kind: "unavailable",
+    reason: "NDBC 46254 returns 404 for its observations.",
+    drift: false,
+    url: "https://example.invalid",
+  });
+
+  const view = await readLatestWaves(
+    "la-jolla-shores-beach",
+    NOON_PACIFIC_20260817,
+  );
+
+  expect(view.state).toEqual({
+    kind: "unavailable",
+    detail: "NDBC 46254 returns 404 for its observations.",
+    drift: false,
+  });
+});
+
+test("the clock is passed to the fetch, so freshness is judged not guessed", async () => {
+  fetchLatestWave.mockResolvedValue({
+    kind: "unavailable",
+    reason: "stale",
+    drift: false,
+    url: "https://example.invalid",
+  });
+
+  await readLatestWaves("la-jolla-shores-beach", NOON_PACIFIC_20260817);
+
+  expect(fetchLatestWave).toHaveBeenCalledWith("46254", NOON_PACIFIC_20260817);
 });

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -11,10 +11,10 @@
  * instants rather than against whatever the test runner's clock says.
  */
 
-import { beachBySlug, tideStationFor } from "./beaches";
+import { beachBySlug, tideStationFor, waveBuoyFor } from "./beaches";
 import { localDateOf, localTimeOf } from "./pacific-time";
 import { lowestLowOn } from "./tide-day";
-import { fetchTideExtremes } from "./upstream";
+import { fetchLatestWave, fetchTideExtremes } from "./upstream";
 
 /**
  * What the view renders. Four states, kept distinct on purpose, because the
@@ -129,5 +129,89 @@ export async function readTodaysLowestLow(
             timeLabel: localTimeOf(lowest.atMs),
             feet: lowest.feet,
           },
+  };
+}
+
+/**
+ * What the waves view renders. The same three-way split as the tide, and for the
+ * same reason: `no-buoy` is a permanent fact about a place, `unavailable` is a
+ * transient fact about a feed.
+ */
+export type WavesState =
+  | {
+      kind: "reading";
+      heightFt: number;
+      periodS: number | null;
+      directionDegT: number | null;
+      waterTempF: number | null;
+    }
+  | { kind: "no-buoy"; reason: string }
+  | { kind: "unavailable"; detail: string; drift: boolean };
+
+export interface WavesView {
+  beachName: string;
+  /** null exactly when the state is `no-buoy`. */
+  buoy: { name: string; distanceM: number | null } | null;
+  state: WavesState;
+}
+
+/**
+ * Read the newest wave observation for one beach.
+ *
+ * Throws only when the slug is not in the inventory. A beach the join bound no
+ * buoy to -- every bay, lagoon and inlet -- arrives as `no-buoy` without a
+ * request being made, because there is nothing to ask.
+ */
+export async function readLatestWaves(
+  slug: string,
+  nowMs: number = Date.now(),
+): Promise<WavesView> {
+  const beach = beachBySlug(slug);
+  if (!beach) {
+    throw new Error(
+      `readLatestWaves: no beach in the inventory with slug "${slug}".`,
+    );
+  }
+
+  const buoy = waveBuoyFor(beach);
+  if (buoy === null) {
+    return {
+      beachName: beach.name,
+      buoy: null,
+      state: {
+        kind: "no-buoy",
+        reason:
+          beach.wave_buoy_null_reason ??
+          "the join bound no wave buoy to this beach, and recorded no reason",
+      },
+    };
+  }
+
+  const binding = {
+    beachName: beach.name,
+    buoy: { name: buoy.name, distanceM: beach.wave_buoy_distance_m },
+  };
+
+  const result = await fetchLatestWave(buoy.id, nowMs);
+  if (result.kind === "unavailable") {
+    return {
+      ...binding,
+      state: {
+        kind: "unavailable",
+        detail: result.reason,
+        drift: result.drift,
+      },
+    };
+  }
+
+  return {
+    ...binding,
+    state: {
+      kind: "reading",
+      heightFt: result.observation.heightFt,
+      periodS: result.observation.periodS,
+      directionDegT: result.observation.directionDegT,
+      waterTempF: result.observation.waterTempF,
+    },
   };
 }

--- a/src/lib/ndbc-realtime2.test.ts
+++ b/src/lib/ndbc-realtime2.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  NdbcDriftError,
+  NdbcNoDataError,
+  parseNdbcRealtime2,
+} from "./ndbc-realtime2";
+
+/**
+ * What buoy 46254 served on 2026-08-18, byte for byte. Read from disk rather
+ * than imported so the test exercises the text as published; the fixture is
+ * excluded from the formatter for the same reason.
+ */
+const CAPTURED = readFileSync(
+  join(process.cwd(), "src/lib/__fixtures__/ndbc-46254-realtime2.txt"),
+  "utf8",
+);
+
+const HEADER = CAPTURED.split("\n").slice(0, 2).join("\n");
+
+describe("against the captured payload", () => {
+  test("reads the newest observation, which is the first row", () => {
+    const observation = parseNdbcRealtime2(CAPTURED, "46254");
+
+    // 2026-08-18 03:26 UTC, the top row. The last row is three hours older, and
+    // NDBC serves newest-first -- the opposite of CO-OPS.
+    expect(observation.atMs).toBe(Date.UTC(2026, 7, 18, 3, 26));
+  });
+
+  test("converts wave height out of the metres NDBC publishes", () => {
+    const observation = parseNdbcRealtime2(CAPTURED, "46254");
+    // 0.8 m
+    expect(observation.heightFt).toBeCloseTo(2.62, 2);
+  });
+
+  test("converts water temperature out of Celsius", () => {
+    const observation = parseNdbcRealtime2(CAPTURED, "46254");
+    // 21.1 degC
+    expect(observation.waterTempF).toBeCloseTo(69.98, 2);
+  });
+
+  test("keeps period and direction as published", () => {
+    const observation = parseNdbcRealtime2(CAPTURED, "46254");
+    expect(observation.periodS).toBe(5);
+    expect(observation.directionDegT).toBe(278);
+  });
+});
+
+describe("missing values", () => {
+  test("MM is absent, never a number", () => {
+    // Every nearshore buoy in this corridor leaves wind and visibility MM on
+    // every row. Reading MM as a number would report a dead calm coastline.
+    const observation = parseNdbcRealtime2(CAPTURED, "46254");
+    expect(observation).not.toHaveProperty("windKt");
+    expect(Number.isFinite(observation.heightFt)).toBe(true);
+  });
+
+  test("a row with no wave height is no data, not a flat sea", () => {
+    const text = `${HEADER}\n2026 08 18 03 26  MM   MM   MM    MM     5   4.6 278     MM    MM  21.1    MM   MM   MM    MM\n`;
+    expect(() => parseNdbcRealtime2(text, "46254")).toThrow(NdbcNoDataError);
+    expect(() => parseNdbcRealtime2(text, "46254")).toThrow(
+      /reporting, and not reporting waves/,
+    );
+  });
+
+  test("a missing water temperature is null rather than an invented one", () => {
+    const text = `${HEADER}\n2026 08 18 03 26  MM   MM   MM   0.8     5   4.6 278     MM    MM    MM    MM   MM   MM    MM\n`;
+    expect(parseNdbcRealtime2(text, "46254").waterTempF).toBeNull();
+  });
+});
+
+describe("refusals", () => {
+  test("headers and no rows is a quiet buoy, not calm water", () => {
+    expect(() => parseNdbcRealtime2(`${HEADER}\n`, "46254")).toThrow(
+      NdbcNoDataError,
+    );
+  });
+
+  test("a shifted column layout is refused rather than read by position", () => {
+    const drifted = HEADER.replace("WVHT", "WVHZ");
+    expect(() =>
+      parseNdbcRealtime2(
+        `${drifted}\n2026 08 18 03 26 MM MM MM 0.8 5 4.6 278 MM MM 21.1 MM MM MM MM\n`,
+        "46254",
+      ),
+    ).toThrow(/column layout has drifted/);
+  });
+
+  test("a change of published units is refused rather than converted anyway", () => {
+    // The payload states its own units on its second header line. If wave height
+    // ever arrives in feet, converting from metres would report a third of the
+    // real height. Replaced by field position rather than by pattern: the units
+    // line also contains "m/s" twice, and a loose match rewrites wind speed
+    // instead -- which this test did on its first run, and passed while
+    // asserting nothing.
+    const [names, units] = HEADER.split("\n");
+    const fields = units.slice(1).trim().split(/\s+/);
+    fields[8] = "ft";
+    const inFeet = [names, `#${fields.join(" ")}`].join("\n");
+    const row =
+      "2026 08 18 03 26 MM MM MM 0.8 5 4.6 278 MM MM 21.1 MM MM MM MM";
+
+    expect(() =>
+      parseNdbcRealtime2([inFeet, row, ""].join("\n"), "46254"),
+    ).toThrow(/published in "ft"/);
+  });
+
+  test("a payload with no header at all is drift", () => {
+    expect(() => parseNdbcRealtime2("2026 08 18 03 26 MM\n", "46254")).toThrow(
+      NdbcDriftError,
+    );
+  });
+
+  test("an unparseable timestamp is refused", () => {
+    const text = `${HEADER}\nyear 08 18 03 26  MM   MM   MM   0.8     5   4.6 278     MM    MM  21.1    MM   MM   MM    MM\n`;
+    expect(() => parseNdbcRealtime2(text, "46254")).toThrow(
+      /timestamp fields did not parse/,
+    );
+  });
+});

--- a/src/lib/ndbc-realtime2.ts
+++ b/src/lib/ndbc-realtime2.ts
@@ -1,0 +1,199 @@
+/**
+ * NDBC `realtime2`: the pinned column layout, and the newest observation.
+ *
+ * Pure and offline, like the CO-OPS parser beside it. It takes the text a buoy
+ * served and returns typed values or raises.
+ *
+ * WHAT IS PINNED, and why each would otherwise produce a confident wrong number:
+ *
+ *   The column names, in order. This is a fixed-width-ish text table with no
+ *   schema, so the only way to know that the ninth field is wave height is to
+ *   assert the header still says so. A column inserted upstream would silently
+ *   shift every reading one place.
+ *
+ *   The units, which -- unusually and helpfully -- the payload states on its
+ *   second header line. So they are read rather than assumed: `m` for wave
+ *   height, `degC` for water temperature, `sec` for period. An upstream switch
+ *   to feet would otherwise be invisible and would read as a very calm day.
+ *
+ *   `MM` as the missing marker. Every nearshore buoy in this corridor leaves
+ *   wind, gusts and visibility as `MM` on every row, so a parser that read `MM`
+ *   as a number would report a dead calm at every beach on the coast.
+ *
+ * The newest observation is the FIRST data row. NDBC serves newest-first, which
+ * is the opposite of CO-OPS, and taking the last row would report a reading
+ * several days old as current.
+ */
+
+/** The 19 columns, in the order the header declares them. */
+const COLUMNS = [
+  "YY",
+  "MM",
+  "DD",
+  "hh",
+  "mm",
+  "WDIR",
+  "WSPD",
+  "GST",
+  "WVHT",
+  "DPD",
+  "APD",
+  "MWD",
+  "PRES",
+  "ATMP",
+  "WTMP",
+  "DEWP",
+  "VIS",
+  "PTDY",
+  "TIDE",
+] as const;
+
+/** Units this parser knows how to convert from, keyed by column. */
+const EXPECTED_UNITS: Record<string, string> = {
+  WVHT: "m",
+  DPD: "sec",
+  WTMP: "degC",
+  MWD: "degT",
+};
+
+/** NDBC's missing-value marker. */
+const MISSING = "MM";
+
+export class NdbcDriftError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NdbcDriftError";
+  }
+}
+
+export class NdbcNoDataError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NdbcNoDataError";
+  }
+}
+
+export interface WaveObservation {
+  /** Instant of the observation, epoch milliseconds UTC. */
+  atMs: number;
+  /** Significant wave height in feet, converted from the metres NDBC publishes. */
+  heightFt: number;
+  /** Dominant period in seconds, or null when the buoy left it missing. */
+  periodS: number | null;
+  /** Mean wave direction in degrees true, or null. */
+  directionDegT: number | null;
+  /** Water temperature in Fahrenheit, converted from Celsius, or null. */
+  waterTempF: number | null;
+}
+
+function assertHeader(lines: string[], buoyId: string): void {
+  const [names, units] = lines;
+  if (!names?.startsWith("#") || !units?.startsWith("#")) {
+    throw new NdbcDriftError(
+      `NDBC ${buoyId}: expected two '#' header lines and did not find them.`,
+    );
+  }
+
+  const declared = names.slice(1).trim().split(/\s+/);
+  if (
+    declared.length !== COLUMNS.length ||
+    declared.some((c, i) => c !== COLUMNS[i])
+  ) {
+    throw new NdbcDriftError(
+      `NDBC ${buoyId}: the column layout has drifted. Expected ${COLUMNS.length} columns ` +
+        `starting ${COLUMNS.slice(0, 9).join(" ")}, and found ${declared.length}: ` +
+        `${declared.slice(0, 9).join(" ")}. Refusing to read a value by position.`,
+    );
+  }
+
+  const declaredUnits = units.slice(1).trim().split(/\s+/);
+  for (const [column, expected] of Object.entries(EXPECTED_UNITS)) {
+    const actual =
+      declaredUnits[COLUMNS.indexOf(column as (typeof COLUMNS)[number])];
+    if (actual !== expected) {
+      throw new NdbcDriftError(
+        `NDBC ${buoyId}: ${column} is published in ${JSON.stringify(actual)}, not ` +
+          `${JSON.stringify(expected)}. The payload states its own units and they have ` +
+          `changed; converting on the old assumption would be a wrong number.`,
+      );
+    }
+  }
+}
+
+function value(
+  fields: string[],
+  column: (typeof COLUMNS)[number],
+): string | null {
+  const raw = fields[COLUMNS.indexOf(column)];
+  return raw === undefined || raw === MISSING ? null : raw;
+}
+
+function numberOrNull(
+  raw: string | null,
+  column: string,
+  buoyId: string,
+): number | null {
+  if (raw === null) return null;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    throw new NdbcDriftError(
+      `NDBC ${buoyId}: ${column} was ${JSON.stringify(raw)}, not a number.`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Parse the newest observation out of a `realtime2` payload.
+ *
+ * Raises `NdbcNoDataError` when the buoy answered with no rows -- which is a
+ * quiet buoy rather than a calm sea -- and `NdbcDriftError` when the layout or
+ * the units are not what is pinned above.
+ */
+export function parseNdbcRealtime2(
+  text: string,
+  buoyId: string,
+): WaveObservation {
+  const lines = text.split("\n").map((line) => line.trimEnd());
+  assertHeader(lines, buoyId);
+
+  const rows = lines.filter((line) => line !== "" && !line.startsWith("#"));
+  if (rows.length === 0) {
+    throw new NdbcNoDataError(
+      `NDBC ${buoyId} served headers and no observations. That is a buoy which is not ` +
+        `reporting, not a calm sea.`,
+    );
+  }
+
+  // Newest first. Taking the last row would report a days-old reading as current.
+  const fields = rows[0].split(/\s+/);
+
+  const [year, month, day, hour, minute] = fields
+    .slice(0, 5)
+    .map((part) => Number(part));
+  if ([year, month, day, hour, minute].some((part) => !Number.isFinite(part))) {
+    throw new NdbcDriftError(
+      `NDBC ${buoyId}: the newest row's timestamp fields did not parse: ` +
+        `${fields.slice(0, 5).join(" ")}.`,
+    );
+  }
+
+  const heightM = numberOrNull(value(fields, "WVHT"), "WVHT", buoyId);
+  if (heightM === null) {
+    throw new NdbcNoDataError(
+      `NDBC ${buoyId}'s newest observation carries no wave height. The buoy is reporting, ` +
+        `and not reporting waves.`,
+    );
+  }
+
+  const waterTempC = numberOrNull(value(fields, "WTMP"), "WTMP", buoyId);
+
+  return {
+    // The header's date fields carry no zone. NDBC publishes realtime2 in UTC.
+    atMs: Date.UTC(year, month - 1, day, hour, minute),
+    heightFt: heightM * 3.280839895,
+    periodS: numberOrNull(value(fields, "DPD"), "DPD", buoyId),
+    directionDegT: numberOrNull(value(fields, "MWD"), "MWD", buoyId),
+    waterTempF: waterTempC === null ? null : waterTempC * 1.8 + 32,
+  };
+}

--- a/src/lib/upstream.test.ts
+++ b/src/lib/upstream.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  fetchLatestWave,
+  fetchTideExtremes,
+  MAX_WAVE_AGE_MINUTES,
+  PREDICTIONS_REVALIDATE_SECONDS,
+  WAVES_REVALIDATE_SECONDS,
+} from "./upstream";
+
+/**
+ * `fetch` is stubbed rather than reached. What is under test is the policy
+ * around the request -- what a 404 means, when a reading is too old to be
+ * called current, and which failures are drift -- none of which can be asserted
+ * against a live buoy that is having a good day.
+ */
+const fetchMock = vi.fn();
+
+const CAPTURED = readFileSync(
+  join(process.cwd(), "src/lib/__fixtures__/ndbc-46254-realtime2.txt"),
+  "utf8",
+);
+
+/** The instant the captured payload's newest row was observed. */
+const OBSERVED_AT = Date.UTC(2026, 7, 18, 3, 26);
+
+function textResponse(body: string, status = 200) {
+  return { ok: status >= 200 && status < 300, status, text: async () => body };
+}
+
+function jsonResponse(payload: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchLatestWave", () => {
+  test("opts the request into caching, since Next 16 does not cache fetch by default", async () => {
+    fetchMock.mockResolvedValue(textResponse(CAPTURED));
+
+    await fetchLatestWave("46254", OBSERVED_AT);
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://www.ndbc.noaa.gov/data/realtime2/46254.txt");
+    // Without this the buoy is asked on every render.
+    expect(options.next.revalidate).toBe(WAVES_REVALIDATE_SECONDS);
+    expect(options.headers["User-Agent"]).toContain("wild-coast-kids");
+  });
+
+  test("returns the newest observation when it is fresh", async () => {
+    fetchMock.mockResolvedValue(textResponse(CAPTURED));
+
+    const result = await fetchLatestWave("46254", OBSERVED_AT + 10 * 60_000);
+
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") {
+      expect(result.ageMinutes).toBeCloseTo(10, 5);
+      expect(result.observation.heightFt).toBeCloseTo(2.62, 2);
+    }
+  });
+
+  test("a reading past the age limit is unknown, not a current number", async () => {
+    fetchMock.mockResolvedValue(textResponse(CAPTURED));
+
+    const tooOld = OBSERVED_AT + (MAX_WAVE_AGE_MINUTES + 5) * 60_000;
+    const result = await fetchLatestWave("46254", tooOld);
+
+    // The buoy is answering and not reporting. Serving its last number as
+    // current is the failure this limit exists to prevent.
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") {
+      expect(result.reason).toMatch(/past the 180 minute limit/);
+      expect(result.drift).toBe(false);
+    }
+  });
+
+  test("a reading exactly at the limit is still served", async () => {
+    fetchMock.mockResolvedValue(textResponse(CAPTURED));
+    const atLimit = OBSERVED_AT + MAX_WAVE_AGE_MINUTES * 60_000;
+    expect((await fetchLatestWave("46254", atLimit)).kind).toBe("ok");
+  });
+
+  test("404 is a buoy that is not publishing, said in those words", async () => {
+    fetchMock.mockResolvedValue(textResponse("", 404));
+
+    const result = await fetchLatestWave("46235", OBSERVED_AT);
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") {
+      expect(result.reason).toMatch(/not publishing/);
+    }
+  });
+
+  test("another bad status is reported with its number", async () => {
+    fetchMock.mockResolvedValue(textResponse("", 503));
+    const result = await fetchLatestWave("46254", OBSERVED_AT);
+    if (result.kind === "unavailable")
+      expect(result.reason).toMatch(/HTTP 503/);
+  });
+
+  test("a request that never completes is unavailable, not a throw", async () => {
+    fetchMock.mockRejectedValue(new Error("socket hang up"));
+
+    const result = await fetchLatestWave("46254", OBSERVED_AT);
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") {
+      expect(result.reason).toMatch(/socket hang up/);
+    }
+  });
+
+  test("a drifted layout is flagged as drift, separately from a quiet buoy", async () => {
+    fetchMock.mockResolvedValue(textResponse(CAPTURED.replace("WVHT", "WVHZ")));
+
+    const result = await fetchLatestWave("46254", OBSERVED_AT);
+
+    // Drift is a bug to chase here; a quiet buoy is not.
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") expect(result.drift).toBe(true);
+  });
+
+  test("headers with no rows is a quiet buoy rather than drift", async () => {
+    const headerOnly = CAPTURED.split("\n").slice(0, 2).join("\n");
+    fetchMock.mockResolvedValue(textResponse(`${headerOnly}\n`));
+
+    const result = await fetchLatestWave("46254", OBSERVED_AT);
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") expect(result.drift).toBe(false);
+  });
+});
+
+describe("fetchTideExtremes", () => {
+  const contract = {
+    stationId: "9410230",
+    beginDate: "20260817",
+    endDate: "20260818",
+  };
+
+  test("opts into caching for six hours, predictions being astronomical", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        predictions: [{ t: "2026-08-17 13:24", v: "1.368", type: "L" }],
+      }),
+    );
+
+    await fetchTideExtremes(contract);
+
+    expect(fetchMock.mock.calls[0][1].next.revalidate).toBe(
+      PREDICTIONS_REVALIDATE_SECONDS,
+    );
+  });
+
+  test("an error under HTTP 200 is unavailable and not drift", async () => {
+    // CO-OPS serves this with a success status. A caller trusting the status
+    // code would treat it as a payload.
+    fetchMock.mockResolvedValue(
+      jsonResponse({ error: { message: "No Predictions data was found." } }),
+    );
+
+    const result = await fetchTideExtremes(contract);
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind === "unavailable") {
+      expect(result.reason).toMatch(/No Predictions data was found/);
+      expect(result.drift).toBe(false);
+    }
+  });
+
+  test("a body that is not JSON is reported as such", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("Unexpected token <");
+      },
+    });
+
+    const result = await fetchTideExtremes(contract);
+    if (result.kind === "unavailable")
+      expect(result.reason).toMatch(/was not JSON/);
+  });
+
+  test("a bad status names the station", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, 500));
+    const result = await fetchTideExtremes(contract);
+    if (result.kind === "unavailable") expect(result.reason).toMatch(/9410230/);
+  });
+
+  test("a drifted payload is flagged as drift", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ somethingElse: [] }));
+    const result = await fetchTideExtremes(contract);
+    if (result.kind === "unavailable") expect(result.drift).toBe(true);
+  });
+});

--- a/src/lib/upstream.ts
+++ b/src/lib/upstream.ts
@@ -42,6 +42,12 @@ import {
   type CoopsRequestContract,
   type TideExtreme,
 } from "./coops-predictions";
+import {
+  NdbcDriftError,
+  NdbcNoDataError,
+  parseNdbcRealtime2,
+  type WaveObservation,
+} from "./ndbc-realtime2";
 
 /** Six hours. Astronomical predictions do not change; the window only rolls forward. */
 export const PREDICTIONS_REVALIDATE_SECONDS = 21600;
@@ -117,4 +123,101 @@ export async function fetchTideExtremes(
     }
     return unavailable(cause instanceof Error ? cause.message : String(cause));
   }
+}
+
+/* ===========================================================================
+ * NDBC waves and water temperature
+ * ========================================================================= */
+
+/**
+ * Fifteen minutes. These buoys publish about every thirty, so a quarter-hour
+ * never serves a reading more than one cycle stale, and asking more often would
+ * cost NDBC requests that cannot return anything new.
+ */
+export const WAVES_REVALIDATE_SECONDS = 900;
+
+/**
+ * Beyond this, a "current" reading is not current. These buoys publish about
+ * every thirty minutes, so three hours means at least five missed cycles: the
+ * buoy is answering and not reporting. Reported as unknown rather than as a
+ * stale number wearing no warning.
+ */
+export const MAX_WAVE_AGE_MINUTES = 180;
+
+const NDBC_BASE = "https://www.ndbc.noaa.gov/data/realtime2";
+
+export type WaveResult =
+  | {
+      kind: "ok";
+      observation: WaveObservation;
+      ageMinutes: number;
+      url: string;
+    }
+  | { kind: "unavailable"; reason: string; drift: boolean; url: string };
+
+/**
+ * Fetch one buoy's newest wave observation.
+ *
+ * Never throws. `nowMs` is passed in rather than read here, so the freshness
+ * limit is testable against a fixed instant and no clock is read during a
+ * render.
+ */
+export async function fetchLatestWave(
+  buoyId: string,
+  nowMs: number,
+): Promise<WaveResult> {
+  const url = `${NDBC_BASE}/${buoyId}.txt`;
+
+  const unavailable = (reason: string, drift = false): WaveResult => ({
+    kind: "unavailable",
+    reason,
+    drift,
+    url,
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { "User-Agent": USER_AGENT },
+      next: { revalidate: WAVES_REVALIDATE_SECONDS },
+    });
+  } catch (cause) {
+    return unavailable(
+      `The request to NDBC for buoy ${buoyId} did not complete: ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+
+  if (response.status === 404) {
+    // What a decommissioned buoy does. Its entry in NDBC's active station list
+    // can outlive it, which is why the inventory records measured delivery.
+    return unavailable(
+      `NDBC ${buoyId} returns 404 for its observations. The buoy is not publishing.`,
+    );
+  }
+  if (!response.ok) {
+    return unavailable(
+      `NDBC returned HTTP ${response.status} for buoy ${buoyId}.`,
+    );
+  }
+
+  let observation: WaveObservation;
+  try {
+    observation = parseNdbcRealtime2(await response.text(), buoyId);
+  } catch (cause) {
+    if (cause instanceof NdbcDriftError)
+      return unavailable(cause.message, true);
+    if (cause instanceof NdbcNoDataError) return unavailable(cause.message);
+    return unavailable(cause instanceof Error ? cause.message : String(cause));
+  }
+
+  const ageMinutes = (nowMs - observation.atMs) / 60_000;
+  if (ageMinutes > MAX_WAVE_AGE_MINUTES) {
+    return unavailable(
+      `NDBC ${buoyId}'s newest observation is ${Math.round(ageMinutes)} minutes old, past the ` +
+        `${MAX_WAVE_AGE_MINUTES} minute limit. Reported as unknown rather than as a current reading.`,
+    );
+  }
+
+  return { kind: "ok", observation, ageMinutes, url };
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -34,10 +34,10 @@ export default defineConfig({
       // run-vitest.mjs and check-built-css.mjs sit at 0% on purpose, and all
       // three drag these figures down in plain sight rather than quietly.
       thresholds: {
-        statements: 80.71,
-        branches: 82.25,
-        functions: 87.78,
-        lines: 80.17,
+        statements: 86.14,
+        branches: 86.87,
+        functions: 90.9,
+        lines: 86.06,
       },
     },
   },


### PR DESCRIPTION
Closes #68

Slice 6. Ten NDBC buoys cover the open coast, and **46 of the 73 beaches** now
carry a wave height, a period and a water temperature from the nearest one that
actually delivers.

Two commits: the geometry extraction first, then the feature.

## Measured, not read off the list

`activestations.xml` lists **19** stations in the box. `realtime2` was then asked
for each one. **Ten deliver.**

`46273` Torrey Pines Inner and `46235` Imperial Beach both **404 while listed
active** — 46235 independently confirming what `socal-coastal-data` recorded — and
the four fixed coastal stations 404 as well. That is the **third** appearance of
listed-but-not-delivering after `TWC0405` in the tide join, which is why every
station table in this repo carries a measured `delivers` rather than an inherited
one.

## No nearshore buoy publishes wind or visibility

**None of the ten.** In slice 3 I saw this on 46254 and recorded it as that
station's quirk; measured across the corridor it is categorical. The only station
in the box with wind, `46086`, sits 27 nautical miles offshore and publishes no
waves at all.

So two of the four words in this site's own **"Surf · Tide · Wind · Visibility"**
can only ever come from the NWS gridpoint forecast. Slice 7 is required, not
optional.

## Bay beaches get nothing, on purpose

The wave join is deliberately **asymmetric** with the tide join. The tide has two
water classes and binds a beach to the matching one; every wave buoy is
open-coast, so a bay, lagoon or inlet binds to **nothing at all**. 27 beaches have
no wave height and their pages say why.

Putting an open-ocean 3 ft on a lagoon would tell a parent something false about
the water their children are about to paddle in. `no-buoy` is a permanent fact
about a place, kept apart from `unavailable`, which is a feed having a bad day.

## The parser reads its own units

`realtime2` states them on its second header line, so `m` and `degC` are asserted
rather than assumed — an upstream switch to feet would otherwise be invisible and
would read as a very calm day. The column layout is pinned **by name**, because
the only way to know the ninth field is wave height is that the header still says
so. `MM` is absent rather than zero: every buoy here leaves wind `MM` on every
row, and reading that as a number would report a dead calm coastline.

The newest observation is the **first** row — NDBC serves newest-first, the
opposite of CO-OPS, and taking the last would report a days-old reading as
current.

## Verification

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

Exit code 0, 321 tests.

Against the running site, live NDBC:

```
/conditions
  Waves and water · La Jolla Shores Beach — 2.6 ft — about waist high, 5 seconds
  apart. The water is 70°F. Measured at NDBC buoy Scripps Nearshore.

/conditions/agua-hedionda-lagoon
  We cannot give a wave height here, and that is what we expect rather than a
  fault. Every wave buoy sits out on the open coast.

/conditions/tijana-river
  4.3 ft — overhead for a child, 14 seconds apart. The water is 71°F. Measured at
  NDBC buoy Point Loma South, about 34 km from this beach.
```

That last one is what 46235 being dead costs the south county, disclosed rather
than hidden. "Tijana River" is upstream's own spelling of Tijuana, reproduced as
published.

**Coverage rose** to 86.14 / 86.87 / 90.9 / 86.06 and the floor is raised to
match. The new fetch policy is tested by stubbing `fetch` rather than left as
plumbing — what a 404 means, when a reading is too old to be called current, and
which failures are drift are rules, and none of them can be asserted against a
live buoy that is having a good day.

## What I did not do, and what is worth arguing with

- **The height bands are my wording, not a standard.** "About waist high",
  "overhead for a child" — these describe a published measurement and are
  deliberately not advice, but they are the most opinionated text on the site and
  the thing most worth a second opinion.
- **No shoaling or refraction transform.** A buoy's significant wave height is not
  the height breaking at the shore. The number shown is what was measured, and
  the attribution says so; converting it would be inventing a figure.
- **Bay beaches still have no water temperature**, since it arrives on the same
  row as the waves. The surf zone forecast's county-wide range fills that in
  slice 9.
- **`46086` is recorded and bound to nothing.** It is the only station in the box
  with wind, so it is in the table for slice 7 to find rather than deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
