### PR TITLE
Name the stations, instead of stripping their callsigns

### DIFF
--- a/scripts/probe-observation-stations.mjs
+++ b/scripts/probe-observation-stations.mjs
@@ -211,6 +211,114 @@ export const SHORE = {
 };
 
 /**
+ * WHAT TO CALL EACH STATION ON THE PAGE.
+ *
+ * Hand-written, on the same precedent as `SHORE` above and `water` in
+ * `tide-stations.json`: something no authority publishes, written by a person
+ * and recorded where it can be read and argued with.
+ *
+ * The `name` field beside this stays exactly as each network serves it, because
+ * that is the record of what upstream said and the thing a later probe compares
+ * against. It is not prose. The mesonet publishes callsigns
+ * ("EW9951 San Diego Shelter Island   CA US"), the tide network publishes
+ * station numbers ("9410230 - La Jolla, CA"), and the reserve network publishes
+ * instrument sites ("Tidal Linkage, Tijuana River Reserve, CA"). Until the air
+ * panel bound a second station only airports reached a reader, and airports are
+ * named readably; now every panel names two stations.
+ *
+ * A MECHANICAL RULE WAS TRIED FIRST AND CANNOT REACH. Stripping callsigns,
+ * trailing country codes and padding gets both piers right and gets the other
+ * two wrong in a way no further rule fixes: nothing turns "Tidal Linkage" into
+ * something a parent recognises, and "9410230" is the pier's *tide station
+ * number* — the place is Scripps Pier, which no part of the published string
+ * says. See #87.
+ *
+ * THE RULE FOR WRITING ONE: the shortest name a parent looking at a map of this
+ * county would recognise, and nothing that repeats what the sentence around it
+ * already says. The panel writes "Sky and visibility at Miramar, 10 km away.
+ * That is an airport reading", so "Miramar" and not "Miramar MCAS/Mitscher
+ * Field Airport". Where upstream's name is already that, it is reused unchanged
+ * rather than improved for the sake of it.
+ *
+ * A station absent from this map stops the probe, exactly as one absent from
+ * `SHORE` does, so a station that appears in a later listing is named by a
+ * person or the table is not written.
+ */
+export const DISPLAY_NAMES = {
+  // On the shore, and the reason this map exists: every one of these renders as
+  // the source of a temperature a reader is being asked to trust.
+  LJAC1: "Scripps Pier",
+  LJPC1: "Scripps Pier",
+  F1327: "San Clemente Pier",
+  E9951: "Shelter Island",
+  TIXC1: "Tijuana River Estuary",
+  TIQC1: "Oneonta Slough",
+  NPQC1: "South San Diego Bay",
+  SDBC1: "San Diego Bay",
+  SOBSD: "Solana Beach",
+  E3174: "Oceanside",
+  CBDSD: "Carlsbad",
+  E3219: "National City",
+
+  // Airports. The panel's own sentence says "that is an airport reading", so
+  // these do not repeat it.
+  KSAN: "San Diego Airport",
+  KNKX: "Miramar",
+  KNFG: "Camp Pendleton",
+  KOKB: "Oceanside Airport",
+  KCRQ: "Palomar Airport",
+  KMYF: "Montgomery Field",
+  KSDM: "Brown Field",
+  KRNM: "Ramona Airport",
+  KL18: "Fallbrook",
+  KF70: "French Valley Airport",
+
+  // Everywhere else. None of these is bound by any beach today, and each is one
+  // measurement away from being bound, so each is named rather than left to a
+  // future probe to guess at.
+  MSDSD: "Mt. Soledad",
+  DMHSD: "Del Mar Heights",
+  D3101: "Torrey Pines Reserve",
+  E9978: "Encinitas",
+  E9873: "University Heights",
+  MVNSD: "Mission Valley North",
+  PSQC1: "San Pasqual",
+  PAUSD: "Pauma Valley",
+  PZAC1: "Pala",
+  E3055: "Vista",
+  E3236: "Escondido",
+  AU709: "Escondido East",
+  WRBSD: "West Rancho Bernardo",
+  C8688: "Mira Mesa",
+  E3241: "Poway",
+  MSXC1: "Miramar East",
+  SVCSD: "San Vicente",
+  E3619: "Santee",
+  E3309: "Santee East",
+  E9965: "Lakeside",
+  E4858: "El Cajon",
+  E3070: "Rancho San Diego",
+  E3680: "Lemon Grove",
+  D5256: "La Mesa",
+  E2652: "San Diego East",
+  BNASD: "Barona",
+  BVYSD: "Blossom Valley",
+  CSTSD: "Crest",
+  C2462: "Alpine",
+  RINSD: "Rincon",
+  ORTSD: "Ortega",
+  CAPC1: "Bell Canyon",
+  GOSC1: "Bud Hill",
+  VLCC1: "Valley Center",
+  SDMEA: "Murrieta",
+  SDFRV: "French Valley",
+  SRUC1: "Santa Rosa Plateau",
+  E4050: "Mountain Center",
+  OTYC1: "Otay Mountain",
+  PAMC1: "Palomar Mountain",
+};
+
+/**
  * What a run of NWS observations shows the station publishing.
  *
  * `textDescription` is the sky field the site already reads, and a station that
@@ -312,8 +420,18 @@ export function tableRow(station) {
     );
   }
 
+  const displayName = DISPLAY_NAMES[station.id];
+  if (displayName === undefined) {
+    throw new Error(
+      `${station.id} (${station.name}) has no entry in DISPLAY_NAMES. Falling back to the ` +
+        `published name would render a callsign at a reader, so the table is not written. ` +
+        `Name it and re-run.`,
+    );
+  }
+
   return {
     name: station.name,
+    display_name: displayName,
     network: station.network,
     lat: station.lat,
     lon: station.lon,
@@ -403,7 +521,9 @@ export function document(table, now = new Date()) {
       `observations carried a field are deliberately absent from this file: they move on every ` +
       `probe, and a --check that fails from noise stops being read.`,
     _schema: {
-      name: "The station name, reproduced as its network serves it. D3101's carries the run of spaces and the trailing 'CA US' that upstream publishes.",
+      name: "The station name, reproduced as its network serves it, run of spaces and trailing 'CA US' included. A record of what upstream said, and what a later probe compares against. NOT what is shown to a reader -- see display_name.",
+      display_name:
+        "What the page calls this station. Hand-written, like `shore` and like tide-stations.json's `water`, because the published name is an identifier rather than prose for most of these: the mesonet publishes callsigns, the tide network publishes station numbers, and the reserve network publishes instrument sites. The rule is the shortest name someone looking at a map of this county would recognise, saying nothing the sentence around it already says. See #87.",
       network:
         "Which publisher serves this station, and therefore which fetcher reads it: 'nws' for api.weather.gov, 'ndbc' for the realtime2 text product.",
       lat: "Decimal degrees north, from the network's own listing.",

--- a/scripts/probe-observation-stations.test.mjs
+++ b/scripts/probe-observation-stations.test.mjs
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  DISPLAY_NAMES,
   NDBC_BOX,
   NWS_BOX,
   SHORE,
@@ -196,6 +197,59 @@ describe("the table", () => {
     expect(() => tableRow(probed({ id: "XXXXX" }))).toThrow(
       /not classified in SHORE/,
     );
+  });
+
+  it("refuses to write a station nobody has named", () => {
+    // Falling back to the published name would put "EW9951 San Diego Shelter
+    // Island   CA US" in front of a reader, which is what #87 removed. A
+    // station added by a later probe has to be named by a person.
+    //
+    // The guard is unreachable while the two maps agree -- which the assertion
+    // further down requires -- so a classified station is un-named for the
+    // length of this test and put back afterwards.
+    const named = DISPLAY_NAMES.LJAC1;
+    delete DISPLAY_NAMES.LJAC1;
+    try {
+      expect(() => tableRow(probed())).toThrow(/no entry in DISPLAY_NAMES/);
+      expect(() => tableRow(probed())).toThrow(/render a callsign at a reader/);
+    } finally {
+      DISPLAY_NAMES.LJAC1 = named;
+    }
+
+    expect(tableRow(probed()).display_name).toBe("Scripps Pier");
+  });
+
+  it("carries the published name and the display name separately", () => {
+    // The published name is the record of what upstream said and the thing the
+    // next probe diffs against; the display name is what a reader sees. Losing
+    // either one loses something the other cannot do.
+    const row = tableRow(probed());
+
+    expect(row.name).toBe("9410230 - La Jolla, CA");
+    expect(row.display_name).toBe("Scripps Pier");
+  });
+
+  it("names every station it classifies, and classifies every one it names", () => {
+    // Two hand-written maps over the same station set. One growing without the
+    // other is how a station ends up rendering as a callsign, or refusing to
+    // write at all, on a probe nobody is watching.
+    expect(Object.keys(DISPLAY_NAMES).sort()).toEqual(
+      Object.keys(SHORE).sort(),
+    );
+  });
+
+  it("gives no station a display name that is still an identifier", () => {
+    // The whole point. A callsign, a tide station number or a trailing country
+    // code in this map means someone pasted the published name in.
+    for (const [id, name] of Object.entries(DISPLAY_NAMES)) {
+      expect(name, `${id} is named by callsign`).not.toMatch(
+        /^[A-Z]{1,2}\d{4,7}\b/,
+      );
+      expect(name, `${id} is named by station number`).not.toMatch(/^\d{5,7}/);
+      expect(name, `${id} carries a country code`).not.toMatch(/\bCA US\b/);
+      expect(name.trim(), `${id} is padded or empty`).toBe(name);
+      expect(name.length, `${id} is empty`).toBeGreaterThan(0);
+    }
   });
 
   it("carries the hand-written shore flag onto the row", () => {

--- a/src/components/WindToday.test.tsx
+++ b/src/components/WindToday.test.tsx
@@ -3,12 +3,9 @@ import { render, screen } from "@testing-library/react";
 import { WindToday } from "./WindToday";
 
 /** Scripps Pier: what La Jolla Shores now reads for temperature and wind. */
-const PIER = { name: "Scripps Pier, La Jolla", distanceM: 1_381 };
+const PIER = { name: "Scripps Pier", distanceM: 1_381 };
 /** Miramar: what it still reads for sky and visibility, ten kilometres inland. */
-const KNKX = {
-  name: "San Diego, Miramar MCAS/Mitscher Field Airport",
-  distanceM: 10_429,
-};
+const KNKX = { name: "Miramar", distanceM: 10_429 };
 
 const AIR = {
   kind: "reading" as const,
@@ -66,7 +63,7 @@ test("both stations are named, each with its own distance", () => {
   expect(
     screen.getByText(/Temperature and wind measured at Scripps Pier/),
   ).toBeDefined();
-  expect(screen.getByText(/Miramar MCAS.*10 km away/)).toBeDefined();
+  expect(screen.getByText(/Miramar, 10 km away/)).toBeDefined();
 });
 
 test("a near station keeps its distance rather than rounding it away", () => {
@@ -82,48 +79,6 @@ test("the airport says it is an airport, and why that is the only option", () =>
   render(<WindToday {...panel()} />);
 
   expect(screen.getByText(/only published by airports/)).toBeDefined();
-});
-
-test("a station named by its callsign is attributed by its place", () => {
-  // The mesonet publishes "EW9951 San Diego Shelter Island   CA US" and the
-  // tide network publishes "9410230 - La Jolla, CA". Until this panel bound a
-  // second station only airports, which are named in prose, reached a reader.
-  render(
-    <WindToday
-      {...panel({
-        airStation: {
-          name: "EW9951 San Diego Shelter Island   CA US",
-          distanceM: 3_600,
-        },
-      })}
-    />,
-  );
-
-  expect(
-    screen.getByText(/measured at San Diego Shelter Island, 3\.6 km/),
-  ).toBeDefined();
-});
-
-test("a tide-network name loses its station number, not its place", () => {
-  render(
-    <WindToday
-      {...panel({
-        airStation: { name: "9410230 - La Jolla, CA", distanceM: 1_381 },
-      })}
-    />,
-  );
-
-  expect(screen.getByText(/measured at La Jolla, CA/)).toBeDefined();
-});
-
-test("a name that is already prose is left exactly as published", () => {
-  // Nothing is invented here. A station this cannot improve is shown as its
-  // network published it rather than replaced with a name of our own.
-  render(<WindToday {...panel()} />);
-
-  expect(
-    screen.getByText(/San Diego, Miramar MCAS\/Mitscher Field Airport/),
-  ).toBeDefined();
 });
 
 test("the ten-mile ceiling reads as a floor, never as an exact measurement", () => {

--- a/src/components/WindToday.tsx
+++ b/src/components/WindToday.tsx
@@ -35,6 +35,13 @@
  * **Ten miles is a ceiling, not a measurement.** METAR stops there, so the top
  * of the range is rendered "10 miles or more". Reading it as exactly ten would
  * be a precision upstream never claimed.
+ *
+ * **The station names arrive ready to print.** `display_name` is hand-written in
+ * the station table, so nothing here tries to turn a callsign into prose. This
+ * component briefly did, by stripping identifiers and country codes, and it
+ * could not reach the two stations that most needed it — "Tidal Linkage" is not
+ * something a mechanical rule turns into a place, and "9410230" is a tide
+ * station number rather than any part of "Scripps Pier". See #87.
  */
 
 import type { AirView } from "@/lib/conditions";
@@ -78,31 +85,6 @@ function visibilityWords(miles: number, atCeiling: boolean): string {
 function distanceWords(metres: number): string {
   const km = metres / 1000;
   return `${km < 10 ? km.toFixed(1) : km.toFixed(0)} km`;
-}
-
-/**
- * The station's name with the parts that are not a name taken off.
- *
- * The table stores what each network publishes, unedited, because it is a
- * record of what upstream said. Airports are named in prose there and the rest
- * are not: the mesonet publishes "EW9951 San Diego Shelter Island   CA US" and
- * the tide network publishes "9410230 - La Jolla, CA". Until this panel bound a
- * second station only airports ever reached a reader, so this is new work rather
- * than a tidy-up.
- *
- * Three removals, each of something that is an identifier or a country rather
- * than a place: a leading callsign-style token, a trailing "CA US", and the runs
- * of padding whitespace. Nothing is added — a name that is already prose comes
- * through untouched, and a name this cannot improve is shown as published rather
- * than replaced with something invented.
- */
-function stationWords(name: string): string {
-  return name
-    .replace(/^[A-Z]{1,2}\d{4,7}\s+/, "")
-    .replace(/^\d{7}\s*-\s*/, "")
-    .replace(/\s+CA\s+US$/, "")
-    .replace(/\s+/g, " ")
-    .trim();
 }
 
 /** The wind, as a sentence, or the reason there is not one. */
@@ -210,7 +192,7 @@ export function WindToday({
       <div className="text-2xs leading-relaxed text-fog">
         {airStation !== null && (
           <p>
-            Temperature and wind measured at {stationWords(airStation.name)}
+            Temperature and wind measured at {airStation.name}
             {airStation.distanceM !== null
               ? `, ${distanceWords(airStation.distanceM)} from this beach`
               : ""}
@@ -219,7 +201,7 @@ export function WindToday({
         )}
         {skyStation !== null && (
           <p>
-            Sky and visibility at {stationWords(skyStation.name)}
+            Sky and visibility at {skyStation.name}
             {skyStation.distanceM !== null
               ? `, ${distanceWords(skyStation.distanceM)} away`
               : ""}

--- a/src/data/weather-stations.json
+++ b/src/data/weather-stations.json
@@ -4,7 +4,8 @@
   "_provenance": "Measured by scripts/probe-observation-stations.mjs; re-runnable and diffable with --check. National Weather Service candidates are the union of https://api.weather.gov/gridpoints/<grid>/stations over every distinct gridpoint the beaches in beaches.json resolve to, filtered to 32.4-33.6N and -117.7 to -116.8E: 56 stations. The state-wide listing at /stations?state=CA is NOT the source; it is capped at 500 results and truncates before reaching either KSAN or KNKX. NDBC candidates are https://www.ndbc.noaa.gov/activestations.xml filtered to the wave corridor box 32.4-33.5N and -118.2 to -117E AND to type \"fixed\": 6 stations. That type filter is the criterion that lost both Scripps Pier stations from wave-buoys.json, so it is stated here rather than applied silently -- NDBC's buoys are that table's subject, eleven of the thirteen in the box publish no air temperature or wind at all, and the one that publishes both, 46086, is twenty-seven nautical miles offshore and out of every beach's reach. Capability was then measured one station at a time against the endpoints this site reads -- /stations/<id>/observations for NWS, https://www.ndbc.noaa.gov/data/realtime2/<id>.txt for NDBC -- rather than inferred from either listing.",
   "_what_was_measured": "6 observations per station; a field counts as published if it appears on at least one of them. Of 62 candidates, 60 deliver, 56 publish air temperature and wind together, and 10 publish sky. So the pool an air join ranks over is 56 stations and not the thirteen a visibility-shaped probe recorded. Sky and visibility are one capability: both were measured, and they select exactly the same stations -- every one an airport METAR -- with sky the scarcer of the two per observation. Only publishes_sky is stored, because two flags for one capability are two things that can drift apart while naming one. Counts of how many of the six observations carried a field are deliberately absent from this file: they move on every probe, and a --check that fails from noise stops being read.",
   "_schema": {
-    "name": "The station name, reproduced as its network serves it. D3101's carries the run of spaces and the trailing 'CA US' that upstream publishes.",
+    "name": "The station name, reproduced as its network serves it, run of spaces and trailing 'CA US' included. A record of what upstream said, and what a later probe compares against. NOT what is shown to a reader -- see display_name.",
+    "display_name": "What the page calls this station. Hand-written, like `shore` and like tide-stations.json's `water`, because the published name is an identifier rather than prose for most of these: the mesonet publishes callsigns, the tide network publishes station numbers, and the reserve network publishes instrument sites. The rule is the shortest name someone looking at a map of this county would recognise, saying nothing the sentence around it already says. See #87.",
     "network": "Which publisher serves this station, and therefore which fetcher reads it: 'nws' for api.weather.gov, 'ndbc' for the realtime2 text product.",
     "lat": "Decimal degrees north, from the network's own listing.",
     "lon": "Decimal degrees east, negative for west.",
@@ -19,6 +20,7 @@
   "stations": {
     "SDFRV": {
       "name": "French Valley",
+      "display_name": "French Valley",
       "network": "nws",
       "lat": 33.597,
       "lon": -117.088,
@@ -31,6 +33,7 @@
     },
     "KF70": {
       "name": "Murrieta/Temecula French Valley",
+      "display_name": "French Valley Airport",
       "network": "nws",
       "lat": 33.5742,
       "lon": -117.1285,
@@ -43,6 +46,7 @@
     },
     "ORTSD": {
       "name": "Ortega",
+      "display_name": "Ortega",
       "network": "nws",
       "lat": 33.56957,
       "lon": -117.51384,
@@ -55,6 +59,7 @@
     },
     "SDMEA": {
       "name": "Murrieta",
+      "display_name": "Murrieta",
       "network": "nws",
       "lat": 33.5681,
       "lon": -117.2522,
@@ -67,6 +72,7 @@
     },
     "E4050": {
       "name": "EW4050 Mountain Center",
+      "display_name": "Mountain Center",
       "network": "nws",
       "lat": 33.561,
       "lon": -117.3165,
@@ -79,6 +85,7 @@
     },
     "CAPC1": {
       "name": "BELL CANYON",
+      "display_name": "Bell Canyon",
       "network": "nws",
       "lat": 33.55183,
       "lon": -117.57294,
@@ -91,6 +98,7 @@
     },
     "SRUC1": {
       "name": "SANTA ROSA PLATEAU",
+      "display_name": "Santa Rosa Plateau",
       "network": "nws",
       "lat": 33.5181,
       "lon": -117.22906,
@@ -103,6 +111,7 @@
     },
     "F1327": {
       "name": "FW1327 San Clemente Pier          CA US",
+      "display_name": "San Clemente Pier",
       "network": "nws",
       "lat": 33.41917,
       "lon": -117.621,
@@ -115,6 +124,7 @@
     },
     "PAUSD": {
       "name": "Pauma Valley",
+      "display_name": "Pauma Valley",
       "network": "nws",
       "lat": 33.37116,
       "lon": -117.07896,
@@ -127,6 +137,7 @@
     },
     "PZAC1": {
       "name": "PALA",
+      "display_name": "Pala",
       "network": "nws",
       "lat": 33.36111,
       "lon": -117.10583,
@@ -139,6 +150,7 @@
     },
     "KL18": {
       "name": "Fallbrook Community Airpark",
+      "display_name": "Fallbrook",
       "network": "nws",
       "lat": 33.3542,
       "lon": -117.2509,
@@ -151,6 +163,7 @@
     },
     "PAMC1": {
       "name": "PALOMAR",
+      "display_name": "Palomar Mountain",
       "network": "nws",
       "lat": 33.35207,
       "lon": -116.86273,
@@ -163,6 +176,7 @@
     },
     "KNFG": {
       "name": "Oceanside, Camp Pendleton, Marine Corps Air Station",
+      "display_name": "Camp Pendleton",
       "network": "nws",
       "lat": 33.30472,
       "lon": -117.35389,
@@ -175,6 +189,7 @@
     },
     "RINSD": {
       "name": "Rincon",
+      "display_name": "Rincon",
       "network": "nws",
       "lat": 33.28783,
       "lon": -116.95643,
@@ -187,6 +202,7 @@
     },
     "VLCC1": {
       "name": "VALLEY CENTER",
+      "display_name": "Valley Center",
       "network": "nws",
       "lat": 33.23701,
       "lon": -117.00859,
@@ -199,6 +215,7 @@
     },
     "E3055": {
       "name": "EW3055 Vista",
+      "display_name": "Vista",
       "network": "nws",
       "lat": 33.23533,
       "lon": -117.23233,
@@ -211,6 +228,7 @@
     },
     "AU709": {
       "name": "AU709 Escondido",
+      "display_name": "Escondido East",
       "network": "nws",
       "lat": 33.225,
       "lon": -117.11467,
@@ -223,6 +241,7 @@
     },
     "KOKB": {
       "name": "Oceanside, Oceanside Municipal Airport",
+      "display_name": "Oceanside Airport",
       "network": "nws",
       "lat": 33.21806,
       "lon": -117.35139,
@@ -235,6 +254,7 @@
     },
     "E3174": {
       "name": "EW3174 Oceanside",
+      "display_name": "Oceanside",
       "network": "nws",
       "lat": 33.20983,
       "lon": -117.39433,
@@ -247,6 +267,7 @@
     },
     "CBDSD": {
       "name": "Carlsbad",
+      "display_name": "Carlsbad",
       "network": "nws",
       "lat": 33.13742,
       "lon": -117.32712,
@@ -259,6 +280,7 @@
     },
     "KCRQ": {
       "name": "Carlsbad, McClellan-Palomar Airport",
+      "display_name": "Palomar Airport",
       "network": "nws",
       "lat": 33.13,
       "lon": -117.27583,
@@ -271,6 +293,7 @@
     },
     "E3236": {
       "name": "EW3236 Escondido",
+      "display_name": "Escondido",
       "network": "nws",
       "lat": 33.12117,
       "lon": -117.08983,
@@ -283,6 +306,7 @@
     },
     "PSQC1": {
       "name": "SAN PASQUAL",
+      "display_name": "San Pasqual",
       "network": "nws",
       "lat": 33.09139,
       "lon": -117.01222,
@@ -295,6 +319,7 @@
     },
     "GOSC1": {
       "name": "BUD HILL",
+      "display_name": "Bud Hill",
       "network": "nws",
       "lat": 33.08432,
       "lon": -116.8769,
@@ -307,6 +332,7 @@
     },
     "E9978": {
       "name": "EW9978 Encinitas",
+      "display_name": "Encinitas",
       "network": "nws",
       "lat": 33.058,
       "lon": -117.25367,
@@ -319,6 +345,7 @@
     },
     "KRNM": {
       "name": "Ramona, Ramona Airport",
+      "display_name": "Ramona Airport",
       "network": "nws",
       "lat": 33.0375,
       "lon": -116.91583,
@@ -331,6 +358,7 @@
     },
     "WRBSD": {
       "name": "West Rancho Bernardo",
+      "display_name": "West Rancho Bernardo",
       "network": "nws",
       "lat": 33.0312,
       "lon": -117.12233,
@@ -343,6 +371,7 @@
     },
     "E2652": {
       "name": "EW2652 San Diego",
+      "display_name": "San Diego East",
       "network": "nws",
       "lat": 33.022,
       "lon": -117.08267,
@@ -355,6 +384,7 @@
     },
     "SOBSD": {
       "name": "Solana Beach",
+      "display_name": "Solana Beach",
       "network": "nws",
       "lat": 33.00733,
       "lon": -117.27623,
@@ -367,6 +397,7 @@
     },
     "DMHSD": {
       "name": "Del Mar Heights",
+      "display_name": "Del Mar Heights",
       "network": "nws",
       "lat": 32.96404,
       "lon": -117.22284,
@@ -379,6 +410,7 @@
     },
     "E3241": {
       "name": "EW3241 Poway",
+      "display_name": "Poway",
       "network": "nws",
       "lat": 32.9605,
       "lon": -117.01917,
@@ -391,6 +423,7 @@
     },
     "BNASD": {
       "name": "Barona",
+      "display_name": "Barona",
       "network": "nws",
       "lat": 32.93442,
       "lon": -116.87602,
@@ -403,6 +436,7 @@
     },
     "C8688": {
       "name": "CW8688 Mira Mesa",
+      "display_name": "Mira Mesa",
       "network": "nws",
       "lat": 32.92933,
       "lon": -117.131,
@@ -415,6 +449,7 @@
     },
     "D3101": {
       "name": "DW3101 Torrey Pines Reserve       CA US",
+      "display_name": "Torrey Pines Reserve",
       "network": "nws",
       "lat": 32.92083,
       "lon": -117.25283,
@@ -427,6 +462,7 @@
     },
     "SVCSD": {
       "name": "San Vicente",
+      "display_name": "San Vicente",
       "network": "nws",
       "lat": 32.91248,
       "lon": -116.95211,
@@ -439,6 +475,7 @@
     },
     "MSXC1": {
       "name": "MIRAMAR EAST",
+      "display_name": "Miramar East",
       "network": "nws",
       "lat": 32.87547,
       "lon": -117.05956,
@@ -451,6 +488,7 @@
     },
     "KNKX": {
       "name": "San Diego, Miramar MCAS/Mitscher Field Airport",
+      "display_name": "Miramar",
       "network": "nws",
       "lat": 32.86833,
       "lon": -117.1425,
@@ -463,6 +501,7 @@
     },
     "BVYSD": {
       "name": "Blossom Valley",
+      "display_name": "Blossom Valley",
       "network": "nws",
       "lat": 32.8678,
       "lon": -116.84305,
@@ -475,6 +514,7 @@
     },
     "LJAC1": {
       "name": "9410230 - La Jolla, CA",
+      "display_name": "Scripps Pier",
       "network": "ndbc",
       "lat": 32.867,
       "lon": -117.257,
@@ -487,6 +527,7 @@
     },
     "LJPC1": {
       "name": "La Jolla, CA (073)",
+      "display_name": "Scripps Pier",
       "network": "ndbc",
       "lat": 32.867,
       "lon": -117.257,
@@ -499,6 +540,7 @@
     },
     "E3309": {
       "name": "EW3309 Santee",
+      "display_name": "Santee East",
       "network": "nws",
       "lat": 32.8625,
       "lon": -117.002,
@@ -511,6 +553,7 @@
     },
     "E3619": {
       "name": "EW3619 Santee",
+      "display_name": "Santee",
       "network": "nws",
       "lat": 32.85417,
       "lon": -117,
@@ -523,6 +566,7 @@
     },
     "E9965": {
       "name": "EW9965 Lakeside",
+      "display_name": "Lakeside",
       "network": "nws",
       "lat": 32.84133,
       "lon": -116.89283,
@@ -535,6 +579,7 @@
     },
     "C2462": {
       "name": "CW2462 Alpine",
+      "display_name": "Alpine",
       "network": "nws",
       "lat": 32.8155,
       "lon": -116.81383,
@@ -547,6 +592,7 @@
     },
     "KMYF": {
       "name": "San Diego, Montgomery Field",
+      "display_name": "Montgomery Field",
       "network": "nws",
       "lat": 32.81444,
       "lon": -117.13639,
@@ -559,6 +605,7 @@
     },
     "MSDSD": {
       "name": "Mt. Soledad",
+      "display_name": "Mt. Soledad",
       "network": "nws",
       "lat": 32.81418,
       "lon": -117.24088,
@@ -571,6 +618,7 @@
     },
     "CSTSD": {
       "name": "Crest",
+      "display_name": "Crest",
       "network": "nws",
       "lat": 32.8115,
       "lon": -116.85432,
@@ -583,6 +631,7 @@
     },
     "E4858": {
       "name": "EW4858 El Cajon",
+      "display_name": "El Cajon",
       "network": "nws",
       "lat": 32.8005,
       "lon": -116.92867,
@@ -595,6 +644,7 @@
     },
     "MVNSD": {
       "name": "Mission Valley North",
+      "display_name": "Mission Valley North",
       "network": "nws",
       "lat": 32.78137,
       "lon": -117.13758,
@@ -607,6 +657,7 @@
     },
     "D5256": {
       "name": "DW5256 La Mesa",
+      "display_name": "La Mesa",
       "network": "nws",
       "lat": 32.76633,
       "lon": -117.01333,
@@ -619,6 +670,7 @@
     },
     "E9873": {
       "name": "EW9873 San Diego University HeightsCA US",
+      "display_name": "University Heights",
       "network": "nws",
       "lat": 32.76033,
       "lon": -117.15417,
@@ -631,6 +683,7 @@
     },
     "E3070": {
       "name": "EW3070 Rancho San Diego",
+      "display_name": "Rancho San Diego",
       "network": "nws",
       "lat": 32.74217,
       "lon": -116.93667,
@@ -643,6 +696,7 @@
     },
     "E3680": {
       "name": "EW3680 Lemon Grove",
+      "display_name": "Lemon Grove",
       "network": "nws",
       "lat": 32.73867,
       "lon": -117.02983,
@@ -655,6 +709,7 @@
     },
     "KSAN": {
       "name": "San Diego International Airport",
+      "display_name": "San Diego Airport",
       "network": "nws",
       "lat": 32.73361,
       "lon": -117.18306,
@@ -667,6 +722,7 @@
     },
     "E9951": {
       "name": "EW9951 San Diego Shelter Island   CA US",
+      "display_name": "Shelter Island",
       "network": "nws",
       "lat": 32.71497,
       "lon": -117.22566,
@@ -679,6 +735,7 @@
     },
     "SDBC1": {
       "name": "9410170 - San Diego, CA",
+      "display_name": "San Diego Bay",
       "network": "ndbc",
       "lat": 32.714,
       "lon": -117.174,
@@ -691,6 +748,7 @@
     },
     "E3219": {
       "name": "EW3219 National City",
+      "display_name": "National City",
       "network": "nws",
       "lat": 32.6705,
       "lon": -117.10083,
@@ -703,6 +761,7 @@
     },
     "NPQC1": {
       "name": "South Bay, Tijuana River Reserve, CA",
+      "display_name": "South San Diego Bay",
       "network": "ndbc",
       "lat": 32.601,
       "lon": -117.116,
@@ -716,6 +775,7 @@
     },
     "OTYC1": {
       "name": "OTAY MOUNTAIN",
+      "display_name": "Otay Mountain",
       "network": "nws",
       "lat": 32.60092,
       "lon": -116.84103,
@@ -728,6 +788,7 @@
     },
     "KSDM": {
       "name": "San Diego, Brown Field Municipal Airport",
+      "display_name": "Brown Field",
       "network": "nws",
       "lat": 32.57528,
       "lon": -116.99306,
@@ -740,6 +801,7 @@
     },
     "TIXC1": {
       "name": "Tidal Linkage, Tijuana River Reserve, CA",
+      "display_name": "Tijuana River Estuary",
       "network": "ndbc",
       "lat": 32.575,
       "lon": -117.127,
@@ -752,6 +814,7 @@
     },
     "TIQC1": {
       "name": "Oneonta Slough, Tijuana River Reserve, CA",
+      "display_name": "Oneonta Slough",
       "network": "ndbc",
       "lat": 32.568,
       "lon": -117.131,

--- a/src/lib/beaches.ts
+++ b/src/lib/beaches.ts
@@ -101,7 +101,17 @@ export interface WaveBuoy {
 }
 
 export interface WeatherStation {
+  /**
+   * As the station's network publishes it, callsign and padding included. The
+   * record of what upstream said, and never what is rendered -- see
+   * `display_name`.
+   */
   name: string;
+  /**
+   * What the page calls this station. Hand-written in the probe, because the
+   * published name is an identifier rather than prose for most of these.
+   */
+  display_name: string;
   lat: number;
   lon: number;
   /** Measured, not assumed. A station that does not deliver is kept and marked. */

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -282,7 +282,9 @@ test("temperature and wind come from the pier, sky and visibility from the airpo
 
   const view = await readLatestAir(BEACH, NOON_PACIFIC_20260817);
 
-  expect(view.airStation?.name).toMatch(/La Jolla/);
+  // The display name, not the "9410230 - La Jolla, CA" the tide network
+  // publishes: what reaches the view is what the page prints.
+  expect(view.airStation?.name).toBe("Scripps Pier");
   expect(view.airStation?.distanceM).toBe(1381);
   expect(view.skyStation?.name).toMatch(/Miramar/);
   expect(view.skyStation?.distanceM).toBe(10429);

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -267,6 +267,7 @@ export type SkyState =
   | { kind: "unavailable"; detail: string; drift: boolean };
 
 export interface StationBinding {
+  /** The station's display name: what the page calls it, never its callsign. */
   name: string;
   distanceM: number | null;
 }
@@ -325,14 +326,14 @@ export async function readLatestAir(
       airStation === null
         ? null
         : {
-            name: airStation.name,
+            name: airStation.display_name,
             distanceM: beach.air_station_distance_m,
           },
     skyStation:
       skyStation === null
         ? null
         : {
-            name: skyStation.name,
+            name: skyStation.display_name,
             distanceM: beach.weather_station_distance_m,
           },
     air,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -35,10 +35,10 @@ export default defineConfig({
       // purpose, and all four drag these figures down in plain sight rather
       // than quietly.
       thresholds: {
-        statements: 89.34,
-        branches: 89.25,
-        functions: 94.29,
-        lines: 89.17,
+        statements: 89.36,
+        branches: 89.28,
+        functions: 94.27,
+        lines: 89.2,
       },
     },
   },


### PR DESCRIPTION
Follow-up to #80, decided with Cole after reading the panel it shipped.

The air panel names two stations on every beach page. Four of the nine stations
the air join binds were named by identifier, because the table stores what each
network publishes and only airports are published readably:

```
beaches  id      published                                  rendered before
     14  LJAC1   9410230 - La Jolla, CA                     La Jolla, CA
     12  E9951   EW9951 San Diego Shelter Island   CA US    San Diego Shelter Island
      7  TIXC1   Tidal Linkage, Tijuana River Reserve, CA   Tidal Linkage, Tijuana River Reserve, CA
      1  F1327   FW1327 San Clemente Pier          CA US    San Clemente Pier
```

## The panel now

```
Air · La Jolla Shores Beach

71°F

Wind 8 mph from the north-west, gusting 10. Sky: clear. Visibility 10 miles or more.

Temperature and wind measured at Scripps Pier, 1.4 km from this beach.
Sky and visibility at Miramar, 10 km away. That is an airport reading rather
than one taken at the shore: cloud and visibility are only published by
airports, and coastal fog is exactly what changes across that distance.
```

## What changed

`WindToday` tried to fix this mechanically — stripping leading callsigns, a
trailing `CA US` and padding runs. **Those regexes are gone.** They reach the two
piers and cannot reach the other two: no rule turns "Tidal Linkage" into a place
a parent recognises, and "9410230" is the pier's *tide station number* — the
place is Scripps Pier, which no part of the published string says.

`display_name` is hand-written per station, on the precedent `shore` set in this
same table and `water` set in `tide-stations.json`: an input no authority
publishes, written by a person and recorded where it can be read and argued with.

`name` is untouched and still exactly what each network serves. It is the record
of what upstream said and the thing the next probe diffs against; it is simply
never what a reader sees.

**The naming rule, written above the map:** the shortest name someone looking at
a map of this county would recognise, saying nothing the sentence around it
already says. The panel writes "Sky and visibility at Miramar, 10 km away. That
is an airport reading", so the airports do not repeat the word — `KNKX` is
"Miramar", not "Miramar MCAS/Mitscher Field Airport". Where upstream's name is
already that, it is reused unchanged rather than improved for its own sake:
"Mt. Soledad", "Solana Beach" and "Carlsbad" are untouched.

## The guard

The probe **refuses to write a station with no display name**, the way it already
refuses one with no `shore`. Falling back to the published name is the exact
behaviour being removed, so there is no fallback.

Two assertions hold that in place, both of which would otherwise fail silently on
a probe nobody is watching:

- the two hand-written maps cover the same 62 stations — one growing without the
  other is how a station ends up rendering as a callsign, or refusing to write at
  all;
- no entry is itself a callsign, a station number, a `CA US` suffix, or padded —
  which is what pasting the published name in would look like.

The refusal path is unreachable while the maps agree, so the test un-names one
station for its own length and restores it.

## Verification

```
$ npm run gate

… format
… lint
… typecheck
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

Nothing about the data moved except the new field — both generators re-derive
their files:

```
$ node scripts/probe-observation-stations.mjs --check
weather-stations.json is current: 62 stations, capabilities unchanged.

$ node scripts/seed-beaches.mjs --check
beaches.json is current: 73 beaches, join unchanged.
```

Coverage rose on statements, branches and lines. **Functions fell 94.29 → 94.27**
because deleting `stationWords` removed a covered function — reason 2 in
`vitest.config.mts`'s own list, and no test was lost.

## What this is, and is not

The names are the whole content of this PR and **no gate can tell you one is
wrong**. Worth your eye specifically:

- `LJAC1` / `LJPC1` → **Scripps Pier**. Both are at 32.867, −117.257 and both are
  the pier; the site has always called it that in the plan and the ADR.
- `TIXC1` → **Tijuana River Estuary**, against upstream's "Tidal Linkage", which
  is the instrument site inside the reserve.
- `E9951` → **Shelter Island**, dropping the "San Diego" upstream prefixes onto
  it, since the panel already names the beach.
- `KSAN` → **San Diego Airport**, the one place I shortened a name that was
  already prose.

The 39 stations no beach binds are named too, rather than left for a later probe
to guess at — each is one measurement away from being bound.

Closes #87
Relates to #80
