### PR TITLE
Record the inventory bound, and correct two beaches typed as the wrong water

### DIFF
--- a/docs/adr/0011-inventory-bounded-by-station-networks.md
+++ b/docs/adr/0011-inventory-bounded-by-station-networks.md
@@ -1,6 +1,7 @@
 # 0011 — The inventory is bounded by the station networks
 
-Date: 2026-08-19. Status: accepted.
+Date: 2026-08-19. Status: accepted. Decision amended 2026-08-19; see the
+amendment at the foot of this file.
 
 ## Context
 
@@ -47,10 +48,12 @@ listing the beach.
 ## Decision
 
 **A beach is in the inventory only if the stations it needs reach it within
-10 km.** Tide within 10 km, and — unless the beach is a bay or lagoon, where
-binding no buoy is already the correct answer — a wave buoy within 10 km. Air is
-not in the predicate; every bound beach already reads air within 7.4 km, so the
-clause would exclude nobody and imply a filter doing work it is not doing.
+10 km.** Its tide station is within 10 km, and if a wave buoy is bound at all,
+that buoy is within 10 km. A beach fails when a binding it _has_ is too far,
+never when a join correctly declined to make one — which is what a bay, or a
+cove closed off by a breakwater, does with a buoy. Air is not in the predicate;
+every bound beach already reads air within 7.4 km, so the clause would exclude
+nobody and imply a filter doing work it is not doing.
 
 Ten kilometres is WMO §1.1.2's stated scale for small-scale and local
 applications. It is a benchmark and not a rule, and it is recorded here as a
@@ -73,11 +76,14 @@ The plan is `docs/plans/inventory-bounded-by-stations.md`.
 
 ## Consequences
 
-**The site answers for 40 beaches instead of 73.** That is the cost and it is
-the point: the 33 it drops are the ones whose numbers it could not defend. What
-remains is La Jolla and Pacific Beach, the Mission Bay and San Diego Bay group,
-Point Loma and Ocean Beach, and the Del Mar run — every one with a tide station
-within 10 km and, on the open coast, a buoy within 10 km.
+**The site answers for 41 beaches instead of 73.** That is the cost and it is
+the point: the 32 it drops are the ones whose numbers it could not defend. What
+remains, by the region labels the seeding script already assigns: 25 bays,
+lagoons and inlets, 13 in La Jolla and Pacific Beach — which by that rule
+includes Del Mar City Beach and both Torrey Pines — and 3 in Point Loma and
+Ocean Beach. No beach survives north of Del Mar or south of Ocean Beach. Every
+one has a tide station within 10 km, and none is bound to a buoy further away
+than that.
 
 **The whole North County coast goes, and its air and wave bindings were the best
 on the site** — 0.3–5.1 km and 1.0–4.7 km. Only tide fails there, and it fails
@@ -100,12 +106,14 @@ segment endpoints are 65.5 km apart and which binds nothing at all, and
 `tide-beach-park`, recorded 34 km from the city it names. Their coordinates are
 not corrected here — this repo is not an authority on where beaches are.
 
-**Two beaches are reclassified rather than excluded.** `fiesta-island` is typed
-open coast inside Mission Bay and `childrens-pool` is typed bay on the open
-ocean. A slug-keyed override joins `tide-stations.json`'s `water` and
-`weather-stations.json`'s `shore` as a hand-written join input with a written
-reason — three now, which is the point at which the pattern should be named
-rather than repeated a fourth time.
+**Two beaches are reclassified rather than excluded**, and one of them needs a
+second input to say what its class cannot. `fiesta-island` is typed open coast
+inside Mission Bay. `childrens-pool` is typed bay on the open ocean, and is
+both open coast for its tide and closed to swell by a breakwater — so a
+`sheltered` flag sits beside the class override, read by the wave join alone.
+That makes three hand-written join inputs alongside `tide-stations.json`'s
+`water` and `weather-stations.json`'s `shore`, which is the point at which the
+pattern should be named rather than repeated a fourth time.
 
 **What this does not decide.** Sky and visibility come from an airport METAR at
 1.6–16.8 km at every beach, including the best-bound ones, and the reference
@@ -113,3 +121,19 @@ above holds that aerodrome observations should not be transferred off-field at
 any distance. No tightening of this predicate fixes that, because the problem is
 the network rather than the reach. It is left open deliberately and named in the
 plan's out-of-scope list.
+
+## Amendment — 2026-08-19
+
+The decision above originally stated the wave clause as "unless the beach is a
+bay or lagoon ... a wave buoy within 10 km", and its consequence as 40 beaches
+kept against 33 dropped. Measuring the two reclassifications against the real
+joins showed that form cuts a beach for lacking a buoy the join was right to
+withhold, so the clause is restated above in the form that separates a binding
+that is too far from a binding correctly not made. The counts are 41 and 32.
+
+The argument is unchanged. What changed is that the water class turned out to
+answer two questions — which water body's level applies here, and whether ocean
+swell reaches this water. They coincide at 71 of 73 beaches and diverge at
+Children's Pool, where a breakwater stands between the two answers. The addendum
+of the same date in `docs/plans/inventory-bounded-by-stations.md` records the
+measurement that found it.

--- a/docs/adr/0011-inventory-bounded-by-station-networks.md
+++ b/docs/adr/0011-inventory-bounded-by-station-networks.md
@@ -1,0 +1,115 @@
+# 0011 — The inventory is bounded by the station networks
+
+Date: 2026-08-19. Status: accepted.
+
+## Context
+
+The site answers for every beach the county lists: 73 of them, from a predicate
+over the state's open data that is deliberately free of judgement — County San
+Diego, Status Active, BeachAccess PUBLIC, CountAsBeach 1.
+
+Nothing bounded the _other_ end. Each join binds the nearest delivering station
+of the right kind, with no ceiling, so a beach the networks cannot reach gets a
+number anyway from whatever is furthest away. Measured over the committed
+`beaches.json` on 2026-08-19:
+
+```
+variable  bound   p50     p90     max     >10km
+tide         72   4.1 km  30.6 km 56.6 km    27
+wave         46   5.9 km  27.9 km 34.2 km    14
+air          72   3.5 km   5.4 km  7.4 km     0
+sky          72   7.3 km  13.4 km 16.8 km    28
+```
+
+Air is bounded in practice, and it is bounded because #80 rebuilt its candidate
+set rather than letting the join reach further. Tide and waves never got that
+treatment, and there is nothing further to reach for: `tide-stations.json` holds
+two delivering open-coast stations, the northernmost at 32.867 °N against a
+county running to 33.39 °N, and no wave buoy sits between 32.868 °N and
+32.517 °N. Twenty-six beaches read a tide station over 15 km away because the
+network ends, not because the join is wrong.
+
+`docs/reference/sensor-representativeness.md` settles what may be concluded from
+a distance. Three points bear:
+
+- **No standard reporting radius exists.** WMO-No. 8 §1.1.2 makes
+  representativeness a property of the application, not of the observation. A
+  threshold is ours to state and defend; it cannot be cited to an authority.
+- **Validity is per variable** (EPA-454/R-99-005 §3.1). Excluding one does not
+  exclude the rest from the same station.
+- **An intervening boundary fails at any distance.** Distance alone is not the
+  criterion, in either direction.
+
+So the choice is not between a right radius and a wrong one. It is between
+publishing a number whose provenance we would not defend if asked, and not
+listing the beach.
+
+## Decision
+
+**A beach is in the inventory only if the stations it needs reach it within
+10 km.** Tide within 10 km, and — unless the beach is a bay or lagoon, where
+binding no buoy is already the correct answer — a wave buoy within 10 km. Air is
+not in the predicate; every bound beach already reads air within 7.4 km, so the
+clause would exclude nobody and imply a filter doing work it is not doing.
+
+Ten kilometres is WMO §1.1.2's stated scale for small-scale and local
+applications. It is a benchmark and not a rule, and it is recorded here as a
+choice rather than as a citation. It is a named constant precisely so that
+changing it is a one-line, reviewable decision.
+
+**The bound is a predicate over the join result, not a list of beaches.** It is
+computed by `seed-beaches.mjs` and re-derivable by `--check`, so a beach
+appearing or moving upstream is judged by the same rule without anyone
+remembering to. A curated list would be invisible to `--check` in exactly the
+way the station tables were before #80 — which is how both Scripps Pier stations
+were lost.
+
+**Every exclusion is recorded with the distance that caused it**, in an
+`_excluded` block in `beaches.json` and in what the site tells a reader. A beach
+that disappears without a reason is the silent failure this repo's `unresolved`
+blocks exist to prevent.
+
+The plan is `docs/plans/inventory-bounded-by-stations.md`.
+
+## Consequences
+
+**The site answers for 40 beaches instead of 73.** That is the cost and it is
+the point: the 33 it drops are the ones whose numbers it could not defend. What
+remains is La Jolla and Pacific Beach, the Mission Bay and San Diego Bay group,
+Point Loma and Ocean Beach, and the Del Mar run — every one with a tide station
+within 10 km and, on the open coast, a buoy within 10 km.
+
+**The whole North County coast goes, and its air and wave bindings were the best
+on the site** — 0.3–5.1 km and 1.0–4.7 km. Only tide fails there, and it fails
+for all fourteen at once because Scripps is the northernmost open-coast station.
+This is the sharpest consequence of choosing removal over per-variable
+suppression, and it is the thing to revisit first if the decision is revisited:
+the machinery to hide one panel already exists, since every panel carries a
+`no-station` state with a reason. What was rejected was not the mechanism but
+the outcome — a beach page with two panels and a hole answers "should we go
+here" worse than no page at all.
+
+**Coverage becomes a measurement rather than an ambition.** "73 beaches" was
+never a claim about what the site could measure; it was a claim about what the
+county lists. Forty is the first number this repo has published about its own
+reach that is true.
+
+**Two upstream rows are excluded for being wrong rather than far**, and the
+predicate catches them without naming them: `imperial-beach-pier-area`, whose
+segment endpoints are 65.5 km apart and which binds nothing at all, and
+`tide-beach-park`, recorded 34 km from the city it names. Their coordinates are
+not corrected here — this repo is not an authority on where beaches are.
+
+**Two beaches are reclassified rather than excluded.** `fiesta-island` is typed
+open coast inside Mission Bay and `childrens-pool` is typed bay on the open
+ocean. A slug-keyed override joins `tide-stations.json`'s `water` and
+`weather-stations.json`'s `shore` as a hand-written join input with a written
+reason — three now, which is the point at which the pattern should be named
+rather than repeated a fourth time.
+
+**What this does not decide.** Sky and visibility come from an airport METAR at
+1.6–16.8 km at every beach, including the best-bound ones, and the reference
+above holds that aerodrome observations should not be transferred off-field at
+any distance. No tightening of this predicate fixes that, because the problem is
+the network rather than the reach. It is left open deliberately and named in the
+plan's out-of-scope list.

--- a/docs/plans/inventory-bounded-by-stations.md
+++ b/docs/plans/inventory-bounded-by-stations.md
@@ -258,3 +258,105 @@ that is true regardless.
   `docs/plans/coastal-air-observations.md` and still deferred.
 - **Re-litigating the upstream inclusion predicate.** County, Active, PUBLIC,
   CountAsBeach stays exactly as it is.
+
+## Addendum — 2026-08-19: the water class answers two questions, and they diverge
+
+Found while measuring slice 2 against the real joins, before writing any of it.
+The slice as specified above cannot be implemented correctly, and the reason
+generalises past the two beaches it names.
+
+**One of the two overrides is clean.** `fiesta-island` improves on every variable
+at once, which is what a single wrong classification looks like when corrected:
+
+```
+fiesta-island   as open-coast   tide 9410230 11.66 km   wave 46254 12.14 km   air KSAN 4.72 km
+                as bay          tide TWC0413  2.10 km   wave none             air KSAN 4.72 km
+```
+
+**The other has no correct value.** Neither class is right for
+`childrens-pool`, and each is wrong about a different panel:
+
+```
+childrens-pool  as open-coast   tide 9410230  2.93 km   wave 46254  2.50 km   air LJAC1 2.94 km
+                as bay          tide 9410196  7.84 km   wave none             air LJAC1 2.94 km
+```
+
+As open coast it gets the tide right — Scripps at 2.93 km is the ocean level
+that actually applies inside the pool — and then publishes an open-coast swell
+height at a walled wading cove. That is the failure `wave-join.mjs` was written
+to prevent, in its own words: "a parent reading three feet before a paddle with
+children would be told something false about the place they are going." At the
+beach named Children's Pool. As bay it withholds the buoy correctly and reads
+Mission Bay's tide curve, 7.84 km away, for a cove in La Jolla.
+
+**The cause is that one field answers two questions.** `waterClassOf` is read by
+the tide join as _which water body's level applies here_ and by the wave join as
+_does ocean swell reach this water_. Those coincide at 71 of 73 beaches, which is
+why the conflation survived three joins. Children's Pool is where a breakwater
+separates them. `docs/reference/sensor-representativeness.md` §5.5 and §12 name
+this directly: validity is per variable, and validating a source wholesale is an
+anti-pattern.
+
+### Revision
+
+**A `sheltered` input joins `water` and `shore`.** Hand-written, keyed by slug,
+with a reason per entry, and read only by the wave join: a sheltered beach binds
+no buoy whatever its water class. `childrens-pool` becomes open coast **and**
+sheltered — Scripps tide at 2.93 km, no wave height, air unchanged.
+`fiesta-island` needs only the class override.
+
+The criterion is written down so the flag is checkable rather than a taste:
+**a fixed constructed structure — breakwater, seawall, jetty — stands between
+the beach and the open ocean.** Not "the waves feel smaller here", which is
+unfalsifiable and would spread. Children's Pool has one. Natural coves do not,
+however sheltered they feel.
+
+`TODO(verify)`: the criterion has been established for `childrens-pool` only.
+Fifteen other open-coast beaches survive the predicate and each must be checked
+against it before slice 3 lands — `bird-rock-nr`, `del-mar-city-beach`,
+`la-jolla-community-beach`, `la-jolla-cove`, `la-jolla-shores-beach`,
+`marine-street-beach`, `mission-beach`, `pacific-beach`, `shell-beach`,
+`south-casa-beach-s-d`, `torrey-pines-city-beach`, `torrey-pines-state-beach`,
+`tourmaline-surfing-park`, `whispering-sands-nicholson-pt`, `windansea-beach`.
+The other 25 survivors are bays and bind no buoy by construction.
+
+**The predicate's wave clause is reformulated.** As written above it reads "tide
+within 10 km, and unless the beach is a bay, a buoy within 10 km" — which would
+cut a sheltered beach for lacking the buoy the join was right to withhold. It
+becomes:
+
+- its tide station is within 10 km, **and**
+- **if** a wave buoy is bound at all, it is within 10 km.
+
+This subsumes the bay exemption rather than special-casing beside it, and states
+the actual rule: a beach fails when a binding it _has_ is too far, never when a
+join correctly declined to make one. Measured effect: **41 kept, 32 cut**, up one
+from 40. Children's Pool survives; no other beach moves.
+
+ADR 0011's decision paragraph is amended in the same commit, because it states
+the superseded form of the predicate and its count.
+
+### Considered and rejected
+
+**Drop `childrens-pool` from the inventory.** One beach, keeps the count at 40,
+and introduces no third join input. Rejected because the beach is well served —
+tide 2.93 km, air 2.94 km, both among the best on the site — and would be removed
+only to avoid naming a distinction that is real and already load-bearing
+elsewhere. Removing a beach the networks _do_ reach is the opposite of what this
+plan is for.
+
+**Split the class into two fields**, `tide_water` and `swell_reaches`, and retire
+the conflation. Conceptually the honest fix, and what the divergence argues for.
+Rejected as premature: the two would hold identical values at 72 of 73 beaches,
+and a three-join refactor to express one exception buys nothing today. This is
+the thing to do if a second divergent beach appears — at which point it is its
+own slice, not an addendum.
+
+### Revised slices
+
+1. Unchanged: this plan, ADR 0011, the reference doc.
+2. The class override **and** the `sheltered` input, with the criterion recorded
+   beside the table. Two beaches change binding.
+3. The predicate in its reformulated shape, the `_excluded` block, the
+   regenerated `beaches.json`, routes and selector. 73 beaches become 41.
+4. Unchanged: the exclusion is disclosed to readers by `Caveats`.

--- a/docs/plans/inventory-bounded-by-stations.md
+++ b/docs/plans/inventory-bounded-by-stations.md
@@ -1,0 +1,260 @@
+# The inventory is bounded by the stations that can serve it
+
+ADR `docs/adr/0011-inventory-bounded-by-station-networks.md` records the decision
+this plan implements. Relates to #86, which this plan's measurement closed as a
+no.
+
+## The problem, from the reader's point of view
+
+A parent opens Tijuana River and is told the water is 68 °F. That reading comes
+from Point Loma South, 34.2 km up the coast. A parent opens San Onofre State
+Beach and is told when low tide is. That curve is Scripps, 56.6 km south. Both
+numbers are produced, disclosed with a distance, and wrong in the sense that
+matters: nobody reading them would act differently if they were right.
+
+The site currently answers for 73 beaches. It can measure at far fewer. The
+difference is being papered over by the join reaching further and further until
+it finds something.
+
+Measured over the committed `src/data/beaches.json` on 2026-08-19:
+
+```
+variable  bound   p50     p90     max     >5km  >10km  >15km
+tide         72   4.1 km  30.6 km 56.6 km   35     27     14
+wave         46   5.9 km  27.9 km 34.2 km   23     14      9
+air          72   3.5 km   5.4 km  7.4 km   11      0      0
+sky          72   7.3 km  13.4 km 16.8 km   61     28      3
+```
+
+Air is the one that is already right, and it is right because #80 rebuilt its
+candidate set rather than stretching its reach. Tide and waves were never given
+that treatment, and their p90s are what happens instead.
+
+## Why the joins stretch
+
+Not a bug in any join. Both networks simply stop.
+
+**There is no open-coast tide station north of Scripps.** `tide-stations.json`
+holds nine stations. Two are open-coast and deliver — 9410230 La Jolla (Scripps,
+32.867 °N) and 9410120 Imperial Beach (32.578 °N). TWC0405 Point Loma is
+open-coast and does not deliver. Everything north of Scripps therefore binds
+Scripps, and the county's beaches run to 33.39 °N:
+
+```
+san-onofre-state-beach            56.6 km    leucadia                  20.5 km
+oceanside-harbor                  40.1 km    moonlight-beach           19.9 km
+agua-hedionda-lagoon              39.7 km    swami-s-park              18.6 km
+harbor-beach                      39.4 km    encinitas-city-beaches    18.6 km
+buccaneer-beach                   35.9 km    san-elijo-state-beach     16.8 km
+oceanside-municipal-beach-other   34.5 km    cardiff-state-beach       14.9 km
+carlsbad-municipal-beach          33.3 km    seascape-beach-park       12.7 km
+carlsbad-state-beach              30.6 km    solana-beach-city-beaches 12.7 km
+south-carlsbad-state-beach        24.4 km    san-dieguito-river-beach  12.0 km
+```
+
+Their wave bindings are 1.0–4.7 km and their air bindings 0.3–5.1 km. It is tide
+alone that fails there, and it fails for all of them at once.
+
+**There is no wave buoy between Scripps Nearshore and Point Loma South.** 46254
+sits at 32.868 °N and 46232 at 32.517 °N. Everything from Coronado to the border
+crosses that gap:
+
+```
+tijana-river                          34.2 km    coronado-central-beach  21.6 km
+north-imperial-beach                  28.5 km    coronado-city-beaches   21.2 km
+border-field-state-park               28.2 km    coronado-north-beach    20.9 km
+silver-strand-state-beach             28.1 km    tide-beach-park         21.8 km
+imperial-beach-municipal-beach-other  27.9 km
+```
+
+**Two rows carry coordinates that are simply wrong.**
+
+- `imperial-beach-pier-area` has segment endpoints 65.5 km apart — 32.5804,
+  −117.5866 and 32.1327, −117.1332, one roughly 40 km offshore and the other
+  south of the border. It binds no tide station, no buoy, no air station and no
+  sky station. It is already a blank page that costs a route.
+- `tide-beach-park` records `nearest_city` "Solana Beach" while its coordinates,
+  32.6925, −117.1640, put it 34 km south inside San Diego Bay. It is typed
+  `Open Coast` while sitting in a bay, so it reads a buoy 21.8 km away.
+
+**Two more are typed as the wrong kind of water.**
+
+- `fiesta-island` is typed `Open Coast`; 32.7694, −117.2111 is inside Mission
+  Bay. It binds a wave buoy 12.1 km away, publishing a surf height for water
+  that has none.
+- `childrens-pool` is typed `Sound, Bay, or Inlet`; it is an ocean cove in La
+  Jolla. The classification sends its tide 7.8 km to Mission Bay Campland when
+  Scripps is 2.5 km away.
+
+## What decides whether a number may be shown
+
+`docs/reference/sensor-representativeness.md` records the standards position, and
+three of its points decide this plan:
+
+1. **No standard reporting radius exists.** WMO-No. 8 §1.1.2 makes
+   representativeness a property of the _application_, not of the observation.
+   Any threshold here is ours to state and defend; it cannot be cited.
+2. **Validity is per variable.** EPA-454/R-99-005 §3.1: excluding one variable
+   does not exclude the others from the same station. Wind may fail where
+   temperature holds.
+3. **An intervening boundary fails at any distance.** A coastline, ridgeline or
+   peninsula between the two points invalidates the transfer regardless of how
+   short it is.
+
+WMO §1.1.2's stated benchmark — small-scale and local applications concern areas
+of **10 km or less** — is the nearest thing to an anchor that exists, and it is
+a benchmark rather than a rule. This plan adopts 10 km as the tolerance because
+it is the only figure in the literature at the right scale, and states plainly
+that it is a choice.
+
+## The solution
+
+**A beach enters the inventory only if the stations it needs can reach it.** Not
+a hand-written removal list; a predicate over the join result, re-derivable by
+`seed-beaches.mjs --check` like every other binding in this repo.
+
+The predicate, per beach:
+
+- its tide station is within 10 km, **and**
+- it is a bay or lagoon, **or** its wave buoy is within 10 km.
+
+Bays are exempted from the wave clause because a bay binding no buoy is the
+correct answer already — swell does not propagate into enclosed water, and the
+site says so. A bay with no tide station within 10 km is a different thing, and
+fails.
+
+Air is not in the predicate. Every bound beach already reads air within 7.4 km
+and 61 of 72 within 5 km, so adding the clause would exclude nobody and would
+imply a filter that is not doing any work.
+
+Measured outcome:
+
+```
+tolerance   kept   cut
+   5 km       33    40
+   8 km       38    35
+  10 km       40    33     <- proposed
+  12 km       41    32
+  15 km       49    24
+  20 km       53    20
+```
+
+At 10 km the site answers for **40 beaches**, every one of them with a tide
+station within 10 km and, where it is open coast, a buoy within 10 km.
+
+The predicate absorbs every case above without naming any of them. Both
+broken-coordinate rows fail it — `imperial-beach-pier-area` binds nothing and
+`tide-beach-park` binds a buoy at 21.8 km. Both North County and the South Bay
+groups fail it. No curated list, nothing to maintain, and a new beach appearing
+upstream is judged by the same rule on the next `--check`.
+
+## Implementation decisions
+
+**The predicate lives in `seed-beaches.mjs`, beside the existing one.** That
+script already carries an inclusion predicate — `County San Diego, Status Active,
+BeachAccess PUBLIC, CountAsBeach 1` — and documents it as "data rather than
+judgement". The new clause is judgement, and the header will say so in the same
+breath, the way `tide-stations.json` defends its hand-written `water` field.
+What keeps it honest is that its _inputs_ are measured: the distances come from
+the join, not from an author.
+
+**Exclusion is recorded, never silent.** `beaches.json` gains an `_excluded`
+block: every beach the county lists that this site does not serve, with the
+binding distance that disqualified it. A beach that vanishes without a reason is
+the failure mode this repo's `unresolved` blocks exist to prevent, and
+`caveats.test.ts` already walks `src/data/*.json` for exactly that.
+
+**Water class gets an override table, not an upstream fix.** `fiesta-island` and
+`childrens-pool` are wrong in the county's data and we cannot correct it there.
+`waterClassOf` grows a small override keyed by slug, with a written reason per
+entry — the same standing as `tide-stations.json`'s `water` and
+`weather-stations.json`'s `shore`, both hand-written join inputs with a recorded
+defence. It ships before the predicate, because Children's Pool's class decides
+which tide station it binds and therefore whether it survives.
+
+**Nothing is built to suppress a panel.** Every panel already has its
+`no-station` / `no-buoy` state with a reason string — `conditions.ts` defines
+them for tide, waves, air and sky. This plan removes beaches; it does not add
+per-variable suppression, because per-variable suppression is the map gymnastics
+it exists to avoid.
+
+## Test seams
+
+All existing.
+
+- `bindTideStation` / `bindWaveBuoy`, pure, against synthetic tables — where the
+  water-class override is asserted.
+- A new pure `servesBeach(bindings, tolerance)` in `seed-beaches.mjs`, exported
+  and tested directly: kept at the boundary, cut past it, bay exempted from the
+  wave clause, a beach binding nothing cut.
+- `seed-beaches.mjs --check` for the join and the exclusion list together, so
+  the cut set is evidence rather than an assertion.
+- `caveats.test.ts`, already walking `src/data/*.json`, extended to the
+  `_excluded` block.
+- `BeachSelector` and the `/conditions/[slug]` route against the smaller
+  inventory; a slug that was cut must 404 rather than render empty.
+
+The coverage floor will need raising after slice 3.
+
+## Slices
+
+1. This plan, ADR 0011, and `docs/reference/sensor-representativeness.md` as the
+   cited source. No behaviour change.
+2. Water-class override for `fiesta-island` and `childrens-pool`, with its
+   reason per entry. Re-joins; two beaches change station. Ships on its own
+   because it is a correctness fix that stands whether or not slice 3 lands.
+3. The served-inventory predicate: `servesBeach`, the `_excluded` block, the
+   regenerated `beaches.json`, and the route and selector reading the smaller
+   set. 73 beaches become 40.
+4. The exclusion is disclosed to readers: `Caveats` states how many beaches the
+   county lists, how many this site serves, and why the others are not here.
+
+Slices 1–2 and 3–4 are two PRs, split at the point where the inventory actually
+changes.
+
+## Considered and rejected
+
+**Per-variable panel suppression instead of removal.** Keep all 73 and hide the
+tide panel where no station is within 10 km. Attractive because the machinery
+exists — every panel has a `no-station` state — and because North County's wave
+and air bindings are the best on the site: 1.0–4.7 km and 0.3–5.1 km. Rejected
+on the stated preference for fewer locations over more locations with weaker
+readings, and because a beach page carrying two panels and a hole is a worse
+answer to "should we go here" than not listing the beach. **This is the decision
+most worth revisiting**, and it is the one an addendum would amend: it is the
+difference between serving 40 beaches and serving 73 with 33 partial pages.
+
+**A curated removal list.** Name the 33 and drop them. Rejected because it does
+not survive contact with upstream: the county's dataset moves, and a hand-written
+list is invisible to `--check` in exactly the way the station tables were before
+#80 — which is how both Scripps Pier stations were lost.
+
+**Raising the tolerance to 15 km to keep the Del Mar–Encinitas run.** Keeps 49
+and rescues nine beaches whose tide is 12.0–14.9 km away. Rejected because 15 km
+has nothing behind it; 10 km at least matches WMO's stated local-application
+scale. If the count matters more than the anchor, this is the knob to turn, and
+turning it is a one-line change to a named constant.
+
+**Fixing the two broken coordinate rows by hand.** `imperial-beach-pier-area`
+and `tide-beach-park` could be re-geocoded. Rejected: their coordinates are
+upstream's, correcting them silently makes this repo a source of beach locations
+it has no authority to be, and the predicate already excludes them for a reason
+that is true regardless.
+
+## Out of scope
+
+- **Sky and visibility, which no removal fixes.** Every sky reading on this site
+  is an airport METAR at 1.6–16.8 km, and the reference above is unambiguous:
+  ceiling and visibility are point measurements by instrument design, ICAO ties
+  aerodrome observations to runway reference points, and they should not be
+  transferred off-field at any distance. That indicts the panel at all 73
+  beaches including the best-bound ones. It is a bigger accuracy gain than this
+  plan and it belongs to its own issue.
+- **Water temperature from LJAC1 (#86).** Measured 2026-08-18/19 and closed as a
+  no: a distance rule applied consistently removes it from 23 beaches and adds it
+  to 3, and no threshold improves coverage and provenance together. This plan
+  removes most of the affected beaches anyway.
+- **Elevation-weighted air ranking**, deferred by
+  `docs/plans/coastal-air-observations.md` and still deferred.
+- **Re-litigating the upstream inclusion predicate.** County, Active, PUBLIC,
+  CountAsBeach stays exactly as it is.

--- a/docs/plans/inventory-bounded-by-stations.md
+++ b/docs/plans/inventory-bounded-by-stations.md
@@ -311,14 +311,23 @@ the beach and the open ocean.** Not "the waves feel smaller here", which is
 unfalsifiable and would spread. Children's Pool has one. Natural coves do not,
 however sheltered they feel.
 
-`TODO(verify)`: the criterion has been established for `childrens-pool` only.
-Fifteen other open-coast beaches survive the predicate and each must be checked
-against it before slice 3 lands — `bird-rock-nr`, `del-mar-city-beach`,
-`la-jolla-community-beach`, `la-jolla-cove`, `la-jolla-shores-beach`,
-`marine-street-beach`, `mission-beach`, `pacific-beach`, `shell-beach`,
-`south-casa-beach-s-d`, `torrey-pines-city-beach`, `torrey-pines-state-beach`,
-`tourmaline-surfing-park`, `whispering-sands-nicholson-pt`, `windansea-beach`.
-The other 25 survivors are bays and bind no buoy by construction.
+Applied to the whole surviving open-coast set on 2026-08-19, and only
+`childrens-pool` qualifies. The other fifteen — `bird-rock-nr`,
+`del-mar-city-beach`, `la-jolla-community-beach`, `la-jolla-cove`,
+`la-jolla-shores-beach`, `marine-street-beach`, `mission-beach`,
+`pacific-beach`, `shell-beach`, `south-casa-beach-s-d`,
+`torrey-pines-city-beach`, `torrey-pines-state-beach`, `tourmaline-surfing-park`,
+`whispering-sands-nicholson-pt`, `windansea-beach` — are natural coves and open
+strand with no structure between them and the ocean; La Jolla Cove in particular
+sits on the same open water as La Jolla Shores. Cole's judgement, recorded here
+because `sheltered` is a hand-written join input and the provenance of a
+hand-written input is part of it. The other 25 survivors are bays and bind no
+buoy by construction.
+
+So `sheltered` ships with exactly one entry. That is the right size for it: the
+criterion is narrow enough to be checkable, and a flag that turned out to apply
+to a third of the coast would have been evidence the criterion was really a
+taste.
 
 **The predicate's wave clause is reformulated.** As written above it reads "tide
 within 10 km, and unless the beach is a bay, a buoy within 10 km" — which would

--- a/docs/reference/sensor-representativeness.md
+++ b/docs/reference/sensor-representativeness.md
@@ -1,0 +1,322 @@
+# Atmospheric sensor spatial representativeness
+
+> **How this file got here.** Supplied as context on 2026-08-19 and committed so
+> that `docs/plans/inventory-bounded-by-stations.md` and ADR 0011 cite something
+> that exists. It is a **compiled reference, not a primary source**: nobody in
+> this repo has checked its citations against WMO-No. 8, ISO 19289,
+> EPA-454/R-99-005 or the CFR. Its own §14 lists what to verify before relying
+> on it. Statements are tagged `[STANDARD]` where the compiler traced them to a
+> cited document and `[DOMAIN]` where they reflect general practice; treat
+> `[DOMAIN]` as a default to be checked.
+>
+> **What this repo uses it for.** One decision: that no citable radius exists, so
+> the 10 km bound in ADR 0011 is ours to state and defend rather than to
+> attribute. Also §5.5 (validity is per variable) and §7 (aerodrome observations
+> do not transfer off-field), both of which are load-bearing there.
+
+---
+
+## 1. The core rule
+
+**There is no standard "valid reporting radius" for an atmospheric sensor.** No
+WMO, ISO, EPA, ICAO, or CFR provision assigns a coverage radius to a station. Any
+answer of the form "sensor data are valid within X km" is unsupported unless X
+was derived for a specific variable, a specific site pair, and a specific
+application tolerance.
+
+`[STANDARD]` WMO-No. 8 §1.1.2 defines representativeness as the degree to which
+an observation describes the value of the variable _needed for a specific
+purpose_. It is explicitly **not a fixed property of the observation**; it
+emerges from a joint appraisal of instrumentation, measurement interval, and
+exposure against the requirements of a given application.
+
+**Consequence for agents:** a representativeness question is malformed until four
+inputs are supplied — (1) the variable, (2) the terrain and land-use relationship
+between the two points, (3) the presence of intervening boundaries, (4) the error
+tolerance of the downstream use. Do not emit a distance threshold without them.
+Ask.
+
+---
+
+## 2. Authoritative sources
+
+| ID                                  | Document                                                                                    | What it governs                                                                                            |
+| ----------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `WMO-8`                             | WMO-No. 8, _Guide to Instruments and Methods of Observation_ (CIMO Guide)                   | Root definition of representativeness (§1.1.2); horizontal scale classification; siting and exposure rules |
+| `WMO-8-Annex-1B` / `ISO 19289:2015` | _Air quality — Meteorology — Siting classifications for surface observing stations on land_ | Site Classes 1–5 and the added uncertainty each implies                                                    |
+| `WMO-488`                           | _Guide to the Global Observing System_                                                      | Network design, station spacing, observing-system requirements                                             |
+| `WMO-306`                           | _Manual on Codes_                                                                           | Report encoding — BUFR, and legacy SYNOP / BUOY / METAR                                                    |
+| `WMO-1192`                          | WIGOS Metadata Standard                                                                     | Station metadata, including siting class and exposure, that carries representativeness info                |
+| `EPA-454/R-99-005`                  | _Meteorological Monitoring Guidance for Regulatory Modeling Applications_ (Feb 2000)        | §3.1 is the most directly applicable treatment of representativeness in regulatory practice                |
+| `40 CFR 51 App. W`                  | _Guideline on Air Quality Models_                                                           | Regulatory modeling requirements; incorporates the above by reference                                      |
+| `40 CFR 58 App. D`                  | _Network Design Criteria for Ambient Air Quality Monitoring_                                | Defines spatial scales with explicit dimensions                                                            |
+| `40 CFR 58 App. E`                  | _Probe and Monitoring Path Siting Criteria_                                                 | Probe placement; reclassification rules when siting criteria are unmet                                     |
+| `ICAO Annex 3`                      | _Meteorological Service for International Air Navigation_                                   | Aerodrome observation reference points                                                                     |
+| `EPA-454/B-08-002`                  | _QA Handbook Vol. IV: Meteorological Measurements_                                          | QA/QC, measurement quality objectives                                                                      |
+
+---
+
+## 3. WMO horizontal scale classification
+
+`[STANDARD]` `WMO-8` §1.1, stated with an explicit **factor-of-two uncertainty**:
+
+| Scale             | Horizontal extent | Example phenomena                       |
+| ----------------- | ----------------- | --------------------------------------- |
+| Microscale        | < 100 m           | Evaporation, agricultural meteorology   |
+| Toposcale / local | 100 m – 3 km      | Air pollution, tornadoes                |
+| Mesoscale         | 3 – 100 km        | Thunderstorms, sea and mountain breezes |
+| Large scale       | 100 – 3,000 km    | Fronts, cyclones, cloud clusters        |
+| Planetary         | > 3,000 km        | Long upper-tropospheric waves           |
+
+`[STANDARD]` `WMO-8` §1.1.2 benchmark: synoptic observations should typically be
+representative of an area up to **100 km** around the station; small-scale or
+local applications may concern areas of **10 km or less**.
+
+**Interpretation.** A 5 km separation falls at the toposcale/mesoscale boundary.
+At that distance, sea breezes, thunderstorms, and slope flows are _resolvable
+distinct features_, not sub-grid noise. This is the single most important framing
+for the common "is 5 km OK?" question.
+
+---
+
+## 4. Site siting classification
+
+`[STANDARD]` `ISO 19289:2015` / `WMO-8` Annex 1.B exist because real sites
+frequently fail the recommended exposure rules. The classification determines a
+site's representativeness at small scale, given its surroundings.
+
+- **Class 1** — reference-quality site.
+- **Classes 2–4** — intermediate; each carries a stated _additional uncertainty_
+  for the affected variable.
+- **Class 5** — nearby obstacles make the environment inappropriate for a
+  measurement intended to represent a wide area.
+
+Lower class number → higher representativeness over a wide area. Classes are
+assigned **per variable** (a site may be Class 2 for temperature and Class 4 for
+wind).
+
+**Agent use:** the class-specific added uncertainty is the correct lever when a
+numeric error budget is required. Prefer it over inventing a distance-based
+degradation factor.
+
+---
+
+## 5. EPA regulatory position (`EPA-454/R-99-005` §3.1)
+
+The most quotable authority for "there is no number." Key positions, paraphrased:
+
+1. Representativeness is an **exact condition** — data either are or are not
+   representative under whatever criteria are prescribed.
+2. Consequently **no quantitative method exists** to determine representativeness
+   absolutely, and there are **no generally accepted analytical or statistical
+   techniques** for determining it for meteorological data or sites.
+3. Representativeness **depends on proximity** to the area of interest, and is
+   **degraded by increasing distance** / increasing size of the area of interest.
+4. But it is **"not simply a function of distance."** Data collected _at_ a
+   source may still be non-representative — e.g. a coastal source whose
+   dispersion is driven by offshore air/sea boundary conditions.
+5. **Exclusion of one variable does not exclude all.** Wind speed and direction
+   may be unrepresentative while temperature, dew point, and cloud cover remain
+   usable from the same station.
+6. Representativeness **increases with measurement height**; upper-air
+   measurements represent much larger domains than surface measurements.
+7. Judgements are **case-by-case and subjective**; the guidance directs that
+   qualified meteorologists be involved and that the reviewing authority approve.
+
+Related: under the RMP program (40 CFR Part 68 Subpart B), EPA states it has
+**not set specific distance limits** for using a weather station's data at a
+stationary source, leaving it to the operator's best judgment.
+
+---
+
+## 6. Numeric thresholds that _do_ exist
+
+Use these; do not extrapolate beyond their stated purpose.
+
+| Value                                                                                  | Source                             | Applies to                                                                                                                                                                                                                                                                  |
+| -------------------------------------------------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **2 km** max horizontal tower separation                                               | `EPA-454/R-99-005` §3.3.3          | Deep-layer absolute temperature method as a surrogate for a vertical temperature profile. Also requires ≥200 m layer depth, ≥60 m measurement height on each tower, **no internal boundary layers** (i.e. not near shorelines), and verification against balloon soundings. |
+| **100 m – 0.5 km** (middle scale)                                                      | `40 CFR 58 App. D`                 | Ambient air monitor spatial scale                                                                                                                                                                                                                                           |
+| **0.5 – 4.0 km** (neighborhood scale)                                                  | `40 CFR 58 App. D`                 | Ambient air monitor spatial scale, relatively uniform land use                                                                                                                                                                                                              |
+| **4 – 50 km** (urban scale)                                                            | `40 CFR 58 App. D`                 | Citywide pollutant conditions                                                                                                                                                                                                                                               |
+| **100 km**                                                                             | `WMO-8` §1.1.2                     | Nominal synoptic representativeness                                                                                                                                                                                                                                         |
+| **10 km or less**                                                                      | `WMO-8` §1.1.2                     | Nominal small-scale / local application                                                                                                                                                                                                                                     |
+| **10 m** standard anemometer height; obstruction distance **≥ 10×** obstruction height | `WMO-8`, `EPA-454/R-99-005` §3.2.1 | Surface wind siting                                                                                                                                                                                                                                                         |
+| **2 m** standard temperature/humidity height                                           | `WMO-8`, `EPA-454/R-99-005` §3.2.2 | Surface temperature siting                                                                                                                                                                                                                                                  |
+| **~2.5×** building height                                                              | `EPA-454/R-99-005` §3.2.1.2        | Rule-of-thumb total depth of a building wake                                                                                                                                                                                                                                |
+| **90%** data completeness, per quarter                                                 | `EPA-454/R-99-005` §5.3.2          | Acceptability of a regulatory met data record                                                                                                                                                                                                                               |
+
+Note that **5 km exceeds neighborhood scale** under `40 CFR 58 App. D` and
+exceeds the 2 km cap EPA places on the two-tower temperature method.
+
+---
+
+## 7. Per-variable assessment at ~5 km
+
+`[DOMAIN]` unless marked. Verdicts assume no intervening boundary; a coastline,
+ridgeline, urban edge, or large water body between the points invalidates the
+"usually OK" cases.
+
+| Variable                        | 5 km verdict            | Dominant failure mode                                                                                                                                    |
+| ------------------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Station pressure / MSLP         | **Usually valid**       | Only elevation reduction error; largest decorrelation length of surface variables                                                                        |
+| Air temperature                 | **Conditionally valid** | Fails across elevation change (~100 m+), land-use change, coastline; nocturnal cold-air pooling can give 5–10 °C differences over 5 km in valley terrain |
+| Dew point / humidity            | **Conditionally valid** | As temperature; plus irrigation, water bodies, TIBL                                                                                                      |
+| Wind speed                      | **Weak**                | Surface roughness change, sheltering, streamline compression over terrain                                                                                |
+| Wind direction                  | **Weakest**             | Channeling, slope flows, sea-breeze front position. `[STANDARD]` EPA singles out wind direction bias as the hardest complex-terrain siting judgement     |
+| Precipitation (convective)      | **Not valid**           | Decorrelation length frequently shorter than the separation itself                                                                                       |
+| Precipitation (stratiform)      | **Conditionally valid** | Orographic enhancement gradients                                                                                                                         |
+| Ceiling / cloud base            | **Not transferable**    | Point measurement by instrument design                                                                                                                   |
+| Visibility / present weather    | **Not transferable**    | Point measurement; fog and convection are highly localized                                                                                               |
+| Solar radiation                 | **Conditionally valid** | Cloud field variability; shading                                                                                                                         |
+| Stability class / mixing height | **Weak**                | Derived quantity; inherits errors of all inputs                                                                                                          |
+
+`[STANDARD]` `WMO-8` §1.3.3.1: an aviation meteorological observing station must
+describe conditions specific to the **aerodrome site**, and `ICAO Annex 3` ties
+observations to specific runway/touchdown reference points. Aerodrome
+observations should never be transferred off-field.
+
+Network-design corroboration: the UK synoptic network averages ~40 km station
+spacing, adequate for frontal and low-pressure systems, but the Met Office states
+that smaller-scale features such as thunderstorms may **evade the surface network
+altogether** — hence radar and satellite.
+
+---
+
+## 8. Marine stations and buoys
+
+There is **no published representativeness radius for NDBC or any moored-buoy
+network.** Distance is usually not the binding constraint; these are:
+
+1. **Anemometer height.** `[STANDARD-adjacent]` Buoy anemometers typically sit at
+   ~3–5 m, not the 10 m land standard. Wind speed **must be height-adjusted**
+   before comparison with land stations, model output, or other buoys. Failing to
+   do this is the most common error.
+2. **Wave sheltering.** NDBC has investigated whether moored-buoy winds read low
+   in high seas — i.e. a negative bias precisely in the high-wind conditions of
+   greatest interest. Do not treat buoy winds as ground truth for extremes
+   without checking this.
+3. **Homogeneity works in your favor offshore.** Over open ocean with uniform
+   fetch and no bathymetric influence, surface variables decorrelate far more
+   slowly than over land; 5 km offshore is a much easier case than 5 km inland.
+4. **But gradients are sharp where they exist.** 5 km _across_ a coastline, a
+   frontal boundary, a bathymetric front, or an SST front (e.g. Gulf Stream) is
+   not valid.
+5. **Sea surface temperature is not air temperature** and the two decorrelate
+   differently.
+
+---
+
+## 9. How the observation pipeline actually assigns spatial validity
+
+Important architectural point — the radius is not attached to the observation:
+
+1. **Observations are reported for the point.** Encoded per `WMO-306` (BUFR;
+   legacy SYNOP for land, BUOY for moored/drifting buoys, METAR/SPECI for
+   aerodromes). The report makes **no areal claim**.
+2. **Metadata carries the representativeness information.** `WMO-1192` (WIGOS)
+   records station siting class, exposure, instrument heights, and surroundings.
+   This is where an agent should look to justify or challenge a transfer.
+3. **Spatial extension happens downstream**, in objective analysis and data
+   assimilation, where _representativeness error_ is a formally budgeted term
+   added to instrument error in the observation error covariance matrix. This is
+   where a defensible, quantified 5 km answer is actually produced.
+4. **Areal validity attaches to forecasts and analyses**, not observations —
+   marine forecast zones, coastal waters zones, land forecast zones, gridded
+   analyses.
+
+---
+
+## 10. Decision procedure
+
+```
+1. Identify the VARIABLE. Resolve per-variable; never in aggregate.       [§7]
+2. Identify the APPLICATION and its error tolerance.
+3. Compare SURFACE CHARACTERISTICS at both points:
+     - surface roughness (z0), albedo/Bowen ratio, land use
+     - elevation difference
+     - vegetation / canopy height
+4. Check for INTERVENING BOUNDARIES:
+     - coastline / large water body  -> likely FAIL (TIBL, sea breeze)
+     - ridgeline or valley wall      -> likely FAIL for wind, temperature
+     - urban/rural edge              -> likely FAIL for temperature, wind
+     - none, uniform terrain         -> proceed
+5. Check MEASUREMENT HEIGHT. Higher = more representative.               [§5.6]
+6. Check SITE CLASS at the source station, per variable.                 [§4]
+7. If the answer must be defensible (regulatory / litigation / safety):
+     -> require a SITE-SPECIFIC COMPARISON STUDY (§11).
+     -> do NOT cite a published radius; none exists.
+```
+
+---
+
+## 11. The defensible method when a number is required
+
+Run a **paired-site comparison study**, not an appeal to authority:
+
+- Co-located or paired observations over a period covering the relevant regimes
+  (minimum one year for regulatory dispersion work per `EPA-454/R-99-005` §5.3.1;
+  five years of NWS data or one year of site-specific data per
+  `40 CFR 51 App. W`).
+- Report **per variable**: bias, RMSE, correlation, and conditional performance
+  stratified by stability class, wind sector, season, and time of day. Aggregate
+  statistics hide exactly the regimes that matter.
+- Stratify by regime. A station that correlates at r = 0.95 annually may be
+  useless during nocturnal drainage flow or sea-breeze hours.
+- State the tolerance the application requires and compare against it explicitly.
+
+---
+
+## 12. Anti-patterns
+
+Flag or refuse these:
+
+- Citing a "standard radius" of 5 km / 10 km / 25 km. **No such standard
+  exists.**
+- Treating distance as the sole criterion. EPA: representativeness is _not simply
+  a function of distance_.
+- Validating a station wholesale. Validity is **per variable**.
+- Transferring aerodrome (METAR) ceiling/visibility off-field.
+- Comparing buoy winds to land or model winds without 10 m height adjustment.
+- Transferring anything across a coastline, ridgeline, or urban boundary without
+  justification, at any distance.
+- Using annual-mean agreement to justify use during a specific event.
+- Assuming a site meets exposure rules without checking its siting class or
+  metadata.
+- Inferring convective precipitation at a point from a gauge kilometres away.
+
+---
+
+## 13. Glossary
+
+- **Representativeness** — degree to which an observation describes the variable
+  value needed for a specific purpose (`WMO-8` §1.1.2). Purpose-relative, not
+  intrinsic.
+- **Representativeness error** — the component of observation error arising from
+  a point measurement standing in for an area/volume; budgeted explicitly in data
+  assimilation.
+- **Decorrelation length** — separation at which the correlation of a field falls
+  to a specified threshold. Variable-, season-, and regime-dependent.
+- **z0 (surface roughness length)** — governs the wind profile; a primary
+  determinant of whether wind data transfer between sites.
+- **TIBL (Thermal Internal Boundary Layer)** — forms when stable marine air
+  advects over heated land; a hard barrier to coastal representativeness.
+- **Siting class** — 1–5 rating per `ISO 19289` / `WMO-8` Annex 1.B, with stated
+  added uncertainty per class.
+- **Simple / intermediate / complex terrain** — in EPA usage, defined by
+  comparing terrain height to stack-top and plume height, not by absolute relief.
+
+---
+
+## 14. Open items / verify before relying
+
+- Exact per-class added-uncertainty values in `ISO 19289` were not retrieved
+  here; consult the standard directly if a numeric error budget is needed.
+- `WMO-8` is revised periodically (2008, 2014, 2018, 2021+ editions). Section
+  numbering shifts between editions — verify §1.1.2 / Annex 1.B numbering against
+  the edition in use.
+- Jurisdiction matters. EU (Air Quality Directive), UK (Met Office observing
+  standards), and national met services impose their own siting and
+  representativeness criteria that may be stricter than the above.
+- Decorrelation-length figures in §7 are `[DOMAIN]` defaults and should be
+  replaced with region-specific empirical values where available.

--- a/scripts/air-join.mjs
+++ b/scripts/air-join.mjs
@@ -39,18 +39,18 @@
  */
 
 import { segmentDistance } from "./geo.mjs";
-import { waterClassOf } from "./tide-join.mjs";
+import { waterClassFor } from "./tide-join.mjs";
 
 /**
  * Bind one beach to the station that measures its air.
  *
- * @param {{segment: object, waterBodyType: string}} beach
+ * @param {{slug?: string, segment: object, waterBodyType: string}} beach
  * @param {Record<string, {lat: number, lon: number, delivers: boolean, publishes_air_temp: boolean, publishes_wind: boolean, shore: boolean}>} stations
  * @returns {{stationId: string, distanceM: number, fromEnd: string, waterClass: string}
  *   | {stationId: null, reason: string}}
  */
 export function bindAirStation(beach, stations) {
-  const waterClass = waterClassOf(beach.waterBodyType);
+  const waterClass = waterClassFor(beach);
   if (waterClass === null) {
     return {
       stationId: null,

--- a/scripts/air-join.test.mjs
+++ b/scripts/air-join.test.mjs
@@ -76,6 +76,27 @@ const LA_JOLLA_SHORES = {
 };
 
 describe("bindAirStation", () => {
+  it("reads the same override the other two joins read", () => {
+    // The class override lives in tide-join.mjs and all three joins resolve it
+    // through waterClassFor. A join that classified a beach on its own would
+    // put one page's panels in two different water bodies, so this asserts the
+    // third join agrees rather than that this beach's air is interesting.
+    const bound = bindAirStation(
+      {
+        slug: "fiesta-island",
+        segment: {
+          upper: { lat: 32.7694, lon: -117.2111 },
+          lower: { lat: 32.769, lon: -117.2109 },
+        },
+        waterBodyType: "Open Coast",
+      },
+      STATIONS,
+    );
+    // Typed open coast upstream, which would restrict the pool to shore
+    // stations. Inside Mission Bay it is a bay, and everything ranks.
+    expect(bound.waterClass).toBe("bay");
+  });
+
   it("binds the pier at La Jolla Shores instead of the airport", () => {
     // The reading this issue was opened for. On 2026-08-18 the pier read 72 F
     // and Miramar 81 F, nine minutes apart.

--- a/scripts/seed-beaches.mjs
+++ b/scripts/seed-beaches.mjs
@@ -230,12 +230,15 @@ export function build(rows, stations, buoys, weatherStations) {
     const bound = fault
       ? { stationId: null, reason: fault }
       : bindTideStation(
-          { segment, waterBodyType: row.WaterBodyType },
+          { slug, segment, waterBodyType: row.WaterBodyType },
           stations,
         );
     const wave = fault
       ? { buoyId: null, reason: fault }
-      : bindWaveBuoy({ segment, waterBodyType: row.WaterBodyType }, buoys);
+      : bindWaveBuoy(
+          { slug, segment, waterBodyType: row.WaterBodyType },
+          buoys,
+        );
     // No water-class rule here, unlike the wave join: air reaches a lagoon.
     // This binds sky and visibility only -- the airport. Temperature and wind
     // come from the air join below, which does have a water-class rule.
@@ -245,7 +248,7 @@ export function build(rows, stations, buoys, weatherStations) {
     const air = fault
       ? { stationId: null, reason: fault }
       : bindAirStation(
-          { segment, waterBodyType: row.WaterBodyType },
+          { slug, segment, waterBodyType: row.WaterBodyType },
           weatherStations,
         );
 

--- a/scripts/tide-join.mjs
+++ b/scripts/tide-join.mjs
@@ -45,15 +45,60 @@ export function waterClassOf(waterBodyType) {
 }
 
 /**
+ * Beaches the state types as the wrong kind of water, and what they are.
+ *
+ * Hand-written, like `tide-stations.json`'s `water` and
+ * `weather-stations.json`'s `shore`, and for the same reason: the join has to be
+ * told, and no authority publishes a correction. Each entry carries what was
+ * measured rather than what it looks like, so the next person can check it
+ * instead of trusting it.
+ *
+ * Keyed by slug, which `seed-beaches.mjs` guarantees is a stable primary key.
+ */
+const WATER_CLASS_OVERRIDES = {
+  "fiesta-island": {
+    waterClass: "bay",
+    why:
+      "typed Open Coast upstream; 32.7694, -117.2111 is inside Mission Bay. As open " +
+      "coast it bound a tide station 11.66 km away and a wave buoy at 12.14 km, " +
+      "publishing a surf height for water that has none. As bay: 2.10 km and no buoy.",
+  },
+  "childrens-pool": {
+    waterClass: "open-coast",
+    why:
+      "typed Sound, Bay, or Inlet upstream; it is an ocean cove in La Jolla and its " +
+      "water level is the ocean's. As bay it bound Mission Bay Campland at 7.84 km; " +
+      "as open coast it binds Scripps at 2.93 km. It is also `sheltered` in " +
+      "wave-join.mjs, which is the half of its old classification that was right.",
+  },
+};
+
+/**
+ * The water class this join should use for a beach.
+ *
+ * Takes the whole beach rather than the published type, so that a call site
+ * cannot apply the classification and forget the override. Every join reads
+ * this; nothing reads `waterClassOf` directly except its own test.
+ *
+ * @param {{slug?: string, waterBodyType: string}} beach
+ * @returns {"open-coast" | "bay" | null}
+ */
+export function waterClassFor(beach) {
+  const override = WATER_CLASS_OVERRIDES[beach.slug];
+  if (override) return override.waterClass;
+  return waterClassOf(beach.waterBodyType);
+}
+
+/**
  * Bind one beach to a station.
  *
- * @param {{segment: object, waterBodyType: string}} beach
+ * @param {{slug?: string, segment: object, waterBodyType: string}} beach
  * @param {Record<string, {lat: number, lon: number, water: string, delivers: boolean}>} stations
  * @returns {{stationId: string, distanceM: number, fromEnd: string, waterClass: string}
  *   | {stationId: null, reason: string}}
  */
 export function bindTideStation(beach, stations) {
-  const waterClass = waterClassOf(beach.waterBodyType);
+  const waterClass = waterClassFor(beach);
   if (waterClass === null) {
     return {
       stationId: null,

--- a/scripts/tide-join.test.mjs
+++ b/scripts/tide-join.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { bindTideStation, waterClassOf } from "./tide-join.mjs";
+import { bindTideStation, waterClassFor, waterClassOf } from "./tide-join.mjs";
 
 /** A cut-down station table with the properties the rule turns on. */
 const STATIONS = {
@@ -35,7 +35,48 @@ describe("waterClassOf", () => {
   });
 });
 
+describe("waterClassFor", () => {
+  it("reads the published type when no override names the beach", () => {
+    expect(
+      waterClassFor({ slug: "windansea-beach", waterBodyType: "Open Coast" }),
+    ).toBe("open-coast");
+  });
+
+  it("overrides a beach the state types as the wrong kind of water", () => {
+    // Both are wrong upstream, and in opposite directions.
+    expect(
+      waterClassFor({ slug: "fiesta-island", waterBodyType: "Open Coast" }),
+    ).toBe("bay");
+    expect(
+      waterClassFor({
+        slug: "childrens-pool",
+        waterBodyType: "Sound, Bay, or Inlet",
+      }),
+    ).toBe("open-coast");
+  });
+
+  it("still classifies a beach with no slug at all", () => {
+    expect(waterClassFor({ waterBodyType: "Open Coast" })).toBe("open-coast");
+    expect(waterClassFor({ waterBodyType: "Great Lakes" })).toBeNull();
+  });
+});
+
 describe("bindTideStation", () => {
+  it("binds an overridden beach by its real water class", () => {
+    // Children's Pool is typed a bay upstream. Its water level is the ocean's,
+    // and binding it as a bay put it on a station in Mission Bay.
+    const bound = bindTideStation(
+      {
+        slug: "childrens-pool",
+        segment: near(32.8476, -117.2784),
+        waterBodyType: "Sound, Bay, or Inlet",
+      },
+      STATIONS,
+    );
+    expect(bound.waterClass).toBe("open-coast");
+    expect(bound.stationId).toBe("9410230");
+  });
+
   it("binds an open-coast beach to the nearest open-coast station", () => {
     const bound = bindTideStation(
       { segment: near(32.85, -117.27), waterBodyType: "Open Coast" },

--- a/scripts/wave-join.mjs
+++ b/scripts/wave-join.mjs
@@ -21,23 +21,61 @@
  */
 
 import { segmentDistance } from "./geo.mjs";
-import { waterClassOf } from "./tide-join.mjs";
+import { waterClassFor } from "./tide-join.mjs";
+
+/**
+ * Open-coast beaches that ocean swell does not reach anyway.
+ *
+ * THE WATER CLASS ANSWERS TWO QUESTIONS AND THEY CAN DIVERGE. The tide join
+ * reads it as which water body's level applies here; this join reads it as
+ * whether ocean swell reaches this water. Those agree at 71 of 73 beaches,
+ * which is why one field carried both until Children's Pool, where a breakwater
+ * stands between the two answers: the water level inside the pool is the
+ * ocean's, and the swell outside it is not.
+ *
+ * THE CRITERION, so this stays checkable rather than becoming a taste: a fixed
+ * constructed structure -- breakwater, seawall, jetty -- stands between the
+ * beach and the open ocean. NOT "the waves feel smaller here", which is
+ * unfalsifiable and would spread along a coast made largely of coves. Applied
+ * to all sixteen open-coast beaches that survive the inventory bound; one
+ * qualifies. See docs/plans/inventory-bounded-by-stations.md.
+ *
+ * Hand-written for the same reason as `water` and `shore`: no authority
+ * publishes it, and a join has to be told.
+ */
+const SHELTERED = {
+  "childrens-pool": {
+    why:
+      "a curved breakwater encloses the cove, which is what it was built for. The " +
+      "nearest buoy is 2.50 km away on the open coast and describes swell the " +
+      "breakwater stops, at the beach in this inventory most likely to be read by " +
+      "someone deciding whether to put children in the water.",
+  },
+};
 
 /**
  * Bind one beach to a wave buoy.
  *
- * @param {{segment: object, waterBodyType: string}} beach
+ * @param {{slug?: string, segment: object, waterBodyType: string}} beach
  * @param {Record<string, {lat: number, lon: number, delivers: boolean, publishes_waves: boolean}>} buoys
  * @returns {{buoyId: string, distanceM: number, fromEnd: string}
  *   | {buoyId: null, reason: string}}
  */
 export function bindWaveBuoy(beach, buoys) {
-  const waterClass = waterClassOf(beach.waterBodyType);
+  const waterClass = waterClassFor(beach);
 
   if (waterClass === null) {
     return {
       buoyId: null,
       reason: `water body type ${JSON.stringify(beach.waterBodyType)} is not one this join recognises`,
+    };
+  }
+
+  const sheltered = SHELTERED[beach.slug];
+  if (sheltered) {
+    return {
+      buoyId: null,
+      reason: `no buoy describes the water here: ${sheltered.why}`,
     };
   }
 

--- a/scripts/wave-join.test.mjs
+++ b/scripts/wave-join.test.mjs
@@ -32,6 +32,36 @@ describe("bindWaveBuoy", () => {
     expect(bound.reason).toMatch(/does not reach into a bay/);
   });
 
+  it("gives a sheltered open-coast beach no buoy, and says why", () => {
+    // Children's Pool is open coast for its tide -- the water level inside is
+    // the ocean's -- and closed to swell by the breakwater that makes it a
+    // pool. The nearest buoy describes water the breakwater stops.
+    const bound = bindWaveBuoy(
+      {
+        slug: "childrens-pool",
+        segment: at(32.8476, -117.2784),
+        waterBodyType: "Sound, Bay, or Inlet",
+      },
+      BUOYS,
+    );
+    expect(bound.buoyId).toBeNull();
+    expect(bound.reason).toMatch(/breakwater/);
+  });
+
+  it("binds the neighbouring cove, which has no structure", () => {
+    // The shelter rule must not spread along a coast made largely of coves:
+    // Shell Beach is 396 m from Children's Pool and open to the same swell.
+    const bound = bindWaveBuoy(
+      {
+        slug: "shell-beach",
+        segment: at(32.8498, -117.2751),
+        waterBodyType: "Open Coast",
+      },
+      BUOYS,
+    );
+    expect(bound.buoyId).toBe("46254");
+  });
+
   it("never chooses a buoy that does not deliver", () => {
     // 46235 is the closest thing to the south county and answers 404.
     const bound = bindWaveBuoy(

--- a/src/data/beaches.json
+++ b/src/data/beaches.json
@@ -955,7 +955,7 @@
     {
       "slug": "childrens-pool",
       "name": "Childrens Pool",
-      "region": "Bays, lagoons and inlets",
+      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.8478,
@@ -976,13 +976,13 @@
         "status": "Active",
         "nearest_city": "La Jolla"
       },
-      "tide_station": "9410196",
-      "tide_station_distance_m": 7842,
-      "tide_station_from_end": "lower",
+      "tide_station": "9410230",
+      "tide_station_distance_m": 2929,
+      "tide_station_from_end": "upper",
       "wave_buoy": null,
       "wave_buoy_distance_m": null,
       "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+      "wave_buoy_null_reason": "no buoy describes the water here: a curved breakwater encloses the cove, which is what it was built for. The nearest buoy is 2.50 km away on the open coast and describes swell the breakwater stops, at the beach in this inventory most likely to be read by someone deciding whether to put children in the water.",
       "weather_station": "KNKX",
       "weather_station_distance_m": 12887,
       "weather_station_from_end": "lower",
@@ -1896,7 +1896,7 @@
     {
       "slug": "fiesta-island",
       "name": "Fiesta Island",
-      "region": "Point Loma and Ocean Beach",
+      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.7694,
@@ -1917,12 +1917,13 @@
         "status": "Active",
         "nearest_city": "San Diego"
       },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 11663,
+      "tide_station": "TWC0413",
+      "tide_station_distance_m": 2097,
       "tide_station_from_end": "upper",
-      "wave_buoy": "46254",
-      "wave_buoy_distance_m": 12145,
-      "wave_buoy_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
       "weather_station": "KSAN",
       "weather_station_distance_m": 4718,
       "weather_station_from_end": "lower",
@@ -2761,7 +2762,7 @@
   "unresolved": [
     "beach_type is UNKNOWN upstream for most of these beaches. That is a gap in the resource, not a shorthand for sand, and nothing may render it as a description of what the shore is made of.",
     "The join binds by nearest station of matching water class, and the distances are large where NOAA publishes no nearby station: the farthest is San Onofre State Beach at 56.6 km. See tide-stations.json, whose own unresolved list records that the one open-coast station between La Jolla and Imperial Beach does not deliver predictions.",
-    "27 of these beaches get no wave height at all. Every NDBC wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so binding one to the nearest buoy would put an open-ocean number on enclosed water. Their water temperature is missing for the same reason and is not yet filled from another source.",
+    "28 of these beaches get no wave height at all. Every NDBC wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so binding one to the nearest buoy would put an open-ocean number on enclosed water. Their water temperature is missing for the same reason and is not yet filled from another source.",
     "A tide prediction is for the station, not for the beach. It is the best published figure for that stretch of shore and it is not a measurement taken there.",
     "Sky and visibility are read at an airport, because the ten stations in this county that publish them are all airport METARs, and airports sit inland. The median beach reads its sky station 7.3 km away and the farthest reads one 16.8 km away, at San Dieguito River Beach. Coastal fog is precisely what changes over that distance, so those two figures describe the airport and not the shoreline.",
     "Air temperature and wind come from a different station than sky and visibility, and the page names both. The median beach reads its air station 3.5 km away against 7.3 km for its sky station. Two provenances behind one panel is a deliberate trade: requiring one station to supply all four values meant the scarcest of them, sky, decided where the temperature was measured, which put an inland reading on a coastal beach. See docs/adr/0010-two-provenances-in-the-air-panel.md.",

--- a/src/lib/beaches.test.ts
+++ b/src/lib/beaches.test.ts
@@ -71,12 +71,32 @@ describe("the tide station binding", () => {
   });
 
   test("never binds an open-coast beach to a bay station, or the reverse", () => {
+    // Two beaches are typed as the wrong kind of water upstream and carry a
+    // written override in scripts/tide-join.mjs: Fiesta Island is typed open
+    // coast inside Mission Bay, Children's Pool is typed a bay on the open
+    // ocean. Everywhere else the published type decides. The exceptions are
+    // listed here rather than skipped by a rule, so that a third override
+    // cannot appear without this test naming it.
+    const OVERRIDDEN = new Set(["childrens-pool", "fiesta-island"]);
+
     for (const beach of allBeaches()) {
       const station = tideStationFor(beach);
-      if (station === null) continue;
+      if (station === null || OVERRIDDEN.has(beach.slug)) continue;
       const expected =
         beach.upstream.water_body_type === "Open Coast" ? "open-coast" : "bay";
       expect(station.water).toBe(expected);
+    }
+  });
+
+  test("applies the water class to the region label and the join alike", () => {
+    // The class is resolved in one place and read by three joins and the region
+    // label. A beach bound to a bay station but filed under a coastal region
+    // would mean an override reached one reader and not the others -- which is
+    // the failure mode a slug-keyed override invites.
+    for (const beach of allBeaches()) {
+      const station = tideStationFor(beach);
+      if (station === null) continue;
+      expect(station.water === "bay").toBe(beach.region.startsWith("Bays"));
     }
   });
 
@@ -127,8 +147,13 @@ describe("grouping for a chooser", () => {
 
   test("puts bays and inlets in one group regardless of latitude", () => {
     const bays = beachesByRegion().find((g) => g.region.startsWith("Bays"))!;
+
+    expect(bays.beaches.length).toBeGreaterThan(0);
     for (const beach of bays.beaches) {
-      expect(beach.upstream.water_body_type).toBe("Sound, Bay, or Inlet");
+      // Read from the binding rather than from `upstream.water_body_type`:
+      // that field is what the override in scripts/tide-join.mjs corrects, so
+      // asserting it here would assert the bug instead of the behaviour.
+      expect(tideStationFor(beach)?.water).toBe("bay");
     }
   });
 });


### PR DESCRIPTION
Slices 1 and 2 of `docs/plans/inventory-bounded-by-stations.md`. **No beach
leaves the inventory in this PR.** The split is at the point where the count
actually changes, because slice 2 is a correctness fix that stands whether or
not the predicate in the follow-up lands.

### Slice 1 — the decision, written down (`8af7119`)

The joins have no ceiling, so a beach the networks cannot reach gets a number
anyway from whatever is furthest away: tide p90 30.6 km and max 56.6 km, waves
p90 27.9 km and max 34.2 km. Neither gap is a join defect — `tide-stations.json`
holds two delivering open-coast stations, the northernmost at 32.867 °N against
a county running to 33.39 °N, and no wave buoy sits between 32.868 °N and
32.517 °N. The networks stop; the joins were reaching past where they end.

Adds the plan, ADR 0011, and `docs/reference/sensor-representativeness.md` — the
standards source the 10 km figure is argued *against* rather than cited to,
including that no such radius is citable, so the number is ours to defend.

### Plan revision — the water class answers two questions (`45b4ffb`)

Measuring slice 2 against the real joins before writing it showed the slice
could not be implemented as specified. `waterClassOf` is read by the tide join
as *which water body's level applies here* and by the wave join as *does ocean
swell reach this water*. Those coincide at 71 of 73 beaches, which is why the
conflation survived three joins. At Children's Pool a breakwater stands between
the answers, and neither class is right.

Adds a `sheltered` join input with a written criterion, reformulates the
predicate's wave clause, and amends ADR 0011, whose decision paragraph stated
the superseded form. 40 kept becomes 41.

### Slice 2 — the two reclassifications (`a7aaa07`)

- `fiesta-island`: typed Open Coast, sits inside Mission Bay. Tide 9410230 at
  11.66 km → TWC0413 at 2.10 km; wave 46254 at 12.14 km → none.
- `childrens-pool`: typed a bay, is an ocean cove. Tide 9410196 at 7.84 km →
  9410230 at 2.93 km, and still no buoy — now by `sheltered` rather than by
  class, which is the half of its old classification that was right.

The class is resolved by `waterClassFor(beach)`, which takes the whole beach so
a call site cannot classify and forget the override. Two tests in
`beaches.test.ts` move off `upstream.water_body_type` — the field the override
exists to correct — onto the resolved class.

### Verification

`npm run gate` at `a7aaa07`, with `.next/` removed first so the stylesheet row
reads a fresh build:

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

`node scripts/seed-beaches.mjs --check` also passes at this commit — the join is
re-derivable, which is what makes the two moved bindings evidence rather than an
assertion. It is deliberately not a gate row: it reaches the network.

### What is not here

- **The predicate itself, and the 32 beaches it removes.** That is the follow-up
  PR, stacked on this branch.
- **ADR 0011's region split is wrong at this commit** — it says 13 in La Jolla
  and Pacific Beach and 3 in Point Loma and Ocean Beach, where the re-joined
  inventory gives 14 and 2. It was miscounted when the total was updated from 40
  to 41. Corrected in the first commit of the follow-up PR, because that is where
  the numbers become measurable.
- **Sky and visibility.** Every sky reading is an airport METAR at 1.6–16.8 km,
  and the reference above holds that aerodrome observations should not be
  transferred off-field at any distance. No tightening of this predicate fixes
  it; named in the plan's out-of-scope list and not yet an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
