### PR TITLE
Publish the session schedule from Supabase

### DIFF
--- a/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
+++ b/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
@@ -68,9 +68,21 @@ wordmark banner. Decided in the brief; not deferred.
 
 `/art`, `/coop`, `/conditions`, `/community` and `/book` share one shape: an
 eyebrow line, an italic title, a lead paragraph, at most one CTA, then
-reserved slots where real content lands. They are structural shells — the
-schedule, pricing, photos, booking scheduler and conditions tool are all
-labeled placeholders, by decision in `docs/plans/nav-pages-scaffolding.md`.
+reserved slots where real content lands. They were structural shells
+throughout, by decision in `docs/plans/nav-pages-scaffolding.md`; photos, the
+booking scheduler and charter-fund details still are.
+
+**The schedule is no longer among them.** `/art` and `/coop` render their own
+program's upcoming sessions in the slot that was reserved for one, read from
+Supabase per request — day, hours, title, an optional summary, a map link and,
+on `/art`, a price. The slot has not been deleted: it is still what the page
+shows when the term has nothing booked yet, and equally when the database
+cannot be reached, because a reader can act on neither. See
+`docs/plans/session-schedule-from-supabase.md`.
+
+A session belongs to a program and is not a page. There is no `/sessions`
+route, no per-session URL and no fifth nav link; the schedule reads inside the
+page a parent already came to.
 
 `/community` is the one that differs: below its reserved slots it renders the
 interest-list form under its own heading, without the landing page's teaser
@@ -140,8 +152,15 @@ lands on `/art` first; that page's CTA is "Book a class →" → `/book`.
 - **A new program area** is a route beside the existing five, plus a teaser
   section on `/` that links to it. That path is established; adding one
   decides nothing new.
-- Anything beyond that (a blog, real schedules, nested or dynamic routes) is a
-  new IA exercise.
+- **Real schedules** arrived, and did not need a new address: they render
+  inside the two program pages rather than at one of their own. Adding a
+  combined `/schedule` route later would be a genuine IA exercise, and is
+  deliberately not one this took.
+- **Dynamic routes** arrived too, in `/conditions/[slug]`, and this document
+  does not describe them anywhere — the sentence you are reading is currently
+  their only mention. That gap belongs to the conditions work rather than to
+  the schedule, and is filed as #78.
+- Anything beyond that (a blog, a store, a login) is a new IA exercise.
 
 ## URL Strategy
 

--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,16 @@
 # Copy to .env.local and fill in, or run: bash scripts/setup-secrets-wizard.sh
 # (the wizard fills .env.local and pushes the same values to Vercel).
 
-# Supabase — browser-safe by design; data is protected by Row Level Security.
-NEXT_PUBLIC_SUPABASE_URL=
-NEXT_PUBLIC_SUPABASE_ANON_KEY=
+# Supabase — read-only public data, protected by Row Level Security. These two
+# would be safe in a browser, and deliberately never reach one: nothing
+# client-side talks to Supabase (ADR-0008), so they carry no NEXT_PUBLIC_
+# prefix. That is not only about exposure. A NEXT_PUBLIC_ value is inlined at
+# build time, so changing one in Vercel does nothing until the next deploy;
+# these are read at runtime and take effect on the next request.
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
 
-# Supabase — server-only, bypasses RLS. Never expose with a NEXT_PUBLIC_ prefix.
+# Supabase — server-only, and unlike the two above it bypasses RLS entirely.
 SUPABASE_SERVICE_ROLE_KEY=
 
 # Cloudflare R2 — server-only, token scoped to the site's bucket.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,8 +9,22 @@ for one concept, this file picks one and lists the rest under _Avoid_.
 
 **Program**:
 One of the two things the site offers — art classes, and the Tuesday co-op.
-Each has a card on the landing page and a page of its own.
+Each has a card on the landing page and a page of its own. A program is the
+standing offer; a **session** is one occasion of it.
 _Avoid_: offering, service, class (a class is one session of the art program)
+
+**Session**:
+One dated occasion of a program — a single art class, or one Tuesday of the
+co-op. It carries its own time, place and optional price, because those vary
+between one occasion and the next. `public.sessions` holds one row per session,
+and the schedule on `/art` and `/coop` is a list of the published ones still to
+come.
+
+The two programs are not sessions and are not data: they are the two cards in
+`ProgramCards.tsx`, and a session's `program` column names one of them.
+_Avoid_: event (in `src/` the word means a DOM event), occurrence, date,
+booking, class (that is one session of the art program), slot (a reserved slot
+stands in for content, not for a date)
 
 **Teaser**:
 A landing-page section that summarises a topic and links to its full page. The

--- a/docs/adr/0008-supabase-reads-over-plain-fetch.md
+++ b/docs/adr/0008-supabase-reads-over-plain-fetch.md
@@ -1,0 +1,97 @@
+# 0008 — Supabase is read over plain fetch, and a failed read degrades
+
+Date: 2026-08-18. Status: accepted.
+
+## Context
+
+Until now this site has talked to nothing. Every page is static, every
+component is a render, and the twenty-five test files are all render tests.
+Supabase and R2 have been provisioned since early on — `.env.example` names the
+variables and `scripts/setup-secrets-wizard.sh` fills them — and no code has
+ever imported either.
+
+The session schedule (#74, `docs/plans/session-schedule-from-supabase.md`) is
+the first data access, so it decides the shape of all of them. Three
+constraints converge on it.
+
+**The dependency budget.** The repo has three runtime dependencies: `next`,
+`react`, `react-dom`. `@supabase/supabase-js` would be the fourth and brings
+five sub-packages — auth, storage, realtime, functions, postgrest — of which a
+read-only anonymous `select` uses one.
+
+**CI has no credentials.** `.github/workflows/gate.yml` passes no `env` and no
+`secrets`, and the gate table runs `npm run build`. Any route that fetched at
+build time would need Supabase credentials in CI, which would make every pull
+request depend on Supabase's uptime and on a key that can rotate. Giving the
+gate secrets would also break the fresh-clone premise CLAUDE.md holds it to.
+
+**The existing test culture has no network in it.** A seam that needs a mocked
+module would be the first of its kind here, and would sit oddly beside
+`gates.mjs` and `built-css.mjs`, where ADR-0002 already established the split
+this repo uses: a thin edge that does I/O over a pure core that decides things
+and is unit-tested directly.
+
+One more thing informed this. The configured project URL turned out to carry a
+`/rest/v1/` suffix, so every request would have asked for `/rest/v1//rest/v1/…`
+and PostgREST answered `PGRST125 — Invalid path specified in request URL`. That
+error is indistinguishable from a dead project, a rotated key or a network
+fault. A malformed value at the edge produced a diagnosis that took a
+half-hour and named nothing useful.
+
+## Decision
+
+Supabase is read with plain `fetch` against PostgREST. No client library.
+
+The `fetch` is a parameter, not an import, so a test passes a stub rather than
+intercepting a module. The base URL is normalized and validated where it enters
+— a trailing slash and a trailing `/rest/v1` are stripped, and a value that is
+not an `https://` URL is refused by name. Routes that read Supabase render
+dynamically, so the build never needs a credential.
+
+A read has three outcomes and the caller must handle all three: rows, no rows,
+or an explicit failure carrying its reason. A failure renders `ReservedSlot` and
+logs why on the server. It does not throw.
+
+This decision covers reads of public data. It says nothing about R2, and
+nothing about authenticated access, which does not exist yet.
+
+## Consequences
+
+We own the query string and the parsing. PostgREST's filter grammar —
+`program=eq.art`, `published=is.true`, `order=starts_at.asc` — is now repo
+knowledge rather than something a library hides. For one table and one query
+that is a few lines; it would stop being a good trade somewhere north of a
+handful of queries, and that is the signal to revisit.
+
+There are no generated types. The TypeScript type is hand-written, which means
+the compiler cannot catch a column renamed in the database — the parser will,
+at runtime, by rejecting rows. That is why `npm run check:db` asserts the
+column set as well as the RLS behaviour: it is the only thing standing where a
+generated type would have stood, and without it a schema change would surface
+as an empty schedule rather than a failure.
+
+The build stays credential-free and CI is unaffected by Supabase's uptime. What
+that costs is static HTML: these routes render per request, so every visitor
+pays a round trip and there is no cached page to serve during an outage. At
+this site's traffic that is not worth optimising, and revalidation is available
+later without revisiting this decision.
+
+Degradation is per section rather than per page. A Supabase outage costs one
+dashed box on `/art` and `/coop`; the rest of both pages, and the whole of the
+rest of the site, are untouched. This is what makes the source build plan's
+`NEXT_PUBLIC_EVENTS_ENABLED` flag unnecessary — the isolation it was there to
+provide is structural, not a switch someone has to remember to throw.
+
+Validating at the boundary is cheap insurance bought after the fact rather than
+before it, which is the honest description. The malformed URL is fixed and
+`scripts/setup-secrets-wizard.sh` should reject it at the prompt (#76), but a
+second line of defence is worth its four lines when the failure it prevents
+presents as "Supabase seems to be down".
+
+What this genuinely costs is the well-lit path. Every Supabase tutorial, answer
+and documentation page assumes `createClient`. Someone arriving to add
+authentication will find no client object to hang a session on, and will have to
+decide whether to adopt the SDK then — which is the right moment for it, because
+token refresh is real work that a library should do. Adopting it later is
+contained: one module changes, and the injected-`fetch` seam its callers depend
+on can stay exactly as it is.

--- a/docs/adr/0008-supabase-reads-over-plain-fetch.md
+++ b/docs/adr/0008-supabase-reads-over-plain-fetch.md
@@ -52,6 +52,9 @@ A read has three outcomes and the caller must handle all three: rows, no rows,
 or an explicit failure carrying its reason. A failure renders `ReservedSlot` and
 logs why on the server. It does not throw.
 
+Neither the project URL nor the anon key carries a `NEXT_PUBLIC_` prefix. They
+are `SUPABASE_URL` and `SUPABASE_ANON_KEY`, read at runtime on the server.
+
 This decision covers reads of public data. It says nothing about R2, and
 nothing about authenticated access, which does not exist yet.
 
@@ -81,6 +84,24 @@ dashed box on `/art` and `/coop`; the rest of both pages, and the whole of the
 rest of the site, are untouched. This is what makes the source build plan's
 `NEXT_PUBLIC_EVENTS_ENABLED` flag unnecessary — the isolation it was there to
 provide is structural, not a switch someone has to remember to throw.
+
+Dropping the `NEXT_PUBLIC_` prefix is not about secrecy — the anon key is
+public by design, and RLS is what protects the data. It is about when the value
+is read. A `NEXT_PUBLIC_` variable is substituted into the bundle at build time,
+including in server code: a probe page built on 2026-08-18 with
+`NEXT_PUBLIC_PROBE_SENTINEL=ZZPUBLICZZ` and `PROBE_SENTINEL=ZZSERVERZZ` put the
+literal `ZZPUBLICZZ` into `.next/server/chunks/ssr/`, while the unprefixed one
+survived as a `process.env` lookup and its value appeared nowhere.
+
+So a prefixed variable would make the environment part of the artefact. Fixing
+a wrong URL in Vercel would need a redeploy rather than an edit, and a preview
+deployment built before its variables existed would serve `undefined` until
+rebuilt — which is exactly the state this project's Preview environment was in.
+That directly contradicts the reason these routes render dynamically at all: a
+change should be live on the next request. Unprefixed, both the data and the
+configuration behave that way. The cost is that a future client component
+wanting Supabase directly would need the names changed back, and ADR-0008's
+own advice is that such a component is the moment to adopt the SDK anyway.
 
 Validating at the boundary is cheap insurance bought after the fact rather than
 before it, which is the honest description. The malformed URL is fixed and

--- a/docs/adr/0008-supabase-reads-over-plain-fetch.md
+++ b/docs/adr/0008-supabase-reads-over-plain-fetch.md
@@ -116,3 +116,35 @@ decide whether to adopt the SDK then — which is the right moment for it, becau
 token refresh is real work that a library should do. Adopting it later is
 contained: one module changes, and the injected-`fetch` seam its callers depend
 on can stay exactly as it is.
+
+## Amendment, 2026-08-18: the seam is the global fetch, not an injected one
+
+The Context above claims that "a seam that needs a mocked module would be the
+first of its kind here". **That was false when it was written.**
+`src/lib/upstream.test.ts` already stubs the global — `vi.stubGlobal("fetch",
+fetchMock)` — with a docstring explaining why. The conditions work landed while
+this decision was being drafted, and the claim was made against the repository
+as it stood earlier in the same session.
+
+So the decision changes to match the repository rather than the other way
+round. `src/lib/sessions.ts` calls the global `fetch` and its tests stub it, the
+way `upstream.ts` does. Changing this repo's fetch-testing convention would be
+its own slice with its own justification, and there is none: the argument for
+injection was never that it was better, only that nothing here did otherwise.
+
+Using the global is in fact the stronger choice for a second reason the original
+draft missed. Next instruments `fetch` itself — caching, revalidation, and the
+`no-store` override that `force-dynamic` applies. A module holding an injected
+function has no guarantee it was handed the instrumented one, which for a
+framework whose caching is a property of that function is a seam that can lie.
+
+`scripts/db-check.mjs` keeps its injected fetch. It is a command-line script
+rather than a rendered route, there is no Next instrumentation to preserve, and
+nothing under `scripts/` sets a contrary precedent — `gates.test.mjs` and
+`built-css.test.mjs` avoid the question entirely by having no I/O to seam. Two
+neighbourhoods, each following its own established practice, is the outcome
+CLAUDE.md's "follow the patterns already in the repo" actually asks for.
+
+Everything else stands: no SDK, nothing throws, failures become an
+`unavailable` result carrying their reason, and the configuration is read at
+runtime without a `NEXT_PUBLIC_` prefix.

--- a/docs/plans/session-schedule-from-supabase.md
+++ b/docs/plans/session-schedule-from-supabase.md
@@ -77,7 +77,7 @@ Three defects in the source document are corrected here rather than copied:
 
 - **The base URL is normalized and validated where it enters.** `getSessions`
   trims a trailing slash and a trailing `/rest/v1` off
-  `NEXT_PUBLIC_SUPABASE_URL`, and rejects a value that is not an `https://` URL,
+  `SUPABASE_URL`, and rejects a value that is not an `https://` URL,
   logging the reason and returning the unavailable result. This is not
   hypothetical hardening: that exact malformation was in `.env.local` during
   planning and made every request fail with a PostgREST error that named nothing
@@ -306,19 +306,20 @@ uncovered and why — which is what the config's own comment requires.
 ## Open questions
 
 - **Resolved.** The Supabase project responded `PGRST125` on every REST path
-  during planning. The cause was `NEXT_PUBLIC_SUPABASE_URL` carrying a
+  during planning. The cause was `SUPABASE_URL` carrying a
   `/rest/v1/` suffix, so every request asked for `/rest/v1//rest/v1/…`. The
   project, both keys and GoTrue are all healthy; `.env.local` is corrected and
   the anon key now returns `PGRST205` — "no such table" — which is what slice 1
   creates. See the boundary-validation decision above, which exists because of
   this.
-- `TODO(verify)` — the same bad URL was pushed to Vercel and cannot be read back
-  because the variable is marked Sensitive there. Re-set
-  `NEXT_PUBLIC_SUPABASE_URL` for Production before slice 2 deploys. Preview
-  currently has **no** variables at all, so preview deploys will render the
-  reserved slot rather than a schedule until they are added.
-- `TODO(verify)` — whether art-class prices vary per session. If they do not,
-  `price_cents` is speculative and pricing belongs in page copy.
+- **Resolved.** Vercel held the same malformed URL under the old
+  `NEXT_PUBLIC_SUPABASE_URL` name, unreadable because the variable was marked
+  Sensitive. Rather than repair it, the rename slice replaced both variables
+  with `SUPABASE_URL` and `SUPABASE_ANON_KEY` across Production, Preview and
+  Development — Preview had none of them at all, which under the old prefix
+  would have baked `undefined` into every preview build until each was rebuilt.
+- **Resolved.** Art-class prices vary per session, confirmed 2026-08-18, so
+  `price_cents` is a real column rather than speculative and slice 3 renders it.
 - **Resolved.** One issue, not four. The slices are strictly sequential and
   touch overlapping files, so two people could not pick two of them up without
   colliding — which is the test CLAUDE.md sets for whether splitting earns its

--- a/docs/plans/session-schedule-from-supabase.md
+++ b/docs/plans/session-schedule-from-supabase.md
@@ -324,3 +324,24 @@ uncovered and why — which is what the config's own comment requires.
   touch overlapping files, so two people could not pick two of them up without
   colliding — which is the test CLAUDE.md sets for whether splitting earns its
   keep. Worked from this file on one branch.
+
+## Addenda
+
+### 2026-08-18 — a fifth slice, before slice 2
+
+The plan above lists four slices. A fifth was added between slices 1 and 2,
+after a question about how the Supabase variables were labelled in Vercel:
+**read the Supabase config at runtime, not from the bundle**
+(`SUPABASE_URL` / `SUPABASE_ANON_KEY`, no `NEXT_PUBLIC_` prefix).
+
+It is not a tidying pass. A `NEXT_PUBLIC_` value is substituted into the build
+output rather than read at run time — measured, not assumed; see ADR-0008 —
+which would have made two of this project's existing problems unfixable without
+a redeploy: the malformed Production URL, and a Preview environment that had no
+Supabase variables at all and would have inlined `undefined` into every build.
+That defeats the reason "The routes render dynamically" was chosen above.
+
+Taken before slice 2 because it was cheapest there: no application code read the
+variables yet, only `check-db.mjs` named them.
+
+The slice order is therefore 0, 1, **runtime config**, 2, 3, 4.

--- a/docs/plans/session-schedule-from-supabase.md
+++ b/docs/plans/session-schedule-from-supabase.md
@@ -1,0 +1,325 @@
+# The session schedule comes from Supabase
+
+Issue: [#74](https://github.com/cweber12/wild-coast-kids/issues/74).
+
+## Problem, from the reader's point of view
+
+A parent who wants to know when the next art class or co-op Tuesday happens
+cannot find out. `/art` and `/coop` each end in a dashed reserved slot
+promising a schedule; `/book` — the target of the nav pill, the hero CTA and
+three in-content CTAs — says online booking is on its way. The site describes
+both programs in detail and cannot say when either one meets.
+
+Supabase has been provisioned since early on: `.env.example` names the
+variables, `scripts/setup-secrets-wizard.sh` fills them, and `.env.local` holds
+values. No code has ever talked to it. This is the first slice that does.
+
+## Solution
+
+One table, `public.sessions`, holding one row per dated session of either
+program. `/art` and `/coop` each render their own program's upcoming published
+sessions in place of the reserved slot. Lena adds and edits rows in Supabase
+Studio; the site follows on the next request.
+
+Nothing is bookable and nothing is collected. There is no account, no RSVP, no
+payment, no email, and no personal data of any kind in this table.
+
+## Relationship to the source build plan
+
+This work started from a seven-step `Events & Calendar Module` build plan
+(`00-overview.md`, `01-schema-and-rls.md`). That document assumes Supabase and
+R2 are "already wired up", which is false here — there is no client, no data
+layer, and no auth — and it assumes a vocabulary this repo has already ruled
+out. What survives is roughly its steps 1 and 2, collapsed into one vertical
+path and rescoped to read-only. Its steps 3–7 (ICS feed, RSVP, admin CRUD,
+Square payments, Google Calendar mirror) are out of scope and undecided.
+
+Three defects in the source document are corrected here rather than copied:
+
+1. `updated_at timestamptz not null default now()` never updates. A column
+   default fires on insert only. All four of its tables carry this, so all four
+   would report a last-modified time that is really a created time. Fixed with
+   a trigger.
+2. Its build order puts a schema-only step first, which CLAUDE.md forbids.
+3. `event_type as enum ('meetup', 'class', 'virtual')` uses `class`, which
+   `CONTEXT.md` reserves for one session of the art program.
+
+## Implementation decisions
+
+- **The word is Session.** `CONTEXT.md` already defines **Program** and says "a
+  class is one session of the art program", and user-facing copy uses "session"
+  five times across `ProgramCards.tsx`, `/art` and `/book`. `event` appears in
+  `src/` only as the DOM handler parameter in `InterestListForm.tsx`, so a
+  domain concept by that name would collide twice over. `CONTEXT.md` gains a
+  **Session** entry in slice 1.
+
+- **One row is one dated session.** Grain is the only part of this schema that
+  is expensive to change, and finer grain aggregates upward cheaply while
+  coarser grain explodes downward expensively. Every future the source document
+  plans — capacity, RSVP, payments, ICS, a Google mirror — arrives as an
+  additive column or as a new table referencing rows that already exist. A term
+  row ("Tuesdays, Sep–Dec") would instead need a data migration the first time
+  anything wants to point at one date, plus an exceptions table the first time a
+  week is skipped. A fall term is roughly 14 rows; volume is a non-issue.
+
+- **Programs stay hardcoded.** `ProgramCards.tsx` is a bespoke design — its own
+  colours, emoji, `[ 01 ]`/`[ 02 ]` numbering and a 520px height budget set by
+  issue #37. Making it data-driven is a design regression, not a feature. The
+  `program` column is a foreign key to code, not to a table.
+
+- **`public`, not a dedicated schema.** The source document's isolation
+  contract was written to fence off four tables, two functions and a view; this
+  is one read-only table. A non-`public` schema only works once it is added to
+  PostgREST's exposed-schemas list, which is a dashboard setting — so "clone the
+  repo, run the migration" would not reproduce a working environment. That is
+  the same silent-divergence failure the CI story below is built to avoid.
+  Isolation here comes from RLS and from the module boundary in code.
+
+- **The base URL is normalized and validated where it enters.** `getSessions`
+  trims a trailing slash and a trailing `/rest/v1` off
+  `NEXT_PUBLIC_SUPABASE_URL`, and rejects a value that is not an `https://` URL,
+  logging the reason and returning the unavailable result. This is not
+  hypothetical hardening: that exact malformation was in `.env.local` during
+  planning and made every request fail with a PostgREST error that named nothing
+  useful. Boundaries validate; interiors trust.
+
+- **`program` is a check constraint, not a Postgres enum.** Adding an enum value
+  later is `alter type … add value`, which has transaction restrictions; a check
+  constraint is a plain `alter table`. The TypeScript union is the source of
+  truth and the data module validates at the boundary.
+
+- **Plain `fetch` against PostgREST, not `@supabase/supabase-js`.** The SDK
+  would be this repo's fourth runtime dependency — it has three — and drags in
+  auth, storage, realtime and functions to use none of them. An injected `fetch`
+  is a cleaner seam than a mocked module, and Next's own fetch handling applies
+  to it. If auth or RSVP ever lands, adopting the SDK is contained behind this
+  one module. Recorded as ADR-0008.
+
+- **The routes render dynamically.** `.github/workflows/gate.yml` passes no
+  `env` and no `secrets`, and the gate table runs `npm run build`. A page that
+  fetched at build time would need credentials in CI, which would turn every PR
+  red whenever Supabase blinked or a key rotated. `export const dynamic =
+"force-dynamic"` keeps the build credential-free and makes a new row live on
+  the next request rather than the next deploy.
+
+- **Emptiness and failure look the same on screen and differ in the log.** Both
+  render the existing `ReservedSlot`, whose copy — "Schedule & pricing coming
+  soon" — is true in both cases and which a parent cannot act on differently.
+  A failure additionally logs its reason server-side: missing configuration,
+  HTTP status, or parse error. The operator learns; the visitor is not handed an
+  error they cannot use. One Supabase outage degrades one section rather than
+  500ing the page.
+
+- **No feature flag.** The source document's `NEXT_PUBLIC_EVENTS_ENABLED` exists
+  to stop a broken module taking the site down, and the fallback above already
+  does that per section, automatically. `published` on each row is the real kill
+  switch and needs no deploy.
+
+- **No slug and no per-session route.** Sessions render inline on the program
+  pages. A detail page is a new route and a new IA exercise, and nothing needs
+  deep links.
+
+- **Migrations are committed SQL, applied by hand.** `supabase/migrations/` is
+  the conventional path, so adopting the Supabase CLI later moves no files. With
+  one migration there is no history to track; `npm run check:db` is the drift
+  detector, which is the property that actually matters. Revisit when there is a
+  second migration.
+
+## Schema
+
+```sql
+-- supabase/migrations/0001_sessions.sql
+
+create table public.sessions (
+  id            uuid primary key default gen_random_uuid(),
+  program       text        not null check (program in ('art', 'coop')),
+  title         text        not null,
+  summary       text,
+  starts_at     timestamptz not null,
+  ends_at       timestamptz not null,
+  location_name text,
+  location_url  text,
+  price_cents   integer     check (price_cents is null or price_cents >= 0),
+  published     boolean     not null default false,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now(),
+  constraint ends_after_start check (ends_at > starts_at)
+);
+
+-- Matches the only query the site makes.
+create index sessions_program_starts_at on public.sessions (program, starts_at);
+
+-- A `default now()` fires on insert only, so without this the column reports a
+-- creation time under a name that promises a modification time. Plain plpgsql
+-- rather than the moddatetime extension: no extension schema to get wrong.
+create function public.set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger sessions_set_updated_at
+  before update on public.sessions
+  for each row execute function public.set_updated_at();
+
+alter table public.sessions enable row level security;
+
+create policy "public reads published sessions"
+  on public.sessions for select
+  using (published = true);
+
+grant select on public.sessions to anon, authenticated;
+```
+
+There is deliberately **no insert, update or delete policy**. Writes happen in
+Studio under the service role, which bypasses RLS. An unpublished row is
+invisible to the anon key, which is what makes `published` a working kill
+switch.
+
+`price_cents` is nullable, and null means "not priced here" rather than free.
+If every art class turns out to be the same price, the column stays null and
+pricing lives in page copy — `TODO(verify)` with Lena whether price varies per
+session.
+
+## Test seams
+
+Agreed before slice 1, per CLAUDE.md.
+
+| Seam                              | What it isolates                      | How it is tested                       |
+| --------------------------------- | ------------------------------------- | -------------------------------------- |
+| `sessionsUrl(base, program, now)` | PostgREST query construction          | Pure function; asserted string         |
+| `parseSessions(body)`             | Boundary validation of untrusted rows | Pure function; malformed rows rejected |
+| `getSessions(program, deps)`      | The network call                      | Injected `fetch` stub — no `vi.mock`   |
+| `SessionSchedule({ result })`     | All three render states               | Synchronous component; RTL render      |
+| `formatSessionWhen(session)`      | `America/Los_Angeles` rendering       | Pure function; fixed instants          |
+| `npm run check:db`                | That the migration did what it says   | Assertions against the live project    |
+
+Two seams are load-bearing enough to have been proven rather than assumed:
+
+- **An async page still renders under the existing test style.** `render(await
+Coop())` works with Testing Library 16, React 19 and jsdom — verified with a
+  throwaway suite on 2026-08-17, which passed and was deleted. This matters
+  because `src/app/coop/page.test.tsx` currently does `render(<Coop />)`, and
+  every page test in the repo shares that shape.
+- **The degradation path is tested for free.** Vitest does not load
+  `.env.local`, so `getSessions` returns its unavailable result inside the test
+  run and the page renders the `ReservedSlot` — exactly what the existing page
+  assertions already check. The page tests change by one word and gain coverage
+  of the failure path.
+
+`npm run check:db` follows ADR-0002's split, the same one `check-built-css.mjs`
+uses: a thin entry point that resolves, prints and exits, over a pure module
+where the verdict is decided and unit-tested. It asserts, against the live
+project, that RLS is enabled, that the anon key sees a published row, that the
+anon key does **not** see an unpublished row, and that the column set matches.
+It is not a gate row: `gates.mjs` declares `skip` as a static string and
+`run-gates.mjs` honours it unconditionally, so a `skip:` row can never run, even
+locally with credentials. Teaching the table a conditional skip is shared
+infrastructure changed for one caller and is filed as [#75](https://github.com/cweber12/wild-coast-kids/issues/75).
+
+## Slices
+
+Each leaves the repo working and the gates green.
+
+| #   | Slice                                                          | Delivers                                                                                    |
+| --- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| 0   | Write this plan down                                           | This file, plus ADR-0008 on reading Supabase over plain fetch                               |
+| 1   | The sessions table, and a command that proves it               | `supabase/migrations/0001_sessions.sql`, `npm run check:db`, `CONTEXT.md` gains **Session** |
+| 2   | `/coop` lists its published sessions                           | `src/lib/sessions.ts`, `SessionSchedule`, `/coop` async, coverage floor re-derived          |
+| 3   | `/art` lists its sessions, with price                          | `/art` async, price rendering, coverage floor re-derived                                    |
+| 4   | The IA document stops calling real schedules a future exercise | `INFORMATION_ARCHITECTURE.md`                                                               |
+
+Slice 1 is not a schema-only slice: `npm run check:db` is a consumer of the
+migration that can be demonstrated on its own, which is the property CLAUDE.md
+is protecting. Slices 2 and 3 each depend on 1. Slice 4 depends on 2 and 3
+because it describes what they built.
+
+Estimated at roughly 500–600 lines including tests, which is at the edge of the
+~400-line reviewability guide. If slice 2 lands larger than expected, split at
+the 2/3 boundary into a second PR rather than growing this one.
+
+## Verification
+
+`npm run gate` at every slice, output pasted in the PR body, plus
+`npm run check:db` output for slices 1–3.
+
+The coverage floor in `vitest.config.mts` is pinned to two decimals at what the
+repo achieves today. New files under `src/` enter the denominator, so the floor
+is re-derived in the same commit that moves it, naming which statements are
+uncovered and why — which is what the config's own comment requires.
+
+## Considered and rejected
+
+- **Following the source document's build order.** Its step 1 delivers schema,
+  RLS and seed data with nothing reading them. That is the horizontal slice
+  CLAUDE.md names explicitly: it cannot be demonstrated except by the step that
+  finally uses it.
+- **`@supabase/supabase-js`.** The boring, well-documented choice, and the right
+  one the moment auth or writes arrive. Today it is five sub-packages for one
+  anonymous `select`, and it replaces an injected function with a mocked module.
+- **A dedicated `schedule` schema.** Better namespace hygiene, and cheap to set
+  up now rather than after `public` becomes a junk drawer. Rejected because it
+  depends on a dashboard setting no migration records, so a fresh project would
+  fail in a way the repo cannot see.
+- **Modelling the co-op as a term with a weekly rhythm.** Matches how the
+  programme is described and keeps a term-wide edit to one row. Rejected on
+  grain: a skipped week, a moved location, or any future RSVP each need concrete
+  dates, and generating them later is a data migration rather than an added
+  column.
+- **Prerendering with Supabase secrets in CI.** Faster pages, real static HTML.
+  Rejected because it makes every pull request depend on Supabase's uptime and
+  breaks the gate's fresh-clone premise.
+- **A `cancelled` flag.** Genuinely useful — deleting a row makes a session
+  vanish with no explanation. Rejected for now because nobody has stated the
+  requirement, and it is a one-column additive change the first time a session
+  is actually cancelled.
+- **A combined `/schedule` route.** Would need a fifth nav link, and the nav
+  already wraps to two rows below `md` with four links plus the pill (ADR-0004).
+  Reconsider when there is enough data to fill a page.
+- **Adopting the Supabase CLI.** `supabase start` would give a local Postgres in
+  Docker and let `check:db` run unskipped in CI, which is strictly better
+  verification. Rejected as disproportionate to one read-only table; revisit when
+  writes arrive.
+
+## Out of scope
+
+- Registrations, RSVP, capacity, waitlists, and any personal data. Nothing in
+  this table describes a person.
+- Payments. `price_cents` is a number to display, not to charge.
+- Auth, admin accounts, and `app_metadata` roles. There is no admin user.
+- Admin CRUD. Lena edits rows in Supabase Studio.
+- Session images and R2. R2 is provisioned and unused; wiring it is separate.
+- An ICS feed and any Google Calendar mirror.
+- `/book`'s reserved slot, which is about a booking provider and stays.
+- The interest-list form's missing destination, which is a different table and
+  a different slice.
+- Whether `gates.mjs` should support a conditional skip. Filed as
+  [#75](https://github.com/cweber12/wild-coast-kids/issues/75).
+- Making `scripts/setup-secrets-wizard.sh` validate what it is handed. It
+  accepted a project URL with `/rest/v1/` on the end and pushed it to Vercel
+  unchallenged, which is how the malformation above survived six days. A shape
+  check at the prompt would have caught it. Different cause, different slice —
+  filed as [#76](https://github.com/cweber12/wild-coast-kids/issues/76).
+
+## Open questions
+
+- **Resolved.** The Supabase project responded `PGRST125` on every REST path
+  during planning. The cause was `NEXT_PUBLIC_SUPABASE_URL` carrying a
+  `/rest/v1/` suffix, so every request asked for `/rest/v1//rest/v1/…`. The
+  project, both keys and GoTrue are all healthy; `.env.local` is corrected and
+  the anon key now returns `PGRST205` — "no such table" — which is what slice 1
+  creates. See the boundary-validation decision above, which exists because of
+  this.
+- `TODO(verify)` — the same bad URL was pushed to Vercel and cannot be read back
+  because the variable is marked Sensitive there. Re-set
+  `NEXT_PUBLIC_SUPABASE_URL` for Production before slice 2 deploys. Preview
+  currently has **no** variables at all, so preview deploys will render the
+  reserved slot rather than a schedule until they are added.
+- `TODO(verify)` — whether art-class prices vary per session. If they do not,
+  `price_cents` is speculative and pricing belongs in page copy.
+- **Resolved.** One issue, not four. The slices are strictly sequential and
+  touch overlapping files, so two people could not pick two of them up without
+  colliding — which is the test CLAUDE.md sets for whether splitting earns its
+  keep. Worked from this file on one branch.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "node scripts/run-vitest.mjs run",
     "test:watch": "node scripts/run-vitest.mjs",
     "test:coverage": "node scripts/run-vitest.mjs run --coverage",
-    "gate": "node scripts/run-gates.mjs"
+    "gate": "node scripts/run-gates.mjs",
+    "check:db": "node scripts/check-db.mjs"
   },
   "dependencies": {
     "next": "16.3.0",

--- a/scripts/check-db.mjs
+++ b/scripts/check-db.mjs
@@ -18,13 +18,13 @@ import { gatherObservations, judge } from "./db-check.mjs";
 
 if (existsSync(".env.local")) process.loadEnvFile(".env.local");
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const url = process.env.SUPABASE_URL;
 
 const { ok, lines } = judge(
   await gatherObservations({
     fetch,
     url,
-    anonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    anonKey: process.env.SUPABASE_ANON_KEY,
     serviceKey: process.env.SUPABASE_SERVICE_ROLE_KEY,
   }),
 );

--- a/scripts/check-db.mjs
+++ b/scripts/check-db.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * `npm run check:db` — asserts that public.sessions is what
+ * supabase/migrations/0001_sessions.sql says it is.
+ *
+ * Entry-point plumbing only: load config, print, exit. Both the talking and the
+ * verdict live in db-check.mjs, where they are unit-tested against a stub fetch
+ * (ADR-0002, same split as run-gates.mjs and check-built-css.mjs).
+ *
+ * Not a gate row: gates.mjs treats `skip` as unconditional, so a row needing
+ * credentials could never run even locally — issue #75. Until that changes this
+ * is a command you run, and whose output belongs in the PR body.
+ *
+ * It writes probe rows and deletes them again. See `gatherObservations`.
+ */
+import { existsSync } from "node:fs";
+import { gatherObservations, judge } from "./db-check.mjs";
+
+if (existsSync(".env.local")) process.loadEnvFile(".env.local");
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+
+const { ok, lines } = judge(
+  await gatherObservations({
+    fetch,
+    url,
+    anonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    serviceKey: process.env.SUPABASE_SERVICE_ROLE_KEY,
+  }),
+);
+
+console.log(`\n  public.sessions — ${url ?? "no project URL configured"}\n`);
+console.log(lines.join("\n"));
+console.log("");
+
+process.exit(ok ? 0 : 1);

--- a/scripts/db-check.mjs
+++ b/scripts/db-check.mjs
@@ -1,0 +1,357 @@
+/**
+ * What `public.sessions` must be true of, and the reading of it.
+ *
+ * Nothing here opens a socket. The part that can be wrong is the part that
+ * decides the verdict, and it is decided by a pure function that tests call
+ * directly with a hand-written set of observations — the same split as
+ * gates.mjs and built-css.mjs (ADR-0002). check-db.mjs does the talking.
+ *
+ * These assertions are the executable form of what
+ * docs/plans/session-schedule-from-supabase.md promised instead of a checklist.
+ * Add an assertion by adding a row to `judge`.
+ */
+
+/**
+ * Every column the site expects, and no others. Checked as a set: a renamed
+ * column fails here rather than surfacing later as an empty schedule, which is
+ * the job a generated type would otherwise do (ADR-0008).
+ */
+export const EXPECTED_COLUMNS = [
+  "id",
+  "program",
+  "title",
+  "summary",
+  "starts_at",
+  "ends_at",
+  "location_name",
+  "location_url",
+  "price_cents",
+  "published",
+  "created_at",
+  "updated_at",
+];
+
+/**
+ * The title both probe rows carry, so cleanup can find them without knowing
+ * their ids. Probe rows are dated far in the past as well, so a leaked one can
+ * never reach the site — its query asks only for sessions still to come.
+ */
+export const PROBE_TITLE = "__db_check_probe__";
+
+/**
+ * What check-db.mjs saw. Every field is `null` when the step could not run,
+ * which is reported as "not checked" rather than counted as a pass.
+ *
+ * @typedef {object} Observations
+ * @property {string|null} configError  Why the environment is unusable, if it is.
+ * @property {string|null} reachError   Why the table could not be read, if it could not.
+ * @property {string[]|null} columns    Column names of a probe row, as the API returned them.
+ * @property {number|null} anonVisible  Probe rows the anon key can see. Must be 1.
+ * @property {number|null} adminVisible Probe rows the service role can see. Must be 2.
+ * @property {boolean|null} badProgramRejected    Did `program = 'nope'` fail to insert?
+ * @property {boolean|null} badRangeRejected      Did `ends_at <= starts_at` fail to insert?
+ */
+
+/**
+ * A step that could not run is not a step that passed.
+ *
+ * Unlike the gate table, where SKIP is a benign "this needs a display or a
+ * credential a fresh clone lacks", every row here is meant to be checkable
+ * whenever this command is run at all. `n/c` therefore fails the run: the whole
+ * point of the command is to verify, and it did not.
+ *
+ * @param {string} name
+ * @param {boolean|null} ok  null means the step could not run.
+ * @param {string} [note]
+ * @returns {{ name: string, ok: boolean, label: string, note?: string }}
+ */
+function row(name, ok, note) {
+  if (ok === null) return { name, ok: false, label: "n/c", note };
+  return { name, ok, label: ok ? "PASS" : "FAIL", note };
+}
+
+/**
+ * Decide every assertion from one set of observations.
+ *
+ * @param {Observations} observations
+ * @returns {{ ok: boolean, lines: string[] }}
+ */
+export function judge(observations) {
+  const {
+    configError,
+    reachError,
+    columns,
+    anonVisible,
+    adminVisible,
+    badProgramRejected,
+    badRangeRejected,
+  } = observations;
+
+  const missing = columns
+    ? EXPECTED_COLUMNS.filter((column) => !columns.includes(column))
+    : [];
+  const extra = columns
+    ? columns.filter((column) => !EXPECTED_COLUMNS.includes(column))
+    : [];
+
+  const rows = [
+    row(
+      "config",
+      configError === null,
+      configError ?? "NEXT_PUBLIC_SUPABASE_URL and both keys are usable",
+    ),
+    row(
+      "table reachable",
+      configError !== null ? null : reachError === null,
+      reachError ?? "public.sessions answered",
+    ),
+    row(
+      "columns",
+      columns === null ? null : missing.length === 0 && extra.length === 0,
+      columns === null
+        ? undefined
+        : [
+            missing.length ? `missing: ${missing.join(", ")}` : "",
+            extra.length ? `unexpected: ${extra.join(", ")}` : "",
+            missing.length || extra.length
+              ? ""
+              : `all ${EXPECTED_COLUMNS.length} columns present, none extra`,
+          ]
+            .filter(Boolean)
+            .join("; "),
+    ),
+    // Ordered deliberately. "Anon is blind to the unpublished row" is the
+    // assertion that matters, and on its own it is satisfied by a table with no
+    // rows in it at all. The service-role row below is what makes it mean
+    // something: it proves both probes exist and only one of them got through.
+    row(
+      "rls: service role sees both probes",
+      adminVisible === null ? null : adminVisible === 2,
+      adminVisible === null ? undefined : `saw ${adminVisible} of 2`,
+    ),
+    row(
+      "rls: anon sees the published probe",
+      anonVisible === null ? null : anonVisible >= 1,
+      anonVisible === null ? undefined : `saw ${anonVisible}`,
+    ),
+    row(
+      "rls: anon is blind to the unpublished probe",
+      anonVisible === null || adminVisible === null
+        ? null
+        : adminVisible === 2 && anonVisible === 1,
+      anonVisible === null || adminVisible === null
+        ? undefined
+        : anonVisible > 1
+          ? `anon saw ${anonVisible} of the ${adminVisible} probe rows — an unpublished row is public`
+          : `anon saw 1 of ${adminVisible}`,
+    ),
+    row(
+      "constraint: program rejects an unknown value",
+      badProgramRejected,
+      badProgramRejected === false
+        ? "a row with program = 'nope' inserted successfully"
+        : undefined,
+    ),
+    row(
+      "constraint: ends_at must follow starts_at",
+      badRangeRejected,
+      badRangeRejected === false
+        ? "a row ending before it starts inserted successfully"
+        : undefined,
+    ),
+  ];
+
+  const width = Math.max(...rows.map((r) => r.name.length));
+  const lines = rows.map((r) => {
+    const note = r.note ? `  (${r.note})` : "";
+    return `  ${r.label.padEnd(4)}  ${r.name.padEnd(width)}${note}`.trimEnd();
+  });
+
+  const notChecked = rows.filter((r) => r.label === "n/c").length;
+  if (notChecked > 0) {
+    lines.push(
+      "",
+      `  ${notChecked} assertion(s) could not be checked, which fails this command:`,
+      "  an unverified table is not a verified one.",
+    );
+  }
+
+  return { ok: rows.every((r) => r.ok), lines };
+}
+
+const PAST = "2000-01-01T00:00:00Z";
+const PAST_END = "2000-01-01T01:00:00Z";
+
+/**
+ * One published and one not. The pair is what makes the RLS reading mean
+ * something: either alone is satisfied by a table nothing can see into.
+ *
+ * Dated to the year 2000 so that a probe left behind by a killed process can
+ * never reach the site — the schedule asks only for sessions still to come.
+ */
+export const PROBES = [
+  {
+    program: "coop",
+    title: PROBE_TITLE,
+    starts_at: PAST,
+    ends_at: PAST_END,
+    published: true,
+  },
+  {
+    program: "art",
+    title: PROBE_TITLE,
+    starts_at: PAST,
+    ends_at: PAST_END,
+    published: false,
+  },
+];
+
+/** Rows that must not insert, and the assertion each one settles. */
+const INVALID = {
+  badProgramRejected: {
+    program: "nope",
+    title: PROBE_TITLE,
+    starts_at: PAST,
+    ends_at: PAST_END,
+  },
+  badRangeRejected: {
+    program: "art",
+    title: PROBE_TITLE,
+    starts_at: PAST_END,
+    ends_at: PAST,
+  },
+};
+
+/**
+ * Talk to the database and report what was seen. Decides nothing — `judge`
+ * does that — so the two can be tested apart.
+ *
+ * `fetch` arrives as a dependency rather than an import, so the tests drive
+ * this with a stub instead of intercepting a module (ADR-0008).
+ *
+ * It writes. Two probe rows go in under the service role, get read back through
+ * the anon key to prove RLS, and are deleted in a `finally`. Leftovers from a
+ * killed run are swept first.
+ *
+ * @param {{ fetch: typeof globalThis.fetch, url?: string, anonKey?: string, serviceKey?: string }} deps
+ * @returns {Promise<Observations>}
+ */
+export async function gatherObservations({ fetch, url, anonKey, serviceKey }) {
+  /** @type {Observations} */
+  const seen = {
+    configError: configErrorFor(url, anonKey, serviceKey),
+    reachError: null,
+    columns: null,
+    anonVisible: null,
+    adminVisible: null,
+    badProgramRejected: null,
+    badRangeRejected: null,
+  };
+  if (seen.configError !== null) return seen;
+
+  const call = async (key, path, init = {}) => {
+    const response = await fetch(`${url}/rest/v1/${path}`, {
+      ...init,
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/json",
+        ...init.headers,
+      },
+    });
+    const text = await response.text();
+    let body = null;
+    if (text) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = text;
+      }
+    }
+    return { ok: response.ok, status: response.status, body };
+  };
+
+  const sweep = () =>
+    call(serviceKey, `sessions?title=eq.${PROBE_TITLE}`, { method: "DELETE" });
+
+  /** A constraint that holds is an insert that does not land. */
+  const rejects = async (values) => {
+    const { ok } = await call(serviceKey, "sessions", {
+      method: "POST",
+      body: JSON.stringify([values]),
+    });
+    if (ok) await sweep();
+    return !ok;
+  };
+
+  const failed = ({ status, body }) =>
+    `HTTP ${status} — ${body?.message ?? "no message"}`;
+
+  try {
+    const reach = await call(serviceKey, "sessions?select=id&limit=1");
+    if (!reach.ok) {
+      seen.reachError = failed(reach);
+      return seen;
+    }
+
+    await sweep();
+    const inserted = await call(serviceKey, "sessions", {
+      method: "POST",
+      body: JSON.stringify(PROBES),
+      headers: { Prefer: "return=representation" },
+    });
+    if (!inserted.ok) {
+      seen.reachError = `could not insert probe rows: ${failed(inserted)}`;
+      return seen;
+    }
+
+    try {
+      seen.columns = Object.keys(inserted.body[0]);
+
+      const query = `sessions?title=eq.${PROBE_TITLE}&select=id,published`;
+      const asAnon = await call(anonKey, query);
+      const asAdmin = await call(serviceKey, query);
+      if (asAnon.ok) seen.anonVisible = asAnon.body.length;
+      if (asAdmin.ok) seen.adminVisible = asAdmin.body.length;
+
+      for (const [field, values] of Object.entries(INVALID)) {
+        seen[field] = await rejects(values);
+      }
+    } finally {
+      // The probes exist by here, so they go whatever the assertions did.
+      await sweep();
+    }
+  } catch (error) {
+    seen.reachError = `${error.name}: ${error.message}`;
+  }
+
+  return seen;
+}
+
+/**
+ * Whether the configured project URL is the bare project origin.
+ *
+ * Strict on purpose, and deliberately unlike the runtime module, which trims
+ * the same mistakes and carries on. A check that quietly repaired its input
+ * would hide the exact malformation that made every request fail with
+ * `PGRST125 — Invalid path specified in request URL` and cost a diagnosis pass
+ * to attribute (issue #76). Here the point is to say so.
+ *
+ * @param {string|undefined} url
+ * @returns {string|null} The reason it is unusable, or null when it is fine.
+ */
+export function configErrorFor(url, anonKey, serviceKey) {
+  if (!url) return "NEXT_PUBLIC_SUPABASE_URL is not set";
+  if (!anonKey) return "NEXT_PUBLIC_SUPABASE_ANON_KEY is not set";
+  if (!serviceKey) return "SUPABASE_SERVICE_ROLE_KEY is not set";
+  if (!url.startsWith("https://"))
+    return `NEXT_PUBLIC_SUPABASE_URL must start with https:// — got ${url.slice(0, 8)}…`;
+  if (url.endsWith("/"))
+    return "NEXT_PUBLIC_SUPABASE_URL has a trailing slash; it must be the bare project URL";
+  // `new URL("https://x.supabase.co").pathname` is "/", not "" — a bare origin
+  // still has a root path. Only anything beyond that is a real path.
+  const { pathname } = new URL(url);
+  if (pathname !== "/" && pathname !== "")
+    return `NEXT_PUBLIC_SUPABASE_URL must have no path — got "${pathname}". Use https://<ref>.supabase.co, not the REST endpoint`;
+  return null;
+}

--- a/scripts/db-check.mjs
+++ b/scripts/db-check.mjs
@@ -98,7 +98,7 @@ export function judge(observations) {
     row(
       "config",
       configError === null,
-      configError ?? "NEXT_PUBLIC_SUPABASE_URL and both keys are usable",
+      configError ?? "SUPABASE_URL and both keys are usable",
     ),
     row(
       "table reachable",
@@ -341,17 +341,17 @@ export async function gatherObservations({ fetch, url, anonKey, serviceKey }) {
  * @returns {string|null} The reason it is unusable, or null when it is fine.
  */
 export function configErrorFor(url, anonKey, serviceKey) {
-  if (!url) return "NEXT_PUBLIC_SUPABASE_URL is not set";
-  if (!anonKey) return "NEXT_PUBLIC_SUPABASE_ANON_KEY is not set";
+  if (!url) return "SUPABASE_URL is not set";
+  if (!anonKey) return "SUPABASE_ANON_KEY is not set";
   if (!serviceKey) return "SUPABASE_SERVICE_ROLE_KEY is not set";
   if (!url.startsWith("https://"))
-    return `NEXT_PUBLIC_SUPABASE_URL must start with https:// — got ${url.slice(0, 8)}…`;
+    return `SUPABASE_URL must start with https:// — got ${url.slice(0, 8)}…`;
   if (url.endsWith("/"))
-    return "NEXT_PUBLIC_SUPABASE_URL has a trailing slash; it must be the bare project URL";
+    return "SUPABASE_URL has a trailing slash; it must be the bare project URL";
   // `new URL("https://x.supabase.co").pathname` is "/", not "" — a bare origin
   // still has a root path. Only anything beyond that is a real path.
   const { pathname } = new URL(url);
   if (pathname !== "/" && pathname !== "")
-    return `NEXT_PUBLIC_SUPABASE_URL must have no path — got "${pathname}". Use https://<ref>.supabase.co, not the REST endpoint`;
+    return `SUPABASE_URL must have no path — got "${pathname}". Use https://<ref>.supabase.co, not the REST endpoint`;
   return null;
 }

--- a/scripts/db-check.test.mjs
+++ b/scripts/db-check.test.mjs
@@ -1,0 +1,363 @@
+import { describe, expect, test } from "vitest";
+import {
+  configErrorFor,
+  EXPECTED_COLUMNS,
+  gatherObservations,
+  judge,
+} from "./db-check.mjs";
+
+/** A run where everything the command can assert, asserted true. */
+const healthy = (overrides = {}) => ({
+  configError: null,
+  reachError: null,
+  columns: [...EXPECTED_COLUMNS],
+  anonVisible: 1,
+  adminVisible: 2,
+  badProgramRejected: true,
+  badRangeRejected: true,
+  ...overrides,
+});
+
+/** The text of one row, found by the name it prints under. */
+const rowFor = (observations, name) =>
+  judge(observations).lines.find((line) => line.includes(name));
+
+describe("judge", () => {
+  test("a healthy database passes every assertion", () => {
+    const { ok, lines } = judge(healthy());
+
+    expect(ok).toBe(true);
+    expect(lines.filter((line) => line.includes("FAIL"))).toEqual([]);
+    expect(lines.filter((line) => line.includes("n/c"))).toEqual([]);
+  });
+
+  test("a bad configuration fails and marks everything downstream unchecked", () => {
+    const { ok, lines } = judge({
+      configError: "NEXT_PUBLIC_SUPABASE_URL is not set",
+      reachError: null,
+      columns: null,
+      anonVisible: null,
+      adminVisible: null,
+      badProgramRejected: null,
+      badRangeRejected: null,
+    });
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toContain("NEXT_PUBLIC_SUPABASE_URL is not set");
+    expect(lines.join("\n")).toContain("could not be checked");
+  });
+
+  // The distinction the `n/c` label exists to keep: unlike a skipped gate row,
+  // an assertion this command could not make is a failure, not a pass.
+  test("an unchecked assertion fails the run rather than passing quietly", () => {
+    const { ok } = judge(healthy({ badRangeRejected: null }));
+
+    expect(ok).toBe(false);
+    expect(rowFor(healthy({ badRangeRejected: null }), "ends_at")).toContain(
+      "n/c",
+    );
+  });
+
+  test("a renamed column is caught as one missing and one unexpected", () => {
+    const renamed = EXPECTED_COLUMNS.map((column) =>
+      column === "starts_at" ? "start_at" : column,
+    );
+    const line = rowFor(healthy({ columns: renamed }), "columns");
+
+    expect(judge(healthy({ columns: renamed })).ok).toBe(false);
+    expect(line).toContain("missing: starts_at");
+    expect(line).toContain("unexpected: start_at");
+  });
+
+  // The assertion the whole command exists for. An unpublished row reaching the
+  // anon key means the select policy is wrong or RLS is off.
+  test("anon seeing both probe rows fails, and says why", () => {
+    const leaking = healthy({ anonVisible: 2 });
+
+    expect(judge(leaking).ok).toBe(false);
+    expect(rowFor(leaking, "blind")).toContain("an unpublished row is public");
+  });
+
+  // A table containing nothing satisfies "anon cannot see the unpublished row"
+  // vacuously. The service-role count is what stops that reading, so an empty
+  // table has to fail rather than look clean.
+  test("an empty table cannot pass the RLS assertions vacuously", () => {
+    const empty = healthy({ anonVisible: 0, adminVisible: 0 });
+
+    expect(judge(empty).ok).toBe(false);
+    expect(rowFor(empty, "service role")).toContain("saw 0 of 2");
+    expect(rowFor(empty, "blind")).toContain("FAIL");
+  });
+
+  test("a constraint that did not reject its bad row fails, naming the row", () => {
+    const line = rowFor(healthy({ badProgramRejected: false }), "program");
+
+    expect(judge(healthy({ badProgramRejected: false })).ok).toBe(false);
+    expect(line).toContain("program = 'nope' inserted successfully");
+  });
+
+  test("an unreachable table fails and reports what the API said", () => {
+    const { ok, lines } = judge(
+      healthy({
+        reachError: "HTTP 404 — Could not find the table 'public.sessions'",
+        columns: null,
+        anonVisible: null,
+        adminVisible: null,
+        badProgramRejected: null,
+        badRangeRejected: null,
+      }),
+    );
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toContain("Could not find the table");
+  });
+});
+
+describe("configErrorFor", () => {
+  const url = "https://abcdefghijklmnopqrst.supabase.co";
+
+  test("a bare project URL with both keys is usable", () => {
+    expect(configErrorFor(url, "anon", "service")).toBeNull();
+  });
+
+  // The exact malformation that made every request fail with PGRST125 and read
+  // as a dead project. The runtime module trims it; this one refuses it.
+  test("the REST endpoint pasted in place of the project URL is refused", () => {
+    expect(configErrorFor(`${url}/rest/v1`, "anon", "service")).toContain(
+      "/rest/v1",
+    );
+  });
+
+  test("a trailing slash is refused before the path check sees it", () => {
+    expect(configErrorFor(`${url}/`, "anon", "service")).toContain(
+      "trailing slash",
+    );
+  });
+
+  test("a bare origin is not mistaken for having a path", () => {
+    // `new URL(...).pathname` is "/" for an origin, so a naive emptiness check
+    // rejects every valid URL there is.
+    expect(configErrorFor(url, "anon", "service")).toBeNull();
+  });
+
+  test.each([
+    ["url", undefined, "anon", "service", "NEXT_PUBLIC_SUPABASE_URL"],
+    ["anon key", url, "", "service", "NEXT_PUBLIC_SUPABASE_ANON_KEY"],
+    ["service key", url, "anon", undefined, "SUPABASE_SERVICE_ROLE_KEY"],
+  ])("a missing %s is named", (_what, u, a, s, expected) => {
+    expect(configErrorFor(u, a, s)).toContain(expected);
+  });
+
+  test("a non-https URL is refused", () => {
+    expect(
+      configErrorFor("http://abcdefghijklmnopqrst.supabase.co", "anon", "svc"),
+    ).toContain("https://");
+  });
+});
+
+/**
+ * A fetch stub standing in for PostgREST. It answers by method, path, key and
+ * the rows being written, and records what it was asked, so a test can assert
+ * the probe rows were swept as well as read.
+ */
+function stubFetch(answer) {
+  const calls = [];
+  const fetch = async (url, init = {}) => {
+    const method = init.method ?? "GET";
+    const path = String(url).split("/rest/v1/")[1] ?? String(url);
+    const rows = init.body ? JSON.parse(init.body) : [];
+    calls.push(`${method} ${path}`);
+    const { status = 200, body = [] } =
+      answer({ method, path, key: init.headers?.apikey, rows }) ?? {};
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      text: async () => JSON.stringify(body),
+    };
+  };
+  return { fetch, calls };
+}
+
+const deps = (fetch) => ({
+  fetch,
+  url: "https://abcdefghijklmnopqrst.supabase.co",
+  anonKey: "anon",
+  serviceKey: "service",
+});
+
+const fullRow = Object.fromEntries(EXPECTED_COLUMNS.map((c) => [c, null]));
+
+/**
+ * A database behaving exactly as the migration intends: both check constraints
+ * hold, and the select policy hides the unpublished probe from the anon key.
+ *
+ * The constraints are modelled rather than stubbed to a constant, because
+ * every insert goes to the same path -- a stub that answered "created" to any
+ * POST would report both constraints holding when neither did.
+ */
+const healthyServer = ({ method, path, key, rows }) => {
+  if (method === "DELETE") return { status: 200 };
+  if (method === "POST") {
+    const violates = rows.some(
+      (r) => !["art", "coop"].includes(r.program) || r.ends_at <= r.starts_at,
+    );
+    return violates
+      ? { status: 400, body: { message: "violates check constraint" } }
+      : { status: 201, body: rows.map(() => fullRow) };
+  }
+  if (path.startsWith("sessions?title="))
+    return {
+      status: 200,
+      body: key === "anon" ? [fullRow] : [fullRow, fullRow],
+    };
+  return { status: 200, body: [] };
+};
+
+describe("gatherObservations", () => {
+  test("a healthy database yields observations that judge accepts", async () => {
+    const { fetch } = stubFetch(healthyServer);
+
+    const seen = await gatherObservations(deps(fetch));
+
+    expect(seen).toMatchObject({
+      configError: null,
+      reachError: null,
+      anonVisible: 1,
+      adminVisible: 2,
+      badProgramRejected: true,
+      badRangeRejected: true,
+    });
+    expect(seen.columns).toEqual(EXPECTED_COLUMNS);
+    expect(judge(seen).ok).toBe(true);
+  });
+
+  test("probe rows are swept before the run and deleted after it", async () => {
+    const { fetch, calls } = stubFetch(healthyServer);
+
+    await gatherObservations(deps(fetch));
+
+    const deletes = calls.filter((c) => c.startsWith("DELETE"));
+    expect(deletes.length).toBeGreaterThanOrEqual(2);
+    expect(calls.at(-1)).toBe("DELETE sessions?title=eq.__db_check_probe__");
+  });
+
+  // The config guard has to come before any traffic: a malformed URL would
+  // otherwise surface as a confusing HTTP error instead of naming itself.
+  test("a bad configuration short-circuits before any request is made", async () => {
+    const { fetch, calls } = stubFetch(healthyServer);
+
+    const seen = await gatherObservations({ ...deps(fetch), url: undefined });
+
+    expect(seen.configError).toContain("NEXT_PUBLIC_SUPABASE_URL");
+    expect(calls).toEqual([]);
+  });
+
+  test("a missing table is reported without attempting to insert probes", async () => {
+    const { fetch, calls } = stubFetch(() => ({
+      status: 404,
+      body: { message: "Could not find the table 'public.sessions'" },
+    }));
+
+    const seen = await gatherObservations(deps(fetch));
+
+    expect(seen.reachError).toContain("Could not find the table");
+    expect(calls.filter((c) => c.startsWith("POST"))).toEqual([]);
+  });
+
+  test("a failed probe insert is reported as such, not as a missing table", async () => {
+    const { fetch } = stubFetch(({ method }) =>
+      method === "POST"
+        ? { status: 403, body: { message: "permission denied" } }
+        : { status: 200, body: [] },
+    );
+
+    const seen = await gatherObservations(deps(fetch));
+
+    expect(seen.reachError).toContain("could not insert probe rows");
+    expect(seen.reachError).toContain("permission denied");
+  });
+
+  test("a network failure is caught and named rather than crashing the command", async () => {
+    const boom = async () => {
+      throw new TypeError("fetch failed");
+    };
+
+    const seen = await gatherObservations(deps(boom));
+
+    expect(seen.reachError).toBe("TypeError: fetch failed");
+    expect(judge(seen).ok).toBe(false);
+  });
+
+  // The leak this whole command exists to catch, driven end to end: a policy
+  // that lets the unpublished probe through must not produce a clean run.
+  test("a server that leaks the unpublished row produces a failing verdict", async () => {
+    const { fetch } = stubFetch((request) =>
+      request.path.startsWith("sessions?title=")
+        ? { status: 200, body: [fullRow, fullRow] }
+        : healthyServer(request),
+    );
+
+    const seen = await gatherObservations(deps(fetch));
+
+    expect(seen.anonVisible).toBe(2);
+    expect(judge(seen).ok).toBe(false);
+  });
+});
+
+describe("gatherObservations, when the API misbehaves", () => {
+  // A proxy or gateway in front of Supabase answers HTML, not JSON. Parsing has
+  // to survive that and still report the status, or the command dies with a
+  // SyntaxError instead of telling you what happened.
+  test("a non-JSON error body is carried through rather than thrown on", async () => {
+    const { fetch } = stubFetch(() => ({ status: 502 }));
+    const html = async (url, init) => {
+      const response = await fetch(url, init);
+      return { ...response, text: async () => "<html>Bad Gateway</html>" };
+    };
+
+    const seen = await gatherObservations(deps(html));
+
+    expect(seen.reachError).toContain("HTTP 502");
+    expect(judge(seen).ok).toBe(false);
+  });
+
+  test("an error body with no message still names the status", async () => {
+    const { fetch } = stubFetch(() => ({ status: 500, body: {} }));
+
+    const seen = await gatherObservations(deps(fetch));
+
+    expect(seen.reachError).toBe("HTTP 500 — no message");
+  });
+
+  // If a check constraint is missing, the row this command uses to probe it
+  // actually lands. That must be reported as a failure *and* cleaned up, or the
+  // next run inherits a stray row.
+  test("a missing constraint fails the assertion and removes the row it let in", async () => {
+    const { fetch, calls } = stubFetch((request) =>
+      request.method === "POST"
+        ? { status: 201, body: request.rows.map(() => fullRow) }
+        : healthyServer(request),
+    );
+
+    const seen = await gatherObservations(deps(fetch));
+
+    expect(seen.badProgramRejected).toBe(false);
+    expect(seen.badRangeRejected).toBe(false);
+    expect(judge(seen).ok).toBe(false);
+    expect(calls.at(-1)).toBe("DELETE sessions?title=eq.__db_check_probe__");
+  });
+
+  test("a read that fails leaves its count unchecked rather than zero", async () => {
+    const { fetch } = stubFetch((request) =>
+      request.path.startsWith("sessions?title=")
+        ? { status: 500, body: { message: "boom" } }
+        : healthyServer(request),
+    );
+
+    const seen = await gatherObservations(deps(fetch));
+
+    expect(seen.anonVisible).toBeNull();
+    expect(seen.adminVisible).toBeNull();
+    expect(judge(seen).ok).toBe(false);
+  });
+});

--- a/scripts/db-check.test.mjs
+++ b/scripts/db-check.test.mjs
@@ -33,7 +33,7 @@ describe("judge", () => {
 
   test("a bad configuration fails and marks everything downstream unchecked", () => {
     const { ok, lines } = judge({
-      configError: "NEXT_PUBLIC_SUPABASE_URL is not set",
+      configError: "SUPABASE_URL is not set",
       reachError: null,
       columns: null,
       anonVisible: null,
@@ -43,7 +43,7 @@ describe("judge", () => {
     });
 
     expect(ok).toBe(false);
-    expect(lines.join("\n")).toContain("NEXT_PUBLIC_SUPABASE_URL is not set");
+    expect(lines.join("\n")).toContain("SUPABASE_URL is not set");
     expect(lines.join("\n")).toContain("could not be checked");
   });
 
@@ -141,8 +141,8 @@ describe("configErrorFor", () => {
   });
 
   test.each([
-    ["url", undefined, "anon", "service", "NEXT_PUBLIC_SUPABASE_URL"],
-    ["anon key", url, "", "service", "NEXT_PUBLIC_SUPABASE_ANON_KEY"],
+    ["url", undefined, "anon", "service", "SUPABASE_URL"],
+    ["anon key", url, "", "service", "SUPABASE_ANON_KEY"],
     ["service key", url, "anon", undefined, "SUPABASE_SERVICE_ROLE_KEY"],
   ])("a missing %s is named", (_what, u, a, s, expected) => {
     expect(configErrorFor(u, a, s)).toContain(expected);
@@ -248,7 +248,7 @@ describe("gatherObservations", () => {
 
     const seen = await gatherObservations({ ...deps(fetch), url: undefined });
 
-    expect(seen.configError).toContain("NEXT_PUBLIC_SUPABASE_URL");
+    expect(seen.configError).toContain("SUPABASE_URL");
     expect(calls).toEqual([]);
   });
 

--- a/scripts/setup-secrets-wizard.sh
+++ b/scripts/setup-secrets-wizard.sh
@@ -206,24 +206,26 @@ vercel_env_push() {
 
 banner "Wild Coast Kids — secrets setup (Supabase, R2, Vercel)"
 
-# ── Stage 1: Supabase public config ───────────────────────────────────────
+# ── Stage 1: Supabase project config ───────────────────────────────────────
 stage "Supabase — project URL and publishable key"
-say "These two are browser-safe by design; Row Level Security is what protects data."
+say "Row Level Security protects the data, so these two would be safe in a"
+say "browser -- but nothing client-side reads Supabase, so they stay server-only"
+say "and carry no NEXT_PUBLIC_ prefix. See docs/adr/0008."
 open_url "https://supabase.com/dashboard/project/_/settings/api"
 step "Pick your project if prompted. On API Settings, copy the Project URL"
 step "(https://<ref>.supabase.co). If the page only shows keys, the URL is"
 step "under Project Settings → Data API."
-ask NEXT_PUBLIC_SUPABASE_URL "Paste the project URL:"
+ask SUPABASE_URL "Paste the project URL:"
 step "Copy the publishable key (sb_publishable_...) — on older dashboards this"
 step "is the 'anon / public' key under Project API keys."
-ask NEXT_PUBLIC_SUPABASE_ANON_KEY "Paste the publishable/anon key:"
-write_env NEXT_PUBLIC_SUPABASE_URL "$NEXT_PUBLIC_SUPABASE_URL"
-write_env NEXT_PUBLIC_SUPABASE_ANON_KEY "$NEXT_PUBLIC_SUPABASE_ANON_KEY"
+ask SUPABASE_ANON_KEY "Paste the publishable/anon key:"
+write_env SUPABASE_URL "$SUPABASE_URL"
+write_env SUPABASE_ANON_KEY "$SUPABASE_ANON_KEY"
 
 # ── Stage 2: Supabase secret key ──────────────────────────────────────────
 stage "Supabase — service-role (secret) key"
-say "Server-only: it bypasses Row Level Security. It never gets a NEXT_PUBLIC_"
-say "prefix and must only be read in route handlers / server actions."
+say "Server-only, and unlike the two above it bypasses Row Level Security"
+say "entirely. Read it in route handlers and server components, nowhere else."
 step "On the same API settings page, reveal and copy the secret key"
 step "(sb_secret_...) — on older dashboards, the 'service_role' key."
 ask_secret SUPABASE_SERVICE_ROLE_KEY "Paste the secret key (input hidden):"
@@ -263,12 +265,12 @@ fi
 
 # ── Stage 5: Push the values to Vercel ────────────────────────────────────
 stage "Vercel — push environment variables"
-say "Public vars go to all three environments; secrets go to production and"
-say "preview only (marked sensitive), so local dev stays on .env.local."
+say "Non-secret vars go to all three environments; the secrets go to production"
+say "and preview only (marked sensitive), so local dev stays on .env.local."
 if confirm "Push the captured values to Vercel now?"; then
   for target in production preview development; do
-    vercel_env_push NEXT_PUBLIC_SUPABASE_URL "$NEXT_PUBLIC_SUPABASE_URL" "$target"
-    vercel_env_push NEXT_PUBLIC_SUPABASE_ANON_KEY "$NEXT_PUBLIC_SUPABASE_ANON_KEY" "$target"
+    vercel_env_push SUPABASE_URL "$SUPABASE_URL" "$target"
+    vercel_env_push SUPABASE_ANON_KEY "$SUPABASE_ANON_KEY" "$target"
     vercel_env_push R2_ACCOUNT_ID "$R2_ACCOUNT_ID" "$target"
     vercel_env_push R2_BUCKET_NAME "$R2_BUCKET_NAME" "$target"
   done

--- a/src/app/art/page.test.tsx
+++ b/src/app/art/page.test.tsx
@@ -1,9 +1,22 @@
-import { expect, test } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import Art from "./page";
 
-test("the art page exposes its landmark, heading and reserved slots", () => {
-  render(<Art />);
+/** Unconfigured on purpose, for the reasons set out in `coop/page.test.tsx`. */
+beforeEach(() => {
+  vi.stubEnv("SUPABASE_URL", "");
+  vi.stubEnv("SUPABASE_ANON_KEY", "");
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+test("the art page exposes its landmark, heading and reserved slots", async () => {
+  render(await Art());
 
   expect(screen.getByRole("main")).toBeDefined();
 
@@ -16,10 +29,92 @@ test("the art page exposes its landmark, heading and reserved slots", () => {
   ).toBeDefined();
 });
 
-test("the page CTA routes to the booking page", () => {
-  render(<Art />);
+test("the page CTA routes to the booking page", async () => {
+  render(await Art());
 
   expect(
     screen.getByRole("link", { name: /book a class/i }).getAttribute("href"),
   ).toBe("/book");
+});
+
+test("an unreachable schedule is reported to the server log", async () => {
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  render(await Art());
+
+  expect(error).toHaveBeenCalledWith(
+    expect.stringContaining("art schedule unavailable"),
+  );
+});
+
+// The half of the reserved slot's promise this slice can keep. Prices vary from
+// one class to the next, which is why they live on the row rather than in page
+// copy, and why the schedule is where a parent finds them.
+test("published art sessions show their times and their prices", async () => {
+  vi.stubEnv("SUPABASE_URL", "https://abcdefghijklmnopqrst.supabase.co");
+  vi.stubEnv("SUPABASE_ANON_KEY", "sb_publishable_test");
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        {
+          id: "22222222-2222-2222-2222-222222222222",
+          program: "art",
+          title: "Watercolor Basics",
+          summary: "Intro watercolor for ages 8+. Materials included.",
+          starts_at: "2026-09-15T20:00:00+00:00",
+          ends_at: "2026-09-15T22:00:00+00:00",
+          location_name: "Studio — North Park",
+          location_url: null,
+          price_cents: 4500,
+        },
+      ],
+    }),
+  );
+
+  render(await Art());
+
+  expect(
+    screen.getByRole("heading", { level: 3, name: "Watercolor Basics" }),
+  ).toBeDefined();
+  expect(screen.getByText("$45")).toBeDefined();
+  expect(screen.getByText("Studio — North Park")).toBeDefined();
+  expect(screen.queryByText(/schedule & pricing coming soon/i)).toBeNull();
+});
+
+// Art's accent is purple where the co-op's is ocean, and the component derives
+// it from the program rather than being told, so a page cannot ask for the
+// wrong one.
+test("the art schedule carries the art accent", async () => {
+  vi.stubEnv("SUPABASE_URL", "https://abcdefghijklmnopqrst.supabase.co");
+  vi.stubEnv("SUPABASE_ANON_KEY", "sb_publishable_test");
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        {
+          id: "33333333-3333-3333-3333-333333333333",
+          program: "art",
+          title: "Ink and Collage",
+          summary: null,
+          starts_at: "2026-09-22T20:00:00+00:00",
+          ends_at: "2026-09-22T22:00:00+00:00",
+          location_name: null,
+          location_url: null,
+          price_cents: null,
+        },
+      ],
+    }),
+  );
+
+  render(await Art());
+
+  expect(
+    screen.getByRole("heading", { level: 2, name: "Upcoming sessions" })
+      .className,
+  ).toContain("text-purple");
 });

--- a/src/app/art/page.tsx
+++ b/src/app/art/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import { PillLink } from "@/components/PillLink";
 import { Placeholder } from "@/components/Placeholder";
-import { ReservedSlot } from "@/components/ReservedSlot";
+import { SessionSchedule } from "@/components/SessionSchedule";
+import { fetchSessions } from "@/lib/sessions";
 
 export const metadata: Metadata = {
   title: "Art Classes",
@@ -9,7 +10,17 @@ export const metadata: Metadata = {
     "Watercolors, ink, collage and printmaking for K–8 kids, inspired by the San Diego coast. Group and private sessions, charter fund eligible.",
 };
 
-export default function Art() {
+/** Per request, and for the reasons given in full on `/coop`. */
+export const dynamic = "force-dynamic";
+
+export default async function Art() {
+  const schedule = await fetchSessions("art");
+
+  if (schedule.kind === "unavailable")
+    console.error(
+      `[sessions] art schedule unavailable${schedule.drift ? " (drift)" : ""}: ${schedule.reason}`,
+    );
+
   return (
     <main className="flex-1">
       <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
@@ -29,10 +40,13 @@ export default function Art() {
             Book a class →
           </PillLink>
         </div>
-        {/* Reserved slots for the content pass: real schedule, pricing and
-            student photos. */}
+        {/* The schedule fills the slot that promised session times and pricing.
+            Charter-fund details are page copy still to be written, not data, so
+            the slot's wording keeps naming them while it stands in. */}
         <div className="grid gap-4 md:grid-cols-2">
-          <ReservedSlot
+          <SessionSchedule
+            result={schedule}
+            program="art"
             emoji="🎨"
             headline="Schedule & pricing coming soon."
             detail="Session times, group and private options, and charter-fund details land here."

--- a/src/app/coop/page.test.tsx
+++ b/src/app/coop/page.test.tsx
@@ -1,9 +1,31 @@
-import { expect, test } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import Coop from "./page";
 
-test("the co-op page exposes its landmark, heading and reserved slots", () => {
-  render(<Coop />);
+/**
+ * The page is an async server component, so it is called and its result
+ * rendered rather than rendered as an element. Testing Library handles the tree
+ * that comes back; what it cannot do is await one for you.
+ *
+ * The environment is stubbed empty on purpose rather than left to chance.
+ * Vitest does not load `.env.local`, so these tests would degrade anyway — but
+ * relying on that would make them start reaching a real project the day someone
+ * adds env loading to the runner.
+ */
+beforeEach(() => {
+  vi.stubEnv("SUPABASE_URL", "");
+  vi.stubEnv("SUPABASE_ANON_KEY", "");
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+test("the co-op page exposes its landmark, heading and reserved slots", async () => {
+  render(await Coop());
 
   expect(screen.getByRole("main")).toBeDefined();
 
@@ -16,12 +38,60 @@ test("the co-op page exposes its landmark, heading and reserved slots", () => {
   ).toBeDefined();
 });
 
-test("the page CTA routes to the landing page's interest list", () => {
-  render(<Coop />);
+test("the page CTA routes to the landing page's interest list", async () => {
+  render(await Coop());
 
   expect(
     screen
       .getByRole("link", { name: /join the interest list/i })
       .getAttribute("href"),
   ).toBe("/#community");
+});
+
+// The reader sees the same reserved slot whether the schedule is empty or
+// unreachable, so the log is the only place the difference exists. A silent
+// fallback would make a broken database indistinguishable from a quiet term.
+test("an unreachable schedule is reported to the server log", async () => {
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  render(await Coop());
+
+  expect(error).toHaveBeenCalledWith(
+    expect.stringContaining("coop schedule unavailable"),
+  );
+});
+
+test("published sessions replace the reserved slot", async () => {
+  vi.stubEnv("SUPABASE_URL", "https://abcdefghijklmnopqrst.supabase.co");
+  vi.stubEnv("SUPABASE_ANON_KEY", "sb_publishable_test");
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => [
+        {
+          id: "11111111-1111-1111-1111-111111111111",
+          program: "coop",
+          title: "Tidepool Walk at Cabrillo",
+          summary: null,
+          starts_at: "2026-09-08T17:00:00+00:00",
+          ends_at: "2026-09-08T20:00:00+00:00",
+          location_name: null,
+          location_url: null,
+          price_cents: null,
+        },
+      ],
+    }),
+  );
+
+  render(await Coop());
+
+  expect(
+    screen.getByRole("heading", {
+      level: 3,
+      name: "Tidepool Walk at Cabrillo",
+    }),
+  ).toBeDefined();
+  expect(screen.queryByText(/full co-op details coming soon/i)).toBeNull();
 });

--- a/src/app/coop/page.tsx
+++ b/src/app/coop/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import { PillLink } from "@/components/PillLink";
 import { Placeholder } from "@/components/Placeholder";
-import { ReservedSlot } from "@/components/ReservedSlot";
+import { SessionSchedule } from "@/components/SessionSchedule";
+import { fetchSessions } from "@/lib/sessions";
 
 export const metadata: Metadata = {
   title: "Tuesday Co-op",
@@ -9,7 +10,32 @@ export const metadata: Metadata = {
     "A Tuesday outdoor co-op for K–8 homeschoolers exploring San Diego's wild coast — tidepools, hikes, nature journaling and science.",
 };
 
-export default function Coop() {
+/**
+ * Rendered per request, not prerendered.
+ *
+ * Unlike `/conditions`, which sets a `revalidate` because its upstream is a
+ * public NOAA endpoint, this page's upstream needs credentials — and the gate
+ * runs `npm run build` in CI with none. A prerendered page would bake in the
+ * reserved slot at build time and serve it until the first background
+ * regeneration. Dynamic keeps the build credential-free and makes a row edited
+ * in Supabase Studio live on the next request.
+ *
+ * The cost is a Supabase round trip per view, and the loss of fetch caching:
+ * `force-dynamic` overrides every fetch to `no-store` in this version of Next,
+ * which is why `lib/sessions.ts` names no revalidate of its own.
+ */
+export const dynamic = "force-dynamic";
+
+export default async function Coop() {
+  const schedule = await fetchSessions("coop");
+
+  // The reader gets the reserved slot either way; only the log distinguishes a
+  // co-op with nothing booked yet from a database that could not be reached.
+  if (schedule.kind === "unavailable")
+    console.error(
+      `[sessions] coop schedule unavailable${schedule.drift ? " (drift)" : ""}: ${schedule.reason}`,
+    );
+
   return (
     <main className="flex-1">
       <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
@@ -29,10 +55,13 @@ export default function Coop() {
             Join the interest list →
           </PillLink>
         </div>
-        {/* Reserved slots for the content pass: the weekly rhythm and photos
-            from past adventures. */}
+        {/* The schedule takes the slot it was always promised; the eyebrow above
+            still carries the weekly rhythm, and this answers which Tuesdays.
+            Photos stay a reserved image beside it. */}
         <div className="grid gap-4 md:grid-cols-2">
-          <ReservedSlot
+          <SessionSchedule
+            result={schedule}
+            program="coop"
             emoji="🌿"
             headline="Full co-op details coming soon."
             detail="The weekly rhythm, meeting spots, and fall sign-up details land here."

--- a/src/components/SessionSchedule.test.tsx
+++ b/src/components/SessionSchedule.test.tsx
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { formatPrice, SessionSchedule } from "./SessionSchedule";
+import type { ScheduleResult, Session } from "@/lib/sessions";
+
+const session = (overrides: Partial<Session> = {}): Session => ({
+  id: "11111111-1111-1111-1111-111111111111",
+  program: "coop",
+  title: "Tidepool Walk at Cabrillo",
+  summary: null,
+  // 10:00 to 13:00 on a Tuesday in San Diego.
+  startsAt: "2026-09-08T17:00:00Z",
+  endsAt: "2026-09-08T20:00:00Z",
+  locationName: null,
+  locationUrl: null,
+  priceCents: null,
+  ...overrides,
+});
+
+const slot = {
+  emoji: "🌿",
+  headline: "Full co-op details coming soon.",
+  detail:
+    "The weekly rhythm, meeting spots, and fall sign-up details land here.",
+  program: "coop" as const,
+};
+
+const ok = (sessions: Session[]): ScheduleResult => ({ kind: "ok", sessions });
+
+describe("SessionSchedule", () => {
+  test("lists each session with its day and hours in Pacific time", () => {
+    render(<SessionSchedule {...slot} result={ok([session()])} />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "Tidepool Walk at Cabrillo",
+      }),
+    ).toBeDefined();
+    expect(screen.getByText("Tue, Sep 8 · 10:00 AM – 1:00 PM")).toBeDefined();
+  });
+
+  test("renders one item per session, in the order given", () => {
+    render(
+      <SessionSchedule
+        {...slot}
+        result={ok([
+          session({ id: "a", title: "First" }),
+          session({ id: "b", title: "Second" }),
+        ])}
+      />,
+    );
+
+    const titles = screen
+      .getAllByRole("heading", { level: 3 })
+      .map((h) => h.textContent);
+    expect(titles).toEqual(["First", "Second"]);
+  });
+
+  // Both states show the same thing on purpose. A parent can act on neither,
+  // and the difference is reported to the operator in the server log instead.
+  test.each([
+    ["no sessions yet", ok([])],
+    [
+      "an unreachable database",
+      {
+        kind: "unavailable",
+        reason: "HTTP 500",
+        drift: false,
+      } as ScheduleResult,
+    ],
+  ])("falls back to the reserved slot when there is %s", (_case, result) => {
+    render(<SessionSchedule {...slot} result={result} />);
+
+    expect(screen.getByText(/full co-op details coming soon/i)).toBeDefined();
+    expect(screen.queryByRole("list")).toBeNull();
+  });
+
+  test("links the location when there is a URL, and opens it detached", () => {
+    render(
+      <SessionSchedule
+        {...slot}
+        result={ok([
+          session({
+            locationName: "Cabrillo National Monument",
+            locationUrl: "https://maps.example.com/cabrillo",
+          }),
+        ])}
+      />,
+    );
+
+    const link = screen.getByRole("link", {
+      name: "Cabrillo National Monument",
+    });
+    expect(link.getAttribute("href")).toBe("https://maps.example.com/cabrillo");
+    expect(link.getAttribute("rel")).toContain("noopener");
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  test("shows a location with no URL as plain text rather than a dead link", () => {
+    render(
+      <SessionSchedule
+        {...slot}
+        result={ok([session({ locationName: "Studio — North Park" })])}
+      />,
+    );
+
+    expect(screen.getByText("Studio — North Park")).toBeDefined();
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  // Null and zero are different facts: one is "not priced here", the other is
+  // "this costs nothing". Rendering null as "Free" would invent a promise.
+  test("prints nothing for an unpriced session and 'Free' for a free one", () => {
+    const { rerender } = render(
+      <SessionSchedule
+        {...slot}
+        result={ok([session({ priceCents: null })])}
+      />,
+    );
+    expect(screen.queryByText(/free|\$/i)).toBeNull();
+
+    rerender(
+      <SessionSchedule {...slot} result={ok([session({ priceCents: 0 })])} />,
+    );
+    expect(screen.getByText("Free")).toBeDefined();
+  });
+
+  test("carries the program's own accent, derived rather than passed", () => {
+    render(
+      <SessionSchedule
+        {...slot}
+        program="art"
+        result={ok([session({ program: "art" })])}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Tue, Sep 8/).className.includes("text-purple"),
+    ).toBe(true);
+  });
+
+  // The page's own title is an h1 and session titles are h3, so the list owes
+  // the document the level in between. The reserved slot has no list to name
+  // and so introduces no heading at all.
+  test("heads the list at level 2, and adds no heading when there is none", () => {
+    const { rerender } = render(
+      <SessionSchedule {...slot} result={ok([session()])} />,
+    );
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Upcoming sessions" }),
+    ).toBeDefined();
+
+    rerender(<SessionSchedule {...slot} result={ok([])} />);
+    expect(screen.queryByRole("heading", { level: 2 })).toBeNull();
+  });
+});
+
+describe("formatPrice", () => {
+  test.each([
+    [0, "Free"],
+    [4500, "$45"],
+    [500, "$5"],
+    [4550, "$45.50"],
+    [99, "$0.99"],
+  ])("%i cents reads as %s", (cents, expected) => {
+    expect(formatPrice(cents)).toBe(expected);
+  });
+});

--- a/src/components/SessionSchedule.tsx
+++ b/src/components/SessionSchedule.tsx
@@ -1,0 +1,131 @@
+/**
+ * A program's upcoming sessions, or the reserved slot that stood there before
+ * any existed.
+ *
+ * Presentational and pure. The fetching happens in the page; this component is
+ * handed a result and decides only how it reads. That is what lets both the
+ * populated and the empty states be asserted without a database.
+ *
+ * **Emptiness and failure look the same here, deliberately.** A reader can act
+ * on neither, and "coming soon" is true in both cases. The distinction is owed
+ * to the operator instead, and the page logs it. This is the one place where
+ * this module departs from the conditions panels next door, which must say in
+ * words why they cannot answer — a blank tide reading looks like calm water,
+ * and a missing schedule looks like a missing schedule.
+ */
+
+import { ReservedSlot } from "./ReservedSlot";
+import { localDayOf, localTimeOf } from "@/lib/pacific-time";
+import type { Program, ScheduleResult, Session } from "@/lib/sessions";
+
+type SessionScheduleProps = {
+  result: ScheduleResult;
+  /** Decides the accent and the heading's id; the two cannot disagree. */
+  program: Program;
+  /** The reserved slot to fall back to, in the page's own words. */
+  emoji: string;
+  headline: string;
+  detail: string;
+};
+
+/** Each program's own colour, the one its card and its page already use. */
+const ACCENTS: Record<Program, string> = {
+  art: "text-purple",
+  coop: "text-ocean",
+};
+
+/**
+ * Whole dollars when the price is whole, cents when it is not. `0` is free and
+ * says so; `null` means the session is not priced here, which is different, and
+ * renders nothing at all.
+ */
+export function formatPrice(cents: number): string {
+  if (cents === 0) return "Free";
+  return cents % 100 === 0 ? `$${cents / 100}` : `$${(cents / 100).toFixed(2)}`;
+}
+
+/**
+ * `Tue, Sep 8 · 10:00 AM – 1:00 PM`, in the site's zone.
+ *
+ * One line rather than two fields, because a parent reads "when" as a single
+ * fact. The end time carries no date even when a session crosses midnight —
+ * none does, and inventing a case nobody has costs the common one its brevity.
+ */
+function when(session: Session): string {
+  const startsMs = Date.parse(session.startsAt);
+  const endsMs = Date.parse(session.endsAt);
+  return `${localDayOf(startsMs)} · ${localTimeOf(startsMs)} – ${localTimeOf(endsMs)}`;
+}
+
+export function SessionSchedule({
+  result,
+  program,
+  emoji,
+  headline,
+  detail,
+}: SessionScheduleProps) {
+  if (result.kind === "unavailable" || result.sessions.length === 0)
+    return <ReservedSlot emoji={emoji} headline={headline} detail={detail} />;
+
+  // The list gets a heading and the reserved slot does not, which is why the
+  // two branches differ in shape. Session titles are h3, so without an h2 here
+  // the page would step from its h1 straight past a level.
+  const headingId = `${program}-schedule-heading`;
+
+  return (
+    <section aria-labelledby={headingId}>
+      <h2
+        id={headingId}
+        className={`text-2xs mb-3 font-extrabold tracking-widest uppercase ${ACCENTS[program]}`}
+      >
+        Upcoming sessions
+      </h2>
+      <ul className="grid gap-3">
+        {result.sessions.map((session) => (
+          <li
+            key={session.id}
+            className="rounded-tile border-[1.5px] border-lavender bg-white/60 p-5"
+          >
+            <p
+              className={`text-2xs mb-1.5 font-extrabold tracking-widest uppercase ${ACCENTS[program]}`}
+            >
+              {when(session)}
+            </p>
+            <h3 className="leading-display text-lg font-black italic">
+              {session.title}
+            </h3>
+            {session.summary && (
+              <p className="leading-relaxed mt-1.5 text-sm text-fog">
+                {session.summary}
+              </p>
+            )}
+            {(session.locationName || session.priceCents !== null) && (
+              <p className="mt-2.5 flex flex-wrap gap-x-4 gap-y-1 text-sm text-fog">
+                {session.locationName &&
+                  (session.locationUrl ? (
+                    <a
+                      href={session.locationUrl}
+                      className="underline decoration-lavender underline-offset-2 transition-colors duration-fast hover:text-dark"
+                      // The row is written by hand in Supabase Studio and can point
+                      // anywhere, so the tab it opens gets no handle on this one.
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {session.locationName}
+                    </a>
+                  ) : (
+                    <span>{session.locationName}</span>
+                  ))}
+                {session.priceCents !== null && (
+                  <span className="font-bold">
+                    {formatPrice(session.priceCents)}
+                  </span>
+                )}
+              </p>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/lib/pacific-time.test.ts
+++ b/src/lib/pacific-time.test.ts
@@ -1,5 +1,10 @@
-import { expect, test } from "vitest";
-import { localDateOf, localTimeOf, SITE_TIME_ZONE } from "./pacific-time";
+import { describe, expect, test } from "vitest";
+import {
+  localDateOf,
+  localDayOf,
+  localTimeOf,
+  SITE_TIME_ZONE,
+} from "./pacific-time";
 
 /** 2026-08-18 13:47 UTC, one of the captured predictions. */
 const SUMMER_INSTANT = Date.UTC(2026, 7, 18, 13, 47);
@@ -32,4 +37,17 @@ test("an instant late in the UTC day can be the previous local day", () => {
 test("the zone is a parameter, so the rule can be tested rather than trusted", () => {
   expect(localDateOf(SUMMER_INSTANT, "UTC")).toBe("2026-08-18");
   expect(localTimeOf(SUMMER_INSTANT, "UTC")).toBe("1:47 PM");
+});
+
+describe("localDayOf", () => {
+  test("names the weekday and date in the site's zone", () => {
+    // 2026-09-08T17:00Z is 10:00 on a Tuesday in San Diego.
+    expect(localDayOf(Date.UTC(2026, 8, 8, 17, 0))).toBe("Tue, Sep 8");
+  });
+
+  // The reason the zone is named rather than inherited: this instant is already
+  // the 9th in UTC while it is still the evening of the 8th on the coast.
+  test("uses Pacific rather than UTC to decide which day it is", () => {
+    expect(localDayOf(Date.UTC(2026, 8, 9, 3, 0))).toBe("Tue, Sep 8");
+  });
 });

--- a/src/lib/pacific-time.ts
+++ b/src/lib/pacific-time.ts
@@ -51,3 +51,23 @@ export function localTimeOf(
     hour12: true,
   }).format(new Date(atMs));
 }
+
+/**
+ * The calendar day an instant falls on, in `timeZone`, as `Tue, Sep 8`.
+ *
+ * Weekday included because the co-op's whole identity is which day of the week
+ * it meets, and a reader scanning a term of Tuesdays should be able to see one
+ * that is not a Tuesday. No year: the schedule only ever lists sessions still
+ * to come, so the year is either this one or obvious from context.
+ */
+export function localDayOf(
+  atMs: number,
+  timeZone: string = SITE_TIME_ZONE,
+): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  }).format(new Date(atMs));
+}

--- a/src/lib/sessions.test.ts
+++ b/src/lib/sessions.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  fetchSessions,
+  MAX_SESSIONS,
+  normalizeBaseUrl,
+  parseSessions,
+  sessionsUrl,
+  SessionsDriftError,
+} from "./sessions";
+
+/**
+ * `fetch` is stubbed rather than reached, the same way `upstream.test.ts` does
+ * it. What is under test is the policy around the request — what a 500 means,
+ * what a changed table means, what an unset variable means — none of which a
+ * live project having a good day can show you.
+ */
+const fetchMock = vi.fn();
+
+const BASE = "https://abcdefghijklmnopqrst.supabase.co";
+const NOW = new Date("2026-08-18T12:00:00Z");
+
+/** A row exactly as PostgREST returns one. */
+const row = (overrides: Record<string, unknown> = {}) => ({
+  id: "11111111-1111-1111-1111-111111111111",
+  program: "coop",
+  title: "Tidepool Walk at Cabrillo",
+  summary: null,
+  starts_at: "2026-09-08T17:00:00+00:00",
+  ends_at: "2026-09-08T20:00:00+00:00",
+  location_name: null,
+  location_url: null,
+  price_cents: null,
+  ...overrides,
+});
+
+function jsonResponse(payload: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+  vi.stubEnv("SUPABASE_URL", BASE);
+  vi.stubEnv("SUPABASE_ANON_KEY", "sb_publishable_test");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("normalizeBaseUrl", () => {
+  // The exact malformation that was in .env.local and made every request fail
+  // with a PostgREST error naming nothing. The site tolerates it; check:db does
+  // not (issue #76).
+  test.each([
+    [BASE, BASE],
+    [`${BASE}/`, BASE],
+    [`${BASE}/rest/v1`, BASE],
+    [`${BASE}/rest/v1/`, BASE],
+  ])("%s becomes %s", (given, expected) => {
+    expect(normalizeBaseUrl(given)).toBe(expected);
+  });
+});
+
+describe("sessionsUrl", () => {
+  test("asks for one program's published, future sessions, oldest first", () => {
+    const url = new URL(sessionsUrl(BASE, "coop", NOW));
+
+    expect(url.pathname).toBe("/rest/v1/sessions");
+    expect(url.searchParams.get("program")).toBe("eq.coop");
+    expect(url.searchParams.get("published")).toBe("is.true");
+    expect(url.searchParams.get("starts_at")).toBe(
+      "gte.2026-08-18T12:00:00.000Z",
+    );
+    expect(url.searchParams.get("order")).toBe("starts_at.asc");
+    expect(url.searchParams.get("limit")).toBe(String(MAX_SESSIONS));
+  });
+
+  // Projecting columns rather than select=* is what keeps a column added later
+  // from silently reaching the page.
+  test("names its columns rather than selecting everything", () => {
+    const select = new URL(sessionsUrl(BASE, "art", NOW)).searchParams.get(
+      "select",
+    );
+
+    expect(select).not.toContain("*");
+    expect(select).toContain("price_cents");
+  });
+
+  test("tolerates a base URL with the REST path already on it", () => {
+    expect(new URL(sessionsUrl(`${BASE}/rest/v1/`, "art", NOW)).pathname).toBe(
+      "/rest/v1/sessions",
+    );
+  });
+});
+
+describe("parseSessions", () => {
+  test("maps a row to camelCase and keeps its nulls distinct", () => {
+    const [parsed] = parseSessions([
+      row({ summary: "Low-tide exploration.", price_cents: 4500 }),
+    ]);
+
+    expect(parsed).toMatchObject({
+      program: "coop",
+      title: "Tidepool Walk at Cabrillo",
+      summary: "Low-tide exploration.",
+      startsAt: "2026-09-08T17:00:00+00:00",
+      locationName: null,
+      priceCents: 4500,
+    });
+  });
+
+  test("an empty result is a valid schedule with nothing in it", () => {
+    expect(parseSessions([])).toEqual([]);
+  });
+
+  // The whole point of parsing rather than casting: the compiler cannot catch a
+  // column renamed in Postgres, so the boundary has to.
+  test.each([
+    ["a payload that is not an array", { rows: [] }],
+    ["a row that is not an object", [null]],
+    ["a renamed title column", [{ ...row(), title: undefined }]],
+    ["an empty title", [row({ title: "" })]],
+    ["a program the site does not have", [row({ program: "virtual" })]],
+    ["a price that is not whole cents", [row({ price_cents: 45.5 })]],
+    ["a price that is a string", [row({ price_cents: "4500" })]],
+    ["a summary that is not text", [row({ summary: 42 })]],
+  ])("refuses %s as drift", (_case, payload) => {
+    expect(() => parseSessions(payload)).toThrow(SessionsDriftError);
+  });
+
+  // location_url is typed by hand and rendered as an href.
+  test.each([
+    ["javascript:alert(1)"],
+    ["data:text/html,<script>alert(1)</script>"],
+    ["not a url at all"],
+  ])("refuses %s as a location URL", (locationUrl) => {
+    expect(() => parseSessions([row({ location_url: locationUrl })])).toThrow(
+      SessionsDriftError,
+    );
+  });
+
+  test("accepts an ordinary map link", () => {
+    const [parsed] = parseSessions([
+      row({
+        location_name: "Cabrillo",
+        location_url: "https://maps.example.com/cabrillo",
+      }),
+    ]);
+
+    expect(parsed.locationUrl).toBe("https://maps.example.com/cabrillo");
+  });
+});
+
+describe("fetchSessions", () => {
+  test("returns the parsed sessions and sends the anon key", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([row()]));
+
+    const result = await fetchSessions("coop", NOW);
+
+    expect(result).toMatchObject({ kind: "ok" });
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers.apikey).toBe("sb_publishable_test");
+  });
+
+  // force-dynamic overrides fetch caching to no-store in this version of Next,
+  // so a revalidate here would be configuration that reads as meaningful and is
+  // discarded. Asserted so nobody adds one back.
+  test("names no revalidate, because the route's dynamic rendering discards it", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([]));
+
+    await fetchSessions("coop", NOW);
+
+    expect(fetchMock.mock.calls[0][1].next).toBeUndefined();
+  });
+
+  test.each([
+    ["SUPABASE_URL", "SUPABASE_ANON_KEY"],
+    ["SUPABASE_ANON_KEY", "SUPABASE_URL"],
+  ])("is unavailable when %s is unset", async (unset) => {
+    vi.stubEnv(unset, "");
+
+    const result = await fetchSessions("coop", NOW);
+
+    expect(result).toMatchObject({ kind: "unavailable", drift: false });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("is unavailable, not thrown, when the request does not complete", async () => {
+    fetchMock.mockRejectedValue(new TypeError("fetch failed"));
+
+    const result = await fetchSessions("coop", NOW);
+
+    expect(result).toMatchObject({ kind: "unavailable", drift: false });
+    if (result.kind === "unavailable")
+      expect(result.reason).toContain("fetch failed");
+  });
+
+  test("is unavailable on an error status, naming it", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, 500));
+
+    const result = await fetchSessions("coop", NOW);
+
+    if (result.kind !== "unavailable") throw new Error("expected unavailable");
+    expect(result.reason).toContain("HTTP 500");
+    expect(result.drift).toBe(false);
+  });
+
+  test("is unavailable when the body is not JSON", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("Unexpected token <");
+      },
+    });
+
+    const result = await fetchSessions("coop", NOW);
+
+    expect(result).toMatchObject({ kind: "unavailable", drift: false });
+  });
+
+  // Drift is flagged separately because it is a bug to chase rather than a
+  // service having a bad day, and `npm run check:db` will name it.
+  test("flags a changed table as drift rather than as an outage", async () => {
+    fetchMock.mockResolvedValue(jsonResponse([row({ program: "virtual" })]));
+
+    const result = await fetchSessions("coop", NOW);
+
+    expect(result).toMatchObject({ kind: "unavailable", drift: true });
+  });
+
+  test("warns rather than truncating silently when the ceiling is reached", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        Array.from({ length: MAX_SESSIONS }, (_, i) => row({ id: `id-${i}` })),
+      ),
+    );
+
+    const result = await fetchSessions("coop", NOW);
+
+    expect(result).toMatchObject({ kind: "ok" });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("truncated"));
+  });
+
+  test("does not warn on an ordinary term's worth of sessions", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        Array.from({ length: 14 }, (_, i) => row({ id: `id-${i}` })),
+      ),
+    );
+
+    await fetchSessions("coop", NOW);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/sessions.ts
+++ b/src/lib/sessions.ts
@@ -1,0 +1,286 @@
+/**
+ * The session schedule, read from Supabase.
+ *
+ * The second module here that touches the network, and the only one that talks
+ * to Supabase. It follows `upstream.ts`'s shape deliberately: a URL builder and
+ * a parser that are pure and asserted against a committed payload, a fetch that
+ * **never throws**, and a result that carries the reason it has nothing rather
+ * than an exception for a caller to remember to catch.
+ *
+ * NO `next.revalidate` HERE, unlike `upstream.ts`. The routes that call this are
+ * `force-dynamic`, which in this version of Next overrides every fetch to
+ * `no-store` — see the comment in `app/conditions/page.tsx` that measured it.
+ * Naming a revalidate would be configuration that reads as meaningful and is
+ * discarded. The freshness this module wants is the freshness it gets: a row
+ * edited in Supabase Studio is live on the next request.
+ *
+ * FAILURE POLICY, and where it differs from the conditions panels. Those must
+ * say in words why they cannot answer, because a blank tide reading looks like
+ * calm water. A schedule has no such hazard: "coming soon" is true whether there
+ * are no sessions yet or Supabase is unreachable, and a parent can act on
+ * neither. So both render the same reserved slot and the distinction lives in
+ * the server log. `drift` still separates a changed table — a bug to chase, and
+ * one `npm run check:db` will name — from a bad day.
+ */
+
+/** The two programs. A foreign key to `ProgramCards.tsx`, not to a table. */
+export type Program = "art" | "coop";
+
+export type Session = {
+  id: string;
+  program: Program;
+  title: string;
+  summary: string | null;
+  /** ISO 8601, UTC. Rendered in America/Los_Angeles by the component. */
+  startsAt: string;
+  endsAt: string;
+  locationName: string | null;
+  locationUrl: string | null;
+  /** Integer cents. Null means "not priced here", which is not the same as free. */
+  priceCents: number | null;
+};
+
+export type ScheduleResult =
+  | { kind: "ok"; sessions: Session[] }
+  | {
+      kind: "unavailable";
+      /** Why there is no schedule, in a sentence fit for a server log. */
+      reason: string;
+      /** True when the table's shape changed, which is a bug rather than an outage. */
+      drift: boolean;
+    };
+
+/** Thrown by `parseSessions` when a row is not the shape the table promises. */
+export class SessionsDriftError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SessionsDriftError";
+  }
+}
+
+/**
+ * A ceiling on one page's query, not a product decision. A term is around
+ * fourteen sessions and both programs together will not approach this; it is
+ * here so a runaway table cannot render an unbounded page. Reaching it is
+ * reported rather than silently truncating the schedule.
+ */
+export const MAX_SESSIONS = 50;
+
+const COLUMNS = [
+  "id",
+  "program",
+  "title",
+  "summary",
+  "starts_at",
+  "ends_at",
+  "location_name",
+  "location_url",
+  "price_cents",
+].join(",");
+
+/**
+ * Trim what the Supabase dashboard hands you that the API does not want.
+ *
+ * Forgiving on purpose, and unlike `scripts/db-check.mjs`, which refuses the
+ * same input by name. A misconfigured site should degrade to its reserved slot
+ * rather than break; a command whose whole job is to verify configuration
+ * should say the configuration is wrong. See issue #76.
+ */
+export function normalizeBaseUrl(raw: string): string {
+  return raw.replace(/\/+$/, "").replace(/\/rest\/v1$/, "");
+}
+
+/**
+ * One program's published sessions that have not yet happened, oldest first.
+ *
+ * `starts_at` rather than `ends_at` is the cutoff, so a session drops off the
+ * list when it begins rather than while families are still at it. That is the
+ * conservative direction: a schedule that still lists something happening right
+ * now is right, and one that lists something already over is not.
+ */
+export function sessionsUrl(
+  base: string,
+  program: Program,
+  now: Date = new Date(),
+): string {
+  const url = new URL(`${normalizeBaseUrl(base)}/rest/v1/sessions`);
+  url.searchParams.set("select", COLUMNS);
+  url.searchParams.set("program", `eq.${program}`);
+  url.searchParams.set("published", "is.true");
+  url.searchParams.set("starts_at", `gte.${now.toISOString()}`);
+  url.searchParams.set("order", "starts_at.asc");
+  url.searchParams.set("limit", String(MAX_SESSIONS));
+  return url.toString();
+}
+
+/** @throws {SessionsDriftError} when a row is not what the table promises. */
+function requireString(row: Record<string, unknown>, key: string): string {
+  const value = row[key];
+  if (typeof value !== "string" || value === "")
+    throw new SessionsDriftError(
+      `A session row has no usable "${key}" (got ${JSON.stringify(value)}).`,
+    );
+  return value;
+}
+
+function optionalString(
+  row: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = row[key];
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "string")
+    throw new SessionsDriftError(
+      `A session row's "${key}" is ${typeof value}, expected text or null.`,
+    );
+  return value;
+}
+
+/**
+ * A map link, or nothing, and never anything that could execute.
+ *
+ * `location_url` is typed into Supabase Studio by hand and rendered as an
+ * `href`, so `javascript:` reaching it would be stored XSS. Treated as drift
+ * rather than quietly dropped: a scheme this refuses cannot have arrived by
+ * accident, and one bad row blanking the schedule with a logged reason is a
+ * failure someone will chase within the hour. A silently missing link is not.
+ *
+ * @throws {SessionsDriftError}
+ */
+function optionalHttpUrl(
+  row: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = optionalString(row, key);
+  if (value === null) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new SessionsDriftError(
+      `A session row's "${key}" is not a URL: ${JSON.stringify(value)}.`,
+    );
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:")
+    throw new SessionsDriftError(
+      `A session row's "${key}" uses the ${parsed.protocol} scheme, which is not a link.`,
+    );
+  return value;
+}
+
+/**
+ * Turn PostgREST's payload into sessions, or refuse it.
+ *
+ * Boundaries validate; interiors trust. Everything downstream — the component,
+ * the date formatter — takes a `Session` and does not re-check it.
+ *
+ * @throws {SessionsDriftError}
+ */
+export function parseSessions(payload: unknown): Session[] {
+  if (!Array.isArray(payload))
+    throw new SessionsDriftError(
+      `Supabase returned ${typeof payload}, expected an array of rows.`,
+    );
+
+  return payload.map((entry) => {
+    if (typeof entry !== "object" || entry === null)
+      throw new SessionsDriftError("A session row is not an object.");
+    const row = entry as Record<string, unknown>;
+
+    const program = row.program;
+    if (program !== "art" && program !== "coop")
+      throw new SessionsDriftError(
+        `A session row's "program" is ${JSON.stringify(program)}, which is neither art nor coop.`,
+      );
+
+    const priceCents = row.price_cents;
+    if (
+      priceCents !== null &&
+      priceCents !== undefined &&
+      (typeof priceCents !== "number" || !Number.isInteger(priceCents))
+    )
+      throw new SessionsDriftError(
+        `A session row's "price_cents" is ${JSON.stringify(priceCents)}, expected whole cents or null.`,
+      );
+
+    return {
+      id: requireString(row, "id"),
+      program,
+      title: requireString(row, "title"),
+      summary: optionalString(row, "summary"),
+      startsAt: requireString(row, "starts_at"),
+      endsAt: requireString(row, "ends_at"),
+      locationName: optionalString(row, "location_name"),
+      locationUrl: optionalHttpUrl(row, "location_url"),
+      priceCents: (priceCents as number | null | undefined) ?? null,
+    };
+  });
+}
+
+/**
+ * Fetch one program's upcoming published sessions.
+ *
+ * Never throws. A missing configuration, an unreachable project, an error
+ * status, a body that is not JSON and a table whose shape has changed all come
+ * back as `unavailable` with the reason attached.
+ */
+export async function fetchSessions(
+  program: Program,
+  now: Date = new Date(),
+): Promise<ScheduleResult> {
+  const base = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_ANON_KEY;
+
+  const unavailable = (reason: string, drift = false): ScheduleResult => ({
+    kind: "unavailable",
+    reason,
+    drift,
+  });
+
+  if (!base || !key)
+    return unavailable(
+      "SUPABASE_URL or SUPABASE_ANON_KEY is not set, so the schedule cannot be read.",
+    );
+
+  let response: Response;
+  try {
+    response = await fetch(sessionsUrl(base, program, now), {
+      headers: { apikey: key, Authorization: `Bearer ${key}` },
+    });
+  } catch (cause) {
+    return unavailable(
+      `The request to Supabase for ${program} sessions did not complete: ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+
+  if (!response.ok)
+    return unavailable(
+      `Supabase returned HTTP ${response.status} for ${program} sessions.`,
+    );
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (cause) {
+    return unavailable(
+      `Supabase's response for ${program} sessions was not JSON: ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+
+  try {
+    const sessions = parseSessions(payload);
+    if (sessions.length === MAX_SESSIONS)
+      // Not a failure, but not silent either: the reader is seeing a truncated
+      // schedule and only the log can say so.
+      console.warn(
+        `[sessions] ${program} hit the ${MAX_SESSIONS}-row ceiling; the schedule shown is truncated.`,
+      );
+    return { kind: "ok", sessions };
+  } catch (cause) {
+    if (cause instanceof SessionsDriftError)
+      return unavailable(cause.message, true);
+    return unavailable(cause instanceof Error ? cause.message : String(cause));
+  }
+}

--- a/src/lib/upstream.ts
+++ b/src/lib/upstream.ts
@@ -1,8 +1,13 @@
 /**
- * The only module here that touches the network.
+ * The only module here that touches NOAA.
  *
- * Fetching, caching and deciding what a failure means live together, and nowhere
- * else: the parsers next door are pure so they can be asserted against committed
+ * Not the only one that touches the network any more: `sessions.ts` reads the
+ * schedule from Supabase and follows this module's shape deliberately. The two
+ * stay apart because they share no upstream, no failure vocabulary and no
+ * cache policy -- only a form.
+ *
+ * Fetching, caching and deciding what a failure means live together for these
+ * three feeds, and nowhere else: the parsers next door are pure so they can be asserted against committed
  * payloads, and a component that wants a reading calls this rather than reaching
  * for `fetch`.
  *

--- a/supabase/migrations/0001_sessions.sql
+++ b/supabase/migrations/0001_sessions.sql
@@ -1,0 +1,53 @@
+-- One dated session of one program. See docs/plans/session-schedule-from-supabase.md.
+--
+-- Apply by hand in the Supabase SQL editor, then run `npm run check:db`, which
+-- asserts every property this file is supposed to establish.
+
+create table public.sessions (
+  id            uuid primary key default gen_random_uuid(),
+  program       text        not null check (program in ('art', 'coop')),
+  title         text        not null,
+  summary       text,
+  starts_at     timestamptz not null,
+  ends_at       timestamptz not null,
+  location_name text,
+  location_url  text,
+  price_cents   integer     check (price_cents is null or price_cents >= 0),
+  published     boolean     not null default false,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now(),
+  constraint ends_after_start check (ends_at > starts_at)
+);
+
+-- Matches the only query the site makes: one program's upcoming sessions,
+-- oldest first.
+create index sessions_program_starts_at on public.sessions (program, starts_at);
+
+-- A column default fires on insert only, so without this trigger `updated_at`
+-- reports a creation time under a name that promises a modification time. The
+-- source build plan this schema descends from has that bug in all four of its
+-- tables. Plain plpgsql rather than the moddatetime extension: nothing to get
+-- wrong about which schema the extension landed in.
+create function public.set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger sessions_set_updated_at
+  before update on public.sessions
+  for each row execute function public.set_updated_at();
+
+alter table public.sessions enable row level security;
+
+-- The only policy. Reads are public but only for published rows; there is
+-- deliberately no insert, update or delete policy, so every write must come
+-- from the service role. That is what makes `published` a working kill switch:
+-- unpublish a row and it leaves the site with no deploy.
+create policy "public reads published sessions"
+  on public.sessions for select
+  using (published = true);
+
+grant select on public.sessions to anon, authenticated;

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -35,10 +35,10 @@ export default defineConfig({
       // purpose, and all four drag these figures down in plain sight rather
       // than quietly.
       thresholds: {
-        statements: 88.36,
-        branches: 89.26,
-        functions: 93.04,
-        lines: 88.35,
+        statements: 89.3,
+        branches: 89.45,
+        functions: 93.56,
+        lines: 89.32,
       },
     },
   },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -31,13 +31,14 @@ export default defineConfig({
       //   2. covered code was deleted, which pulls the whole-project ratio
       //      toward the 0% plumbing even though no test was lost.
       // Nothing is excluded to flatter the number: run-gates.mjs,
-      // run-vitest.mjs and check-built-css.mjs sit at 0% on purpose, and all
-      // three drag these figures down in plain sight rather than quietly.
+      // run-vitest.mjs, check-built-css.mjs and check-db.mjs sit at 0% on
+      // purpose, and all four drag these figures down in plain sight rather
+      // than quietly.
       thresholds: {
-        statements: 88.1,
-        branches: 88.66,
-        functions: 92.48,
-        lines: 88.12,
+        statements: 88.36,
+        branches: 89.26,
+        functions: 93.04,
+        lines: 88.35,
       },
     },
   },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -35,10 +35,10 @@ export default defineConfig({
       // purpose, and all four drag these figures down in plain sight rather
       // than quietly.
       thresholds: {
-        statements: 89.3,
-        branches: 89.45,
+        statements: 89.35,
+        branches: 89.52,
         functions: 93.56,
-        lines: 89.32,
+        lines: 89.38,
       },
     },
   },


### PR DESCRIPTION
Closes #74.

Plan: `docs/plans/session-schedule-from-supabase.md`. Decision record: `docs/adr/0008-supabase-reads-over-plain-fetch.md`.

`/art` and `/coop` now render their own program's upcoming published sessions in the slots that were reserved for them. Read-only: nothing bookable, nothing collected, no personal data in the table.

This is also the first code in this repo that talks to Supabase at all, so it decides how the site reads a database — hence an ADR alongside the plan.

## Slices

| Commit | |
|---|---|
| `Write down how the session schedule reaches the site` | Plan + ADR-0008 |
| `Add the sessions table and a command that proves it` | Migration, `npm run check:db`, `Session` in CONTEXT.md |
| `Read the Supabase config at runtime, not from the bundle` | `NEXT_PUBLIC_` dropped, Vercel updated |
| `Record the fifth slice as a dated addendum` | Plan amended, not rewritten |
| `Show the co-op's upcoming sessions on its page` | `lib/sessions.ts`, `SessionSchedule`, `/coop` |
| `Show the art classes' upcoming sessions, with their prices` | `/art` |
| `Stop the IA document calling real schedules a future exercise` | `INFORMATION_ARCHITECTURE.md` |

## Scope, versus the document this came from

The source was a seven-step events module assuming Supabase, R2 and auth were already wired up here. None were. Its vocabulary collided twice with `CONTEXT.md` — which reserves "class" for one session of the art program, and where `event` already means a DOM handler — and its build order opened with a schema-only step CLAUDE.md forbids. What survives is one table, read-only. Steps 3–7 (ICS, RSVP, admin CRUD, Square, Google mirror) are out of scope and undecided.

Three defects in it were corrected rather than copied. The sharpest: `updated_at timestamptz not null default now()` never updates, because a default fires on insert only — present in all four of its tables. Ours has a trigger.

## Gate output

Run at `dc81e20`, rebased onto `main` at `892a4a3`:

```
$ npm run gate

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

460 tests. Coverage rose at every slice and the floor rose with it, from 88.1 / 88.66 / 92.48 / 88.12 to **89.35 / 89.52 / 93.56 / 89.38**. `check-db.mjs` sits at 0% beside `run-gates.mjs`, `run-vitest.mjs` and `check-built-css.mjs`, for the same reason: it is 36 lines of load, print and exit over a fully covered module.

## Database output

Not a gate row — `gates.mjs` treats `skip` as unconditional, so a row needing credentials could never run even locally (#75). It is a command, and this is its output against the live project:

```
$ npm run check:db

  public.sessions — https://<project>.supabase.co

  PASS  config                                        (SUPABASE_URL and both keys are usable)
  PASS  table reachable                               (public.sessions answered)
  PASS  columns                                       (all 12 columns present, none extra)
  PASS  rls: service role sees both probes            (saw 2 of 2)
  PASS  rls: anon sees the published probe            (saw 1)
  PASS  rls: anon is blind to the unpublished probe   (anon saw 1 of 2)
  PASS  constraint: program rejects an unknown value
  PASS  constraint: ends_at must follow starts_at
```

"Anon cannot see the unpublished row" is satisfied vacuously by a table nothing can see into, so it does not stand alone: the command inserts two probe rows under the service role, one published and one not, and requires anon to see exactly one of the two the service role sees. Probes are dated to the year 2000 and swept before and after each run, so one left by a killed process can never reach the site.

Separately, the real payload shape was checked rather than assumed: a published row inserted and read back through the anon key with exactly the query `sessionsUrl` builds returns `starts_at` as `"2099-09-15T20:00:00+00:00"` and `price_cents` as an integer. The probe was removed; the table is empty.

## Things worth a reviewer's attention

**I corrected my own ADR mid-branch.** ADR-0008 argued for an injected `fetch` partly because a stubbed global "would be the first of its kind here". That was already false — `upstream.test.ts` does exactly that, and the conditions work landed while the ADR was being drafted. `lib/sessions.ts` follows `upstream.ts` instead, and the ADR carries a dated amendment rather than having the claim edited away.

**`NEXT_PUBLIC_` was dropped, and it was not cosmetic.** A probe page proved `NEXT_PUBLIC_*` is inlined into the build output even in server code, while an unprefixed variable stays a runtime lookup. Under the prefix, Production's malformed URL could not have been fixed without a redeploy, and Preview — which had no Supabase variables at all — would have baked in `undefined` until every preview was rebuilt. Vercel now holds `SUPABASE_URL` and `SUPABASE_ANON_KEY` across all three environments.

**`location_url` is refused unless it is http(s).** It is typed into Studio by hand and rendered as an `href`, so `javascript:` reaching it would be stored XSS. Refused as drift rather than dropped — that scheme cannot arrive by accident, and one row blanking the schedule with a logged reason gets chased where a silently missing link does not.

**Emptiness and failure look identical to a reader.** Both render the existing `ReservedSlot`; only the server log distinguishes them. Deliberate, and the one place this departs from the conditions panels next door, which must say in words why they cannot answer — a blank tide reading looks like calm water, a missing schedule looks like a missing schedule.

## Not done

- **The slice list grew from four to five**, recorded as a dated addendum rather than by editing the plan's list. Slice 3 also came out thinner than planned: price rendering had already landed in slice 2 because both pages share one component.
- **No `cancelled` flag, no per-session URL, no `/schedule` route.** Each considered and rejected in the plan.
- **`gates.mjs` still cannot express a conditional skip** (#75), so the database check runs by hand.
- **The wizard still accepts a malformed project URL** (#76) — the cause of the `/rest/v1/` suffix that made every request fail with `PGRST125`.
- **`INFORMATION_ARCHITECTURE.md` still does not describe `/conditions/[slug]`** (#78). That clause was the document's only mention of the route; rewriting the sentence around it would have erased it, so it now states the gap instead. Belongs to the conditions work.
- **Nothing seeds real sessions.** Both pages show their reserved slot until Lena adds rows in Studio, which is the intended workflow.