### PR TITLE
Show visibility, wind, air temperature and sky, from the station that publishes them

### DIFF
--- a/docs/plans/conditions-tool.md
+++ b/docs/plans/conditions-tool.md
@@ -78,19 +78,20 @@ authority can state which beaches this repo chose to ask about.
 
 ### What is fetched, and its contract
 
-| Product                              | Serves                             | Horizon         | Contract facts, measured                                                                                                                                                                                                                                         |
-| ------------------------------------ | ---------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CO-OPS predictions                   | tides                              | years           | `time_zone=gmt`, `units=english`, `datum=MLLW`. Returned timestamps carry no offset. Serves `{"error":{...}}` under HTTP 200 — a dead response, not a payload.                                                                                                   |
-| NDBC `realtime2`                     | waves, water temp                  | now             | 19-column pinned header. Wave height in metres, `WTMP` in °C. On 46254, `WDIR`, `WSPD`, `GST`, `ATMP`, `VIS` are all `MM` — so wave and water temp yes, **wind and visibility no**. A reading older than 180 minutes is reported unknown.                        |
-| NWS `/points` → `/gridpoints`        | wind, visibility, air temp, sky    | 7 d             | Resolve `gridId`/`gridX`/`gridY` once per beach and commit it, so an NWS re-grid appears as a diff. Self-identifying User-Agent required.                                                                                                                        |
-| NWS active alerts                    | hazards                            | now             | An empty `features` array is a valid empty response, not a failure.                                                                                                                                                                                              |
-| NWS surf zone forecast, SGX          | rip current risk, surf, water temp | ~3 d            | Two zones cover the whole extent: `CAZ043` San Diego County Coastal and `CAZ552` Orange County Coastal. Measured 2026-08-17: rip current risk "Moderate", surf 2 to 4 feet, water temperature "65 to 73 degrees", tides quoted at La Jolla. Already °F and feet. |
-| CO-OPS `water_temperature` @ 9410230 | swimmers                           | now             | `&date=latest`. A real station reading where the SRF gives a county range.                                                                                                                                                                                       |
-| SCCOOS ERDDAP                        | water science                      | trailing weekly | Columns are `time,Temp,Salinity,Avg_Chloro,Pseudo_nitzschia_seriata_group` — capitalised `Temp`; `temperature` exists on no SCCOOS dataset. A 404 carrying "no matching results" means the query was valid and the window empty.                                 |
-| iNaturalist                          | education                          | trailing 14 d   | One request per beach on its own coordinates and radius, never a corridor bbox: the bbox needs ~12 pages and ~144 MB and still misses coastal sites, where per-beach requests total ~142 kB. HTTP 422 is a rejected query, not an empty one.                     |
-| CDFW ds582 marine protected areas    | tidepoolers                        | dated snapshot  | Content date 2019-01-01, layer last edit 2024-01-09 — both recorded. `Type` is a join result, never string-matched off the name. Publisher disclaimer: "not intended for navigational use or defining legal boundaries."                                         |
-| Beach advisories archive             | water quality                      | historical only | See below.                                                                                                                                                                                                                                                       |
-| Daylight                             | all                                | any             | Computed in-repo. There is no sun API here and there should not be.                                                                                                                                                                                              |
+| Product                              | Serves                             | Horizon         | Contract facts, measured                                                                                                                                                                                                                                                                                                                                                                   |
+| ------------------------------------ | ---------------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| CO-OPS predictions                   | tides                              | years           | `time_zone=gmt`, `units=english`, `datum=MLLW`. Returned timestamps carry no offset. Serves `{"error":{...}}` under HTTP 200 — a dead response, not a payload.                                                                                                                                                                                                                             |
+| NDBC `realtime2`                     | waves, water temp                  | now             | 19-column pinned header. Wave height in metres, `WTMP` in °C. On 46254, `WDIR`, `WSPD`, `GST`, `ATMP`, `VIS` are all `MM` — so wave and water temp yes, **wind and visibility no**. A reading older than 180 minutes is reported unknown.                                                                                                                                                  |
+| NWS `/points` → `/gridpoints`        | wind, air temp, sky                | 7 d             | Resolve `gridId`/`gridX`/`gridY` once per beach and commit it, so an NWS re-grid appears as a diff. Self-identifying User-Agent required. **Publishes no visibility**: the key is present and its `values` array is empty at every grid in the county, measured 2026-08-18. `/points` 301-redirects on coordinates finer than four decimals and returns no marine zone.                    |
+| NWS `/stations/{id}/observations`    | visibility, wind, air temp, sky    | now             | `wmoUnit:m`, `wmoUnit:degC`, `wmoUnit:km_h-1`, asserted per field. Visibility tops out at ten statute miles, published as 16093.44 m or 16090 m, so the ceiling is a floor. A station that stops publishing serves `{"value": null}` rather than dropping the key. Only 9 of the 56 candidates in the county publish visibility, and the two nearest the default beach are not among them. |
+| NWS active alerts                    | hazards                            | now             | An empty `features` array is a valid empty response, not a failure.                                                                                                                                                                                                                                                                                                                        |
+| NWS surf zone forecast, SGX          | rip current risk, surf, water temp | ~3 d            | Two zones cover the whole extent: `CAZ043` San Diego County Coastal and `CAZ552` Orange County Coastal. Measured 2026-08-17: rip current risk "Moderate", surf 2 to 4 feet, water temperature "65 to 73 degrees", tides quoted at La Jolla. Already °F and feet.                                                                                                                           |
+| CO-OPS `water_temperature` @ 9410230 | swimmers                           | now             | `&date=latest`. A real station reading where the SRF gives a county range.                                                                                                                                                                                                                                                                                                                 |
+| SCCOOS ERDDAP                        | water science                      | trailing weekly | Columns are `time,Temp,Salinity,Avg_Chloro,Pseudo_nitzschia_seriata_group` — capitalised `Temp`; `temperature` exists on no SCCOOS dataset. A 404 carrying "no matching results" means the query was valid and the window empty.                                                                                                                                                           |
+| iNaturalist                          | education                          | trailing 14 d   | One request per beach on its own coordinates and radius, never a corridor bbox: the bbox needs ~12 pages and ~144 MB and still misses coastal sites, where per-beach requests total ~142 kB. HTTP 422 is a rejected query, not an empty one.                                                                                                                                               |
+| CDFW ds582 marine protected areas    | tidepoolers                        | dated snapshot  | Content date 2019-01-01, layer last edit 2024-01-09 — both recorded. `Type` is a join result, never string-matched off the name. Publisher disclaimer: "not intended for navigational use or defining legal boundaries."                                                                                                                                                                   |
+| Beach advisories archive             | water quality                      | historical only | See below.                                                                                                                                                                                                                                                                                                                                                                                 |
+| Daylight                             | all                                | any             | Computed in-repo. There is no sun API here and there should not be.                                                                                                                                                                                                                                                                                                                        |
 
 **The surf zone forecast is zone-level.** Its values render identically at all 82
 beaches, so it is presented as what the county forecast says, never as a reading
@@ -209,9 +210,13 @@ boundaries, because five slices or ~400 lines is the reviewable limit.
 6. Waves and water temp from NDBC: buoy binding with fallback, the 180-minute
    limit, substitution disclosed, and the "no water temp at this buoy" state,
    which is measured rather than hypothetical.
-7. Wind, visibility, air temp and sky from NWS gridpoint. Until this lands, two
-   of the four words in "Surf · Tide · Wind · Visibility" have nothing behind
-   them.
+7. Split after measurement; see the 2026-08-18 addendum.
+   - **7a.** Visibility, wind, air temp and sky from the NWS **observation
+     station**, joined on measured delivery. Until this lands, two of the four
+     words in "Surf · Tide · Wind · Visibility" have nothing behind them.
+   - **7b.** The gridpoint's wind, air temp and sky, which are a forecast and
+     therefore belong with the forward panel in slice 8 rather than beside a
+     reading.
 
 **PR D — planning and safety**
 
@@ -297,7 +302,8 @@ the 82 beaches.
    coast, 9410170 is bay only, and the lagoons are neither.
 3. **Does SCCOOS still cover anything in San Diego County beyond Scripps Pier?**
    If not, the water-science panel is one location's data and must say so rather
-   than render blank elsewhere.
+   than render blank elsewhere. **Answered — no. See the 2026-08-18 slice 7a
+   addendum.**
 4. **Next 16.3's caching API.** Every revalidate interval here is provisional
    until slice 3 reads the shipped documentation. **Answered — see the addendum.**
 
@@ -452,6 +458,11 @@ nautical miles offshore and publishes no waves. So slice 7 is not an enhancement
 two of the four words in the site's own "Surf · Tide · Wind · Visibility" can only
 ever come from the National Weather Service gridpoint forecast.
 
+> Corrected 2026-08-18 by the slice 7a addendum below, on two counts. The
+> gridpoint publishes no visibility anywhere in the county, so visibility comes
+> from an observation station rather than the gridpoint; and 46086 does publish
+> waves, on 27 of 48 rows — see #70. Neither changes what slice 6 shipped.
+
 **Two more listed-but-dead stations.** 46273 Torrey Pines Inner and 46235 Imperial
 Beach both 404 while listed active — 46235 independently confirming what
 `socal-coastal-data` recorded. That is the third time the pattern has appeared,
@@ -479,3 +490,86 @@ match. The new fetch policy is tested by stubbing `fetch` rather than left as
 plumbing: what a 404 means, when a reading is too old to be called current, and
 which failures are drift are rules, not wiring, and none of them can be asserted
 against a live buoy that is having a good day.
+
+### 2026-08-18 — slice 7a, and the gridpoint that has no visibility
+
+**The plan was wrong about where visibility comes from, and slice 6's addendum
+repeated it.** Both said wind and visibility "can only ever come from the
+National Weather Service gridpoint forecast". Measured by calling
+`/gridpoints/SGX/{x},{y}` at four widely separated points, the gridpoint
+publishes **no visibility at all** — the key is present, its `values` array is
+empty, and it carries no `uom`:
+
+```
+Oceanside      SGX/52,36  vis=0  wind=56  temp=74  sky=35
+La Jolla       SGX/55,22  vis=0  wind=63  temp=92  sky=34
+Mission Beach  SGX/54,17  vis=0  wind=65  temp=91  sky=36
+Imperial Beach SGX/57,8   vis=0  wind=58  temp=85  sky=36
+```
+
+Visibility is an **observation**, served by `/stations/{id}/observations/latest`.
+That reclassifies the work: the gridpoint is a seven-day forecast, and PR C is
+where the site's promised _readings_ live. So slice 7 split. 7a is this slice —
+the observed reading. 7b is the gridpoint, folded into slice 8's forward panel,
+where forecast provenance is already the frame and the plan's rule against
+blending a forecast into a reading is already enforced by a type.
+
+**The listed-but-dead trap, a fourth and fifth time.** Of 163 candidate stations
+across the 35 distinct grids the 73 beaches resolve to, 159 answered and **only
+24 published a visibility value** — every one an airport METAR. Inside the county
+box: 56 candidates, **9 publish visibility**, 46 answer perfectly without it, and
+`KF70` 404s while listed. The two stations nearest the default beach, `D3101` and
+`MSDSD`, are both in the 46. A nearest-station join would therefore have bound
+this site's visibility promise to a station that has never published one, which
+is why the join filters on measured `publishes_visibility` rather than on
+distance alone. It also means one station supplies all four values, so the panel
+never blends two provenances.
+
+The join produces KSAN 36, KNKX 14, KCRQ 11, KOKB 5, KSDM 5, KNFG 1, and no
+station for the one beach whose coordinates upstream publishes transposed —
+the same beach the tide and wave joins already refuse. Median distance 7.3 km,
+farthest 16.8 km.
+
+**This join is deliberately not asymmetric the way the wave join is.** Every
+beach binds a station, bays and lagoons included: ocean swell does not propagate
+into enclosed water, and air does. Making the two joins symmetric out of a sense
+of tidiness would silently strip wind and visibility from twenty-six beaches, so
+`weather-join.test.mjs` asserts a bay beach binds.
+
+**Ten miles is a ceiling, not a measurement**, decided with Cole. METAR stops
+there, and the nine stations publish it as either 16093.44 m or 16090 m, so an
+equality test against one spelling would let the other render as a measurement.
+The parser carries `visibilityAtCeiling` out as a flag rather than leaving the
+view to rediscover it from a magic number, and the view renders "10 miles or
+more".
+
+**Open question 3 is answered: no.** SCCOOS ERDDAP lists 35 datasets, four inside
+the county box, and only the Scripps Pier pair still delivers:
+
+```
+HABs-ScrippsPier   32.867  -117.257    newest 2026-07-13  ALIVE (Temp 21.9)
+SPATT-ScrippsPier  32.867  -117.257    (Scripps Pier)
+delmar_salinity    32.93   -117.32     newest 2022-05-18  DEAD, no temperature column
+pH-AHL             33.1425 -117.3275   newest 2021-01-06  DEAD
+```
+
+`delmar_salinity` carries no temperature column at all, and `pH-AHL` — a SeapHOx
+in Agua Hedionda Lagoon, which would have been the one instrument inside any of
+the lagoons — stopped in January 2021. The water-science panel is one location's
+data and must say so rather than render blank elsewhere, exactly as the question
+anticipated. `HABs-ScrippsPier`'s newest sample is 35 days old against a trailing
+weekly product, which is its own thing to watch.
+
+**One thing outside this slice came with it.** `wave-buoys.json` records that
+46086 "delivers wind and water temp but no waves". Measured twice, it publishes
+`WVHT` on 27 of 48 rows and the newest row carried 1.6 m; the buoy reports on a
+shorter cycle than it measures waves, and a single read lands on an `MM` row
+about a third of the time. Nothing renders it — 46086 is bound to no beach — but
+the sentence reaches a reader through the caveats gate. Filed as #70 rather than
+folded into this diff.
+
+**Coverage rose to 88.1 / 88.66 / 92.48 / 88.12** and the floor was raised to
+match. Raising it surfaced a real gap rather than a bookkeeping one: `document()`
+was only ever exercised with a single beach, so its `reduce` and `sort`
+callbacks never ran and "the farthest beach from its station" was asserted by
+nothing. That test now builds two.

--- a/scripts/seed-beaches.mjs
+++ b/scripts/seed-beaches.mjs
@@ -28,6 +28,7 @@ import { pathToFileURL } from "node:url";
 import { distanceMetres } from "./geo.mjs";
 import { bindTideStation } from "./tide-join.mjs";
 import { bindWaveBuoy } from "./wave-join.mjs";
+import { bindWeatherStation } from "./weather-join.mjs";
 
 const PORTAL = "https://data.cnra.ca.gov";
 const RESOURCE = "cc674e59-036c-45c3-bec2-5d3d294e0e3d";
@@ -39,6 +40,10 @@ const BEACHES_PATH = new URL("../src/data/beaches.json", import.meta.url);
 const BUOYS_PATH = new URL("../src/data/wave-buoys.json", import.meta.url);
 const STATIONS_PATH = new URL(
   "../src/data/tide-stations.json",
+  import.meta.url,
+);
+const WEATHER_PATH = new URL(
+  "../src/data/weather-stations.json",
   import.meta.url,
 );
 
@@ -192,7 +197,7 @@ export function regionOf(waterClass, meanLat) {
   return "South County coast";
 }
 
-export function build(rows, stations, buoys) {
+export function build(rows, stations, buoys, weatherStations) {
   const seen = new Map();
 
   const beaches = rows.map((row) => {
@@ -230,6 +235,10 @@ export function build(rows, stations, buoys) {
     const wave = fault
       ? { buoyId: null, reason: fault }
       : bindWaveBuoy({ segment, waterBodyType: row.WaterBodyType }, buoys);
+    // No water-class rule here, unlike the wave join: air reaches a lagoon.
+    const weather = fault
+      ? { stationId: null, reason: fault }
+      : bindWeatherStation({ segment }, weatherStations);
 
     const meanLat = (segment.upper.lat + segment.lower.lat) / 2;
 
@@ -258,6 +267,14 @@ export function build(rows, stations, buoys) {
       wave_buoy_distance_m: wave.buoyId ? Math.round(wave.distanceM) : null,
       wave_buoy_from_end: wave.buoyId ? wave.fromEnd : null,
       wave_buoy_null_reason: wave.buoyId ? undefined : wave.reason,
+      weather_station: weather.stationId,
+      weather_station_distance_m: weather.stationId
+        ? Math.round(weather.distanceM)
+        : null,
+      weather_station_from_end: weather.stationId ? weather.fromEnd : null,
+      weather_station_null_reason: weather.stationId
+        ? undefined
+        : weather.reason,
     };
   });
 
@@ -274,6 +291,14 @@ export function build(rows, stations, buoys) {
 
 export function document(beaches) {
   const unbound = beaches.filter((b) => b.tide_station === null);
+  const withWeather = beaches.filter((b) => b.weather_station !== null);
+  const farthestWeather = withWeather.reduce((a, b) =>
+    b.weather_station_distance_m > a.weather_station_distance_m ? b : a,
+  );
+  const weatherKm = withWeather
+    .map((b) => b.weather_station_distance_m / 1000)
+    .sort((a, b) => a - b);
+  const medianWeatherKm = weatherKm[Math.floor(weatherKm.length / 2)];
   const farthest = beaches
     .filter((b) => b.tide_station !== null)
     .reduce((a, b) =>
@@ -322,6 +347,15 @@ export function document(beaches) {
         "Great-circle metres from the nearer segment end to the station.",
       tide_station_from_end:
         "Which end of the segment supplied the distance, upper or lower.",
+      weather_station:
+        "Joined, never typed: the nearest station that both answers and publishes visibility. " +
+        "Unlike the wave buoy, every beach binds one -- air reaches a lagoon. null means the " +
+        "join could not bind one, and weather_station_null_reason says why.",
+      weather_station_distance_m:
+        "Great-circle metres from the nearer segment end to the station. Larger than the tide " +
+        "and buoy distances by nature: the stations that publish visibility are airports.",
+      weather_station_from_end:
+        "Which end of the segment supplied the distance, upper or lower.",
     },
     beaches,
     // Written out in full every run, never merged with what is already on disk:
@@ -343,6 +377,12 @@ export function document(beaches) {
         `Their water temperature is missing for the same reason and is not yet filled from another source.`,
       "A tide prediction is for the station, not for the beach. It is the best published figure " +
         "for that stretch of shore and it is not a measurement taken there.",
+      `Visibility, wind, air temperature and sky are read at an airport, because the airports are ` +
+        `the only stations in this county that publish visibility at all. The median beach here ` +
+        `reads a station ${Math.round(medianWeatherKm * 10) / 10} km away and the farthest reads ` +
+        `one ${(farthestWeather.weather_station_distance_m / 1000).toFixed(1)} km away, at ` +
+        `${farthestWeather.name}. Coastal fog is precisely what changes over that distance, so ` +
+        `those four figures describe the airport and not the shoreline.`,
       ...(unbound.length > 0
         ? [
             `${unbound.length} beach(es) could not be bound to a station: ` +
@@ -372,6 +412,9 @@ async function main() {
 
   const stations = JSON.parse(readFileSync(STATIONS_PATH, "utf8")).stations;
   const buoys = JSON.parse(readFileSync(BUOYS_PATH, "utf8")).buoys;
+  const weatherStations = JSON.parse(
+    readFileSync(WEATHER_PATH, "utf8"),
+  ).stations;
   let existing = null;
   try {
     existing = JSON.parse(readFileSync(BEACHES_PATH, "utf8"));
@@ -380,7 +423,7 @@ async function main() {
   }
 
   const rows = await fetchRows();
-  const built = document(build(rows, stations, buoys));
+  const built = document(build(rows, stations, buoys, weatherStations));
 
   // `generated` is the one field that moves on every run by design, so comparing
   // it would make every check fail and mean nothing.

--- a/scripts/seed-beaches.test.mjs
+++ b/scripts/seed-beaches.test.mjs
@@ -32,6 +32,29 @@ const STATIONS = {
   9410170: { lat: 32.7156, lon: -117.1767, water: "bay", delivers: true },
 };
 
+const WEATHER = {
+  KNKX: {
+    lat: 32.86833,
+    lon: -117.1425,
+    delivers: true,
+    publishes_visibility: true,
+  },
+  KSAN: {
+    lat: 32.73361,
+    lon: -117.18306,
+    delivers: true,
+    publishes_visibility: true,
+  },
+  // Answers, publishes no visibility. Nearer most of these beaches than either
+  // of the above, and refused by the join for exactly that reason.
+  D3101: {
+    lat: 32.92083,
+    lon: -117.25283,
+    delivers: true,
+    publishes_visibility: false,
+  },
+};
+
 const at = (lat, lon, dLat = 0.01) => ({
   upper: { lat: lat + dLat, lon },
   lower: { lat, lon },
@@ -120,7 +143,7 @@ describe("regionOf", () => {
 
 describe("build", () => {
   it("binds a beach and records how the join measured it", () => {
-    const [beach] = build([row()], STATIONS, BUOYS);
+    const [beach] = build([row()], STATIONS, BUOYS, WEATHER);
 
     expect(beach.slug).toBe("somewhere-beach");
     expect(beach.tide_station).toBe("9410230");
@@ -131,6 +154,13 @@ describe("build", () => {
     // gets one.
     expect(beach.wave_buoy).toBe("46254");
     expect(beach.wave_buoy_distance_m).toBeGreaterThan(0);
+
+    // So does the observation station, and it is the nearest one that
+    // publishes visibility rather than the nearest one full stop: D3101 is
+    // closer to this row than KNKX and publishes none.
+    expect(beach.weather_station).toBe("KNKX");
+    expect(beach.weather_station_distance_m).toBeGreaterThan(0);
+    expect(["upper", "lower"]).toContain(beach.weather_station_from_end);
   });
 
   it("gives a bay beach a tide station and no wave buoy", () => {
@@ -138,12 +168,18 @@ describe("build", () => {
       [row({ WaterBodyType: "Sound, Bay, or Inlet" })],
       STATIONS,
       BUOYS,
+      WEATHER,
     );
 
     // Swell does not reach into a bay, and the tide certainly does.
     expect(beach.tide_station).toBe("9410170");
     expect(beach.wave_buoy).toBeNull();
     expect(beach.wave_buoy_null_reason).toMatch(/does not reach into a bay/);
+
+    // Air does reach into a bay, so this join is not asymmetric the way the
+    // wave join is. Making the two symmetric would silently strip wind and
+    // visibility from twenty-six beaches.
+    expect(beach.weather_station).not.toBeNull();
   });
 
   it("refuses a beach whose coordinates cannot be used, and says why", () => {
@@ -159,16 +195,23 @@ describe("build", () => {
       ],
       STATIONS,
       BUOYS,
+      WEATHER,
     );
 
     expect(beach.tide_station).toBeNull();
     expect(beach.tide_station_null_reason).toMatch(/outside San Diego County/);
+    // The fault stops every join, not just the tide one. A coordinate nobody
+    // can trust must not produce a confident airport reading either.
+    expect(beach.weather_station).toBeNull();
+    expect(beach.weather_station_null_reason).toMatch(
+      /outside San Diego County/,
+    );
   });
 
   it("stops on a duplicate slug rather than disambiguating one", () => {
     // A slug is a primary key. Making one unique automatically would make it
     // unstable, and data accumulates against it.
-    expect(() => build([row(), row()], STATIONS, BUOYS)).toThrow(
+    expect(() => build([row(), row()], STATIONS, BUOYS, WEATHER)).toThrow(
       /is claimed by both/,
     );
   });
@@ -176,12 +219,14 @@ describe("build", () => {
   it("stops when a pinned column is missing", () => {
     const missing = row();
     delete missing["Beach_ UpperLon"];
-    expect(() => build([missing], STATIONS, BUOYS)).toThrow(/has drifted/);
+    expect(() => build([missing], STATIONS, BUOYS, WEATHER)).toThrow(
+      /has drifted/,
+    );
   });
 
   it("stops when a coordinate does not parse", () => {
     expect(() =>
-      build([row({ Beach_UpperLat: "north a bit" })], STATIONS, BUOYS),
+      build([row({ Beach_UpperLat: "north a bit" })], STATIONS, BUOYS, WEATHER),
     ).toThrow(/did not parse as numbers/);
   });
 
@@ -201,6 +246,7 @@ describe("build", () => {
       ],
       STATIONS,
       BUOYS,
+      WEATHER,
     );
     expect(built.map((b) => b.slug)).toEqual(["north-one", "south-one"]);
   });
@@ -218,6 +264,7 @@ describe("document", () => {
       ],
       STATIONS,
       BUOYS,
+      WEATHER,
     );
     const doc = document(built);
 
@@ -226,11 +273,52 @@ describe("document", () => {
     );
   });
 
+  it("tells a reader the weather figures are read at an airport", () => {
+    const built = document(build([row()], STATIONS, BUOYS, WEATHER));
+    const airport = built.unresolved.find((entry) =>
+      entry.includes("read at an airport"),
+    );
+
+    // The four values in that panel come from a station some kilometres
+    // inland, and coastal fog is precisely what changes over that distance.
+    // A reader who is not told that will read it as a beach measurement.
+    expect(airport).toBeDefined();
+    expect(airport).toMatch(/km away/);
+  });
+
+  it("names the farthest beach from its station, not merely the first", () => {
+    // Two beaches, so the reduce and the sort actually run. With one, the
+    // callbacks never fire and "farthest" is whatever happened to be there --
+    // which is how a single-row fixture can leave a real rule unasserted.
+    const near = row({
+      Beach_Name: "Near The Airport",
+      Beach_UpperLat: "32.87",
+      "Beach_ UpperLon": "-117.15",
+      Beach_LowerLat: "32.86",
+      Beach_LowerLon: "-117.16",
+    });
+    const far = row({
+      Beach_Name: "Far From The Airport",
+      Beach_UpperLat: "33.05",
+      "Beach_ UpperLon": "-117.30",
+      Beach_LowerLat: "33.04",
+      Beach_LowerLon: "-117.31",
+    });
+
+    const built = document(build([near, far], STATIONS, BUOYS, WEATHER));
+    const airport = built.unresolved.find((entry) =>
+      entry.includes("read at an airport"),
+    );
+
+    expect(airport).toContain("Far From The Airport");
+    expect(airport).not.toContain("at Near The Airport");
+  });
+
   it("writes its caveats out in full, so two runs agree", () => {
     // Carrying entries forward from the file duplicated them on the second run,
     // and made --check report movement immediately after a seed. A check that
     // cannot say "unchanged" says nothing.
-    const built = build([row()], STATIONS, BUOYS);
+    const built = build([row()], STATIONS, BUOYS, WEATHER);
     const first = document(built).unresolved;
     const second = document(built).unresolved;
 

--- a/scripts/weather-join.mjs
+++ b/scripts/weather-join.mjs
@@ -1,0 +1,62 @@
+/**
+ * Binding a beach to a National Weather Service observation station.
+ *
+ * Pure, like the two joins beside it, and the same shape: nearest **delivering**
+ * candidate, measured from whichever end of the beach's segment is closer, ties
+ * broken on the id so two runs over the same inputs produce the same file.
+ *
+ * WHAT DIFFERS FROM THE WAVE JOIN IS THE CLASS RULE, AND IT IS THE OTHER WAY
+ * ROUND. The wave join binds nothing to a bay or lagoon, because ocean swell
+ * does not propagate into enclosed water. Air does. Fog, wind and temperature
+ * reach a lagoon exactly as they reach the open coast, so every beach binds here
+ * regardless of its water body type, and the asymmetry is deliberate rather than
+ * an oversight in one of the two.
+ *
+ * WHAT IT FILTERS ON IS `publishes_visibility`, NOT PROXIMITY. Forty-six of the
+ * fifty-six candidate stations in the county box answer perfectly and carry no
+ * visibility at all, and the two nearest La Jolla Shores -- D3101 and MSDSD --
+ * are both of that kind. A nearest-station join would therefore bind this site's
+ * visibility promise to a station that has never published one. Requiring the
+ * field means the binding is further away and can actually answer, and it means
+ * one station supplies all four of the panel's values rather than two stations
+ * being blended behind one heading.
+ */
+
+import { segmentDistance } from "./geo.mjs";
+
+/**
+ * Bind one beach to an observation station.
+ *
+ * @param {{segment: object}} beach
+ * @param {Record<string, {lat: number, lon: number, delivers: boolean, publishes_visibility: boolean}>} stations
+ * @returns {{stationId: string, distanceM: number, fromEnd: string}
+ *   | {stationId: null, reason: string}}
+ */
+export function bindWeatherStation(beach, stations) {
+  const candidates = Object.entries(stations).filter(
+    ([, station]) => station.delivers && station.publishes_visibility,
+  );
+
+  if (candidates.length === 0) {
+    return {
+      stationId: null,
+      reason:
+        "no observation station in the table both answers and publishes visibility, so " +
+        "there is nothing to bind to",
+    };
+  }
+
+  let best = null;
+  for (const [stationId, station] of candidates) {
+    const { metres, end } = segmentDistance(beach.segment, station);
+    if (
+      best === null ||
+      metres < best.distanceM ||
+      (metres === best.distanceM && stationId < best.stationId)
+    ) {
+      best = { stationId, distanceM: metres, fromEnd: end };
+    }
+  }
+
+  return best;
+}

--- a/scripts/weather-join.test.mjs
+++ b/scripts/weather-join.test.mjs
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { bindWeatherStation } from "./weather-join.mjs";
+
+/**
+ * A cut-down table with the shapes that matter: two stations that publish
+ * visibility, one that answers without it, and one that does not answer.
+ *
+ * The coordinates are the real ones, because the whole point of the join is
+ * which station is nearest.
+ */
+const STATIONS = {
+  KNKX: {
+    lat: 32.86833,
+    lon: -117.1425,
+    delivers: true,
+    publishes_visibility: true,
+  },
+  KSAN: {
+    lat: 32.73361,
+    lon: -117.18306,
+    delivers: true,
+    publishes_visibility: true,
+  },
+  // Nearer La Jolla Shores than either of the above, and publishes no
+  // visibility at all. This is the station the join has to refuse.
+  D3101: {
+    lat: 32.92083,
+    lon: -117.25283,
+    delivers: true,
+    publishes_visibility: false,
+  },
+  KF70: {
+    lat: 33.5742,
+    lon: -117.1285,
+    delivers: false,
+    publishes_visibility: false,
+  },
+};
+
+/** La Jolla Shores Beach, as the inventory holds it. */
+const LA_JOLLA_SHORES = {
+  segment: {
+    upper: { lat: 32.883647, lon: -117.252681 },
+    lower: { lat: 32.854717, lon: -117.259183 },
+  },
+};
+
+describe("bindWeatherStation", () => {
+  it("binds the nearest station that publishes visibility", () => {
+    const bound = bindWeatherStation(LA_JOLLA_SHORES, STATIONS);
+
+    expect(bound.stationId).toBe("KNKX");
+    expect(bound.fromEnd).toBe("upper");
+    expect(Math.round(bound.distanceM)).toBe(10429);
+  });
+
+  it("refuses a nearer station that publishes no visibility", () => {
+    // D3101 sits about 3.5 km from this beach and KNKX about 10.4 km, so
+    // proximity alone would pick D3101 -- which has never published a
+    // visibility value. Requiring the field is what makes the binding able to
+    // answer the question the site promises.
+    const bound = bindWeatherStation(LA_JOLLA_SHORES, STATIONS);
+    expect(bound.stationId).not.toBe("D3101");
+  });
+
+  it("refuses a station that does not answer at all", () => {
+    const onlyDead = {
+      KF70: STATIONS.KF70,
+      KSAN: STATIONS.KSAN,
+    };
+    expect(bindWeatherStation(LA_JOLLA_SHORES, onlyDead).stationId).toBe(
+      "KSAN",
+    );
+  });
+
+  it("binds a bay beach too, unlike the wave join", () => {
+    // Air reaches a lagoon; ocean swell does not. The asymmetry between this
+    // join and the wave join is deliberate, and this is the assertion that
+    // would fail if someone made them symmetric.
+    const missionBay = {
+      segment: {
+        upper: { lat: 32.7937, lon: -117.2238 },
+        lower: { lat: 32.7837, lon: -117.2238 },
+      },
+    };
+    expect(bindWeatherStation(missionBay, STATIONS).stationId).not.toBeNull();
+  });
+
+  it("says why when nothing in the table can be bound", () => {
+    const none = { D3101: STATIONS.D3101, KF70: STATIONS.KF70 };
+    const bound = bindWeatherStation(LA_JOLLA_SHORES, none);
+
+    expect(bound.stationId).toBeNull();
+    expect(bound.reason).toMatch(/publishes visibility/);
+  });
+
+  it("breaks a tie on the id, so two runs agree", () => {
+    // Two stations equidistant from the segment. Without a deterministic tie
+    // break the committed file would flip between runs and --check's diff
+    // would stop meaning anything.
+    const tied = {
+      KZZZ: {
+        lat: 32.9,
+        lon: -117.3,
+        delivers: true,
+        publishes_visibility: true,
+      },
+      KAAA: {
+        lat: 32.9,
+        lon: -117.3,
+        delivers: true,
+        publishes_visibility: true,
+      },
+    };
+    expect(bindWeatherStation(LA_JOLLA_SHORES, tied).stationId).toBe("KAAA");
+  });
+});

--- a/src/components/ConditionsSection.test.tsx
+++ b/src/components/ConditionsSection.test.tsx
@@ -7,6 +7,9 @@ vi.mock("@/components/TidePanel", () => ({
 vi.mock("@/components/WavePanel", () => ({
   WavePanel: ({ slug }: { slug: string }) => <p>waves for {slug}</p>,
 }));
+vi.mock("@/components/WindPanel", () => ({
+  WindPanel: ({ slug }: { slug: string }) => <p>wind for {slug}</p>,
+}));
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 const { ConditionsSection } = await import("./ConditionsSection");
@@ -18,6 +21,10 @@ test("the view carries the chooser, the reading and the caveats", () => {
   expect(screen.getByLabelText("Choose a beach")).toBeDefined();
   expect(screen.getByText(`panel for ${DEFAULT_BEACH_SLUG}`)).toBeDefined();
   expect(screen.getByText(`waves for ${DEFAULT_BEACH_SLUG}`)).toBeDefined();
+  // Reachable by a reader, not merely built: the three panels come from three
+  // agencies and each is mounted on its own Suspense boundary, so a section
+  // that dropped one would still render and still pass every other assertion.
+  expect(screen.getByText(`wind for ${DEFAULT_BEACH_SLUG}`)).toBeDefined();
   expect(
     screen.getByText("What we are unsure about in this data"),
   ).toBeDefined();

--- a/src/components/ConditionsSection.tsx
+++ b/src/components/ConditionsSection.tsx
@@ -14,6 +14,7 @@ import { BeachSelector } from "./BeachSelector";
 import { Caveats } from "./Caveats";
 import { TidePanel } from "./TidePanel";
 import { WavePanel } from "./WavePanel";
+import { WindPanel } from "./WindPanel";
 
 export function ConditionsSection({ slug }: { slug: string }) {
   const groups = beachesByRegion().map((group) => ({
@@ -58,6 +59,21 @@ export function ConditionsSection({ slug }: { slug: string }) {
         fallback={<p className="mt-9 text-base text-fog">Reading the buoy…</p>}
       >
         <WavePanel slug={slug} />
+      </Suspense>
+
+      {/*
+        Its own boundary again. Three agencies, three failure modes: NOAA's tide
+        service, NDBC's buoys and the National Weather Service's stations all go
+        quiet independently, and none of them should hold up the other two.
+      */}
+      <Suspense
+        fallback={
+          <p className="mt-9 text-base text-fog">
+            Reading the weather station…
+          </p>
+        }
+      >
+        <WindPanel slug={slug} />
       </Suspense>
 
       <Caveats entries={inventoryCaveats()} />

--- a/src/components/WindPanel.test.tsx
+++ b/src/components/WindPanel.test.tsx
@@ -1,0 +1,49 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const readLatestAir = vi.fn();
+vi.mock("@/lib/conditions", () => ({ readLatestAir }));
+
+const { WindPanel } = await import("./WindPanel");
+
+beforeEach(() => {
+  readLatestAir.mockReset();
+});
+
+test("asks for the slug it was given and renders the reading", async () => {
+  readLatestAir.mockResolvedValue({
+    beachName: "La Jolla Shores Beach",
+    station: { name: "San Diego, Miramar MCAS", distanceM: 10_429 },
+    state: {
+      kind: "reading",
+      visibilityMi: 10,
+      visibilityAtCeiling: true,
+      airTempF: 69.98,
+      windMph: 5.82,
+      gustMph: null,
+      windDirDegT: 320,
+      sky: "Clear",
+    },
+  });
+
+  render(await WindPanel({ slug: "la-jolla-shores-beach" }));
+
+  expect(readLatestAir).toHaveBeenCalledWith("la-jolla-shores-beach");
+  expect(screen.getByText("10 miles or more")).toBeDefined();
+});
+
+test("the beach with no station renders its own state, not an outage", async () => {
+  readLatestAir.mockResolvedValue({
+    beachName: "Imperial Beach pier area",
+    station: null,
+    state: {
+      kind: "no-station",
+      reason:
+        "the lower endpoint published upstream is outside San Diego County",
+    },
+  });
+
+  render(await WindPanel({ slug: "imperial-beach-pier-area" }));
+
+  expect(screen.getByText(/gap in what is published/)).toBeDefined();
+});

--- a/src/components/WindPanel.tsx
+++ b/src/components/WindPanel.tsx
@@ -1,0 +1,12 @@
+/**
+ * The seam between the network and the wind-and-visibility markup, kept as thin
+ * as the two panels beside it: read, render.
+ */
+
+import { readLatestAir } from "@/lib/conditions";
+import { WindToday } from "./WindToday";
+
+export async function WindPanel({ slug }: { slug: string }) {
+  const view = await readLatestAir(slug);
+  return <WindToday {...view} />;
+}

--- a/src/components/WindToday.test.tsx
+++ b/src/components/WindToday.test.tsx
@@ -1,0 +1,254 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { WindToday } from "./WindToday";
+
+const KNKX = {
+  name: "San Diego, Miramar MCAS/Mitscher Field Airport",
+  distanceM: 10_429,
+};
+const NEAR = { name: "San Diego International Airport", distanceM: 1_600 };
+
+const READING = {
+  kind: "reading" as const,
+  visibilityMi: 10.0,
+  visibilityAtCeiling: true,
+  airTempF: 69.98,
+  windMph: 5.82,
+  gustMph: null,
+  windDirDegT: 320,
+  sky: "Clear",
+};
+
+test("the ten-mile ceiling reads as a floor, never as an exact measurement", () => {
+  render(
+    <WindToday
+      beachName="La Jolla Shores Beach"
+      station={KNKX}
+      state={READING}
+    />,
+  );
+
+  // METAR stops at ten miles. "10 miles" would claim a precision upstream
+  // never offered.
+  expect(screen.getByText("10 miles or more")).toBeDefined();
+});
+
+test("a visibility below the ceiling is given as the measurement it is", () => {
+  render(
+    <WindToday
+      beachName="Oceanside Harbor Beach"
+      station={NEAR}
+      state={{ ...READING, visibilityMi: 8.0, visibilityAtCeiling: false }}
+    />,
+  );
+
+  expect(screen.getByText("8 miles")).toBeDefined();
+});
+
+test("wind is given in plain words, from the direction it blows from", () => {
+  render(
+    <WindToday
+      beachName="La Jolla Shores Beach"
+      station={KNKX}
+      state={READING}
+    />,
+  );
+
+  // 320 degrees true. Naming it as the direction the wind blows *towards*
+  // would reverse every reading on the page.
+  expect(screen.getByText(/Wind 6 mph from the north-west/)).toBeDefined();
+});
+
+test("air temperature and sky come from the same reading", () => {
+  render(
+    <WindToday
+      beachName="La Jolla Shores Beach"
+      station={KNKX}
+      state={READING}
+    />,
+  );
+
+  expect(screen.getByText(/The air is 70°F/)).toBeDefined();
+  expect(screen.getByText(/Sky: clear/)).toBeDefined();
+});
+
+test("a gust is shown when the station published one", () => {
+  render(
+    <WindToday
+      beachName="La Jolla Shores Beach"
+      station={KNKX}
+      state={{ ...READING, gustMph: 14.2 }}
+    />,
+  );
+
+  expect(screen.getByText(/gusting 14/)).toBeDefined();
+});
+
+test("no wind value says so rather than reading as calm", () => {
+  render(
+    <WindToday
+      beachName="La Jolla Shores Beach"
+      station={KNKX}
+      state={{ ...READING, windMph: null, windDirDegT: null }}
+    />,
+  );
+
+  // A blank here would read as a still day.
+  expect(screen.getByText(/reported no wind speed/)).toBeDefined();
+});
+
+test("a genuine calm is named as calm, not as a missing reading", () => {
+  render(
+    <WindToday
+      beachName="La Jolla Shores Beach"
+      station={KNKX}
+      state={{ ...READING, windMph: 0, windDirDegT: 0 }}
+    />,
+  );
+
+  expect(screen.getByText(/The wind is calm/)).toBeDefined();
+});
+
+test("a station publishing no visibility says so rather than rendering blank", () => {
+  render(
+    <WindToday
+      beachName="La Jolla Shores Beach"
+      station={KNKX}
+      state={{ ...READING, visibilityMi: null, visibilityAtCeiling: false }}
+    />,
+  );
+
+  expect(screen.getByText("No visibility reading")).toBeDefined();
+});
+
+test("the airport and its distance are attributed, because fog differs across it", () => {
+  render(
+    <WindToday
+      beachName="La Jolla Shores Beach"
+      station={KNKX}
+      state={READING}
+    />,
+  );
+
+  expect(
+    screen.getByText(/Miramar MCAS.*about 10 km from this beach/),
+  ).toBeDefined();
+  expect(screen.getByText(/not a reading taken at the shore/)).toBeDefined();
+});
+
+test("a nearby station is attributed without a distance", () => {
+  render(
+    <WindToday
+      beachName="Spanish Landing Park"
+      station={NEAR}
+      state={READING}
+    />,
+  );
+
+  expect(screen.getByText(/San Diego International Airport\./)).toBeDefined();
+});
+
+test("no station is a permanent fact about the place, with its reason", () => {
+  render(
+    <WindToday
+      beachName="Imperial Beach pier area"
+      station={null}
+      state={{
+        kind: "no-station",
+        reason:
+          "the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it",
+      }}
+    />,
+  );
+
+  expect(screen.getByText(/gap in what is published/)).toBeDefined();
+  expect(screen.getByText(/outside San Diego County/)).toBeDefined();
+  // Never invite a reader to retry something that will never work.
+  expect(screen.queryByText(/Try again shortly/)).toBeNull();
+});
+
+test("an unavailable feed is transient, and says so differently", () => {
+  render(
+    <WindToday
+      beachName="La Jolla Shores Beach"
+      station={KNKX}
+      state={{
+        kind: "unavailable",
+        detail: "NWS KNKX returns 404 for its latest observation.",
+        drift: false,
+      }}
+    />,
+  );
+
+  expect(screen.getByText(/Try again shortly/)).toBeDefined();
+  expect(screen.getByText(/returns 404/)).toBeDefined();
+});
+
+test("drift is disclosed as a bug here rather than a problem upstream", () => {
+  render(
+    <WindToday
+      beachName="La Jolla Shores Beach"
+      station={KNKX}
+      state={{
+        kind: "unavailable",
+        detail: "windSpeed is published in wmoUnit:kn, not wmoUnit:km_h-1.",
+        drift: true,
+      }}
+    />,
+  );
+
+  expect(
+    screen.getByText(/bug here rather than a problem at the station/),
+  ).toBeDefined();
+});
+
+test("a visibility under a mile keeps its decimal, being the reading that matters", () => {
+  render(
+    <WindToday
+      beachName="Torrey Pines State Beach"
+      station={KNKX}
+      state={{ ...READING, visibilityMi: 0.25, visibilityAtCeiling: false }}
+    />,
+  );
+
+  // Rounded to whole miles this would render "0 miles", which reads as an
+  // instrument fault rather than as thick fog.
+  expect(screen.getByText("0.3 miles")).toBeDefined();
+});
+
+test("one mile is singular", () => {
+  render(
+    <WindToday
+      beachName="Torrey Pines State Beach"
+      station={KNKX}
+      state={{ ...READING, visibilityMi: 1.2, visibilityAtCeiling: false }}
+    />,
+  );
+
+  expect(screen.getByText("1 mile")).toBeDefined();
+});
+
+test("wind with no direction is still given as a speed", () => {
+  render(
+    <WindToday
+      beachName="La Jolla Shores Beach"
+      station={KNKX}
+      state={{ ...READING, windDirDegT: null }}
+    />,
+  );
+
+  expect(screen.getByText(/Wind 6 mph\./)).toBeDefined();
+});
+
+test("no air temperature and no sky simply go unsaid", () => {
+  render(
+    <WindToday
+      beachName="La Jolla Shores Beach"
+      station={KNKX}
+      state={{ ...READING, airTempF: null, sky: null }}
+    />,
+  );
+
+  expect(screen.queryByText(/The air is/)).toBeNull();
+  expect(screen.queryByText(/Sky:/)).toBeNull();
+});

--- a/src/components/WindToday.tsx
+++ b/src/components/WindToday.tsx
@@ -1,0 +1,142 @@
+/**
+ * Wind, visibility, air temperature and sky at the bound observation station.
+ *
+ * Presentational and pure, like the two panels beside it.
+ *
+ * **Four values, one station.** The join binds a station that publishes
+ * visibility, and that same station supplies the wind, the temperature and the
+ * sky. Several stations sit nearer each beach and publish wind without
+ * visibility; binding those separately would put two provenances behind one
+ * heading, which is the thing this site does not do.
+ *
+ * **Ten miles is a ceiling, not a measurement.** METAR stops there, so the top
+ * of the range is rendered "10 miles or more". Reading it as exactly ten would
+ * be a precision upstream never claimed.
+ *
+ * **The station is an airport, and says so.** Every station in the county that
+ * publishes visibility is an airport, inland of the beach it is bound to — a
+ * median of 7.3 km and up to 16.8 km. Coastal fog is exactly what changes across
+ * that distance, so the distance is given for the same reason the buoy's is.
+ */
+
+import type { AirView } from "@/lib/conditions";
+
+/** Past this, the station is far enough away that the reader is owed the number. */
+const DISTANT_STATION_M = 5_000;
+
+const COMPASS = [
+  "north",
+  "north-east",
+  "east",
+  "south-east",
+  "south",
+  "south-west",
+  "west",
+  "north-west",
+] as const;
+
+/**
+ * Plain words for a direction in degrees true.
+ *
+ * METAR publishes the direction the wind blows *from*, which is why the caller
+ * says "from the". Naming it as the direction it blows towards would reverse
+ * every reading on the page.
+ */
+function compassWords(degreesTrue: number): string {
+  return COMPASS[Math.round(degreesTrue / 45) % 8];
+}
+
+/** Whole miles read better than a decimal that upstream did not measure to. */
+function visibilityWords(miles: number, atCeiling: boolean): string {
+  if (atCeiling) return "10 miles or more";
+  const rounded = miles < 1 ? miles.toFixed(1) : String(Math.round(miles));
+  return `${rounded} ${rounded === "1" ? "mile" : "miles"}`;
+}
+
+export function WindToday({ beachName, station, state }: AirView) {
+  const distanceM = station?.distanceM ?? null;
+  const distantKm =
+    distanceM !== null && distanceM > DISTANT_STATION_M
+      ? (distanceM / 1000).toFixed(0)
+      : null;
+
+  return (
+    <section aria-labelledby="wind-today-heading" className="mt-9 max-w-130">
+      <h2
+        id="wind-today-heading"
+        className="text-2xs mb-3 font-extrabold tracking-widest text-ocean uppercase"
+      >
+        Wind and visibility · {beachName}
+      </h2>
+
+      {state.kind === "reading" && (
+        <>
+          <p className="leading-tight mb-2 text-4xl font-black italic">
+            {state.visibilityMi === null
+              ? "No visibility reading"
+              : visibilityWords(state.visibilityMi, state.visibilityAtCeiling)}
+          </p>
+          <p className="leading-relaxed mb-4 text-base text-fog">
+            {state.windMph === null
+              ? "The station reported no wind speed."
+              : state.windMph < 1
+                ? "The wind is calm."
+                : `Wind ${Math.round(state.windMph)} mph` +
+                  (state.windDirDegT !== null
+                    ? ` from the ${compassWords(state.windDirDegT)}`
+                    : "") +
+                  (state.gustMph !== null
+                    ? `, gusting ${Math.round(state.gustMph)}`
+                    : "") +
+                  "."}
+            {state.airTempF !== null
+              ? ` The air is ${Math.round(state.airTempF)}°F.`
+              : ""}
+            {state.sky !== null ? ` Sky: ${state.sky.toLowerCase()}.` : ""}
+          </p>
+        </>
+      )}
+
+      {state.kind === "no-station" && (
+        <>
+          <p className="leading-relaxed mb-4 text-base text-fog">
+            We cannot give wind or visibility here, and that is a gap in what is
+            published rather than a fault at the beach.
+          </p>
+          <details className="mb-4 text-sm text-fog">
+            <summary>Why not</summary>
+            <p className="mt-2">{state.reason}</p>
+          </details>
+        </>
+      )}
+
+      {state.kind === "unavailable" && (
+        <>
+          <p className="leading-relaxed mb-4 text-base text-fog">
+            We could not get a weather reading just now. Try again shortly.
+          </p>
+          <details className="mb-4 text-sm text-fog">
+            <summary>What went wrong</summary>
+            <p className="mt-2">{state.detail}</p>
+            {state.drift && (
+              <p className="mt-2">
+                The National Weather Service&apos;s payload was not the shape
+                this site pins, which is a bug here rather than a problem at the
+                station.
+              </p>
+            )}
+          </details>
+        </>
+      )}
+
+      {station !== null && (
+        <p className="text-2xs leading-relaxed text-fog">
+          Measured at {station.name}
+          {distantKm !== null ? `, about ${distantKm} km from this beach` : ""}.
+          That is an airport reading, not a reading taken at the shore, and
+          coastal fog can differ across that distance.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/data/beaches.json
+++ b/src/data/beaches.json
@@ -17,7 +17,10 @@
     "upstream": "Fields reproduced from the resource, unmodified.",
     "tide_station": "Joined, never typed: the nearest delivering station of the beach's own water class. Re-runnable with scripts/seed-beaches.mjs --check. null means the join could not bind one, and tide_station_null_reason says why.",
     "tide_station_distance_m": "Great-circle metres from the nearer segment end to the station.",
-    "tide_station_from_end": "Which end of the segment supplied the distance, upper or lower."
+    "tide_station_from_end": "Which end of the segment supplied the distance, upper or lower.",
+    "weather_station": "Joined, never typed: the nearest station that both answers and publishes visibility. Unlike the wave buoy, every beach binds one -- air reaches a lagoon. null means the join could not bind one, and weather_station_null_reason says why.",
+    "weather_station_distance_m": "Great-circle metres from the nearer segment end to the station. Larger than the tide and buoy distances by nature: the stations that publish visibility are airports.",
+    "weather_station_from_end": "Which end of the segment supplied the distance, upper or lower."
   },
   "beaches": [
     {
@@ -49,7 +52,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46275",
       "wave_buoy_distance_m": 4524,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KNFG",
+      "weather_station_distance_m": 14254,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "oceanside-harbor",
@@ -80,7 +86,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46224",
       "wave_buoy_distance_m": 7749,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KOKB",
+      "weather_station_distance_m": 4345,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "harbor-beach",
@@ -111,7 +120,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46224",
       "wave_buoy_distance_m": 7557,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KOKB",
+      "weather_station_distance_m": 4235,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "oceanside-municipal-beach-other",
@@ -142,7 +154,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46224",
       "wave_buoy_distance_m": 7557,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KOKB",
+      "weather_station_distance_m": 4555,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "buccaneer-beach",
@@ -173,7 +188,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46224",
       "wave_buoy_distance_m": 9488,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KOKB",
+      "weather_station_distance_m": 4889,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "carlsbad-municipal-beach",
@@ -204,7 +222,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46224",
       "wave_buoy_distance_m": 10578,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KOKB",
+      "weather_station_distance_m": 5936,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "carlsbad-state-beach",
@@ -235,7 +256,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46274",
       "wave_buoy_distance_m": 8278,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KCRQ",
+      "weather_station_distance_m": 5758,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "agua-hedionda-lagoon",
@@ -267,7 +291,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KCRQ",
+      "weather_station_distance_m": 4316,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "south-carlsbad-state-beach",
@@ -298,7 +325,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46274",
       "wave_buoy_distance_m": 2181,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KCRQ",
+      "weather_station_distance_m": 5401,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "leucadia",
@@ -329,7 +359,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46274",
       "wave_buoy_distance_m": 2101,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KCRQ",
+      "weather_station_distance_m": 6310,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "encinitas-city-beaches",
@@ -360,7 +393,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46274",
       "wave_buoy_distance_m": 2762,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KCRQ",
+      "weather_station_distance_m": 5921,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "moonlight-beach",
@@ -391,7 +427,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46274",
       "wave_buoy_distance_m": 2064,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KCRQ",
+      "weather_station_distance_m": 9338,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "swami-s-park",
@@ -422,7 +461,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46274",
       "wave_buoy_distance_m": 3569,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KCRQ",
+      "weather_station_distance_m": 10720,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "san-elijo-state-beach",
@@ -453,7 +495,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46274",
       "wave_buoy_distance_m": 3986,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KCRQ",
+      "weather_station_distance_m": 11003,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "cardiff-state-beach",
@@ -484,7 +529,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46266",
       "wave_buoy_distance_m": 4724,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KCRQ",
+      "weather_station_distance_m": 12736,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "solana-beach-city-beaches",
@@ -515,7 +563,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46266",
       "wave_buoy_distance_m": 2664,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KCRQ",
+      "weather_station_distance_m": 14516,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "seascape-beach-park",
@@ -546,7 +597,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46266",
       "wave_buoy_distance_m": 2664,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KCRQ",
+      "weather_station_distance_m": 16418,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "san-dieguito-river-beach",
@@ -577,7 +631,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46266",
       "wave_buoy_distance_m": 2119,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KNKX",
+      "weather_station_distance_m": 16793,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "del-mar-city-beach",
@@ -608,7 +665,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46266",
       "wave_buoy_distance_m": 1565,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KNKX",
+      "weather_station_distance_m": 14548,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "powerhouse-park-15th-street",
@@ -639,7 +699,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46266",
       "wave_buoy_distance_m": 1016,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KNKX",
+      "weather_station_distance_m": 15548,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "torrey-pines-state-beach",
@@ -670,7 +733,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46266",
       "wave_buoy_distance_m": 1565,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KNKX",
+      "weather_station_distance_m": 10797,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "torrey-pines-city-beach",
@@ -701,7 +767,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 2194,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KNKX",
+      "weather_station_distance_m": 10429,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "la-jolla-shores-beach",
@@ -732,7 +801,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 1648,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KNKX",
+      "weather_station_distance_m": 10429,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "la-jolla-cove",
@@ -763,7 +835,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 1991,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KNKX",
+      "weather_station_distance_m": 12294,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "shell-beach",
@@ -794,7 +869,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 2126,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KNKX",
+      "weather_station_distance_m": 12524,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "childrens-pool",
@@ -826,7 +904,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KNKX",
+      "weather_station_distance_m": 12887,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "south-casa-beach-s-d",
@@ -857,7 +938,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 2555,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KNKX",
+      "weather_station_distance_m": 12952,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "whispering-sands-nicholson-pt",
@@ -888,7 +972,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 2702,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KNKX",
+      "weather_station_distance_m": 12991,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "marine-street-beach",
@@ -919,7 +1006,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 3478,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KNKX",
+      "weather_station_distance_m": 13449,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "la-jolla-community-beach",
@@ -950,7 +1040,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 1648,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KNKX",
+      "weather_station_distance_m": 11003,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "windansea-beach",
@@ -981,7 +1074,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 3737,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KNKX",
+      "weather_station_distance_m": 13458,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "bird-rock-nr",
@@ -1012,7 +1108,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 5876,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 11702,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "tourmaline-surfing-park",
@@ -1043,7 +1142,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 6683,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 10333,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "pacific-beach",
@@ -1074,7 +1176,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 7506,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 9523,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay-campland-on-the-bay",
@@ -1106,7 +1211,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 7748,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "mission-bay-de-anza-cove",
@@ -1138,7 +1246,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 7097,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay-visitor-s-center",
@@ -1170,7 +1281,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 6588,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay-fanuel-park",
@@ -1202,7 +1316,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 7918,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay-leisure-lagoon",
@@ -1234,7 +1351,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 6193,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay-crown-point-shores",
@@ -1266,7 +1386,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 7112,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay-riviera-shores",
@@ -1298,7 +1421,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 7125,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay-north-pacific-passage",
@@ -1330,7 +1456,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 5536,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay-san-juan-cove",
@@ -1362,7 +1491,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 7993,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay-sail-bay",
@@ -1394,7 +1526,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 7740,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay-santa-barbara-cove",
@@ -1426,7 +1561,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 7595,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-beach",
@@ -1457,7 +1595,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 8366,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 7225,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "tecolote-shores",
@@ -1489,7 +1630,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 4871,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay-bahia-point",
@@ -1521,7 +1665,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 7259,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay-vacation-isle",
@@ -1553,7 +1700,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 6959,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "mission-bay-ventura-cove",
@@ -1585,7 +1735,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 6990,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "fiesta-island",
@@ -1616,7 +1769,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 12145,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 4718,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay-sea-world",
@@ -1648,7 +1804,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 5099,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay-mariners-basin",
@@ -1680,7 +1839,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 6682,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "mission-bay-quivera-basin",
@@ -1712,7 +1874,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 6295,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "mission-bay",
@@ -1744,7 +1909,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 6287,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "dog-beach-o-b",
@@ -1775,7 +1943,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 12506,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 6825,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "ocean-beach",
@@ -1806,7 +1977,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 12476,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 6807,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "spanish-landing-park",
@@ -1838,7 +2012,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 1615,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "sunset-cliffs-park",
@@ -1869,7 +2046,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 14805,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 6807,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "shoreline-park",
@@ -1901,7 +2081,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 3803,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "san-diego-bay",
@@ -1933,7 +2116,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 3400,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "tide-beach-park",
@@ -1964,7 +2150,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 21763,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 4908,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "coronado-north-beach",
@@ -1995,7 +2184,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 20940,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 5348,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "coronado-central-beach",
@@ -2026,7 +2218,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 21596,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 5478,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "coronado-city-beaches",
@@ -2057,7 +2252,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 21178,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 5391,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "coronado-cays-nr",
@@ -2089,7 +2287,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 11444,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "silver-strand-state-beach",
@@ -2120,7 +2321,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46254",
       "wave_buoy_distance_m": 28149,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSAN",
+      "weather_station_distance_m": 11356,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "north-imperial-beach",
@@ -2151,7 +2355,10 @@
       "tide_station_from_end": "lower",
       "wave_buoy": "46232",
       "wave_buoy_distance_m": 28469,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KSDM",
+      "weather_station_distance_m": 13144,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "imperial-beach-municipal-beach-other",
@@ -2182,7 +2389,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46232",
       "wave_buoy_distance_m": 27913,
-      "wave_buoy_from_end": "lower"
+      "wave_buoy_from_end": "lower",
+      "weather_station": "KSDM",
+      "weather_station_distance_m": 13145,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "tijuana-slough-national-wildlife-refuge",
@@ -2214,7 +2424,10 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here"
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "weather_station": "KSDM",
+      "weather_station_distance_m": 12852,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "tijana-river",
@@ -2245,7 +2458,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46232",
       "wave_buoy_distance_m": 34159,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSDM",
+      "weather_station_distance_m": 6125,
+      "weather_station_from_end": "lower"
     },
     {
       "slug": "border-field-state-park",
@@ -2276,7 +2492,10 @@
       "tide_station_from_end": "upper",
       "wave_buoy": "46232",
       "wave_buoy_distance_m": 28153,
-      "wave_buoy_from_end": "upper"
+      "wave_buoy_from_end": "upper",
+      "weather_station": "KSDM",
+      "weather_station_distance_m": 12863,
+      "weather_station_from_end": "upper"
     },
     {
       "slug": "imperial-beach-pier-area",
@@ -2309,7 +2528,11 @@
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it"
+      "wave_buoy_null_reason": "the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it",
+      "weather_station": null,
+      "weather_station_distance_m": null,
+      "weather_station_from_end": null,
+      "weather_station_null_reason": "the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it"
     }
   ],
   "unresolved": [
@@ -2317,6 +2540,7 @@
     "The join binds by nearest station of matching water class, and the distances are large where NOAA publishes no nearby station: the farthest is San Onofre State Beach at 56.6 km. See tide-stations.json, whose own unresolved list records that the one open-coast station between La Jolla and Imperial Beach does not deliver predictions.",
     "27 of these beaches get no wave height at all. Every NDBC wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so binding one to the nearest buoy would put an open-ocean number on enclosed water. Their water temperature is missing for the same reason and is not yet filled from another source.",
     "A tide prediction is for the station, not for the beach. It is the best published figure for that stretch of shore and it is not a measurement taken there.",
+    "Visibility, wind, air temperature and sky are read at an airport, because the airports are the only stations in this county that publish visibility at all. The median beach here reads a station 7.3 km away and the farthest reads one 16.8 km away, at San Dieguito River Beach. Coastal fog is precisely what changes over that distance, so those four figures describe the airport and not the shoreline.",
     "1 beach(es) could not be bound to a station: Imperial Beach pier area (the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it). A null station must never render as a reading.",
     "The network module carries no build-time guard against being imported by a browser bundle. The `server-only` package is the intended enforcement and is not installed: importing it breaks the tests under jsdom until vitest is configured with the `react-server` resolve condition. Today the guarantee rests on the module having no client-side importer, which nothing checks."
   ]

--- a/src/data/weather-stations.json
+++ b/src/data/weather-stations.json
@@ -1,0 +1,114 @@
+{
+  "version": "0.1.0",
+  "generated": "2026-08-18",
+  "_provenance": "Station ids, names and coordinates read from the National Weather Service API, https://api.weather.gov/gridpoints/<grid>/stations, taking the union over the 35 distinct gridpoints the 73 beaches in beaches.json resolve to, on 2026-08-18. That union listed 163 stations. Delivery was then measured one station at a time against https://api.weather.gov/stations/<id>/observations/latest, the same endpoint this site reads, rather than inferred from the list. The state-wide listing at /stations?state=CA is NOT the source: it is capped at 500 results and truncates before reaching either KSAN or KNKX.",
+  "_what_was_measured": "Of the 163 candidates, 159 answered and only 24 published a visibility value -- every one of the 24 an airport METAR. Inside the county box used here (32.4-33.6N, -117.7 to -116.8E) there are 56 candidates: 9 publish visibility, 46 answer without it, and KF70 404s while listed. The two stations nearest La Jolla Shores, D3101 and MSDSD, are both in the second group, so a join on proximity alone would bind this site's visibility promise to a station that has never published one. That is why publishes_visibility is measured, and why it filters the join rather than sitting beside it as a note. Units are stated by the payload per field and are identical across all nine: wmoUnit:m for visibility, wmoUnit:degC for temperature, wmoUnit:km_h-1 for wind.",
+  "_schema": {
+    "name": "The NWS station name, reproduced as the API serves it. D3101's carries the run of spaces and the trailing 'CA US' that upstream publishes.",
+    "lat": "Decimal degrees north, from the NWS station list.",
+    "lon": "Decimal degrees east, negative for west.",
+    "delivers": "Whether the latest-observation endpoint answers at all, measured rather than assumed. A station that does not deliver is kept and marked, never deleted.",
+    "publishes_visibility": "Whether the answering station carries a visibility value. Recorded separately from delivers because 46 of the 56 candidates in the box answer perfectly and carry no visibility at all. This is the join's filter.",
+    "dead_note": "Present only when delivers is false. What the station did when asked."
+  },
+  "stations": {
+    "KL18": {
+      "name": "Fallbrook Community Airpark",
+      "lat": 33.3542,
+      "lon": -117.2509,
+      "delivers": true,
+      "publishes_visibility": true
+    },
+    "KNFG": {
+      "name": "Oceanside, Camp Pendleton, Marine Corps Air Station",
+      "lat": 33.30472,
+      "lon": -117.35389,
+      "delivers": true,
+      "publishes_visibility": true
+    },
+    "KOKB": {
+      "name": "Oceanside, Oceanside Municipal Airport",
+      "lat": 33.21806,
+      "lon": -117.35139,
+      "delivers": true,
+      "publishes_visibility": true
+    },
+    "KCRQ": {
+      "name": "Carlsbad, McClellan-Palomar Airport",
+      "lat": 33.13,
+      "lon": -117.27583,
+      "delivers": true,
+      "publishes_visibility": true
+    },
+    "KRNM": {
+      "name": "Ramona, Ramona Airport",
+      "lat": 33.0375,
+      "lon": -116.91583,
+      "delivers": true,
+      "publishes_visibility": true
+    },
+    "KNKX": {
+      "name": "San Diego, Miramar MCAS/Mitscher Field Airport",
+      "lat": 32.86833,
+      "lon": -117.1425,
+      "delivers": true,
+      "publishes_visibility": true
+    },
+    "KMYF": {
+      "name": "San Diego, Montgomery Field",
+      "lat": 32.81444,
+      "lon": -117.13639,
+      "delivers": true,
+      "publishes_visibility": true
+    },
+    "KSAN": {
+      "name": "San Diego International Airport",
+      "lat": 32.73361,
+      "lon": -117.18306,
+      "delivers": true,
+      "publishes_visibility": true
+    },
+    "KSDM": {
+      "name": "San Diego, Brown Field Municipal Airport",
+      "lat": 32.57528,
+      "lon": -116.99306,
+      "delivers": true,
+      "publishes_visibility": true
+    },
+    "KF70": {
+      "name": "Murrieta/Temecula French Valley",
+      "lat": 33.5742,
+      "lon": -117.1285,
+      "delivers": false,
+      "publishes_visibility": false,
+      "dead_note": "Returns HTTP 404 for its latest observation while listed as serving these grids. Kept and marked rather than deleted, so the next probe compares against a station that was measured rather than one that quietly vanished."
+    },
+    "DMHSD": {
+      "name": "Del Mar Heights",
+      "lat": 32.96404,
+      "lon": -117.22284,
+      "delivers": true,
+      "publishes_visibility": false
+    },
+    "D3101": {
+      "name": "DW3101 Torrey Pines Reserve       CA US",
+      "lat": 32.92083,
+      "lon": -117.25283,
+      "delivers": true,
+      "publishes_visibility": false
+    },
+    "MSDSD": {
+      "name": "Mt. Soledad",
+      "lat": 32.81418,
+      "lon": -117.24088,
+      "delivers": true,
+      "publishes_visibility": false
+    }
+  },
+  "unresolved": [
+    "Every station that publishes visibility is an airport, and airports sit inland of the beaches they are bound to: the median beach reads a station 7.3 km away and the farthest reads one 16.8 km away. Coastal fog is exactly the thing that differs across that distance, so a visibility figure here describes the airport and not the shoreline. The distance is recorded per beach and shown to the reader rather than hidden.",
+    "METAR stops at ten statute miles. The nine stations publish that ceiling as either 16093.44 m or 16090 m depending on the station, so a reading at the top of the range means \"at least ten miles\" and never \"exactly ten miles\". It is rendered as \"10 miles or more\" for that reason.",
+    "KF70 Murrieta/Temecula French Valley is listed as serving these grids and returns HTTP 404 for its observations. That is the fifth listed-but-dead station this repo has measured, after TWC0405 in the tide join and 46273 and 46235 in the wave join, and it is why every station table here carries a measured delivers rather than an inherited one.",
+    "Wind, air temperature and sky come from the same station as visibility, so the four values in this panel always share one provenance. That is a deliberate constraint rather than a fact about the network: several stations nearer each beach publish wind and temperature without visibility, and binding those separately would put two stations behind one panel."
+  ]
+}

--- a/src/lib/__fixtures__/nws-d3101-observation-20260818.json
+++ b/src/lib/__fixtures__/nws-d3101-observation-20260818.json
@@ -1,0 +1,139 @@
+{
+    "@context": [
+        "https://geojson.org/geojson-ld/geojson-context.jsonld",
+        {
+            "@version": "1.1",
+            "wx": "https://api.weather.gov/ontology#",
+            "s": "https://schema.org/",
+            "geo": "http://www.opengis.net/ont/geosparql#",
+            "unit": "http://codes.wmo.int/common/unit/",
+            "@vocab": "https://api.weather.gov/ontology#",
+            "geometry": {
+                "@id": "s:GeoCoordinates",
+                "@type": "geo:wktLiteral"
+            },
+            "city": "s:addressLocality",
+            "state": "s:addressRegion",
+            "distance": {
+                "@id": "s:Distance",
+                "@type": "s:QuantitativeValue"
+            },
+            "bearing": {
+                "@type": "s:QuantitativeValue"
+            },
+            "value": {
+                "@id": "s:value"
+            },
+            "unitCode": {
+                "@id": "s:unitCode",
+                "@type": "@id"
+            },
+            "forecastOffice": {
+                "@type": "@id"
+            },
+            "forecastGridData": {
+                "@type": "@id"
+            },
+            "publicZone": {
+                "@type": "@id"
+            },
+            "county": {
+                "@type": "@id"
+            }
+        }
+    ],
+    "id": "https://api.weather.gov/stations/D3101/observations/2026-08-18T05:10:00+00:00",
+    "type": "Feature",
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            -117.25,
+            32.92
+        ]
+    },
+    "properties": {
+        "@id": "https://api.weather.gov/stations/D3101/observations/2026-08-18T05:10:00+00:00",
+        "@type": "wx:ObservationStation",
+        "elevation": {
+            "unitCode": "wmoUnit:m",
+            "value": 104.69
+        },
+        "station": "https://api.weather.gov/stations/D3101",
+        "stationId": "D3101",
+        "stationName": "DW3101 Torrey Pines Reserve       CA US",
+        "timestamp": "2026-08-18T05:10:00+00:00",
+        "rawMessage": "",
+        "textDescription": "",
+        "icon": null,
+        "presentWeather": [],
+        "temperature": {
+            "unitCode": "wmoUnit:degC",
+            "value": 21.11,
+            "qualityControl": "V"
+        },
+        "dewpoint": {
+            "unitCode": "wmoUnit:degC",
+            "value": 19.74,
+            "qualityControl": "V"
+        },
+        "windDirection": {
+            "unitCode": "wmoUnit:degree_(angle)",
+            "value": 347,
+            "qualityControl": "V"
+        },
+        "windSpeed": {
+            "unitCode": "wmoUnit:km_h-1",
+            "value": 3.204,
+            "qualityControl": "V"
+        },
+        "windGust": {
+            "unitCode": "wmoUnit:km_h-1",
+            "value": 6.444,
+            "qualityControl": "S"
+        },
+        "barometricPressure": {
+            "unitCode": "wmoUnit:Pa",
+            "value": 101530,
+            "qualityControl": "V"
+        },
+        "seaLevelPressure": {
+            "unitCode": "wmoUnit:Pa",
+            "value": null,
+            "qualityControl": "Z"
+        },
+        "visibility": {
+            "unitCode": "wmoUnit:m",
+            "value": null,
+            "qualityControl": "Z"
+        },
+        "maxTemperatureLast24Hours": {
+            "unitCode": "wmoUnit:degC",
+            "value": null
+        },
+        "minTemperatureLast24Hours": {
+            "unitCode": "wmoUnit:degC",
+            "value": null
+        },
+        "precipitationLast3Hours": {
+            "unitCode": "wmoUnit:mm",
+            "value": null,
+            "qualityControl": "Z"
+        },
+        "relativeHumidity": {
+            "unitCode": "wmoUnit:percent",
+            "value": 91.893091124629,
+            "qualityControl": "V"
+        },
+        "windChill": {
+            "unitCode": "wmoUnit:degC",
+            "value": null,
+            "qualityControl": "V"
+        },
+        "heatIndex": {
+            "unitCode": "wmoUnit:degC",
+            "value": null,
+            "qualityControl": "V"
+        },
+        "cloudLayers": []
+    }
+}

--- a/src/lib/__fixtures__/nws-knkx-observation-20260818.json
+++ b/src/lib/__fixtures__/nws-knkx-observation-20260818.json
@@ -1,0 +1,157 @@
+{
+    "@context": [
+        "https://geojson.org/geojson-ld/geojson-context.jsonld",
+        {
+            "@version": "1.1",
+            "wx": "https://api.weather.gov/ontology#",
+            "s": "https://schema.org/",
+            "geo": "http://www.opengis.net/ont/geosparql#",
+            "unit": "http://codes.wmo.int/common/unit/",
+            "@vocab": "https://api.weather.gov/ontology#",
+            "geometry": {
+                "@id": "s:GeoCoordinates",
+                "@type": "geo:wktLiteral"
+            },
+            "city": "s:addressLocality",
+            "state": "s:addressRegion",
+            "distance": {
+                "@id": "s:Distance",
+                "@type": "s:QuantitativeValue"
+            },
+            "bearing": {
+                "@type": "s:QuantitativeValue"
+            },
+            "value": {
+                "@id": "s:value"
+            },
+            "unitCode": {
+                "@id": "s:unitCode",
+                "@type": "@id"
+            },
+            "forecastOffice": {
+                "@type": "@id"
+            },
+            "forecastGridData": {
+                "@type": "@id"
+            },
+            "publicZone": {
+                "@type": "@id"
+            },
+            "county": {
+                "@type": "@id"
+            }
+        }
+    ],
+    "id": "https://api.weather.gov/stations/KNKX/observations/2026-08-18T04:55:00+00:00",
+    "type": "Feature",
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            -117.12,
+            32.85
+        ]
+    },
+    "properties": {
+        "@id": "https://api.weather.gov/stations/KNKX/observations/2026-08-18T04:55:00+00:00",
+        "@type": "wx:ObservationStation",
+        "elevation": {
+            "unitCode": "wmoUnit:m",
+            "value": 128
+        },
+        "station": "https://api.weather.gov/stations/KNKX",
+        "stationId": "KNKX",
+        "stationName": "San Diego, Miramar MCAS/Mitscher Field Airport",
+        "timestamp": "2026-08-18T04:55:00+00:00",
+        "rawMessage": "KNKX 180455Z 32005KT 10SM CLR 21/19 A2997 RMK AO2 SLP140 T02110189 $",
+        "textDescription": "Clear",
+        "icon": "https://api.weather.gov/icons/land/night/skc?size=medium",
+        "presentWeather": [],
+        "temperature": {
+            "unitCode": "wmoUnit:degC",
+            "value": 21.1,
+            "qualityControl": "V"
+        },
+        "dewpoint": {
+            "unitCode": "wmoUnit:degC",
+            "value": 18.9,
+            "qualityControl": "V"
+        },
+        "windDirection": {
+            "unitCode": "wmoUnit:degree_(angle)",
+            "value": 320,
+            "qualityControl": "V"
+        },
+        "windSpeed": {
+            "unitCode": "wmoUnit:km_h-1",
+            "value": 9.36,
+            "qualityControl": "V"
+        },
+        "windGust": {
+            "unitCode": "wmoUnit:km_h-1",
+            "value": null,
+            "qualityControl": "Z"
+        },
+        "barometricPressure": {
+            "unitCode": "wmoUnit:Pa",
+            "value": 101490,
+            "qualityControl": "V"
+        },
+        "seaLevelPressure": {
+            "unitCode": "wmoUnit:Pa",
+            "value": 101400,
+            "qualityControl": "V"
+        },
+        "visibility": {
+            "unitCode": "wmoUnit:m",
+            "value": 16090,
+            "qualityControl": "C"
+        },
+        "maxTemperatureLast24Hours": {
+            "unitCode": "wmoUnit:degC",
+            "value": null
+        },
+        "minTemperatureLast24Hours": {
+            "unitCode": "wmoUnit:degC",
+            "value": null
+        },
+        "precipitationLastHour": {
+            "unitCode": "wmoUnit:mm",
+            "value": null,
+            "qualityControl": "Z"
+        },
+        "precipitationLast3Hours": {
+            "unitCode": "wmoUnit:mm",
+            "value": null,
+            "qualityControl": "Z"
+        },
+        "precipitationLast6Hours": {
+            "unitCode": "wmoUnit:mm",
+            "value": null,
+            "qualityControl": "Z"
+        },
+        "relativeHumidity": {
+            "unitCode": "wmoUnit:percent",
+            "value": 87.266357692714,
+            "qualityControl": "V"
+        },
+        "windChill": {
+            "unitCode": "wmoUnit:degC",
+            "value": null,
+            "qualityControl": "V"
+        },
+        "heatIndex": {
+            "unitCode": "wmoUnit:degC",
+            "value": null,
+            "qualityControl": "V"
+        },
+        "cloudLayers": [
+            {
+                "base": {
+                    "unitCode": "wmoUnit:m",
+                    "value": null
+                },
+                "amount": "CLR"
+            }
+        ]
+    }
+}

--- a/src/lib/beaches.ts
+++ b/src/lib/beaches.ts
@@ -14,6 +14,7 @@
 import inventory from "@/data/beaches.json";
 import stationTable from "@/data/tide-stations.json";
 import buoyTable from "@/data/wave-buoys.json";
+import weatherTable from "@/data/weather-stations.json";
 
 export interface Coordinate {
   lat: number;
@@ -58,6 +59,12 @@ export interface Beach {
   wave_buoy_from_end: string | null;
   /** Present exactly when wave_buoy is null, and required then. */
   wave_buoy_null_reason?: string;
+  /** Joined, never typed. Unlike the buoy, every beach binds one: air reaches a lagoon. */
+  weather_station: string | null;
+  weather_station_distance_m: number | null;
+  weather_station_from_end: string | null;
+  /** Present exactly when weather_station is null, and required then. */
+  weather_station_null_reason?: string;
 }
 
 export interface WaveBuoy {
@@ -70,6 +77,21 @@ export interface WaveBuoy {
   /** One delivering station carries no wave height at all, so this is separate. */
   publishes_waves: boolean;
   dead_note?: string | null;
+}
+
+export interface WeatherStation {
+  name: string;
+  lat: number;
+  lon: number;
+  /** Measured, not assumed. A station that does not deliver is kept and marked. */
+  delivers: boolean;
+  /**
+   * Measured separately from `delivers`, and the join's filter. Forty-six of the
+   * fifty-six candidates in this county answer perfectly and publish no
+   * visibility, including the two nearest the default beach.
+   */
+  publishes_visibility: boolean;
+  dead_note?: string;
 }
 
 export interface TideStation {
@@ -87,6 +109,9 @@ export interface TideStation {
 const BEACHES = inventory.beaches as readonly Beach[];
 const STATIONS = stationTable.stations as Readonly<Record<string, TideStation>>;
 const BUOYS = buoyTable.buoys as Readonly<Record<string, WaveBuoy>>;
+const WEATHER = weatherTable.stations as Readonly<
+  Record<string, WeatherStation>
+>;
 
 /**
  * The beach the conditions view opens on when no other is asked for.
@@ -187,11 +212,34 @@ export function waveBuoyFor(beach: Beach): (WaveBuoy & { id: string }) | null {
   return { id: beach.wave_buoy, ...buoy };
 }
 
+/**
+ * The observation station a beach reads, or null when the join bound none.
+ *
+ * Throws when a beach names a station the table does not describe -- a broken
+ * pair of data files, which should stop a build rather than render an
+ * unlabelled number.
+ */
+export function weatherStationFor(
+  beach: Beach,
+): (WeatherStation & { id: string }) | null {
+  if (beach.weather_station === null) return null;
+
+  const station = WEATHER[beach.weather_station];
+  if (!station) {
+    throw new Error(
+      `beaches.json: ${beach.slug} names weather station ${beach.weather_station}, ` +
+        `which has no entry in weather-stations.json.`,
+    );
+  }
+  return { id: beach.weather_station, ...station };
+}
+
 /** Caveats carried by every data file. Every one owes the reader a rendering. */
 export function inventoryCaveats(): readonly string[] {
   return [
     ...(inventory.unresolved as readonly string[]),
     ...(stationTable.unresolved as readonly string[]),
     ...(buoyTable.unresolved as readonly string[]),
+    ...(weatherTable.unresolved as readonly string[]),
   ];
 }

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -2,9 +2,15 @@ import { beforeEach, expect, test, vi } from "vitest";
 
 const fetchTideExtremes = vi.fn();
 const fetchLatestWave = vi.fn();
-vi.mock("./upstream", () => ({ fetchTideExtremes, fetchLatestWave }));
+const fetchLatestObservation = vi.fn();
+vi.mock("./upstream", () => ({
+  fetchTideExtremes,
+  fetchLatestWave,
+  fetchLatestObservation,
+}));
 
-const { readTodaysLowestLow, readLatestWaves } = await import("./conditions");
+const { readTodaysLowestLow, readLatestWaves, readLatestAir } =
+  await import("./conditions");
 
 const BEACH = "la-jolla-shores-beach";
 
@@ -23,6 +29,7 @@ const JUST_AFTER_MIDNIGHT_20260817 = Date.UTC(2026, 7, 17, 7, 30);
 beforeEach(() => {
   fetchTideExtremes.mockReset();
   fetchLatestWave.mockReset();
+  fetchLatestObservation.mockReset();
 });
 
 function ok(extremes: { atMs: number; feet: number; kind: "low" | "high" }[]) {
@@ -226,4 +233,106 @@ test("the clock is passed to the fetch, so freshness is judged not guessed", asy
   await readLatestWaves("la-jolla-shores-beach", NOON_PACIFIC_20260817);
 
   expect(fetchLatestWave).toHaveBeenCalledWith("46254", NOON_PACIFIC_20260817);
+});
+
+/** What KNKX served on 2026-08-18, as the parser hands it on. */
+const KNKX_OBSERVATION = {
+  atMs: Date.UTC(2026, 7, 18, 4, 55),
+  visibilityMi: 10.0,
+  visibilityAtCeiling: true,
+  airTempF: 69.98,
+  windMph: 5.82,
+  gustMph: null,
+  windDirDegT: 320,
+  sky: "Clear",
+};
+
+test("the air reading names its station and carries the ceiling flag through", async () => {
+  fetchLatestObservation.mockResolvedValue({
+    kind: "ok",
+    observation: KNKX_OBSERVATION,
+    ageMinutes: 12,
+    url: "https://example.invalid",
+  });
+
+  const view = await readLatestAir(BEACH, NOON_PACIFIC_20260817);
+
+  expect(view.station?.name).toMatch(/Miramar/);
+  expect(view.station?.distanceM).toBe(10429);
+  expect(view.state.kind).toBe("reading");
+  if (view.state.kind === "reading") {
+    // The flag has to survive the trip, or the view re-derives it from a
+    // magic number and the two can disagree.
+    expect(view.state.visibilityAtCeiling).toBe(true);
+    expect(view.state.visibilityMi).toBe(10.0);
+    expect(view.state.sky).toBe("Clear");
+  }
+});
+
+test("a bay beach still gets an air reading, unlike its waves", async () => {
+  fetchLatestObservation.mockResolvedValue({
+    kind: "ok",
+    observation: KNKX_OBSERVATION,
+    ageMinutes: 3,
+    url: "https://example.invalid",
+  });
+
+  // A lagoon: no wave buoy by design, and an observation station all the same,
+  // because air reaches enclosed water and swell does not.
+  const view = await readLatestAir(
+    "agua-hedionda-lagoon",
+    NOON_PACIFIC_20260817,
+  );
+
+  expect(view.station).not.toBeNull();
+  expect(view.state.kind).toBe("reading");
+});
+
+test("the beach the join refused asks nobody and says why", async () => {
+  const view = await readLatestAir(UNBOUND_BEACH, NOON_PACIFIC_20260817);
+
+  expect(view.state.kind).toBe("no-station");
+  expect(view.station).toBeNull();
+  // No station means nothing to ask. A request here would be a wasted call
+  // whose failure would then be reported as a transient one.
+  expect(fetchLatestObservation).not.toHaveBeenCalled();
+});
+
+test("an unavailable station carries its reason and its drift flag through", async () => {
+  fetchLatestObservation.mockResolvedValue({
+    kind: "unavailable",
+    reason: "NWS KNKX returns 404 for its latest observation.",
+    drift: false,
+    url: "https://example.invalid",
+  });
+
+  const view = await readLatestAir(BEACH, NOON_PACIFIC_20260817);
+
+  expect(view.state).toEqual({
+    kind: "unavailable",
+    detail: "NWS KNKX returns 404 for its latest observation.",
+    drift: false,
+  });
+});
+
+test("the clock is passed to the fetch, so freshness is judged not guessed", async () => {
+  fetchLatestObservation.mockResolvedValue({
+    kind: "unavailable",
+    reason: "stale",
+    drift: false,
+    url: "https://example.invalid",
+  });
+
+  await readLatestAir(BEACH, NOON_PACIFIC_20260817);
+
+  expect(fetchLatestObservation).toHaveBeenCalledWith(
+    "KNKX",
+    NOON_PACIFIC_20260817,
+  );
+});
+
+test("an unknown slug is a coding error, not a quiet feed", async () => {
+  await expect(
+    readLatestAir("not-a-beach", NOON_PACIFIC_20260817),
+  ).rejects.toThrow(/no beach in the inventory/);
 });

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -11,10 +11,19 @@
  * instants rather than against whatever the test runner's clock says.
  */
 
-import { beachBySlug, tideStationFor, waveBuoyFor } from "./beaches";
+import {
+  beachBySlug,
+  tideStationFor,
+  waveBuoyFor,
+  weatherStationFor,
+} from "./beaches";
 import { localDateOf, localTimeOf } from "./pacific-time";
 import { lowestLowOn } from "./tide-day";
-import { fetchLatestWave, fetchTideExtremes } from "./upstream";
+import {
+  fetchLatestObservation,
+  fetchLatestWave,
+  fetchTideExtremes,
+} from "./upstream";
 
 /**
  * What the view renders. Four states, kept distinct on purpose, because the
@@ -212,6 +221,106 @@ export async function readLatestWaves(
       periodS: result.observation.periodS,
       directionDegT: result.observation.directionDegT,
       waterTempF: result.observation.waterTempF,
+    },
+  };
+}
+
+/**
+ * What the wind-and-visibility view renders. The same three-way split as the
+ * tide and the waves, and for the same reason: `no-station` is a permanent fact
+ * about a place, `unavailable` is a transient fact about a feed.
+ *
+ * Unlike the wave view, `no-station` is rare here rather than routine — every
+ * beach binds a station because air reaches a lagoon, and the only beach without
+ * one is the beach whose coordinates upstream publishes transposed.
+ */
+export type AirState =
+  | {
+      kind: "reading";
+      /** Statute miles, or null when the bound station published none this hour. */
+      visibilityMi: number | null;
+      /** True when visibility is at METAR's ten-mile ceiling, so it is a floor. */
+      visibilityAtCeiling: boolean;
+      airTempF: number | null;
+      windMph: number | null;
+      gustMph: number | null;
+      windDirDegT: number | null;
+      sky: string | null;
+    }
+  | { kind: "no-station"; reason: string }
+  | { kind: "unavailable"; detail: string; drift: boolean };
+
+export interface AirView {
+  beachName: string;
+  /** null exactly when the state is `no-station`. */
+  station: { name: string; distanceM: number | null } | null;
+  state: AirState;
+}
+
+/**
+ * Read the newest observation for one beach: visibility, wind, air temperature
+ * and sky, all from the one station, so the panel never blends two.
+ *
+ * Throws only when the slug is not in the inventory, which is a coding error
+ * rather than a quiet feed.
+ */
+export async function readLatestAir(
+  slug: string,
+  nowMs: number = Date.now(),
+): Promise<AirView> {
+  const beach = beachBySlug(slug);
+  if (!beach) {
+    throw new Error(
+      `readLatestAir: no beach in the inventory with slug "${slug}".`,
+    );
+  }
+
+  const station = weatherStationFor(beach);
+  if (station === null) {
+    return {
+      beachName: beach.name,
+      station: null,
+      state: {
+        kind: "no-station",
+        reason:
+          beach.weather_station_null_reason ??
+          "the join bound no observation station to this beach, and recorded no reason",
+      },
+    };
+  }
+
+  const binding = {
+    beachName: beach.name,
+    station: {
+      name: station.name,
+      distanceM: beach.weather_station_distance_m,
+    },
+  };
+
+  const result = await fetchLatestObservation(station.id, nowMs);
+  if (result.kind === "unavailable") {
+    return {
+      ...binding,
+      state: {
+        kind: "unavailable",
+        detail: result.reason,
+        drift: result.drift,
+      },
+    };
+  }
+
+  const { observation } = result;
+  return {
+    ...binding,
+    state: {
+      kind: "reading",
+      visibilityMi: observation.visibilityMi,
+      visibilityAtCeiling: observation.visibilityAtCeiling,
+      airTempF: observation.airTempF,
+      windMph: observation.windMph,
+      gustMph: observation.gustMph,
+      windDirDegT: observation.windDirDegT,
+      sky: observation.sky,
     },
   };
 }

--- a/src/lib/nws-observation.test.ts
+++ b/src/lib/nws-observation.test.ts
@@ -1,0 +1,207 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  NwsObservationDriftError,
+  NwsObservationNoDataError,
+  parseNwsObservation,
+} from "./nws-observation";
+
+const fixture = (name: string): unknown =>
+  JSON.parse(
+    readFileSync(join(process.cwd(), "src/lib/__fixtures__", name), "utf8"),
+  );
+
+/** What KNKX served on 2026-08-18, byte for byte. The station la-jolla-shores-beach binds to. */
+const KNKX = fixture("nws-knkx-observation-20260818.json");
+
+/**
+ * What D3101 served on the same day: the nearest station to that same beach,
+ * answering with nulls. This is the shape the join exists to exclude, kept as a
+ * fixture because a bound station can fall into it later.
+ */
+const D3101 = fixture("nws-d3101-observation-20260818.json");
+
+/** A payload built from KNKX's, with one field replaced. */
+function withField(field: string, replacement: unknown): unknown {
+  const base = KNKX as { properties: Record<string, unknown> };
+  return {
+    ...base,
+    properties: { ...base.properties, [field]: replacement },
+  };
+}
+
+describe("against the captured payload", () => {
+  test("reads the observation's own instant, offset included", () => {
+    const observation = parseNwsObservation(KNKX, "KNKX");
+    // "2026-08-18T04:55:00+00:00". This payload carries its offset, unlike
+    // CO-OPS, which carries none, and NDBC, which carries none and means UTC.
+    expect(observation.atMs).toBe(Date.UTC(2026, 7, 18, 4, 55));
+  });
+
+  test("converts visibility out of the metres NWS publishes", () => {
+    const observation = parseNwsObservation(KNKX, "KNKX");
+    // 16090 m
+    expect(observation.visibilityMi).toBeCloseTo(10.0, 2);
+  });
+
+  test("converts air temperature out of Celsius", () => {
+    const observation = parseNwsObservation(KNKX, "KNKX");
+    // 21.1 degC
+    expect(observation.airTempF).toBeCloseTo(69.98, 2);
+  });
+
+  test("converts wind out of the km/h NWS publishes, not knots or mph", () => {
+    const observation = parseNwsObservation(KNKX, "KNKX");
+    // 9.36 km/h. Read as mph it would be 9.36; read as knots, 10.8. Both are
+    // plausible-looking wind speeds, which is exactly why the unit is asserted.
+    expect(observation.windMph).toBeCloseTo(5.82, 2);
+    expect(observation.windDirDegT).toBe(320);
+  });
+
+  test("keeps the station's own plain-words sky", () => {
+    expect(parseNwsObservation(KNKX, "KNKX").sky).toBe("Clear");
+  });
+});
+
+describe("the ten-mile ceiling", () => {
+  test("16090 m is flagged as the ceiling, not reported as an exact ten miles", () => {
+    // METAR stops at ten statute miles, so the top of the range is a floor.
+    expect(parseNwsObservation(KNKX, "KNKX").visibilityAtCeiling).toBe(true);
+  });
+
+  test("the other spelling of the ceiling is flagged too", () => {
+    // Nine stations publish the cap; some as 16090, some as 16093.44. Testing
+    // equality against one would let the other render as a measurement.
+    const exact = withField("visibility", {
+      unitCode: "wmoUnit:m",
+      value: 16093.44,
+      qualityControl: "C",
+    });
+    expect(parseNwsObservation(exact, "KSAN").visibilityAtCeiling).toBe(true);
+  });
+
+  test("a reading below the ceiling is a measurement", () => {
+    // KOKB published 12874.75 m on the same morning: eight miles, and real.
+    const below = withField("visibility", {
+      unitCode: "wmoUnit:m",
+      value: 12874.75,
+      qualityControl: "C",
+    });
+    const observation = parseNwsObservation(below, "KOKB");
+    expect(observation.visibilityAtCeiling).toBe(false);
+    expect(observation.visibilityMi).toBeCloseTo(8.0, 2);
+  });
+});
+
+describe("missing values", () => {
+  test("a null value is absent, never a zero", () => {
+    // KNKX published no gust that hour. Read as 0 this would say "calm".
+    expect(parseNwsObservation(KNKX, "KNKX").gustMph).toBeNull();
+  });
+
+  test("a station answering with nulls yields nulls, not a clear calm day", () => {
+    // D3101 is nearer la-jolla-shores-beach than KNKX and publishes no
+    // visibility at all. The join excludes it; the parser must not invent one.
+    const observation = parseNwsObservation(D3101, "D3101");
+    expect(observation.visibilityMi).toBeNull();
+    expect(observation.visibilityAtCeiling).toBe(false);
+    expect(observation.airTempF).toBeCloseTo(69.998, 2);
+  });
+
+  test("an empty textDescription is no sky, not a sky", () => {
+    // D3101 serves "". Rendered as a sky it would read as an answer.
+    expect(parseNwsObservation(D3101, "D3101").sky).toBeNull();
+  });
+
+  test("a station with nothing in any field is no data", () => {
+    const empty = {
+      properties: {
+        timestamp: "2026-08-18T04:55:00+00:00",
+        textDescription: "",
+        visibility: { unitCode: "wmoUnit:m", value: null },
+        temperature: { unitCode: "wmoUnit:degC", value: null },
+        windSpeed: { unitCode: "wmoUnit:km_h-1", value: null },
+        windGust: { unitCode: "wmoUnit:km_h-1", value: null },
+        windDirection: { unitCode: "wmoUnit:degree_(angle)", value: null },
+      },
+    };
+    expect(() => parseNwsObservation(empty, "D3101")).toThrow(
+      NwsObservationNoDataError,
+    );
+  });
+});
+
+describe("refusals", () => {
+  test("a changed unit is drift, not a conversion to attempt", () => {
+    const feet = withField("visibility", {
+      unitCode: "wmoUnit:ft",
+      value: 52789,
+      qualityControl: "C",
+    });
+    expect(() => parseNwsObservation(feet, "KNKX")).toThrow(
+      NwsObservationDriftError,
+    );
+  });
+
+  test("wind published in knots is refused rather than shown as mph", () => {
+    // The failure this prevents does not look like an error. It looks like a
+    // breezier day.
+    const knots = withField("windSpeed", {
+      unitCode: "wmoUnit:kn",
+      value: 9.36,
+      qualityControl: "V",
+    });
+    expect(() => parseNwsObservation(knots, "KNKX")).toThrow(
+      NwsObservationDriftError,
+    );
+  });
+
+  test("a field that disappeared is drift, not a missing reading", () => {
+    const base = KNKX as { properties: Record<string, unknown> };
+    const gone = { ...base, properties: { ...base.properties } };
+    delete (gone.properties as Record<string, unknown>).visibility;
+    expect(() => parseNwsObservation(gone, "KNKX")).toThrow(
+      NwsObservationDriftError,
+    );
+  });
+
+  test("a payload with no properties is refused", () => {
+    expect(() => parseNwsObservation({ id: "x" }, "KNKX")).toThrow(
+      NwsObservationDriftError,
+    );
+  });
+
+  test("an unparseable timestamp is refused rather than dated now", () => {
+    const bad = withField("timestamp", "the eighteenth");
+    expect(() => parseNwsObservation(bad, "KNKX")).toThrow(
+      NwsObservationDriftError,
+    );
+  });
+});
+
+describe("refusals, continued", () => {
+  test("a measurement that is not an object is drift", () => {
+    const scalar = withField("temperature", 21.1);
+    expect(() => parseNwsObservation(scalar, "KNKX")).toThrow(
+      NwsObservationDriftError,
+    );
+  });
+
+  test("a non-numeric value is drift, not a missing reading", () => {
+    const text = withField("temperature", {
+      unitCode: "wmoUnit:degC",
+      value: "twenty-one",
+    });
+    expect(() => parseNwsObservation(text, "KNKX")).toThrow(
+      NwsObservationDriftError,
+    );
+  });
+
+  test("a missing timestamp is refused rather than dated now", () => {
+    const undated = withField("timestamp", null);
+    expect(() => parseNwsObservation(undated, "KNKX")).toThrow(
+      NwsObservationDriftError,
+    );
+  });
+});

--- a/src/lib/nws-observation.ts
+++ b/src/lib/nws-observation.ts
@@ -1,0 +1,207 @@
+/**
+ * NWS `/stations/{id}/observations/latest`: the pinned units, and the newest
+ * observation.
+ *
+ * Pure and offline, like the two parsers beside it. It takes the payload a
+ * station served and returns typed values or raises.
+ *
+ * WHAT IS PINNED, and why each would otherwise produce a confident wrong number:
+ *
+ *   The unit codes, per field. Unlike NDBC this payload states its units on
+ *   every measurement rather than once in a header, so each is asserted where it
+ *   is read: `wmoUnit:m` for visibility, `wmoUnit:degC` for temperature,
+ *   `wmoUnit:km_h-1` for wind. All three differ from what this site displays --
+ *   miles, Fahrenheit, miles per hour -- so an upstream switch that went
+ *   unnoticed would not look like an error, it would look like weather.
+ *
+ *   `null` as the missing marker, per field, inside an object that is still
+ *   present. A station that has stopped publishing visibility does not drop the
+ *   `visibility` key; it serves `{"value": null, "qualityControl": "Z"}`. So
+ *   presence of the key proves nothing and only the value counts. Forty-six of
+ *   the fifty-six candidate stations in this county answer exactly that way,
+ *   which is why the join filters on measured delivery -- see
+ *   `weather-stations.json`.
+ *
+ * WHAT IS NOT PINNED, deliberately: `qualityControl`. Its values are upstream's
+ * own vocabulary and this site does not gate on them, because a reading marked
+ * `V` and a reading marked `C` are both what the station published and neither
+ * is this site's to second-guess.
+ *
+ * THE TEN-MILE CEILING IS NOT A MEASUREMENT. METAR stops at ten statute miles,
+ * published as either 16093.44 m or 16090 m depending on the station, so the top
+ * of the range means "at least ten miles". That distinction is carried out of
+ * here as a flag rather than left for the view to rediscover from a magic
+ * number.
+ */
+
+/** Unit codes this parser knows how to convert from, per field. */
+const EXPECTED_UNITS = {
+  visibility: "wmoUnit:m",
+  temperature: "wmoUnit:degC",
+  windSpeed: "wmoUnit:km_h-1",
+  windGust: "wmoUnit:km_h-1",
+  windDirection: "wmoUnit:degree_(angle)",
+} as const;
+
+/**
+ * METAR's maximum reportable visibility, ten statute miles, in metres. Stations
+ * publish it as 16093.44 (the exact conversion) or 16090 (rounded), so the test
+ * is a threshold rather than an equality.
+ */
+const VISIBILITY_CEILING_M = 16090;
+
+const METRES_PER_MILE = 1609.344;
+
+export class NwsObservationDriftError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NwsObservationDriftError";
+  }
+}
+
+export class NwsObservationNoDataError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NwsObservationNoDataError";
+  }
+}
+
+export interface StationObservation {
+  /** Instant of the observation, epoch milliseconds UTC. */
+  atMs: number;
+  /** Visibility in statute miles, converted from metres, or null when unpublished. */
+  visibilityMi: number | null;
+  /** True when visibility sits at METAR's ten-mile ceiling, so the figure is a floor. */
+  visibilityAtCeiling: boolean;
+  /** Air temperature in Fahrenheit, converted from Celsius, or null. */
+  airTempF: number | null;
+  /** Wind speed in miles per hour, converted from km/h, or null. */
+  windMph: number | null;
+  /** Gust in miles per hour, or null. Frequently null while wind speed is not. */
+  gustMph: number | null;
+  /** Wind direction in degrees true, or null. */
+  windDirDegT: number | null;
+  /** The station's own plain-words sky, e.g. "Clear". Empty string becomes null. */
+  sky: string | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * One measurement's value, with its declared unit asserted.
+ *
+ * A missing key is drift -- the shape changed. A present key carrying a null
+ * value is not: that is a station which is answering and not measuring.
+ */
+function measured(
+  properties: Record<string, unknown>,
+  field: keyof typeof EXPECTED_UNITS,
+  stationId: string,
+): number | null {
+  const raw = properties[field];
+  if (raw === undefined || raw === null) {
+    throw new NwsObservationDriftError(
+      `NWS ${stationId}: the observation carries no ${field} object at all. The payload's ` +
+        `shape has drifted; refusing to guess which field replaced it.`,
+    );
+  }
+  if (!isRecord(raw) || !("value" in raw)) {
+    throw new NwsObservationDriftError(
+      `NWS ${stationId}: ${field} was ${JSON.stringify(raw)}, not a measurement object.`,
+    );
+  }
+
+  const { value, unitCode } = raw;
+  if (value === null || value === undefined) return null;
+
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new NwsObservationDriftError(
+      `NWS ${stationId}: ${field} was ${JSON.stringify(value)}, not a number.`,
+    );
+  }
+
+  const expected = EXPECTED_UNITS[field];
+  if (unitCode !== expected) {
+    throw new NwsObservationDriftError(
+      `NWS ${stationId}: ${field} is published in ${JSON.stringify(unitCode)}, not ` +
+        `${JSON.stringify(expected)}. The payload states its own units and they have ` +
+        `changed; converting on the old assumption would be a wrong number.`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Parse the newest observation out of a `latest` payload.
+ *
+ * Raises `NwsObservationNoDataError` when the station answered with nothing
+ * usable -- no timestamp, or no value in any field this panel shows, which is a
+ * station that is not observing rather than a calm clear day. Raises
+ * `NwsObservationDriftError` when the shape or the units are not what is pinned
+ * above.
+ */
+export function parseNwsObservation(
+  payload: unknown,
+  stationId: string,
+): StationObservation {
+  if (!isRecord(payload) || !isRecord(payload.properties)) {
+    throw new NwsObservationDriftError(
+      `NWS ${stationId}: the response carried no properties object.`,
+    );
+  }
+  const properties = payload.properties;
+
+  const timestamp = properties.timestamp;
+  if (typeof timestamp !== "string") {
+    throw new NwsObservationDriftError(
+      `NWS ${stationId}: the observation carries no timestamp string.`,
+    );
+  }
+  // Unlike CO-OPS and NDBC, this one carries its offset. Parsing it as anything
+  // other than what it says would be inventing a zone.
+  const atMs = Date.parse(timestamp);
+  if (!Number.isFinite(atMs)) {
+    throw new NwsObservationDriftError(
+      `NWS ${stationId}: the timestamp ${JSON.stringify(timestamp)} did not parse.`,
+    );
+  }
+
+  const visibilityM = measured(properties, "visibility", stationId);
+  const airTempC = measured(properties, "temperature", stationId);
+  const windKmh = measured(properties, "windSpeed", stationId);
+  const gustKmh = measured(properties, "windGust", stationId);
+  const windDirDegT = measured(properties, "windDirection", stationId);
+
+  const rawSky = properties.textDescription;
+  // Served as "" by stations that publish no sky, which is not a description of
+  // the sky. An empty string rendered as a sky would read as an answer.
+  const sky =
+    typeof rawSky === "string" && rawSky.trim() !== "" ? rawSky : null;
+
+  if (
+    visibilityM === null &&
+    airTempC === null &&
+    windKmh === null &&
+    sky === null
+  ) {
+    throw new NwsObservationNoDataError(
+      `NWS ${stationId} answered with no visibility, no temperature, no wind and no sky. ` +
+        `That is a station which is not observing, not a clear calm day.`,
+    );
+  }
+
+  return {
+    atMs,
+    visibilityMi: visibilityM === null ? null : visibilityM / METRES_PER_MILE,
+    visibilityAtCeiling:
+      visibilityM !== null && visibilityM >= VISIBILITY_CEILING_M,
+    airTempF: airTempC === null ? null : airTempC * 1.8 + 32,
+    windMph: windKmh === null ? null : windKmh / 1.609344,
+    gustMph: gustKmh === null ? null : gustKmh / 1.609344,
+    windDirDegT,
+    sky,
+  };
+}

--- a/src/lib/upstream.test.ts
+++ b/src/lib/upstream.test.ts
@@ -2,9 +2,12 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
+  fetchLatestObservation,
   fetchLatestWave,
   fetchTideExtremes,
+  MAX_OBSERVATION_AGE_MINUTES,
   MAX_WAVE_AGE_MINUTES,
+  OBSERVATIONS_REVALIDATE_SECONDS,
   PREDICTIONS_REVALIDATE_SECONDS,
   WAVES_REVALIDATE_SECONDS,
 } from "./upstream";
@@ -203,5 +206,145 @@ describe("fetchTideExtremes", () => {
     fetchMock.mockResolvedValue(jsonResponse({ somethingElse: [] }));
     const result = await fetchTideExtremes(contract);
     if (result.kind === "unavailable") expect(result.drift).toBe(true);
+  });
+});
+
+describe("fetchLatestObservation", () => {
+  const OBSERVED = Date.UTC(2026, 7, 18, 4, 55);
+  const CAPTURED_OBS = JSON.parse(
+    readFileSync(
+      join(
+        process.cwd(),
+        "src/lib/__fixtures__/nws-knkx-observation-20260818.json",
+      ),
+      "utf8",
+    ),
+  );
+
+  test("opts the request into caching and identifies this site", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(CAPTURED_OBS));
+
+    await fetchLatestObservation("KNKX", OBSERVED);
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      "https://api.weather.gov/stations/KNKX/observations/latest",
+    );
+    expect(options.next.revalidate).toBe(OBSERVATIONS_REVALIDATE_SECONDS);
+    // The National Weather Service requires a self-identifying User-Agent.
+    expect(options.headers["User-Agent"]).toContain("wild-coast-kids");
+  });
+
+  test("returns the newest observation when it is fresh", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(CAPTURED_OBS));
+
+    const result = await fetchLatestObservation("KNKX", OBSERVED);
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.observation.visibilityMi).toBeCloseTo(10.0, 2);
+    expect(result.ageMinutes).toBe(0);
+  });
+
+  test("a reading past the age limit is unknown, not a current number", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(CAPTURED_OBS));
+
+    const stale = OBSERVED + (MAX_OBSERVATION_AGE_MINUTES + 1) * 60_000;
+    const result = await fetchLatestObservation("KNKX", stale);
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.reason).toContain("minutes old");
+    // An hours-old visibility rendered as current is exactly the number a
+    // reader would act on.
+    expect(result.drift).toBe(false);
+  });
+
+  test("a reading exactly at the limit is still served", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(CAPTURED_OBS));
+
+    const edge = OBSERVED + MAX_OBSERVATION_AGE_MINUTES * 60_000;
+    expect((await fetchLatestObservation("KNKX", edge)).kind).toBe("ok");
+  });
+
+  test("404 is a station that is not publishing, said in those words", async () => {
+    // KF70 does exactly this while still listed as serving these grids.
+    fetchMock.mockResolvedValue(jsonResponse({}, 404));
+
+    const result = await fetchLatestObservation("KF70", OBSERVED);
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.reason).toContain("not publishing");
+    expect(result.drift).toBe(false);
+  });
+
+  test("another bad status is reported with its number", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, 503));
+
+    const result = await fetchLatestObservation("KNKX", OBSERVED);
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.reason).toContain("503");
+  });
+
+  test("a request that never completes is unavailable, not a throw", async () => {
+    fetchMock.mockRejectedValue(new Error("socket hang up"));
+
+    const result = await fetchLatestObservation("KNKX", OBSERVED);
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.reason).toContain("socket hang up");
+  });
+
+  test("a changed unit is flagged as drift, separately from a quiet station", async () => {
+    const knots = {
+      properties: {
+        ...CAPTURED_OBS.properties,
+        windSpeed: { unitCode: "wmoUnit:kn", value: 9.36 },
+      },
+    };
+    fetchMock.mockResolvedValue(jsonResponse(knots));
+
+    const result = await fetchLatestObservation("KNKX", OBSERVED);
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    // Drift is a bug to chase here; a quiet station is a bad day upstream.
+    expect(result.drift).toBe(true);
+  });
+
+  test("a station answering with nothing is quiet rather than drifted", async () => {
+    const empty = {
+      properties: {
+        timestamp: "2026-08-18T04:55:00+00:00",
+        textDescription: "",
+        visibility: { unitCode: "wmoUnit:m", value: null },
+        temperature: { unitCode: "wmoUnit:degC", value: null },
+        windSpeed: { unitCode: "wmoUnit:km_h-1", value: null },
+        windGust: { unitCode: "wmoUnit:km_h-1", value: null },
+        windDirection: { unitCode: "wmoUnit:degree_(angle)", value: null },
+      },
+    };
+    fetchMock.mockResolvedValue(jsonResponse(empty));
+
+    const result = await fetchLatestObservation("D3101", OBSERVED);
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.drift).toBe(false);
+  });
+
+  test("a body that is not JSON is reported as such", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("Unexpected token <");
+      },
+    });
+
+    const result = await fetchLatestObservation("KNKX", OBSERVED);
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.reason).toContain("not JSON");
   });
 });

--- a/src/lib/upstream.ts
+++ b/src/lib/upstream.ts
@@ -48,6 +48,12 @@ import {
   parseNdbcRealtime2,
   type WaveObservation,
 } from "./ndbc-realtime2";
+import {
+  NwsObservationDriftError,
+  NwsObservationNoDataError,
+  parseNwsObservation,
+  type StationObservation,
+} from "./nws-observation";
 
 /** Six hours. Astronomical predictions do not change; the window only rolls forward. */
 export const PREDICTIONS_REVALIDATE_SECONDS = 21600;
@@ -216,6 +222,116 @@ export async function fetchLatestWave(
     return unavailable(
       `NDBC ${buoyId}'s newest observation is ${Math.round(ageMinutes)} minutes old, past the ` +
         `${MAX_WAVE_AGE_MINUTES} minute limit. Reported as unknown rather than as a current reading.`,
+    );
+  }
+
+  return { kind: "ok", observation, ageMinutes, url };
+}
+
+/* ===========================================================================
+ * NWS station observations: visibility, wind, air temperature and sky
+ * ========================================================================= */
+
+/**
+ * Fifteen minutes, matching the page's own revalidate. These stations publish
+ * hourly, with unscheduled specials when conditions change sharply — and a
+ * special is exactly the moment worth catching, since it is what a bank of fog
+ * rolling in looks like from here.
+ */
+export const OBSERVATIONS_REVALIDATE_SECONDS = 900;
+
+/**
+ * Beyond this, a "current" observation is not current. These stations publish
+ * hourly, so three hours means at least three missed cycles: the station is
+ * answering and not observing. Reported as unknown rather than as a stale
+ * number wearing no warning.
+ */
+export const MAX_OBSERVATION_AGE_MINUTES = 180;
+
+const NWS_BASE = "https://api.weather.gov";
+
+export type ObservationResult =
+  | {
+      kind: "ok";
+      observation: StationObservation;
+      ageMinutes: number;
+      url: string;
+    }
+  | { kind: "unavailable"; reason: string; drift: boolean; url: string };
+
+/**
+ * Fetch one station's newest observation.
+ *
+ * Never throws. `nowMs` is passed in rather than read here, so the freshness
+ * limit is testable against a fixed instant and no clock is read during a
+ * render.
+ */
+export async function fetchLatestObservation(
+  stationId: string,
+  nowMs: number,
+): Promise<ObservationResult> {
+  const url = `${NWS_BASE}/stations/${stationId}/observations/latest`;
+
+  const unavailable = (reason: string, drift = false): ObservationResult => ({
+    kind: "unavailable",
+    reason,
+    drift,
+    url,
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { "User-Agent": USER_AGENT },
+      next: { revalidate: OBSERVATIONS_REVALIDATE_SECONDS },
+    });
+  } catch (cause) {
+    return unavailable(
+      `The request to the National Weather Service for station ${stationId} did not ` +
+        `complete: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+
+  if (response.status === 404) {
+    // What a retired station does while still listed as serving a grid. KF70
+    // does exactly this, which is why the inventory records measured delivery.
+    return unavailable(
+      `NWS ${stationId} returns 404 for its latest observation. The station is not publishing.`,
+    );
+  }
+  if (!response.ok) {
+    return unavailable(
+      `The National Weather Service returned HTTP ${response.status} for station ${stationId}.`,
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (cause) {
+    return unavailable(
+      `The National Weather Service's response for station ${stationId} was not JSON: ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+
+  let observation: StationObservation;
+  try {
+    observation = parseNwsObservation(payload, stationId);
+  } catch (cause) {
+    if (cause instanceof NwsObservationDriftError)
+      return unavailable(cause.message, true);
+    if (cause instanceof NwsObservationNoDataError)
+      return unavailable(cause.message);
+    return unavailable(cause instanceof Error ? cause.message : String(cause));
+  }
+
+  const ageMinutes = (nowMs - observation.atMs) / 60_000;
+  if (ageMinutes > MAX_OBSERVATION_AGE_MINUTES) {
+    return unavailable(
+      `NWS ${stationId}'s newest observation is ${Math.round(ageMinutes)} minutes old, past ` +
+        `the ${MAX_OBSERVATION_AGE_MINUTES} minute limit. Reported as unknown rather than as ` +
+        `a current reading.`,
     );
   }
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -34,10 +34,10 @@ export default defineConfig({
       // run-vitest.mjs and check-built-css.mjs sit at 0% on purpose, and all
       // three drag these figures down in plain sight rather than quietly.
       thresholds: {
-        statements: 86.14,
-        branches: 86.87,
-        functions: 90.9,
-        lines: 86.06,
+        statements: 88.1,
+        branches: 88.66,
+        functions: 92.48,
+        lines: 88.12,
       },
     },
   },


### PR DESCRIPTION
Closes #71.

Slice 7a of `docs/plans/conditions-tool.md`. The site header has promised
"Surf · Tide · Wind · Visibility" since before any of it had data behind it.
Slice 6 supplied the surf; this supplies the other two words.

## The plan was wrong about where visibility comes from

The product table and slice 6's addendum both said wind and visibility "can only
ever come from the National Weather Service gridpoint forecast". Measured at four
widely separated grids across the county, the gridpoint publishes **none** — the
`visibility` key is present, its `values` array is empty, and it carries no `uom`:

```
Oceanside      SGX/52,36  vis=0  wind=56  temp=74  sky=35
La Jolla       SGX/55,22  vis=0  wind=63  temp=92  sky=34
Mission Beach  SGX/54,17  vis=0  wind=65  temp=91  sky=36
Imperial Beach SGX/57,8   vis=0  wind=58  temp=85  sky=36
```

Visibility is an **observation**, so this reads `/stations/{id}/observations/latest`.
That also puts it on the right side of the plan's own line: the gridpoint is a
seven-day forecast and this panel sits among today's readings. Slice 7 therefore
split — 7b moves the gridpoint into slice 8's forward panel.

## The slices

1. **Show visibility, wind, air temperature and sky at each beach** — the station
   inventory with measured delivery, the join wired into `seed-beaches.mjs`, a
   pure parser against two committed fixtures, the fetch policy, and the four
   render states.
2. **Record what slice 7a settled** — plan addendum; the product table corrected
   in place; slice 6's paragraph marked with what superseded it rather than
   rewritten; open question 3 answered.
3. **Assert the wind panel is reachable from the conditions section** — a gap I
   left in the first commit and caught afterwards.

## The join filters on delivery, not distance

Of 163 candidate stations across the 35 grids the 73 beaches resolve to, 159
answer and **only 24 carry a visibility value** — every one an airport METAR.
Inside the county box, 9 do and 46 answer perfectly without one:

```
KNKX   vis=16090[C]    temp=21.1[V]  "Clear"
KSAN   vis=16093.44[C] temp=22[V]    "Clear"
D3101  vis=null        temp=null     ""     <- nearest station to the default beach
MSDSD  vis=null        temp=20.41[V] ""     <- second nearest
```

Binding by proximity alone would have pointed the visibility promise at a station
that has never published one. Requiring the field costs distance and buys an
answer, and it keeps all four values on one station so the panel never blends two
provenances. Result: KSAN 36, KNKX 14, KCRQ 11, KOKB 5, KSDM 5, KNFG 1, and none
for the one beach whose coordinates upstream publishes transposed — the same
beach the tide and wave joins already refuse. Median 7.3 km, farthest 16.8 km.

`KF70` 404s while listed: the fifth listed-but-dead station measured here, after
TWC0405, 46273 and 46235. Kept and marked, not deleted.

**This join is deliberately not asymmetric like the wave join.** Every beach
binds, bays and lagoons included — swell does not propagate into enclosed water,
air does. That reads like an oversight someone would tidy away, so a test asserts
a bay beach binds.

**Ten miles is a ceiling.** METAR stops there, published as 16093.44 m by some
stations and 16090 m by others, so an equality test against one spelling would let
the other render as a measurement. The parser carries `visibilityAtCeiling` out as
a flag and the view renders "10 miles or more".

## Gates

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

```
 Test Files  54 passed (54)
Statements   : 88.1% ( 659/748 )
Branches     : 88.66% ( 438/494 )
Functions    : 92.48% ( 160/173 )
Lines        : 88.12% ( 601/682 )
```

Floor raised to match. Raising it found a real gap rather than a bookkeeping one:
`document()` had only ever run against a single beach, so its `reduce` and `sort`
callbacks never fired and "the farthest beach from its station" was asserted by
nothing. That test now builds two.

The re-join, run against live upstream:

```
$ node scripts/seed-beaches.mjs --check
beaches.json is current: 73 beaches, join unchanged.
exit=0
```

And with `la-jolla-shores-beach` perturbed from KNKX to KSAN:

```
beaches.json has moved. Re-run without --check, read the diff, and say in the
commit what moved upstream and why.
exit=1
```

The reachability assertion was checked the same way — removed the panel from the
section, watched it fail, restored it.

## What I did not do

- **The gridpoint (7b).** It has wind, air temp and sky in km/h and °C, on ISO
  8601 intervals whose duration varies per property. It is a forecast, so it goes
  to slice 8.
- **#70, the 46086 wave claim.** `wave-buoys.json` says it "delivers wind and
  water temp but no waves"; measured twice, it publishes `WVHT` on 27 of 48 rows
  and the newest row carried 1.6 m. Nothing renders it — 46086 is bound to no
  beach — but the sentence reaches a reader through the caveats gate. Filed
  separately rather than folded into this diff.
- **Marine zones.** `/points` has no marine-zone key at all, and a segment
  endpoint that resolves offshore returns a `PZZ` zone with `county` and
  `fireWeatherZone` absent. The plan's "land/county/marine zones" needs revisiting
  when 7b lands; not touched here.

## Size

~800 hand-written lines including tests, past the ~400 guide. There is no
dependency boundary inside 7a to split on — the inventory without the reading is
a file nothing reads, and the reading without the inventory does not build — so it
is one slice plus its record. Flagging it rather than pretending otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)