### PR TITLE
Stop claiming 46086 publishes no waves

### DIFF
--- a/docs/plans/conditions-tool.md
+++ b/docs/plans/conditions-tool.md
@@ -573,3 +573,70 @@ match. Raising it surfaced a real gap rather than a bookkeeping one: `document()
 was only ever exercised with a single beach, so its `reduce` and `sort`
 callbacks never ran and "the farthest beach from its station" was asserted by
 nothing. That test now builds two.
+
+### 2026-08-18 — #70, and the field that outlived its reason
+
+**46086 publishes waves.** The claim that it does not was measured a third time
+against `https://www.ndbc.noaa.gov/data/realtime2/46086.txt`, the endpoint this
+site reads, over the whole file rather than a window:
+
+```
+rows          : 6482 (newest 2026 08 18 06 00 UTC)
+WVHT present  : 27 / 48 newest      3567 / 6482 whole file (55%)
+WSPD present  : 48 / 48             6446 / 6482
+WTMP present  : 47 / 48             6281 / 6482
+VIS  present  :  0 / 48                0 / 6482
+```
+
+The gap is a cadence, not an absence. `WVHT` lands on exactly two rows in three —
+the rows at `:00` and `:30` are `MM` — and the values repeat in pairs, so a
+slower wave cycle is being carried on ten-minute met rows. A single read has
+about a one-in-three chance of landing on an `MM` row, which is how "no waves"
+was arrived at honestly and recorded wrongly.
+
+Everything else in the entry survived the re-measurement: 46086 does publish wind
+and water temperature, publishes **no** visibility anywhere in 6,482 rows, sits
+twenty-seven nautical miles offshore, and is bound to no beach.
+
+**The false clause was in six places, not one.** `_what_was_measured` and
+`unresolved[2]` in `wave-buoys.json`; the `publishes_waves: false` datum itself;
+and three code comments — `wave-join.mjs`, `wave-join.test.mjs` and
+`beaches.ts` — each restating "carries no wave height at all" as the reason the
+field exists. Correcting the caveat alone would have left five copies of the
+thing the caveat was corrected for.
+
+**`publishes_waves` was invented for a belief that turned out false.** The field
+exists to give the join a second filter beside `delivers`, and the only station
+it was ever meant to exclude was 46086. With the measurement corrected, no
+station in the table fails it on its own terms: `delivers && publishes_waves`
+became equivalent to `delivers`, and 46086's exclusion needed a reason it did not
+have.
+
+**Decided with Cole: redefine the field, do not change the join.** The
+`_schema` entry now says what the join actually uses the field for — whether the
+station's wave height is one a beach may bind to — and 46086 carries `false` with
+its real reason, distance, alongside the measured `WVHT` ratio so the number and
+the exclusion are never again the same sentence.
+
+Two alternatives were rejected:
+
+- **Flip the field to `true` and change nothing else.** Verified against all 73
+  beaches: no binding changes today, because every open-coast beach has a
+  nearshore buoy closer than twenty-seven nautical miles. But it makes 46086 an
+  eligible wave source held out by distance alone, and 46235 and 46273 have
+  already died. If 46232 Point Loma South follows them, a south-county beach
+  reaches twenty-seven miles offshore for a height that describes different
+  water, and nothing in the repo would say so.
+- **Flip the field to `true` and add an eligibility rule** — an explicit
+  out-of-corridor flag as a second condition in the join's filter. The honest
+  shape, and where this goes if a second out-of-corridor station ever appears.
+  Rejected now because it changes the join to express something one station
+  needs, and the issue that raised this put the join out of scope. The
+  redefinition leaves that door open: the field's meaning is already
+  "bindable", so the rename is all that would be left to do.
+
+**What the regression test can and cannot do.** It asserts the caveat's sentence
+through `inventoryCaveats()`, the seam the caveats gate already walks — the claim
+cannot silently revert. It does not assert the ocean: a gate must not fetch NDBC,
+so nothing in CI notices if NOAA changes what 46086 publishes. The measurement
+above is the evidence for the sentence; the test only holds the sentence still.

--- a/scripts/wave-join.mjs
+++ b/scripts/wave-join.mjs
@@ -14,7 +14,10 @@
  * is better than a confident wrong one.
  *
  * `publishes_waves` is checked separately from `delivers` because one station in
- * the table answers perfectly and carries no wave height at all.
+ * the table answers perfectly, publishes waves, and still must not be bound:
+ * 46086 sits twenty-seven nautical miles offshore, outside the corridor these
+ * beaches share. The field is this join's verdict on a station rather than a
+ * claim about what its rows carry.
  */
 
 import { segmentDistance } from "./geo.mjs";

--- a/scripts/wave-join.test.mjs
+++ b/scripts/wave-join.test.mjs
@@ -42,8 +42,10 @@ describe("bindWaveBuoy", () => {
     expect(bound.buoyId).toBe("46232");
   });
 
-  it("never chooses a delivering station that carries no wave height", () => {
-    // 46086 answers with rows, and none of them has WVHT in it.
+  it("never chooses a delivering station the table marks unbindable", () => {
+    // 46086 answers perfectly and does publish waves, but sits twenty-seven
+    // nautical miles offshore where the swell is not this coast's, so the table
+    // sets publishes_waves false and the filter has to honour that.
     const bound = bindWaveBuoy(
       { segment: at(32.5, -117.9), waterBodyType: "Open Coast" },
       BUOYS,

--- a/src/data/wave-buoys.json
+++ b/src/data/wave-buoys.json
@@ -2,14 +2,15 @@
   "version": "0.1.0",
   "generated": "2026-08-18",
   "_provenance": "Station ids, names and coordinates read from NOAA NDBC's active station list, https://www.ndbc.noaa.gov/activestations.xml, filtered to 32.4-33.5N and -118.2 to -117.0E, on 2026-08-18. Nineteen stations were listed. Delivery was then measured one station at a time against https://www.ndbc.noaa.gov/data/realtime2/<id>.txt, the same endpoint this site reads, rather than inferred from the list.",
-  "_what_was_measured": "Every delivering buoy publishes WVHT, DPD, MWD and WTMP. NOT ONE publishes WDIR, WSPD or VIS -- ten out of ten leave them MM. Slice 3 saw this on 46254 and recorded it as one station's quirk; it is categorical. The only station in the box with wind is 46086, twenty-seven nautical miles offshore in the San Clemente Basin, and it publishes no waves at all. That is why this site's wind and visibility must come from the National Weather Service gridpoint forecast and can never come from a buoy.",
+  "_what_was_measured": "Every delivering buoy publishes WVHT, DPD, MWD and WTMP. NOT ONE publishes WDIR, WSPD or VIS -- ten out of ten leave them MM. Slice 3 saw this on 46254 and recorded it as one station's quirk; it is categorical. The only station in the box with wind is 46086, twenty-seven nautical miles offshore in the San Clemente Basin, and it lies outside the corridor every beach in this file sits on. That is why this site's wind and visibility must come from the National Weather Service gridpoint forecast and can never come from a buoy.",
   "_schema": {
     "name": "NDBC's own station name.",
     "cdip": "The CDIP station number NDBC prints in parentheses after the name, where it prints one. Recorded because it is published, and because the relay is what makes these nearshore buoys wave-only.",
     "lat": "Decimal degrees north, from the NDBC station list.",
     "lon": "Decimal degrees east, negative for west.",
     "delivers": "Whether realtime2 actually answers with data rows, measured rather than assumed. A station that does not deliver is kept and marked, never deleted.",
-    "publishes_waves": "Whether the delivering station's rows carry WVHT. Recorded separately from `delivers` because one station does neither the same way.",
+    "publishes_waves": "Whether this station's wave height is one a beach may bind to -- the wave join's second filter, read beside `delivers`. NOT a claim that the rows carry WVHT, though the name says so: 46086 carries it on 27 of the 48 newest rows and is false here because it sits twenty-seven nautical miles offshore, outside the corridor, where the swell is not this coast's. The name predates that measurement; see #70 and `waves_note`.",
+    "waves_note": "Present only when `publishes_waves` is false for a reason other than absence. What the station's rows actually carry, and why it is left out anyway.",
     "dead_note": "Present only when delivers is false. What the station did when asked."
   },
   "buoys": {
@@ -118,12 +119,13 @@
       "lon": -118.029,
       "delivers": true,
       "publishes_waves": false,
+      "waves_note": "Carries WVHT on 27 of the 48 newest rows, and on 3567 of 6482 over the whole file, measured against realtime2 on 2026-08-18. WVHT lands on two rows in three -- the rows at :00 and :30 are MM -- so its wave cycle is slower than its reporting cycle and a single read has a one-in-three chance of an empty one. `publishes_waves` is false above for the distance, not for the measurement.",
       "dead_note": null
     }
   },
   "unresolved": [
     "46235 Imperial Beach Nearshore is the only buoy south of Point Loma and it does not deliver, so every south-county beach reads a buoy well to its north-west across water of different exposure. The join records the distance rather than hiding it. This is a gap in what NDBC publishes, not one this site can close.",
     "A buoy's significant wave height is not the height of the wave breaking at the shore. No shoaling or refraction transform is applied, and none is planned: the number shown is what the buoy reported, which is the only thing actually measured.",
-    "46086 San Clemente Basin delivers wind and water temp but no waves, and sits twenty-seven nautical miles offshore outside the county. It is recorded here because it is the only station in the box with wind, and it is bound to no beach."
+    "46086 San Clemente Basin sits twenty-seven nautical miles offshore, outside the county, and no beach is bound to it. It publishes wind, water temperature, and wave height on 27 of the 48 newest rows -- its wave cycle is slower than its reporting cycle, so a third of its rows carry none. It is recorded here because it is the only station in the box with wind, and it is left out of the wave join by that distance rather than by what it measures."
   ]
 }

--- a/src/lib/beaches.test.ts
+++ b/src/lib/beaches.test.ts
@@ -190,4 +190,22 @@ describe("the wave buoy binding", () => {
     const caveats = inventoryCaveats();
     expect(caveats.some((c) => c.includes("46235"))).toBe(true);
   });
+
+  test("the excluded offshore buoy is excluded for its distance, not for waves", () => {
+    // 46086 was recorded as publishing no waves. It publishes WVHT on 27 of 48
+    // rows -- #70. Nothing renders the station, but this sentence reaches a
+    // reader through the caveats gate, and it is the whole reason the station
+    // is in the table, so a future slice looking for an offshore wave reference
+    // would take the false clause at face value.
+    //
+    // This holds the sentence still. It cannot hold NDBC still: a gate must not
+    // fetch realtime2, so nothing here notices if what 46086 publishes changes.
+    // The measurement is evidence in the plan file, not in this assertion.
+    const caveat = inventoryCaveats().find((c) => c.includes("46086"));
+
+    expect(caveat, "no caveat mentions 46086 at all").toBeTruthy();
+    expect(caveat).not.toMatch(/no waves/i);
+    expect(caveat).toMatch(/27 of the 48/);
+    expect(caveat).toMatch(/distance/i);
+  });
 });

--- a/src/lib/beaches.ts
+++ b/src/lib/beaches.ts
@@ -74,8 +74,14 @@ export interface WaveBuoy {
   lon: number;
   /** Measured, not assumed. A buoy that does not deliver is kept and marked. */
   delivers: boolean;
-  /** One delivering station carries no wave height at all, so this is separate. */
+  /**
+   * The wave join's verdict on a station, not a count of WVHT rows. The one
+   * station it excludes does publish waves, and is left out for its distance --
+   * see `waves_note` and wave-buoys.json's schema.
+   */
   publishes_waves: boolean;
+  /** Present when `publishes_waves` is false for a reason other than absence. */
+  waves_note?: string | null;
   dead_note?: string | null;
 }
 


### PR DESCRIPTION
Closes #70

`wave-buoys.json` said 46086 San Clemente Basin "delivers wind and water temp
but no waves". It publishes `WVHT`. The clause reached a reader through the
caveats gate, and it was the reason the station is recorded at all.

## What was measured

Third measurement, against `https://www.ndbc.noaa.gov/data/realtime2/46086.txt`
— the endpoint this site reads — over the whole file rather than a window:

```
rows          : 6482 (newest 2026 08 18 06 00 UTC)
WVHT present  : 27 / 48 newest      3567 / 6482 whole file (55%)
WSPD present  : 48 / 48             6446 / 6482
WTMP present  : 47 / 48             6281 / 6482
VIS  present  :  0 / 48                0 / 6482
```

The gap is a cadence, not an absence: `WVHT` lands on exactly two rows in three
— the rows at `:00` and `:30` are `MM` — and values repeat in pairs, so a slower
wave cycle is carried on ten-minute met rows. A single read has a one-in-three
chance of an empty one, which is how "no waves" was reached honestly and
recorded wrongly.

Everything else in the entry survived: 46086 does publish wind and water
temperature, publishes **no** visibility in 6,482 rows, sits twenty-seven
nautical miles offshore, and is bound to no beach.

## Slices

**1. `db5eb3a` — Record why 46086's wave field stays false after the correction**
Dated addendum to `docs/plans/conditions-tool.md`: the measurement, the decision,
and the two rejected alternatives. Docs only.

**2. `623b07c` — Stop claiming 46086 publishes no waves**
The false clause was in **six** places, not the one the issue named:
`_what_was_measured`, `unresolved[2]`, the `publishes_waves: false` datum, and
three code comments (`wave-join.mjs`, `wave-join.test.mjs`, `beaches.ts`) each
citing "carries no wave height at all" as the field's reason to exist.
Correcting only the caveat would have left five copies of the thing the caveat
was corrected for. Ships with its regression test.

## The decision, and why the join is untouched

`publishes_waves` is the wave join's filter (`wave-join.mjs:51`), and 46086 is
the only station it ever excluded. Once the station measures true,
`delivers && publishes_waves` says nothing `delivers` does not, and the
exclusion needs a reason it never had.

Decided with Cole: **redefine the field, do not change the join.** The `_schema`
entry now states what the join reads it for — whether the station's wave height
is one a beach may bind to — and 46086 carries the measured ratio in a new
`waves_note` beside the real reason it is left out, so the number and the
exclusion are never again the same sentence.

Rejected: flipping the field to `true` and changing nothing else. **Verified
against all 73 beaches: no binding changes today**, because every open-coast
beach has a nearshore buoy closer than twenty-seven nautical miles. But it would
make 46086 an eligible wave source held out by distance alone, and 46235 and
46273 are already dead. Also rejected: an explicit out-of-corridor flag as a
second filter condition — the honest shape, but it changes the join, which #70
put out of scope. The redefinition leaves that door open.

## Gates

Run on the tree at `623b07c`, immediately before commit:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

The regression test was confirmed **failing first**, against the false clause
itself:

```
FAIL  src/lib/beaches.test.ts > the wave buoy binding >
      the excluded offshore buoy is excluded for its distance, not for waves
AssertionError: expected '46086 San Clemente Basin delivers win…' not to match /no waves/i

- Expected:  /no waves/i
+ Received:  "46086 San Clemente Basin delivers wind and water temp but no waves, …"
```

**One gate run is not being presented as evidence.** A later re-run was
interrupted when another session checked out a different branch mid-run; it hit
the vitest worker-timeout flake under the contention and never printed its
table. It says nothing about this branch either way. CI on this head is the
independent check.

## What this does not do

- **The test asserts the sentence, not the ocean.** It reads the caveat through
  `inventoryCaveats()`, the seam the caveats gate already walks, so the claim
  cannot silently revert. A gate must not fetch `realtime2`, so nothing in CI
  notices if NOAA changes what 46086 publishes. The measurement above is the
  evidence for the sentence; the test only holds the sentence still.
- **No binding, join logic or rendered number changes.**
- **A second false claim in the same string was left alone and filed as #73.**
  `_what_was_measured` still says wind and visibility "must come from the
  National Weather Service gridpoint forecast". Both actually come from the NWS
  observation-station endpoint (`nws-observation.ts:172-176`); there is no
  gridpoint module in `src/lib/`. It is a maintainer note, so nothing renders
  wrong today. Folding it in would have made this two changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)