### PR TITLE
Bound the inventory by the stations that reach it, and tell a reader

### DIFF
--- a/docs/adr/0011-inventory-bounded-by-station-networks.md
+++ b/docs/adr/0011-inventory-bounded-by-station-networks.md
@@ -79,11 +79,15 @@ The plan is `docs/plans/inventory-bounded-by-stations.md`.
 **The site answers for 41 beaches instead of 73.** That is the cost and it is
 the point: the 32 it drops are the ones whose numbers it could not defend. What
 remains, by the region labels the seeding script already assigns: 25 bays,
-lagoons and inlets, 13 in La Jolla and Pacific Beach — which by that rule
-includes Del Mar City Beach and both Torrey Pines — and 3 in Point Loma and
-Ocean Beach. No beach survives north of Del Mar or south of Ocean Beach. Every
-one has a tide station within 10 km, and none is bound to a buoy further away
-than that.
+lagoons and inlets, 14 in La Jolla and Pacific Beach — which by that rule
+includes Del Mar City Beach and both Torrey Pines — and 2 in Point Loma and
+Ocean Beach, which by the same rule are Pacific Beach and Mission Beach. No
+beach survives north of Del Mar, and on the open coast none survives south of
+Mission Beach: Ocean Beach, Sunset Cliffs and the whole Coronado and Imperial
+Beach run are cut. The bays reach further south than that, to Coronado Cays and
+the Tijuana Slough, because they are bound to bay stations that are nearby.
+Every surviving beach has a tide station within 10 km, and none is bound to a
+buoy further away than that.
 
 **The whole North County coast goes, and its air and wave bindings were the best
 on the site** — 0.3–5.1 km and 1.0–4.7 km. Only tide fails there, and it fails
@@ -97,7 +101,7 @@ here" worse than no page at all.
 
 **Coverage becomes a measurement rather than an ambition.** "73 beaches" was
 never a claim about what the site could measure; it was a claim about what the
-county lists. Forty is the first number this repo has published about its own
+county lists. Forty-one is the first number this repo has published about its own
 reach that is true.
 
 **Two upstream rows are excluded for being wrong rather than far**, and the
@@ -130,6 +134,16 @@ kept against 33 dropped. Measuring the two reclassifications against the real
 joins showed that form cuts a beach for lacking a buoy the join was right to
 withhold, so the clause is restated above in the form that separates a binding
 that is too far from a binding correctly not made. The counts are 41 and 32.
+
+The consequences above originally split the 41 as 13 in La Jolla and Pacific
+Beach and 3 in Point Loma and Ocean Beach, and called the total forty in one
+sentence and forty-one in another. Measured over the re-joined inventory the
+split is 14 and 2: Children's Pool moved out of the bay group when it was
+reclassified, and it moved into La Jolla rather than into the band below.
+Pacific Beach and Mission Beach are the only two the latitude bands put in
+Point Loma and Ocean Beach, and the beach actually named Ocean Beach is cut, so
+the claim that nothing survives south of it was misleading as well as
+miscounted. Both are restated above.
 
 The argument is unchanged. What changed is that the water class turned out to
 answer two questions — which water body's level applies here, and whether ocean

--- a/docs/plans/inventory-bounded-by-stations.md
+++ b/docs/plans/inventory-bounded-by-stations.md
@@ -369,3 +369,29 @@ own slice, not an addendum.
 3. The predicate in its reformulated shape, the `_excluded` block, the
    regenerated `beaches.json`, routes and selector. 73 beaches become 41.
 4. Unchanged: the exclusion is disclosed to readers by `Caveats`.
+
+## Addendum — 2026-08-19: the `no-station` states survive their last beach
+
+Found while implementing slice 3. The predicate requires a tide station within
+10 km, so no beach that reaches the inventory can have a null binding — and
+`imperial-beach-pier-area`, the one beach the joins refused outright, is
+excluded by the same rule. Every beach that survives also binds an air station
+and a sky station, because only that one row lacked them.
+
+So the `no-station` state of the tide, air and sky panels is no longer
+reachable through `beaches.json`. The plan says above that nothing is built to
+suppress a panel because every panel already has that state; what it did not
+anticipate is that the removal empties the state of occupants.
+
+**They stay, and they stay tested.** The state is not dead: `beaches.json` is
+written by joins that can fail, `Beach.tide_station` is `string | null` by
+contract with the seeding script, and the distinction the state exists for —
+a permanent fact about a place against a feed having a bad day — is what a
+reader would lose if the two collapsed. `conditions.test.ts` now reaches them
+through one synthetic beach added to the real inventory, so the rest of that
+file still runs against the shipped data.
+
+Collapsing them, or narrowing the `Beach` type so the compiler knows a served
+beach has a station, is a separate slice with its own argument. It is not this
+one: it would touch three joins, the type and four components, and it would be
+reversed the moment the per-variable-suppression decision above is revisited.

--- a/scripts/seed-beaches.mjs
+++ b/scripts/seed-beaches.mjs
@@ -19,8 +19,12 @@
  *   - that the datastore serialises numerics as JSON strings, so coordinates are
  *     converted once, here, and never by a reader.
  *
- * The inclusion predicate is data rather than judgement: County San Diego,
- * Status Active, BeachAccess PUBLIC, CountAsBeach 1.
+ * TWO PREDICATES DECIDE WHAT IS IN THE FILE, and they differ in kind. The
+ * inclusion predicate is data rather than judgement: County San Diego, Status
+ * Active, BeachAccess PUBLIC, CountAsBeach 1. The service predicate --
+ * `servesBeach` below -- is judgement and says so, because it decides how far a
+ * measurement may be taken from the place it is shown for. Every beach the
+ * second refuses is written to `_excluded` with the distance that refused it.
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
@@ -186,7 +190,7 @@ export function slugify(name) {
 
 /**
  * Display grouping only. Never an input to any join — it exists so a reader can
- * find their beach in a list of seventy-odd, and the bands are latitudes rather
+ * find their beach in a long list, and the bands are latitudes rather
  * than anyone's idea of where a neighbourhood ends. Bay and inlet sites group
  * together regardless of latitude, because that is how someone looks for them.
  */
@@ -305,8 +309,107 @@ export function build(rows, stations, buoys, weatherStations) {
   return beaches;
 }
 
-export function document(beaches) {
-  const unbound = beaches.filter((b) => b.tide_station === null);
+/**
+ * How far a reading may travel before this site stops publishing it, in metres.
+ *
+ * A named constant because it is the one number in this file that is a
+ * judgement, and changing it must be a one-line reviewable edit rather than a
+ * hunt. Ten kilometres is WMO-No. 8 §1.1.2's stated scale for small-scale and
+ * local applications, which is the nearest thing to an anchor that exists: no
+ * standard reporting radius does, and docs/reference/sensor-representativeness.md
+ * records why. A benchmark rather than a rule, so the figure is ours to defend
+ * and not to cite. At 15 km the site would list 49 beaches instead of 41; the
+ * whole trade curve is in docs/plans/inventory-bounded-by-stations.md.
+ */
+export const SERVICE_TOLERANCE_M = 10_000;
+
+const kilometres = (metres) => `${(metres / 1000).toFixed(1)} km`;
+
+/**
+ * Why the station networks cannot serve this beach, or null when they can.
+ *
+ * The second predicate over the inventory, and the one that is judgement. The
+ * first -- County, Active, PUBLIC, CountAsBeach, up in `query` -- is a filter
+ * over published fields and decides nothing about what is worth listing. This
+ * one decides how far a measurement may be taken from the place it is shown
+ * for. What keeps it honest is that its inputs are measured: every distance
+ * here came out of a join, and every beach it refuses is written to
+ * `_excluded` with the distance that refused it.
+ *
+ * THE RULE: a tide station within the tolerance, and if a wave buoy is bound at
+ * all, that buoy within the tolerance. A beach fails when a binding it *has* is
+ * too far, never when a join correctly declined to make one -- which is what
+ * the wave join does at a bay, where swell does not reach, and at a cove closed
+ * off by a breakwater. Stating it that way subsumes the bay exemption rather
+ * than special-casing beside it.
+ *
+ * Air is deliberately not a clause. Every bound beach already reads air within
+ * 7.4 km, so adding it would exclude nobody while implying a filter doing work
+ * it is not doing. See docs/adr/0011-inventory-bounded-by-station-networks.md.
+ *
+ * @param {object} beach A built beach, with its bindings and their distances.
+ * @param {number} [toleranceM]
+ * @returns {string | null}
+ */
+export function serviceFault(beach, toleranceM = SERVICE_TOLERANCE_M) {
+  if (beach.tide_station === null) {
+    return `no tide station was bound to it at all: ${beach.tide_station_null_reason}`;
+  }
+
+  const tooFar = [];
+  if (beach.tide_station_distance_m > toleranceM) {
+    tooFar.push(
+      `its tide station ${beach.tide_station} is ` +
+        `${kilometres(beach.tide_station_distance_m)} away`,
+    );
+  }
+  if (beach.wave_buoy !== null && beach.wave_buoy_distance_m > toleranceM) {
+    tooFar.push(
+      `its wave buoy ${beach.wave_buoy} is ` +
+        `${kilometres(beach.wave_buoy_distance_m)} away`,
+    );
+  }
+  if (tooFar.length === 0) return null;
+
+  return (
+    `${tooFar.join(" and ")}, and this site does not publish a reading taken more than ` +
+    `${kilometres(toleranceM)} from the beach it is shown for`
+  );
+}
+
+/**
+ * Whether the stations this beach needs reach it.
+ *
+ * Defined in terms of `serviceFault` so the verdict and the reason recorded
+ * beside it cannot drift apart: there is one rule, and the boolean is a reading
+ * of it rather than a second copy.
+ *
+ * @param {object} beach
+ * @param {number} [toleranceM]
+ * @returns {boolean}
+ */
+export function servesBeach(beach, toleranceM = SERVICE_TOLERANCE_M) {
+  return serviceFault(beach, toleranceM) === null;
+}
+
+export function document(built) {
+  const beaches = built.filter((beach) => servesBeach(beach));
+  const excluded = built
+    .filter((beach) => !servesBeach(beach))
+    .map((beach) => ({
+      slug: beach.slug,
+      name: beach.name,
+      why: serviceFault(beach),
+    }));
+
+  if (beaches.length === 0) {
+    throw new Error(
+      `the service predicate excluded all ${built.length} beaches. That is a broken join or a ` +
+        `moved station table, not a county whose coastline no station reaches; refusing to ` +
+        `overwrite the inventory with an empty one.`,
+    );
+  }
+
   const withWeather = beaches.filter((b) => b.weather_station !== null);
   const farthestWeather = withWeather.reduce((a, b) =>
     b.weather_station_distance_m > a.weather_station_distance_m ? b : a,
@@ -340,6 +443,17 @@ export function document(beaches) {
     _inclusion:
       "County San Diego, Status Active, BeachAccess PUBLIC, CountAsBeach 1. A predicate over " +
       "published fields rather than a judgement about which beaches are worth listing.",
+    _served:
+      `And then, of those: a tide station within ${kilometres(SERVICE_TOLERANCE_M)}, and if a ` +
+      `wave buoy is bound at all, that buoy within ${kilometres(SERVICE_TOLERANCE_M)}. Unlike ` +
+      `_inclusion this one IS a judgement -- it decides how far a measurement may be taken ` +
+      `from the place it is shown for -- and it is stated here rather than left implicit in ` +
+      `how far a join happened to reach. Ten kilometres is WMO-No. 8 §1.1.2's scale for ` +
+      `small-scale and local applications; no standard reporting radius exists, so the figure ` +
+      `is defended rather than cited. What keeps it honest is that its inputs are measured: ` +
+      `every distance came out of a join. Every beach it refuses is in _excluded below, with ` +
+      `the binding distance that refused it, so nothing leaves this inventory silently. See ` +
+      `docs/adr/0011-inventory-bounded-by-station-networks.md.`,
     _pinned: {
       field_name_with_a_space:
         "Upstream names one field 'Beach_ UpperLon', with an embedded space. That is the " +
@@ -392,6 +506,11 @@ export function document(beaches) {
         "Which end of the segment supplied the distance, upper or lower.",
     },
     beaches,
+    // The other half of the same predicate. A beach that vanished with no
+    // record of why would be the silent failure the unresolved blocks exist to
+    // prevent, and this one is worse than most: the reader cannot miss what
+    // they were never shown.
+    _excluded: excluded,
     // Written out in full every run, never merged with what is already on disk:
     // carrying entries forward duplicated them on the second run and made
     // --check report movement immediately after a seed. A check that cannot say
@@ -400,11 +519,12 @@ export function document(beaches) {
       "beach_type is UNKNOWN upstream for most of these beaches. That is a gap in the resource, " +
         "not a shorthand for sand, and nothing may render it as a description of what the shore " +
         "is made of.",
-      `The join binds by nearest station of matching water class, and the distances are large ` +
-        `where NOAA publishes no nearby station: the farthest is ${farthest.name} at ` +
-        `${(farthest.tide_station_distance_m / 1000).toFixed(1)} km. See tide-stations.json, ` +
-        `whose own unresolved list records that the one open-coast station between La Jolla and ` +
-        `Imperial Beach does not deliver predictions.`,
+      `The join binds by nearest station of matching water class, and a beach whose nearest is ` +
+        `further than ${kilometres(SERVICE_TOLERANCE_M)} away is not listed here at all rather ` +
+        `than listed with a reading from out of range. The farthest any listed beach reads is ` +
+        `${farthest.name}'s, at ${kilometres(farthest.tide_station_distance_m)}. See ` +
+        `tide-stations.json, whose own unresolved list records that the one open-coast station ` +
+        `between La Jolla and Imperial Beach does not deliver predictions.`,
       `${beaches.filter((b) => b.wave_buoy === null).length} of these beaches get no wave height at all. ` +
         `Every NDBC wave buoy sits on the open coast, and ocean swell does not reach into a bay or ` +
         `lagoon, so binding one to the nearest buoy would put an open-ocean number on enclosed water. ` +
@@ -429,15 +549,6 @@ export function document(beaches) {
         `station standing in the marine layer at the shoreline, a bay or lagoon binds the ` +
         `nearest of any kind. The shore classification is an author judgement; ` +
         `weather-stations.json records it and says so.`,
-      ...(unbound.length > 0
-        ? [
-            `${unbound.length} beach(es) could not be bound to a station: ` +
-              unbound
-                .map((b) => `${b.name} (${b.tide_station_null_reason})`)
-                .join("; ") +
-              ". A null station must never render as a reading.",
-          ]
-        : []),
       "The network module carries no build-time guard against being imported by a browser " +
         "bundle. The `server-only` package is the intended enforcement and is not installed: " +
         "importing it breaks the tests under jsdom until vitest is configured with the " +

--- a/scripts/seed-beaches.test.mjs
+++ b/scripts/seed-beaches.test.mjs
@@ -4,6 +4,9 @@ import {
   document,
   regionOf,
   segmentFault,
+  SERVICE_TOLERANCE_M,
+  serviceFault,
+  servesBeach,
   slugify,
 } from "./seed-beaches.mjs";
 
@@ -105,6 +108,16 @@ function row(overrides = {}) {
     ...overrides,
   };
 }
+
+/** Inside the county, and further from every station in the tables above than
+ * the service predicate will publish a reading from. */
+const FAR_ROW = row({
+  Beach_Name: "Far From Any Station",
+  Beach_UpperLat: "33.21",
+  "Beach_ UpperLon": "-117.40",
+  Beach_LowerLat: "33.20",
+  Beach_LowerLon: "-117.40",
+});
 
 describe("segmentFault", () => {
   it("passes a real beach", () => {
@@ -349,25 +362,198 @@ describe("build", () => {
   });
 });
 
-describe("document", () => {
-  it("names an unbound beach in the caveats a reader is owed", () => {
-    const built = build(
-      [
-        row(),
-        row({
-          Beach_Name: "Broken coordinates",
-          Beach_LowerLat: "32.1327",
+/**
+ * A built beach reduced to what the service predicate reads. Written out rather
+ * than produced by `build` so the boundary cases are stated in metres instead
+ * of hidden inside a pair of coordinates.
+ */
+function bound(overrides = {}) {
+  return {
+    slug: "somewhere-beach",
+    name: "Somewhere Beach",
+    tide_station: "9410230",
+    tide_station_distance_m: 1_000,
+    wave_buoy: "46254",
+    wave_buoy_distance_m: 1_000,
+    ...overrides,
+  };
+}
+
+describe("servesBeach", () => {
+  it("is a ten-kilometre rule by default, and says so in one place", () => {
+    // The figure is a judgement rather than a citation, so changing it has to
+    // be a one-line edit to a named constant and not a hunt through the file.
+    expect(SERVICE_TOLERANCE_M).toBe(10_000);
+    expect(servesBeach(bound({ tide_station_distance_m: 10_001 }))).toBe(false);
+  });
+
+  it("keeps a beach whose bindings sit exactly on the tolerance", () => {
+    expect(
+      servesBeach(
+        bound({
+          tide_station_distance_m: 10_000,
+          wave_buoy_distance_m: 10_000,
         }),
-      ],
-      STATIONS,
-      BUOYS,
-      WEATHER,
+      ),
+    ).toBe(true);
+  });
+
+  it("cuts a beach one metre past it", () => {
+    expect(servesBeach(bound({ tide_station_distance_m: 10_001 }))).toBe(false);
+  });
+
+  it("reads the tolerance it is given, not the constant", () => {
+    const beach = bound({ tide_station_distance_m: 5_000 });
+    expect(servesBeach(beach, 4_000)).toBe(false);
+    expect(servesBeach(beach, 6_000)).toBe(true);
+  });
+
+  it("cuts a beach whose buoy is too far even when its tide station is near", () => {
+    // Ocean Beach: Scripps at 12.3 km and Scripps Nearshore at 12.5 km. Either
+    // clause alone is enough to refuse it.
+    expect(
+      servesBeach(
+        bound({ tide_station_distance_m: 4_000, wave_buoy_distance_m: 12_476 }),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps a beach that binds no buoy at all, whatever declined it", () => {
+    // The clause is "if a buoy is bound, it is within range", not "a buoy is
+    // within range". A bay binds none because swell does not reach it, and
+    // Children's Pool binds none because a breakwater stops the swell. Both are
+    // the join answering correctly, and neither is a reason to drop a beach.
+    expect(
+      servesBeach(bound({ wave_buoy: null, wave_buoy_distance_m: null })),
+    ).toBe(true);
+  });
+
+  it("cuts a beach the join could not bind a tide station to", () => {
+    expect(
+      servesBeach(
+        bound({
+          tide_station: null,
+          tide_station_distance_m: null,
+          wave_buoy: null,
+          wave_buoy_distance_m: null,
+          tide_station_null_reason: "the upper endpoint is outside the county",
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("serviceFault", () => {
+  it("is silent about a beach the stations reach", () => {
+    expect(serviceFault(bound())).toBeNull();
+  });
+
+  it("names the distance that disqualified the beach", () => {
+    const why = serviceFault(bound({ tide_station_distance_m: 56_557 }));
+    expect(why).toContain("9410230");
+    expect(why).toContain("56.6 km");
+    expect(why).toContain("10.0 km");
+  });
+
+  it("names every binding that is too far, not merely the first", () => {
+    // Sunset Cliffs is past the tolerance on both, and a reason that mentioned
+    // only the tide would read as though moving one station would rescue it.
+    const why = serviceFault(
+      bound({ tide_station_distance_m: 14_646, wave_buoy_distance_m: 14_805 }),
     );
+    expect(why).toContain("14.6 km");
+    expect(why).toContain("14.8 km");
+  });
+
+  it("repeats the join's own reason when nothing was bound", () => {
+    const why = serviceFault(
+      bound({
+        tide_station: null,
+        tide_station_distance_m: null,
+        wave_buoy: null,
+        wave_buoy_distance_m: null,
+        tide_station_null_reason:
+          "the lower endpoint published upstream is outside San Diego County",
+      }),
+    );
+    expect(why).toContain("outside San Diego County");
+  });
+});
+
+describe("document", () => {
+  it("lists only the beaches whose stations reach them", () => {
+    const doc = document(build([row(), FAR_ROW], STATIONS, BUOYS, WEATHER));
+
+    expect(doc.beaches.map((b) => b.slug)).toEqual(["somewhere-beach"]);
+  });
+
+  it("records every beach it does not list, with the distance that cut it", () => {
+    const doc = document(build([row(), FAR_ROW], STATIONS, BUOYS, WEATHER));
+
+    expect(doc._excluded).toEqual([
+      {
+        slug: "far-from-any-station",
+        name: "Far From Any Station",
+        why: expect.stringContaining("km away"),
+      },
+    ]);
+  });
+
+  it("accounts for every beach the county lists, in one block or the other", () => {
+    // The failure mode this exists to stop: a beach leaving the inventory with
+    // nothing anywhere saying it did.
+    const built = build([row(), FAR_ROW], STATIONS, BUOYS, WEATHER);
     const doc = document(built);
 
-    expect(doc.unresolved.some((c) => c.includes("Broken coordinates"))).toBe(
-      true,
+    const listed = [
+      ...doc.beaches.map((b) => b.slug),
+      ...doc._excluded.map((b) => b.slug),
+    ];
+    expect(listed.sort()).toEqual(built.map((b) => b.slug).sort());
+  });
+
+  it("records a beach nothing could be bound to, and repeats the join's reason", () => {
+    const doc = document(
+      build(
+        [
+          row(),
+          row({
+            Beach_Name: "Broken coordinates",
+            Beach_LowerLat: "32.1327",
+          }),
+        ],
+        STATIONS,
+        BUOYS,
+        WEATHER,
+      ),
     );
+
+    const broken = doc._excluded.find((b) => b.name === "Broken coordinates");
+    expect(broken).toBeDefined();
+    expect(broken.why).toMatch(/outside San Diego County/);
+  });
+
+  it("refuses to write an inventory with nothing in it", () => {
+    // Every beach failing the predicate is a broken join or a moved station
+    // table, not a county with no reachable coastline. Writing the empty file
+    // would replace the whole inventory with a silence.
+    expect(() => document(build([FAR_ROW], STATIONS, BUOYS, WEATHER))).toThrow(
+      /excluded all 1/,
+    );
+  });
+
+  it("tells a reader that a beach out of range is not listed at all", () => {
+    const doc = document(build([row()], STATIONS, BUOYS, WEATHER));
+    const bound = doc.unresolved.find((entry) =>
+      entry.includes("nearest station of matching water class"),
+    );
+
+    // The old wording said the distances were large where NOAA publishes no
+    // nearby station. They are not large any more -- the beaches that had them
+    // are gone -- and a caveat that describes the previous inventory is worse
+    // than none.
+    expect(bound).toContain("10.0 km");
+    expect(bound).not.toMatch(/distances are large/);
   });
 
   it("tells a reader the weather figures are read at an airport", () => {
@@ -387,19 +573,22 @@ describe("document", () => {
     // Two beaches, so the reduce and the sort actually run. With one, the
     // callbacks never fire and "farthest" is whatever happened to be there --
     // which is how a single-row fixture can leave a real rule unasserted.
+    // Both are inside the service tolerance of the tide station and the buoy,
+    // and differ only in how far the airport is: a fixture the predicate cuts
+    // never reaches the reduce this test is about.
     const near = row({
       Beach_Name: "Near The Airport",
-      Beach_UpperLat: "32.87",
-      "Beach_ UpperLon": "-117.15",
-      Beach_LowerLat: "32.86",
-      Beach_LowerLon: "-117.16",
+      Beach_UpperLat: "32.88",
+      "Beach_ UpperLon": "-117.20",
+      Beach_LowerLat: "32.87",
+      Beach_LowerLon: "-117.20",
     });
     const far = row({
       Beach_Name: "Far From The Airport",
-      Beach_UpperLat: "33.05",
-      "Beach_ UpperLon": "-117.30",
-      Beach_LowerLat: "33.04",
-      Beach_LowerLon: "-117.31",
+      Beach_UpperLat: "32.88",
+      "Beach_ UpperLon": "-117.34",
+      Beach_LowerLat: "32.87",
+      Beach_LowerLon: "-117.34",
     });
 
     const built = document(build([near, far], STATIONS, BUOYS, WEATHER));

--- a/src/app/conditions/[slug]/page.test.tsx
+++ b/src/app/conditions/[slug]/page.test.tsx
@@ -26,10 +26,10 @@ const {
 const params = (slug: string) => ({ params: Promise.resolve({ slug }) });
 
 test("renders the beach named in the route", async () => {
-  render(await BeachConditions(params("harbor-beach")));
+  render(await BeachConditions(params("torrey-pines-state-beach")));
 
   expect(screen.getByRole("main")).toBeDefined();
-  expect(screen.getByText("panel for harbor-beach")).toBeDefined();
+  expect(screen.getByText("panel for torrey-pines-state-beach")).toBeDefined();
 });
 
 test("a slug outside the inventory is a 404, not an apology page", async () => {
@@ -40,9 +40,19 @@ test("a slug outside the inventory is a 404, not an apology page", async () => {
 });
 
 test("the title names the beach, so a shared link says where it is about", async () => {
-  const metadata = await generateMetadata(params("harbor-beach"));
-  expect(metadata.title).toBe("Harbor Beach conditions");
-  expect(String(metadata.description)).toContain("Harbor Beach");
+  const metadata = await generateMetadata(params("torrey-pines-state-beach"));
+  expect(metadata.title).toBe("Torrey Pines State Beach conditions");
+  expect(String(metadata.description)).toContain("Torrey Pines State Beach");
+});
+
+test("a beach the stations cannot reach is a 404, not an empty page", async () => {
+  // Harbor Beach is in the county's list and reads Scripps 39.4 km away, so the
+  // service predicate leaves it out of the inventory. A link shared before that
+  // has to fail rather than render a page with no readings in it.
+  await expect(BeachConditions(params("harbor-beach"))).rejects.toThrow(
+    "NEXT_NOT_FOUND",
+  );
+  expect(notFound).toHaveBeenCalled();
 });
 
 test("metadata for an unknown slug falls back rather than throwing", async () => {
@@ -54,8 +64,7 @@ test("metadata for an unknown slug falls back rather than throwing", async () =>
 });
 
 test("nothing is prerendered at build, so upstream load follows real readers", () => {
-  // 73 beaches times a NOAA request each, on every build, for pages nobody has
-  // looked at.
+  // A NOAA request per beach, on every build, for pages nobody has looked at.
   expect(generateStaticParams()).toEqual([]);
 });
 

--- a/src/app/conditions/[slug]/page.tsx
+++ b/src/app/conditions/[slug]/page.tsx
@@ -14,10 +14,10 @@ export const revalidate = 900;
 /**
  * Nothing prerendered at build, and every beach reachable.
  *
- * Seventy-three beaches times a NOAA request each, on every build, would ask the
- * publisher for a great deal that nobody has looked at. Returning none means a
- * beach is fetched the first time somebody actually chooses it and is served
- * from the cache after that, so upstream load follows real readers.
+ * A NOAA request per beach on every build would ask the publisher for a great
+ * deal that nobody has looked at. Returning none means a beach is fetched the
+ * first time somebody actually chooses it and is served from the cache after
+ * that, so upstream load follows real readers.
  */
 export function generateStaticParams() {
   return [];

--- a/src/app/conditions/page.test.tsx
+++ b/src/app/conditions/page.test.tsx
@@ -36,8 +36,10 @@ test("a reader can choose another beach from here", () => {
 
   const select = screen.getByLabelText("Choose a beach") as HTMLSelectElement;
   expect(select.value).toBe(DEFAULT_BEACH_SLUG);
-  // Every beach in the inventory is offered, not a curated subset.
-  expect(select.querySelectorAll("option").length).toBe(73);
+  // Every beach in the inventory is offered, not a curated subset. It is 41
+  // rather than the county's 73 because the inventory itself is bounded by the
+  // stations that reach it, not because the chooser hides any of it.
+  expect(select.querySelectorAll("option").length).toBe(41);
 });
 
 test("the page revalidates often enough that 'today' does not go stale", () => {

--- a/src/components/BeachSelector.test.tsx
+++ b/src/components/BeachSelector.test.tsx
@@ -8,50 +8,53 @@ vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }));
 
 const GROUPS = [
   {
-    region: "North County coast",
+    region: "La Jolla and Pacific Beach",
     beaches: [
-      { slug: "san-onofre-state-beach", name: "San Onofre State Beach" },
-      { slug: "harbor-beach", name: "Harbor Beach" },
+      { slug: "del-mar-city-beach", name: "Del Mar City Beach" },
+      { slug: "la-jolla-shores-beach", name: "La Jolla Shores Beach" },
     ],
   },
   {
     region: "Bays, lagoons and inlets",
-    beaches: [{ slug: "agua-hedionda-lagoon", name: "Agua Hedionda Lagoon" }],
+    beaches: [{ slug: "mission-bay", name: "Mission Bay" }],
   },
 ];
 
 test("the chooser is labelled, so it is reachable without sight of it", () => {
-  render(<BeachSelector groups={GROUPS} current="harbor-beach" />);
+  render(<BeachSelector groups={GROUPS} current="la-jolla-shores-beach" />);
 
   const select = screen.getByLabelText("Choose a beach");
   expect(select).toBeDefined();
-  expect((select as HTMLSelectElement).value).toBe("harbor-beach");
+  expect((select as HTMLSelectElement).value).toBe("la-jolla-shores-beach");
 });
 
 test("beaches are grouped by region rather than listed flat", () => {
   const { container } = render(
-    <BeachSelector groups={GROUPS} current="harbor-beach" />,
+    <BeachSelector groups={GROUPS} current="la-jolla-shores-beach" />,
   );
 
   const labels = [...container.querySelectorAll("optgroup")].map((group) =>
     group.getAttribute("label"),
   );
-  // Seventy-three entries is too many to scan as one list.
-  expect(labels).toEqual(["North County coast", "Bays, lagoons and inlets"]);
+  // Forty-odd entries is still too many to scan as one list.
+  expect(labels).toEqual([
+    "La Jolla and Pacific Beach",
+    "Bays, lagoons and inlets",
+  ]);
 });
 
 test("every beach given is offered exactly once", () => {
   const { container } = render(
-    <BeachSelector groups={GROUPS} current="harbor-beach" />,
+    <BeachSelector groups={GROUPS} current="la-jolla-shores-beach" />,
   );
 
   const values = [...container.querySelectorAll("option")].map(
     (option) => (option as HTMLOptionElement).value,
   );
   expect(values).toEqual([
-    "san-onofre-state-beach",
-    "harbor-beach",
-    "agua-hedionda-lagoon",
+    "del-mar-city-beach",
+    "la-jolla-shores-beach",
+    "mission-bay",
   ]);
 });
 
@@ -60,14 +63,14 @@ test("a beach without scripting is still reachable, as a link", () => {
   // does its job: the client renderer never parses its contents, and a family on
   // a phone with a blocked script only ever sees the HTML the server sent.
   const markup = renderToStaticMarkup(
-    <BeachSelector groups={GROUPS} current="harbor-beach" />,
+    <BeachSelector groups={GROUPS} current="la-jolla-shores-beach" />,
   );
 
   expect(markup).toContain("<noscript>");
-  expect(markup).toContain("San Onofre State Beach");
-  expect(markup).toContain("/conditions/agua-hedionda-lagoon");
+  expect(markup).toContain("Del Mar City Beach");
+  expect(markup).toContain("/conditions/mission-bay");
   // Two-sided: markup containing every beach twice would pass the lines above
   // whether or not the fallback exists, so the links must be inside it.
   const fallback = markup.slice(markup.indexOf("<noscript>"));
-  expect(fallback).toContain("/conditions/san-onofre-state-beach");
+  expect(fallback).toContain("/conditions/del-mar-city-beach");
 });

--- a/src/components/BeachSelector.tsx
+++ b/src/components/BeachSelector.tsx
@@ -5,8 +5,8 @@ import { useRouter } from "next/navigation";
 /**
  * Choosing which beach the conditions view is about.
  *
- * Seventy-three entries is too many to scan flat, so they are grouped by region
- * — a display grouping the inventory derives from water class and latitude, and
+ * The inventory is too long to scan flat, so it is grouped by region — a
+ * display grouping the inventory derives from water class and latitude, and
  * never a join input. Bays, lagoons and inlets group together regardless of
  * where they are, because that is how someone looks for them.
  *

--- a/src/components/Caveats.test.tsx
+++ b/src/components/Caveats.test.tsx
@@ -7,16 +7,78 @@ const ENTRIES = [
   "TWC0405 Point Loma does not deliver predictions.",
 ];
 
+const REACH = {
+  listed: 73,
+  served: 41,
+  excluded: [
+    {
+      slug: "san-onofre-state-beach",
+      name: "San Onofre State Beach",
+      why: "its tide station 9410230 is 56.6 km away",
+    },
+    {
+      slug: "harbor-beach",
+      name: "Harbor Beach",
+      why: "its tide station 9410230 is 39.4 km away",
+    },
+  ],
+};
+
 test("every caveat given is rendered, not a summary of them", () => {
-  render(<Caveats entries={ENTRIES} />);
+  render(<Caveats entries={ENTRIES} reach={REACH} />);
 
   for (const entry of ENTRIES) {
     expect(screen.getByText(entry)).toBeDefined();
   }
 });
 
+test("says how far the site reaches, in beaches, without being opened", () => {
+  // A reader looking for a beach that is not in the chooser has no way to
+  // tell whether the county never listed it or this site left it out. The
+  // sentence is outside the disclosures for that reason.
+  render(<Caveats entries={ENTRIES} reach={REACH} />);
+
+  expect(
+    screen.getByText(/answers for 41 of the 73 beaches San Diego County lists/),
+  ).toBeDefined();
+});
+
+test("names every beach it does not serve, and the reason for each", () => {
+  render(<Caveats entries={ENTRIES} reach={REACH} />);
+
+  for (const beach of REACH.excluded) {
+    expect(screen.getByText(beach.name)).toBeDefined();
+    expect(screen.getByText(new RegExp(beach.why))).toBeDefined();
+  }
+});
+
+test("puts the excluded beaches behind their own disclosure, counted", () => {
+  // Thirty-two names would bury the sentence above them, and a reader who
+  // wants one of them is looking for a specific beach rather than reading a
+  // list. The count belongs in the summary, where it is visible closed.
+  render(<Caveats entries={ENTRIES} reach={REACH} />);
+
+  expect(screen.getByText(/Why the other 2 are not here/)).toBeDefined();
+});
+
+test("claims no exclusions when there are none", () => {
+  // A disclosure headed "why the other 0 are not here" is worse than none,
+  // and this is the state the tolerance being raised would produce.
+  render(
+    <Caveats
+      entries={ENTRIES}
+      reach={{ listed: 41, served: 41, excluded: [] }}
+    />,
+  );
+
+  expect(screen.queryByText(/are not here/)).toBeNull();
+  expect(
+    screen.getByText(/answers for 41 of the 41 beaches San Diego County lists/),
+  ).toBeDefined();
+});
+
 test("they sit behind a disclosure, so the tide time is not buried", () => {
-  const { container } = render(<Caveats entries={ENTRIES} />);
+  const { container } = render(<Caveats entries={ENTRIES} reach={REACH} />);
 
   expect(container.querySelector("details")).not.toBeNull();
   expect(
@@ -24,9 +86,14 @@ test("they sit behind a disclosure, so the tide time is not buried", () => {
   ).toBeDefined();
 });
 
-test("nothing is rendered when there is nothing to disclose", () => {
+test("the uncertainty disclosure is absent when there is nothing to disclose", () => {
   // An empty disclosure inviting a reader to open it and find nothing is worse
-  // than no disclosure.
-  const { container } = render(<Caveats entries={[]} />);
-  expect(container.firstChild).toBeNull();
+  // than no disclosure. The reach sentence stays: it is a statement about what
+  // this site covers rather than a caveat, and it is true either way.
+  render(<Caveats entries={[]} reach={REACH} />);
+
+  expect(
+    screen.queryByText("What we are unsure about in this data"),
+  ).toBeNull();
+  expect(screen.getByText(/answers for 41 of the 73/)).toBeDefined();
 });

--- a/src/components/Caveats.tsx
+++ b/src/components/Caveats.tsx
@@ -1,5 +1,6 @@
 /**
- * What this site does not know, on the page where it matters.
+ * What this site does not know, and what it does not cover, on the page where
+ * both matter.
  *
  * The data files carry `unresolved` arrays: a station whose water class is an
  * author's judgement, a beach whose coordinates upstream published wrong, a gap
@@ -7,29 +8,70 @@
  * on the number, not by whoever maintains the repo — a caveat that reaches only a
  * maintainer is a caveat nobody was warned by.
  *
- * They sit behind a disclosure rather than on the page, because the reader came
- * for a tide time and a wall of qualifications would bury it. The disclosure is
- * the compromise that lets the list be comprehensive and the page stay readable:
- * a beach whose water-quality station is unresolved can still ship, because the
- * page says it is unresolved.
+ * The inventory's reach is the same obligation pointed the other way. The chooser
+ * offers the beaches this site can measure at, which is fewer than the county
+ * lists, and a parent looking for one that is missing cannot tell whether the
+ * county never listed it or this site left it out. That sentence sits outside the
+ * disclosures, because it is the one thing here a reader may need before they
+ * have a question.
+ *
+ * Everything else sits behind a disclosure: the reader came for a tide time and a
+ * wall of qualifications would bury it. The disclosure is the compromise that lets
+ * the list be comprehensive and the page stay readable — a beach whose
+ * water-quality station is unresolved can still ship, because the page says it is
+ * unresolved.
  *
  * The gate asserts that every entry in every data file arrives here, so a caveat
  * cannot be added to a file and quietly reach no reader.
  */
 
-export function Caveats({ entries }: { entries: readonly string[] }) {
-  if (entries.length === 0) return null;
+import type { InventoryReach } from "@/lib/beaches";
 
+export function Caveats({
+  entries,
+  reach,
+}: {
+  entries: readonly string[];
+  reach: InventoryReach;
+}) {
   return (
-    <details className="mt-9 max-w-130 text-sm text-fog">
-      <summary>What we are unsure about in this data</summary>
-      <ul className="leading-relaxed mt-3">
-        {entries.map((entry) => (
-          <li key={entry} className="mb-3">
-            {entry}
-          </li>
-        ))}
-      </ul>
-    </details>
+    <div className="mt-9 max-w-130 text-sm text-fog">
+      <p className="leading-relaxed">
+        This site answers for {reach.served} of the {reach.listed} beaches San
+        Diego County lists.
+      </p>
+
+      {reach.excluded.length > 0 && (
+        <details className="mt-3">
+          <summary>Why the other {reach.excluded.length} are not here</summary>
+          <p className="leading-relaxed mt-3">
+            A beach is left out rather than answered with a reading measured
+            somewhere else — a station further away than we would publish a
+            reading from, or coordinates published upstream that cannot be used
+            at all.
+          </p>
+          <ul className="leading-relaxed mt-3">
+            {reach.excluded.map((beach) => (
+              <li key={beach.slug} className="mb-3">
+                <strong>{beach.name}</strong> — {beach.why}.
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+
+      {entries.length > 0 && (
+        <details className="mt-3">
+          <summary>What we are unsure about in this data</summary>
+          <ul className="leading-relaxed mt-3">
+            {entries.map((entry) => (
+              <li key={entry} className="mb-3">
+                {entry}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
   );
 }

--- a/src/components/ConditionsSection.test.tsx
+++ b/src/components/ConditionsSection.test.tsx
@@ -28,6 +28,11 @@ test("the view carries the chooser, the reading and the caveats", () => {
   expect(
     screen.getByText("What we are unsure about in this data"),
   ).toBeDefined();
+  // The reach is part of what this view owes a reader: the chooser offers 41
+  // beaches and the county lists 73, and nothing else on the page says so.
+  expect(
+    screen.getByText(/answers for \d+ of the \d+ beaches San Diego County/),
+  ).toBeDefined();
 });
 
 test("every caveat the data files carry reaches this page", () => {

--- a/src/components/ConditionsSection.tsx
+++ b/src/components/ConditionsSection.tsx
@@ -9,7 +9,11 @@
  */
 
 import { Suspense } from "react";
-import { beachesByRegion, inventoryCaveats } from "@/lib/beaches";
+import {
+  beachesByRegion,
+  inventoryCaveats,
+  inventoryReach,
+} from "@/lib/beaches";
 import { BeachSelector } from "./BeachSelector";
 import { Caveats } from "./Caveats";
 import { TidePanel } from "./TidePanel";
@@ -76,7 +80,7 @@ export function ConditionsSection({ slug }: { slug: string }) {
         <WindPanel slug={slug} />
       </Suspense>
 
-      <Caveats entries={inventoryCaveats()} />
+      <Caveats entries={inventoryCaveats()} reach={inventoryReach()} />
     </section>
   );
 }

--- a/src/data/beaches.json
+++ b/src/data/beaches.json
@@ -4,6 +4,7 @@
   "time_zone": "America/Los_Angeles",
   "_provenance": "Seeded from the Beach Detail Information resource of \"Beach Advisories (Postings and Closures) and Beach Water Quality Monitoring\", published by the California State Water Resources Control Board: https://data.cnra.ca.gov/dataset/beach-advisories-postings-and-closures-and-beach-water-quality-monitoring, resource cc674e59-036c-45c3-bec2-5d3d294e0e3d. The data.ca.gov copy (resource fcbc9250-06e3-437d-b0c6-3cc5ddde93fc) serves identical content and is the mirror. Rebuilt by scripts/seed-beaches.mjs; re-runnable and diffable with --check. Field values are reproduced as the resource serves them, including BeachType \"UNKNOWN\".",
   "_inclusion": "County San Diego, Status Active, BeachAccess PUBLIC, CountAsBeach 1. A predicate over published fields rather than a judgement about which beaches are worth listing.",
+  "_served": "And then, of those: a tide station within 10.0 km, and if a wave buoy is bound at all, that buoy within 10.0 km. Unlike _inclusion this one IS a judgement -- it decides how far a measurement may be taken from the place it is shown for -- and it is stated here rather than left implicit in how far a join happened to reach. Ten kilometres is WMO-No. 8 §1.1.2's scale for small-scale and local applications; no standard reporting radius exists, so the figure is defended rather than cited. What keeps it honest is that its inputs are measured: every distance came out of a join. Every beach it refuses is in _excluded below, with the binding distance that refused it, so nothing leaves this inventory silently. See docs/adr/0011-inventory-bounded-by-station-networks.md.",
   "_pinned": {
     "field_name_with_a_space": "Upstream names one field 'Beach_ UpperLon', with an embedded space. That is the resource's own spelling, and the seeding script asserts it rather than tolerating its absence.",
     "numerics_are_strings": "The datastore serialises numeric columns as JSON strings. They are converted once, at seed time, and anything that does not parse stops the seed.",
@@ -26,673 +27,6 @@
     "air_station_from_end": "Which end of the segment supplied the distance, upper or lower."
   },
   "beaches": [
-    {
-      "slug": "san-onofre-state-beach",
-      "name": "San Onofre State Beach",
-      "region": "North County coast",
-      "segment": {
-        "upper": {
-          "lat": 33.38685,
-          "lon": -117.59623
-        },
-        "lower": {
-          "lat": 33.331617,
-          "lon": -117.503883
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA981113",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "USMC Camp Pendleton"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 56557,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46275",
-      "wave_buoy_distance_m": 4524,
-      "wave_buoy_from_end": "lower",
-      "weather_station": "KNFG",
-      "weather_station_distance_m": 14254,
-      "weather_station_from_end": "lower",
-      "air_station": "F1327",
-      "air_station_distance_m": 4266,
-      "air_station_from_end": "upper"
-    },
-    {
-      "slug": "oceanside-harbor",
-      "name": "Oceanside Harbor",
-      "region": "North County coast",
-      "segment": {
-        "upper": {
-          "lat": 33.208892,
-          "lon": -117.397348
-        },
-        "lower": {
-          "lat": 33.207721,
-          "lon": -117.396431
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA359747",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Oceanside"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 40061,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46224",
-      "wave_buoy_distance_m": 7749,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KOKB",
-      "weather_station_distance_m": 4345,
-      "weather_station_from_end": "lower",
-      "air_station": "E3174",
-      "air_station_distance_m": 300,
-      "air_station_from_end": "upper"
-    },
-    {
-      "slug": "harbor-beach",
-      "name": "Harbor Beach",
-      "region": "North County coast",
-      "segment": {
-        "upper": {
-          "lat": 33.206959,
-          "lon": -117.398525
-        },
-        "lower": {
-          "lat": 33.202442,
-          "lon": -117.392907
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA624767",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Oceanside"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 39400,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46224",
-      "wave_buoy_distance_m": 7557,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KOKB",
-      "weather_station_distance_m": 4235,
-      "weather_station_from_end": "lower",
-      "air_station": "E3174",
-      "air_station_distance_m": 504,
-      "air_station_from_end": "upper"
-    },
-    {
-      "slug": "oceanside-municipal-beach-other",
-      "name": "Oceanside municipal beach, other",
-      "region": "North County coast",
-      "segment": {
-        "upper": {
-          "lat": 33.206959,
-          "lon": -117.398525
-        },
-        "lower": {
-          "lat": 33.165153,
-          "lon": -117.359478
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA333308",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Oceanside"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 34511,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46224",
-      "wave_buoy_distance_m": 7557,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KOKB",
-      "weather_station_distance_m": 4555,
-      "weather_station_from_end": "upper",
-      "air_station": "E3174",
-      "air_station_distance_m": 504,
-      "air_station_from_end": "upper"
-    },
-    {
-      "slug": "buccaneer-beach",
-      "name": "Buccaneer Beach",
-      "region": "North County coast",
-      "segment": {
-        "upper": {
-          "lat": 33.176962,
-          "lon": -117.370063
-        },
-        "lower": {
-          "lat": 33.17577,
-          "lon": -117.368925
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA976061",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Oceanside"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 35892,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46224",
-      "wave_buoy_distance_m": 9488,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KOKB",
-      "weather_station_distance_m": 4889,
-      "weather_station_from_end": "upper",
-      "air_station": "E3174",
-      "air_station_distance_m": 4296,
-      "air_station_from_end": "upper"
-    },
-    {
-      "slug": "carlsbad-municipal-beach",
-      "name": "Carlsbad municipal beach",
-      "region": "North County coast",
-      "segment": {
-        "upper": {
-          "lat": 33.1651,
-          "lon": -117.3594
-        },
-        "lower": {
-          "lat": 33.1559,
-          "lon": -117.3526
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA789152",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Carlsbad"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 33346,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46224",
-      "wave_buoy_distance_m": 10578,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KOKB",
-      "weather_station_distance_m": 5936,
-      "weather_station_from_end": "upper",
-      "air_station": "CBDSD",
-      "air_station_distance_m": 3138,
-      "air_station_from_end": "lower"
-    },
-    {
-      "slug": "carlsbad-state-beach",
-      "name": "Carlsbad State Beach",
-      "region": "North County coast",
-      "segment": {
-        "upper": {
-          "lat": 33.1559,
-          "lon": -117.3526
-        },
-        "lower": {
-          "lat": 33.1338,
-          "lon": -117.3375
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA009204",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Carlsbad"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 30610,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46274",
-      "wave_buoy_distance_m": 8278,
-      "wave_buoy_from_end": "lower",
-      "weather_station": "KCRQ",
-      "weather_station_distance_m": 5758,
-      "weather_station_from_end": "lower",
-      "air_station": "CBDSD",
-      "air_station_distance_m": 1047,
-      "air_station_from_end": "lower"
-    },
-    {
-      "slug": "agua-hedionda-lagoon",
-      "name": "Agua Hedionda Lagoon",
-      "region": "Bays, lagoons and inlets",
-      "segment": {
-        "upper": {
-          "lat": 33.147393,
-          "lon": -117.333249
-        },
-        "lower": {
-          "lat": 33.141831,
-          "lon": -117.319977
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA953023",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Sound, Bay, or Inlet",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Del Mar"
-      },
-      "tide_station": "9410196",
-      "tide_station_distance_m": 39737,
-      "tide_station_from_end": "lower",
-      "wave_buoy": null,
-      "wave_buoy_distance_m": null,
-      "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
-      "weather_station": "KCRQ",
-      "weather_station_distance_m": 4316,
-      "weather_station_from_end": "lower",
-      "air_station": "CBDSD",
-      "air_station_distance_m": 826,
-      "air_station_from_end": "lower"
-    },
-    {
-      "slug": "south-carlsbad-state-beach",
-      "name": "South Carlsbad State Beach",
-      "region": "North County coast",
-      "segment": {
-        "upper": {
-          "lat": 33.1285,
-          "lon": -117.3338
-        },
-        "lower": {
-          "lat": 33.0815,
-          "lon": -117.3115
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA606869",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Carlsbad"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 24396,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46274",
-      "wave_buoy_distance_m": 2181,
-      "wave_buoy_from_end": "lower",
-      "weather_station": "KCRQ",
-      "weather_station_distance_m": 5401,
-      "weather_station_from_end": "upper",
-      "air_station": "CBDSD",
-      "air_station_distance_m": 1171,
-      "air_station_from_end": "upper"
-    },
-    {
-      "slug": "leucadia",
-      "name": "Leucadia",
-      "region": "North County coast",
-      "segment": {
-        "upper": {
-          "lat": 33.0817,
-          "lon": -117.3114
-        },
-        "lower": {
-          "lat": 33.0482,
-          "lon": -117.2986
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA331931",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Encinitas"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 20528,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46274",
-      "wave_buoy_distance_m": 2101,
-      "wave_buoy_from_end": "lower",
-      "weather_station": "KCRQ",
-      "weather_station_distance_m": 6310,
-      "weather_station_from_end": "upper",
-      "air_station": "SOBSD",
-      "air_station_distance_m": 5000,
-      "air_station_from_end": "lower"
-    },
-    {
-      "slug": "encinitas-city-beaches",
-      "name": "Encinitas City Beaches",
-      "region": "North County coast",
-      "segment": {
-        "upper": {
-          "lat": 33.086824,
-          "lon": -117.313045
-        },
-        "lower": {
-          "lat": 33.031856,
-          "lon": -117.290849
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA121276",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Encinitas"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 18611,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46274",
-      "wave_buoy_distance_m": 2762,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KCRQ",
-      "weather_station_distance_m": 5921,
-      "weather_station_from_end": "upper",
-      "air_station": "SOBSD",
-      "air_station_distance_m": 3049,
-      "air_station_from_end": "lower"
-    },
-    {
-      "slug": "moonlight-beach",
-      "name": "Moonlight Beach",
-      "region": "North County coast",
-      "segment": {
-        "upper": {
-          "lat": 33.04831,
-          "lon": -117.299051
-        },
-        "lower": {
-          "lat": 33.0438,
-          "lon": -117.2925
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA326620",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Encinitas"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 19946,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46274",
-      "wave_buoy_distance_m": 2064,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KCRQ",
-      "weather_station_distance_m": 9338,
-      "weather_station_from_end": "upper",
-      "air_station": "SOBSD",
-      "air_station_distance_m": 4330,
-      "air_station_from_end": "lower"
-    },
-    {
-      "slug": "swami-s-park",
-      "name": "Swami's Park",
-      "region": "North County coast",
-      "segment": {
-        "upper": {
-          "lat": 33.034763,
-          "lon": -117.293736
-        },
-        "lower": {
-          "lat": 33.031856,
-          "lon": -117.290849
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA789562",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Encinitas"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 18611,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46274",
-      "wave_buoy_distance_m": 3569,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KCRQ",
-      "weather_station_distance_m": 10720,
-      "weather_station_from_end": "upper",
-      "air_station": "SOBSD",
-      "air_station_distance_m": 3049,
-      "air_station_from_end": "lower"
-    },
-    {
-      "slug": "san-elijo-state-beach",
-      "name": "San Elijo State Beach",
-      "region": "North County coast",
-      "segment": {
-        "upper": {
-          "lat": 33.031855,
-          "lon": -117.290849
-        },
-        "lower": {
-          "lat": 33.016626,
-          "lon": -117.282485
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA059339",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Del Mar"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 16816,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46274",
-      "wave_buoy_distance_m": 3986,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KCRQ",
-      "weather_station_distance_m": 11003,
-      "weather_station_from_end": "upper",
-      "air_station": "SOBSD",
-      "air_station_distance_m": 1187,
-      "air_station_from_end": "lower"
-    },
-    {
-      "slug": "cardiff-state-beach",
-      "name": "Cardiff State Beach",
-      "region": "North County coast",
-      "segment": {
-        "upper": {
-          "lat": 33.01556,
-          "lon": -117.281346
-        },
-        "lower": {
-          "lat": 32.99947,
-          "lon": -117.277931
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA152716",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Del Mar"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 14869,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46266",
-      "wave_buoy_distance_m": 4724,
-      "wave_buoy_from_end": "lower",
-      "weather_station": "KCRQ",
-      "weather_station_distance_m": 12736,
-      "weather_station_from_end": "upper",
-      "air_station": "SOBSD",
-      "air_station_distance_m": 888,
-      "air_station_from_end": "lower"
-    },
-    {
-      "slug": "solana-beach-city-beaches",
-      "name": "Solana Beach City Beaches",
-      "region": "La Jolla and Pacific Beach",
-      "segment": {
-        "upper": {
-          "lat": 32.99947,
-          "lon": -117.277931
-        },
-        "lower": {
-          "lat": 32.980308,
-          "lon": -117.272381
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA505182",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Solana Beach"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 12691,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46266",
-      "wave_buoy_distance_m": 2664,
-      "wave_buoy_from_end": "lower",
-      "weather_station": "KCRQ",
-      "weather_station_distance_m": 14516,
-      "weather_station_from_end": "upper",
-      "air_station": "SOBSD",
-      "air_station_distance_m": 888,
-      "air_station_from_end": "upper"
-    },
-    {
-      "slug": "seascape-beach-park",
-      "name": "Seascape Beach Park",
-      "region": "La Jolla and Pacific Beach",
-      "segment": {
-        "upper": {
-          "lat": 32.982363,
-          "lon": -117.273475
-        },
-        "lower": {
-          "lat": 32.980308,
-          "lon": -117.272381
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA723256",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Solana Beach"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 12691,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46266",
-      "wave_buoy_distance_m": 2664,
-      "wave_buoy_from_end": "lower",
-      "weather_station": "KCRQ",
-      "weather_station_distance_m": 16418,
-      "weather_station_from_end": "upper",
-      "air_station": "SOBSD",
-      "air_station_distance_m": 2788,
-      "air_station_from_end": "upper"
-    },
-    {
-      "slug": "san-dieguito-river-beach",
-      "name": "San Dieguito River Beach",
-      "region": "La Jolla and Pacific Beach",
-      "segment": {
-        "upper": {
-          "lat": 32.976558,
-          "lon": -117.270906
-        },
-        "lower": {
-          "lat": 32.974609,
-          "lon": -117.27033
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA531242",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Del Mar"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 12040,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46266",
-      "wave_buoy_distance_m": 2119,
-      "wave_buoy_from_end": "lower",
-      "weather_station": "KNKX",
-      "weather_station_distance_m": 16793,
-      "weather_station_from_end": "lower",
-      "air_station": "SOBSD",
-      "air_station_distance_m": 3458,
-      "air_station_from_end": "upper"
-    },
     {
       "slug": "del-mar-city-beach",
       "name": "Del Mar City Beach",
@@ -728,43 +62,6 @@
       "weather_station_from_end": "lower",
       "air_station": "SOBSD",
       "air_station_distance_m": 3026,
-      "air_station_from_end": "upper"
-    },
-    {
-      "slug": "powerhouse-park-15th-street",
-      "name": "Powerhouse Park 15th Street",
-      "region": "La Jolla and Pacific Beach",
-      "segment": {
-        "upper": {
-          "lat": 32.961524,
-          "lon": -117.268705
-        },
-        "lower": {
-          "lat": 32.959689,
-          "lon": -117.268595
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA650180",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Del Mar"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 10373,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46266",
-      "wave_buoy_distance_m": 1016,
-      "wave_buoy_from_end": "lower",
-      "weather_station": "KNKX",
-      "weather_station_distance_m": 15548,
-      "weather_station_from_end": "lower",
-      "air_station": "SOBSD",
-      "air_station_distance_m": 5142,
       "air_station_from_end": "upper"
     },
     {
@@ -2084,80 +1381,6 @@
       "air_station_from_end": "lower"
     },
     {
-      "slug": "dog-beach-o-b",
-      "name": "Dog Beach, O.B.",
-      "region": "Point Loma and Ocean Beach",
-      "segment": {
-        "upper": {
-          "lat": 32.75617,
-          "lon": -117.252734
-        },
-        "lower": {
-          "lat": 32.747069,
-          "lon": -117.254253
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA316627",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "San Diego"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 12319,
-      "tide_station_from_end": "upper",
-      "wave_buoy": "46254",
-      "wave_buoy_distance_m": 12506,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KSAN",
-      "weather_station_distance_m": 6825,
-      "weather_station_from_end": "lower",
-      "air_station": "E9951",
-      "air_station_distance_m": 4460,
-      "air_station_from_end": "lower"
-    },
-    {
-      "slug": "ocean-beach",
-      "name": "Ocean Beach",
-      "region": "Point Loma and Ocean Beach",
-      "segment": {
-        "upper": {
-          "lat": 32.756524,
-          "lon": -117.251911
-        },
-        "lower": {
-          "lat": 32.735192,
-          "lon": -117.255806
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA799523",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "San Diego"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 12283,
-      "tide_station_from_end": "upper",
-      "wave_buoy": "46254",
-      "wave_buoy_distance_m": 12476,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KSAN",
-      "weather_station_distance_m": 6807,
-      "weather_station_from_end": "lower",
-      "air_station": "E9951",
-      "air_station_distance_m": 3607,
-      "air_station_from_end": "lower"
-    },
-    {
       "slug": "spanish-landing-park",
       "name": "Spanish Landing Park",
       "region": "Bays, lagoons and inlets",
@@ -2193,43 +1416,6 @@
       "weather_station_from_end": "lower",
       "air_station": "KSAN",
       "air_station_distance_m": 1615,
-      "air_station_from_end": "lower"
-    },
-    {
-      "slug": "sunset-cliffs-park",
-      "name": "Sunset Cliffs Park",
-      "region": "Point Loma and Ocean Beach",
-      "segment": {
-        "upper": {
-          "lat": 32.735192,
-          "lon": -117.255806
-        },
-        "lower": {
-          "lat": 32.713183,
-          "lon": -117.256222
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA628494",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "San Diego"
-      },
-      "tide_station": "9410230",
-      "tide_station_distance_m": 14646,
-      "tide_station_from_end": "upper",
-      "wave_buoy": "46254",
-      "wave_buoy_distance_m": 14805,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KSAN",
-      "weather_station_distance_m": 6807,
-      "weather_station_from_end": "upper",
-      "air_station": "E9951",
-      "air_station_distance_m": 2866,
       "air_station_from_end": "lower"
     },
     {
@@ -2309,154 +1495,6 @@
       "air_station_from_end": "upper"
     },
     {
-      "slug": "tide-beach-park",
-      "name": "Tide Beach Park",
-      "region": "Point Loma and Ocean Beach",
-      "segment": {
-        "upper": {
-          "lat": 32.692502,
-          "lon": -117.16396
-        },
-        "lower": {
-          "lat": 32.688449,
-          "lon": -117.163634
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA654912",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Solana Beach"
-      },
-      "tide_station": "9410120",
-      "tide_station_distance_m": 12538,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46254",
-      "wave_buoy_distance_m": 21763,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KSAN",
-      "weather_station_distance_m": 4908,
-      "weather_station_from_end": "upper",
-      "air_station": "KSAN",
-      "air_station_distance_m": 4908,
-      "air_station_from_end": "upper"
-    },
-    {
-      "slug": "coronado-north-beach",
-      "name": "Coronado north beach",
-      "region": "Point Loma and Ocean Beach",
-      "segment": {
-        "upper": {
-          "lat": 32.683267,
-          "lon": -117.223496
-        },
-        "lower": {
-          "lat": 32.6864,
-          "lon": -117.194
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA604254",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "San Diego"
-      },
-      "tide_station": "9410120",
-      "tide_station_distance_m": 13229,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46254",
-      "wave_buoy_distance_m": 20940,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KSAN",
-      "weather_station_distance_m": 5348,
-      "weather_station_from_end": "lower",
-      "air_station": "E9951",
-      "air_station_distance_m": 3531,
-      "air_station_from_end": "upper"
-    },
-    {
-      "slug": "coronado-central-beach",
-      "name": "Coronado, Central beach",
-      "region": "Point Loma and Ocean Beach",
-      "segment": {
-        "upper": {
-          "lat": 32.684744,
-          "lon": -117.19049
-        },
-        "lower": {
-          "lat": 32.680392,
-          "lon": -117.18199
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA594160",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Coronado"
-      },
-      "tide_station": "9410120",
-      "tide_station_distance_m": 12175,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46254",
-      "wave_buoy_distance_m": 21596,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KSAN",
-      "weather_station_distance_m": 5478,
-      "weather_station_from_end": "upper",
-      "air_station": "E9951",
-      "air_station_distance_m": 4704,
-      "air_station_from_end": "upper"
-    },
-    {
-      "slug": "coronado-city-beaches",
-      "name": "Coronado City beaches",
-      "region": "Point Loma and Ocean Beach",
-      "segment": {
-        "upper": {
-          "lat": 32.6867,
-          "lon": -117.1976
-        },
-        "lower": {
-          "lat": 32.6739,
-          "lon": -117.1721
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA204955",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Coronado"
-      },
-      "tide_station": "9410120",
-      "tide_station_distance_m": 11184,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46254",
-      "wave_buoy_distance_m": 21178,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KSAN",
-      "weather_station_distance_m": 5391,
-      "weather_station_from_end": "upper",
-      "air_station": "E9951",
-      "air_station_distance_m": 4096,
-      "air_station_from_end": "upper"
-    },
-    {
       "slug": "coronado-cays-nr",
       "name": "Coronado Cays (NR)",
       "region": "Bays, lagoons and inlets",
@@ -2492,117 +1530,6 @@
       "weather_station_from_end": "upper",
       "air_station": "TIXC1",
       "air_station_distance_m": 6282,
-      "air_station_from_end": "lower"
-    },
-    {
-      "slug": "silver-strand-state-beach",
-      "name": "Silver Strand State Beach",
-      "region": "South County coast",
-      "segment": {
-        "upper": {
-          "lat": 32.636836,
-          "lon": -117.144303
-        },
-        "lower": {
-          "lat": 32.608936,
-          "lon": -117.134783
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA801475",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "San Diego"
-      },
-      "tide_station": "9410120",
-      "tide_station_distance_m": 3407,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46254",
-      "wave_buoy_distance_m": 28149,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KSAN",
-      "weather_station_distance_m": 11356,
-      "weather_station_from_end": "upper",
-      "air_station": "TIXC1",
-      "air_station_distance_m": 3843,
-      "air_station_from_end": "lower"
-    },
-    {
-      "slug": "north-imperial-beach",
-      "name": "north Imperial Beach",
-      "region": "South County coast",
-      "segment": {
-        "upper": {
-          "lat": 32.6089,
-          "lon": -117.1347
-        },
-        "lower": {
-          "lat": 32.5866,
-          "lon": -117.1327
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA134387",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Imperial Beach"
-      },
-      "tide_station": "9410120",
-      "tide_station_distance_m": 948,
-      "tide_station_from_end": "lower",
-      "wave_buoy": "46232",
-      "wave_buoy_distance_m": 28469,
-      "wave_buoy_from_end": "lower",
-      "weather_station": "KSDM",
-      "weather_station_distance_m": 13144,
-      "weather_station_from_end": "lower",
-      "air_station": "TIXC1",
-      "air_station_distance_m": 1396,
-      "air_station_from_end": "lower"
-    },
-    {
-      "slug": "imperial-beach-municipal-beach-other",
-      "name": "Imperial Beach municipal beach, other",
-      "region": "South County coast",
-      "segment": {
-        "upper": {
-          "lat": 32.587527,
-          "lon": -117.132598
-        },
-        "lower": {
-          "lat": 32.566219,
-          "lon": -117.133006
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA068221",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Imperial Beach"
-      },
-      "tide_station": "9410120",
-      "tide_station_distance_m": 1050,
-      "tide_station_from_end": "upper",
-      "wave_buoy": "46232",
-      "wave_buoy_distance_m": 27913,
-      "wave_buoy_from_end": "lower",
-      "weather_station": "KSDM",
-      "weather_station_distance_m": 13145,
-      "weather_station_from_end": "upper",
-      "air_station": "TIXC1",
-      "air_station_distance_m": 1127,
       "air_station_from_end": "lower"
     },
     {
@@ -2642,132 +1569,178 @@
       "air_station": "TIXC1",
       "air_station_distance_m": 1129,
       "air_station_from_end": "upper"
+    }
+  ],
+  "_excluded": [
+    {
+      "slug": "san-onofre-state-beach",
+      "name": "San Onofre State Beach",
+      "why": "its tide station 9410230 is 56.6 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "oceanside-harbor",
+      "name": "Oceanside Harbor",
+      "why": "its tide station 9410230 is 40.1 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "harbor-beach",
+      "name": "Harbor Beach",
+      "why": "its tide station 9410230 is 39.4 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "oceanside-municipal-beach-other",
+      "name": "Oceanside municipal beach, other",
+      "why": "its tide station 9410230 is 34.5 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "buccaneer-beach",
+      "name": "Buccaneer Beach",
+      "why": "its tide station 9410230 is 35.9 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "carlsbad-municipal-beach",
+      "name": "Carlsbad municipal beach",
+      "why": "its tide station 9410230 is 33.3 km away and its wave buoy 46224 is 10.6 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "carlsbad-state-beach",
+      "name": "Carlsbad State Beach",
+      "why": "its tide station 9410230 is 30.6 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "agua-hedionda-lagoon",
+      "name": "Agua Hedionda Lagoon",
+      "why": "its tide station 9410196 is 39.7 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "south-carlsbad-state-beach",
+      "name": "South Carlsbad State Beach",
+      "why": "its tide station 9410230 is 24.4 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "leucadia",
+      "name": "Leucadia",
+      "why": "its tide station 9410230 is 20.5 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "encinitas-city-beaches",
+      "name": "Encinitas City Beaches",
+      "why": "its tide station 9410230 is 18.6 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "moonlight-beach",
+      "name": "Moonlight Beach",
+      "why": "its tide station 9410230 is 19.9 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "swami-s-park",
+      "name": "Swami's Park",
+      "why": "its tide station 9410230 is 18.6 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "san-elijo-state-beach",
+      "name": "San Elijo State Beach",
+      "why": "its tide station 9410230 is 16.8 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "cardiff-state-beach",
+      "name": "Cardiff State Beach",
+      "why": "its tide station 9410230 is 14.9 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "solana-beach-city-beaches",
+      "name": "Solana Beach City Beaches",
+      "why": "its tide station 9410230 is 12.7 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "seascape-beach-park",
+      "name": "Seascape Beach Park",
+      "why": "its tide station 9410230 is 12.7 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "san-dieguito-river-beach",
+      "name": "San Dieguito River Beach",
+      "why": "its tide station 9410230 is 12.0 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "powerhouse-park-15th-street",
+      "name": "Powerhouse Park 15th Street",
+      "why": "its tide station 9410230 is 10.4 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "dog-beach-o-b",
+      "name": "Dog Beach, O.B.",
+      "why": "its tide station 9410230 is 12.3 km away and its wave buoy 46254 is 12.5 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "ocean-beach",
+      "name": "Ocean Beach",
+      "why": "its tide station 9410230 is 12.3 km away and its wave buoy 46254 is 12.5 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "sunset-cliffs-park",
+      "name": "Sunset Cliffs Park",
+      "why": "its tide station 9410230 is 14.6 km away and its wave buoy 46254 is 14.8 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "tide-beach-park",
+      "name": "Tide Beach Park",
+      "why": "its tide station 9410120 is 12.5 km away and its wave buoy 46254 is 21.8 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "coronado-north-beach",
+      "name": "Coronado north beach",
+      "why": "its tide station 9410120 is 13.2 km away and its wave buoy 46254 is 20.9 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "coronado-central-beach",
+      "name": "Coronado, Central beach",
+      "why": "its tide station 9410120 is 12.2 km away and its wave buoy 46254 is 21.6 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "coronado-city-beaches",
+      "name": "Coronado City beaches",
+      "why": "its tide station 9410120 is 11.2 km away and its wave buoy 46254 is 21.2 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "silver-strand-state-beach",
+      "name": "Silver Strand State Beach",
+      "why": "its wave buoy 46254 is 28.1 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "north-imperial-beach",
+      "name": "north Imperial Beach",
+      "why": "its wave buoy 46232 is 28.5 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+    },
+    {
+      "slug": "imperial-beach-municipal-beach-other",
+      "name": "Imperial Beach municipal beach, other",
+      "why": "its wave buoy 46232 is 27.9 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
     },
     {
       "slug": "tijana-river",
       "name": "Tijana River",
-      "region": "South County coast",
-      "segment": {
-        "upper": {
-          "lat": 32.55358,
-          "lon": -117.06321
-        },
-        "lower": {
-          "lat": 32.54168,
-          "lon": -117.04485
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA630931",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Chula Vista"
-      },
-      "tide_station": "9410120",
-      "tide_station_distance_m": 7267,
-      "tide_station_from_end": "upper",
-      "wave_buoy": "46232",
-      "wave_buoy_distance_m": 34159,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KSDM",
-      "weather_station_distance_m": 6125,
-      "weather_station_from_end": "lower",
-      "air_station": "TIXC1",
-      "air_station_distance_m": 6435,
-      "air_station_from_end": "upper"
+      "why": "its wave buoy 46232 is 34.2 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
     },
     {
       "slug": "border-field-state-park",
       "name": "Border Field State Park",
-      "region": "South County coast",
-      "segment": {
-        "upper": {
-          "lat": 32.55282,
-          "lon": -117.127708
-        },
-        "lower": {
-          "lat": 32.534367,
-          "lon": -117.124197
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA809706",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "San Diego"
-      },
-      "tide_station": "9410120",
-      "tide_station_distance_m": 2914,
-      "tide_station_from_end": "upper",
-      "wave_buoy": "46232",
-      "wave_buoy_distance_m": 28153,
-      "wave_buoy_from_end": "upper",
-      "weather_station": "KSDM",
-      "weather_station_distance_m": 12863,
-      "weather_station_from_end": "upper",
-      "air_station": "TIXC1",
-      "air_station_distance_m": 2467,
-      "air_station_from_end": "upper"
+      "why": "its wave buoy 46232 is 28.2 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
     },
     {
       "slug": "imperial-beach-pier-area",
       "name": "Imperial Beach pier area",
-      "region": "South County coast",
-      "segment": {
-        "upper": {
-          "lat": 32.5804,
-          "lon": -117.5866
-        },
-        "lower": {
-          "lat": 32.1327,
-          "lon": -117.1332
-        }
-      },
-      "upstream": {
-        "usepa_id": "CA432983",
-        "agency": "County of San Diego Department of Environmental Health",
-        "water_body_name": "Pacific Ocean",
-        "water_body_type": "Open Coast",
-        "beach_type": "UNKNOWN",
-        "beach_access": "PUBLIC",
-        "status": "Active",
-        "nearest_city": "Imperial Beach"
-      },
-      "tide_station": null,
-      "tide_station_distance_m": null,
-      "tide_station_from_end": null,
-      "tide_station_null_reason": "the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it",
-      "wave_buoy": null,
-      "wave_buoy_distance_m": null,
-      "wave_buoy_from_end": null,
-      "wave_buoy_null_reason": "the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it",
-      "weather_station": null,
-      "weather_station_distance_m": null,
-      "weather_station_from_end": null,
-      "weather_station_null_reason": "the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it",
-      "air_station": null,
-      "air_station_distance_m": null,
-      "air_station_from_end": null,
-      "air_station_null_reason": "the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it"
+      "why": "no tide station was bound to it at all: the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it"
     }
   ],
   "unresolved": [
     "beach_type is UNKNOWN upstream for most of these beaches. That is a gap in the resource, not a shorthand for sand, and nothing may render it as a description of what the shore is made of.",
-    "The join binds by nearest station of matching water class, and the distances are large where NOAA publishes no nearby station: the farthest is San Onofre State Beach at 56.6 km. See tide-stations.json, whose own unresolved list records that the one open-coast station between La Jolla and Imperial Beach does not deliver predictions.",
-    "28 of these beaches get no wave height at all. Every NDBC wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so binding one to the nearest buoy would put an open-ocean number on enclosed water. Their water temperature is missing for the same reason and is not yet filled from another source.",
+    "The join binds by nearest station of matching water class, and a beach whose nearest is further than 10.0 km away is not listed here at all rather than listed with a reading from out of range. The farthest any listed beach reads is Del Mar City Beach's, at 9.2 km. See tide-stations.json, whose own unresolved list records that the one open-coast station between La Jolla and Imperial Beach does not deliver predictions.",
+    "26 of these beaches get no wave height at all. Every NDBC wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so binding one to the nearest buoy would put an open-ocean number on enclosed water. Their water temperature is missing for the same reason and is not yet filled from another source.",
     "A tide prediction is for the station, not for the beach. It is the best published figure for that stretch of shore and it is not a measurement taken there.",
-    "Sky and visibility are read at an airport, because the ten stations in this county that publish them are all airport METARs, and airports sit inland. The median beach reads its sky station 7.3 km away and the farthest reads one 16.8 km away, at San Dieguito River Beach. Coastal fog is precisely what changes over that distance, so those two figures describe the airport and not the shoreline.",
-    "Air temperature and wind come from a different station than sky and visibility, and the page names both. The median beach reads its air station 3.5 km away against 7.3 km for its sky station. Two provenances behind one panel is a deliberate trade: requiring one station to supply all four values meant the scarcest of them, sky, decided where the temperature was measured, which put an inland reading on a coastal beach. See docs/adr/0010-two-provenances-in-the-air-panel.md.",
+    "Sky and visibility are read at an airport, because the ten stations in this county that publish them are all airport METARs, and airports sit inland. The median beach reads its sky station 7.7 km away and the farthest reads one 14.5 km away, at Del Mar City Beach. Coastal fog is precisely what changes over that distance, so those two figures describe the airport and not the shoreline.",
+    "Air temperature and wind come from a different station than sky and visibility, and the page names both. The median beach reads its air station 3.7 km away against 7.7 km for its sky station. Two provenances behind one panel is a deliberate trade: requiring one station to supply all four values meant the scarcest of them, sky, decided where the temperature was measured, which put an inland reading on a coastal beach. See docs/adr/0010-two-provenances-in-the-air-panel.md.",
     "An air station is still not the beach. It is the nearest measurement of the air the beach is in, chosen for exposure as well as distance -- an open-coast beach binds a station standing in the marine layer at the shoreline, a bay or lagoon binds the nearest of any kind. The shore classification is an author judgement; weather-stations.json records it and says so.",
-    "1 beach(es) could not be bound to a station: Imperial Beach pier area (the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego County, so no station can be joined to it). A null station must never render as a reading.",
     "The network module carries no build-time guard against being imported by a browser bundle. The `server-only` package is the intended enforcement and is not installed: importing it breaks the tests under jsdom until vitest is configured with the `react-server` resolve condition. Today the guarantee rests on the module having no client-side importer, which nothing checks."
   ]
 }

--- a/src/lib/beaches.test.ts
+++ b/src/lib/beaches.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_BEACH_SLUG,
   defaultBeach,
   inventoryCaveats,
+  inventoryReach,
   tideStationFor,
   waveBuoyFor,
 } from "./beaches";
@@ -55,6 +56,35 @@ describe("the inventory", () => {
 
   test("an unknown slug is null rather than a throw", () => {
     expect(beachBySlug("no-such-beach")).toBeNull();
+  });
+});
+
+describe("the inventory's reach", () => {
+  test("counts what the county lists as what it serves plus what it does not", () => {
+    // Derived rather than written down, so the two halves cannot disagree and
+    // the figure cannot go stale the next time upstream adds a row.
+    const reach = inventoryReach();
+
+    expect(reach.served).toBe(allBeaches().length);
+    expect(reach.listed).toBe(reach.served + reach.excluded.length);
+    expect(reach.listed).toBe(73);
+  });
+
+  test("names each beach it does not serve, and why", () => {
+    const onofre = inventoryReach().excluded.find(
+      (beach) => beach.slug === "san-onofre-state-beach",
+    );
+
+    expect(onofre?.name).toBe("San Onofre State Beach");
+    expect(onofre?.why).toContain("56.6 km");
+  });
+
+  test("serves none of the beaches it says it does not", () => {
+    // The contradiction a reader would catch first: a beach listed as absent
+    // that the chooser still offers.
+    for (const beach of inventoryReach().excluded) {
+      expect(beachBySlug(beach.slug)).toBeNull();
+    }
   });
 });
 

--- a/src/lib/beaches.test.ts
+++ b/src/lib/beaches.test.ts
@@ -11,8 +11,30 @@ import {
 } from "./beaches";
 
 describe("the inventory", () => {
-  test("holds every public, active San Diego beach the state publishes", () => {
-    expect(allBeaches()).toHaveLength(73);
+  test("holds only the beaches the station networks reach", () => {
+    // The county lists 73. The other 32 are in beaches.json's `_excluded`
+    // block, each with the binding distance that removed it; see
+    // docs/adr/0011-inventory-bounded-by-station-networks.md.
+    expect(allBeaches()).toHaveLength(41);
+  });
+
+  test("a beach the county lists but no station reaches is not in it", () => {
+    // San Onofre reads Scripps 56.6 km away, which is most of the way to Los
+    // Angeles. It is absent rather than answered for.
+    expect(beachBySlug("san-onofre-state-beach")).toBeNull();
+  });
+
+  test("every binding it does have is inside the ten-kilometre tolerance", () => {
+    // The predicate, asserted against the file that ships rather than against
+    // the fixtures the seeding script was tested with. A buoy the join
+    // deliberately withheld is not a binding, and disqualifies nobody.
+    for (const beach of allBeaches()) {
+      expect(beach.tide_station).not.toBeNull();
+      expect(beach.tide_station_distance_m).toBeLessThanOrEqual(10_000);
+      if (beach.wave_buoy !== null) {
+        expect(beach.wave_buoy_distance_m).toBeLessThanOrEqual(10_000);
+      }
+    }
   });
 
   test("is ordered north to south", () => {
@@ -106,18 +128,23 @@ describe("the tide station binding", () => {
     }
   });
 
-  test("a beach the join could not bind is null with a stated reason", () => {
-    const unbound = allBeaches().filter((beach) => beach.tide_station === null);
+  test("no beach in the inventory is missing one", () => {
+    // Upstream publishes one row whose coordinates are transposed, so the join
+    // binds it nothing. It used to ship as a page carrying a stated reason; the
+    // service predicate keeps it out of the inventory entirely now, and
+    // beaches.json's `_excluded` block carries the reason instead.
+    expect(allBeaches().filter((beach) => beach.tide_station === null)).toEqual(
+      [],
+    );
+    expect(beachBySlug("imperial-beach-pier-area")).toBeNull();
+  });
 
-    // Upstream publishes one row whose coordinates are transposed; it is refused
-    // rather than corrected here, because correcting it would be inventing a
-    // location. If this count changes, upstream changed.
-    expect(unbound).toHaveLength(1);
-    for (const beach of unbound) {
-      expect(beach.tide_station_null_reason).toBeTruthy();
-      expect(tideStationFor(beach)).toBeNull();
-      expect(beach.tide_station_distance_m).toBeNull();
-    }
+  test("resolves to null for a beach with none, which the type still allows", () => {
+    // No beach in the inventory has one. The field is still written by a join
+    // that can fail, so the reader of the data file validates rather than
+    // trusts, and conditions.ts still has a state to render if one ever does.
+    const beach = { ...defaultBeach(), tide_station: null };
+    expect(tideStationFor(beach)).toBeNull();
   });
 
   test("a beach naming an undescribed station is a broken data file, and says so", () => {

--- a/src/lib/beaches.ts
+++ b/src/lib/beaches.ts
@@ -143,6 +143,35 @@ export interface WeatherStation {
   dead_note?: string;
 }
 
+/**
+ * A beach San Diego County lists that this site does not answer for.
+ *
+ * Written into `beaches.json`'s `_excluded` block by the same predicate in
+ * `scripts/seed-beaches.mjs` that decides which beaches are in `beaches`, so
+ * the two cannot disagree about one. Nothing here is hand-maintained.
+ */
+export interface ExcludedBeach {
+  /** Stable, and not a route: `/conditions/<slug>` 404s for every one of these. */
+  slug: string;
+  name: string;
+  /**
+   * The binding distance that disqualified it, or the fault that stopped a
+   * binding being made at all. A beach that disappeared without one would be
+   * the silent failure this repo's `unresolved` blocks exist to prevent, and a
+   * worse one: a reader cannot notice what they were never shown.
+   */
+  why: string;
+}
+
+/** How far this site's answer reaches, counted in beaches. */
+export interface InventoryReach {
+  /** What the county's list holds: the beaches served plus the beaches excluded. */
+  listed: number;
+  /** What this site answers for. */
+  served: number;
+  excluded: readonly ExcludedBeach[];
+}
+
 export interface TideStation {
   name: string;
   lat: number;
@@ -156,6 +185,7 @@ export interface TideStation {
 }
 
 const BEACHES = inventory.beaches as readonly Beach[];
+const EXCLUDED = inventory._excluded as readonly ExcludedBeach[];
 const STATIONS = stationTable.stations as Readonly<Record<string, TideStation>>;
 const BUOYS = buoyTable.buoys as Readonly<Record<string, WaveBuoy>>;
 const WEATHER = weatherTable.stations as Readonly<
@@ -304,6 +334,22 @@ export function airStationFor(
     );
   }
   return { id: beach.air_station, ...station };
+}
+
+/**
+ * What this site covers, and what it leaves out.
+ *
+ * `listed` is derived from the two halves rather than written down, because a
+ * count of somebody else's list that this repo maintains by hand goes stale the
+ * first time that list moves -- and the number a reader is owed is the one that
+ * makes the site's own reach checkable.
+ */
+export function inventoryReach(): InventoryReach {
+  return {
+    listed: BEACHES.length + EXCLUDED.length,
+    served: BEACHES.length,
+    excluded: EXCLUDED,
+  };
 }
 
 /** Caveats carried by every data file. Every one owes the reader a rendering. */

--- a/src/lib/beaches.ts
+++ b/src/lib/beaches.ts
@@ -165,11 +165,13 @@ const WEATHER = weatherTable.stations as Readonly<
 /**
  * The beach the conditions view opens on when no other is asked for.
  *
- * Named rather than derived. "First in the inventory" would be San Onofre, at
- * the county's northern edge and 57 km from the nearest station that publishes
- * predictions, which is the worst-supported reading on the site. This one is
- * central, sits 1.4 km from its station, and is the beach the National Weather
- * Service means when its surf zone forecast says "La Jolla".
+ * Named rather than derived. "First in the inventory" meant San Onofre until
+ * the service predicate removed it, 57 km from the nearest station that
+ * publishes predictions; it now means Del Mar City Beach, which is served but
+ * sits at the northern edge of what survives and would move again the next time
+ * upstream adds a row. This one is central, sits 1.4 km from its station, and is
+ * the beach the National Weather Service means when its surf zone forecast says
+ * "La Jolla".
  */
 export const DEFAULT_BEACH_SLUG = "la-jolla-shores-beach";
 

--- a/src/lib/caveats.test.ts
+++ b/src/lib/caveats.test.ts
@@ -32,6 +32,65 @@ function unresolvedIn(file: string): string[] {
   return entries;
 }
 
+/**
+ * A beach a data file records that it does not serve. The same failure mode as
+ * an unread caveat and a worse one: a reader cannot notice what they were never
+ * shown, so a beach leaving the inventory has to leave a record behind it.
+ */
+function excludedIn(file: string): {
+  slug?: string;
+  name?: string;
+  why?: string;
+}[] {
+  const parsed = JSON.parse(readFileSync(join(DATA_DIRECTORY, file), "utf8"));
+  const entries = parsed._excluded;
+  if (entries === undefined) return [];
+  expect(Array.isArray(entries), `${file}: _excluded must be an array`).toBe(
+    true,
+  );
+  return entries;
+}
+
+describe("every excluded beach", () => {
+  test("the walk finds exclusions to check, so a green run is not an empty one", () => {
+    // Two-sided, like the caveat walk below: a discovery that found nothing
+    // would satisfy every assertion here and assert nothing at all.
+    expect(dataFiles().flatMap(excludedIn).length).toBeGreaterThan(0);
+  });
+
+  test("names which beach it was, and why it is not served", () => {
+    for (const file of dataFiles()) {
+      for (const entry of excludedIn(file)) {
+        expect(typeof entry.slug).toBe("string");
+        expect(entry.slug?.trim().length ?? 0).toBeGreaterThan(0);
+        expect(typeof entry.name).toBe("string");
+        expect(entry.name?.trim().length ?? 0).toBeGreaterThan(0);
+        expect(
+          entry.why?.trim().length ?? 0,
+          `${file}: ${entry.slug} was excluded with no reason recorded`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("is not also served by the same file, which would be a contradiction", () => {
+    for (const file of dataFiles()) {
+      const parsed = JSON.parse(
+        readFileSync(join(DATA_DIRECTORY, file), "utf8"),
+      );
+      const served = new Set(
+        (parsed.beaches ?? []).map((beach: { slug: string }) => beach.slug),
+      );
+      for (const entry of excludedIn(file)) {
+        expect(
+          served.has(entry.slug),
+          `${file}: ${entry.slug} is both listed and excluded`,
+        ).toBe(false);
+      }
+    }
+  });
+});
+
 describe("every data file's caveats", () => {
   test("the walk finds files to check, so a green run is not an empty one", () => {
     // Two-sided: a discovery that found nothing would satisfy every assertion

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -11,13 +11,59 @@ vi.mock("./upstream", () => ({
   fetchLatestNdbcAir,
 }));
 
-const { readTodaysLowestLow, readLatestWaves, readLatestAir } =
-  await import("./conditions");
-
 const BEACH = "la-jolla-shores-beach";
 
-/** The one beach the join refuses, because upstream's coordinates are transposed. */
-const UNBOUND_BEACH = "imperial-beach-pier-area";
+/**
+ * A beach with nothing bound to it, which the inventory no longer contains.
+ *
+ * It used to be Imperial Beach pier area, whose upstream coordinates are
+ * transposed. The service predicate removes every beach a join could not bind,
+ * so no slug in `beaches.json` reaches the `no-station` states any
+ * more -- and those states stay, because that file is written by joins that can
+ * fail and the four-state model exists to keep a permanent fact about a place
+ * apart from a feed having a bad day.
+ *
+ * So one synthetic beach, added to the real inventory rather than replacing it:
+ * every other test in this file still runs against the shipped file, which is
+ * what makes them evidence rather than assertions about a fixture.
+ */
+const UNBOUND_BEACH = "nothing-is-bound-here";
+
+vi.mock("./beaches", async (importOriginal) => {
+  const real = await importOriginal<typeof import("./beaches")>();
+  const reason =
+    "the lower endpoint published upstream (32.1327, -117.1332) is outside San Diego " +
+    "County, so no station can be joined to it";
+  const unbound: import("./beaches").Beach = {
+    ...real.beachBySlug("la-jolla-shores-beach")!,
+    slug: UNBOUND_BEACH,
+    name: "Nothing Is Bound Here",
+    tide_station: null,
+    tide_station_distance_m: null,
+    tide_station_from_end: null,
+    tide_station_null_reason: reason,
+    wave_buoy: null,
+    wave_buoy_distance_m: null,
+    wave_buoy_from_end: null,
+    wave_buoy_null_reason: reason,
+    weather_station: null,
+    weather_station_distance_m: null,
+    weather_station_from_end: null,
+    weather_station_null_reason: reason,
+    air_station: null,
+    air_station_distance_m: null,
+    air_station_from_end: null,
+    air_station_null_reason: reason,
+  };
+  return {
+    ...real,
+    beachBySlug: (slug: string) =>
+      slug === UNBOUND_BEACH ? unbound : real.beachBySlug(slug),
+  };
+});
+
+const { readTodaysLowestLow, readLatestWaves, readLatestAir } =
+  await import("./conditions");
 
 /**
  * Noon Pacific on 2026-08-17. The clock is injected rather than faked, which is
@@ -163,8 +209,12 @@ test("a slug outside the inventory is a coding error, and nothing is fetched", a
  * Waves
  * ========================================================================= */
 
-/** A bay beach, which the join deliberately binds to no buoy. */
-const BAY_BEACH = "agua-hedionda-lagoon";
+/**
+ * A bay beach, which the join deliberately binds to no buoy. Agua Hedionda
+ * Lagoon used to stand here and left the inventory with the rest of North
+ * County: its nearest bay tide station is 39.7 km away.
+ */
+const BAY_BEACH = "mission-bay";
 
 test("a wave reading carries the buoy, its distance and the water temperature", async () => {
   fetchLatestWave.mockResolvedValue({
@@ -324,15 +374,12 @@ test("the air station is asked on its own network, not the weather service's", a
 });
 
 test("an air station on the weather service's own network is read there", async () => {
-  // Most beaches bind an NWS mesonet station for air. Only the pier and the
-  // Tijuana estuary are NDBC, so the common path must not go through the NDBC
+  // Most beaches bind an NWS mesonet station for air. The La Jolla run and the
+  // two southern bays are NDBC, so the common path must not go through the NDBC
   // fetcher at all.
   fetchLatestObservation.mockResolvedValue(skyOk());
 
-  const view = await readLatestAir(
-    "agua-hedionda-lagoon",
-    NOON_PACIFIC_20260817,
-  );
+  const view = await readLatestAir(BAY_BEACH, NOON_PACIFIC_20260817);
 
   expect(fetchLatestNdbcAir).not.toHaveBeenCalled();
   expect(view.air.kind).toBe("reading");
@@ -341,12 +388,9 @@ test("an air station on the weather service's own network is read there", async 
 test("a bay beach still gets an air reading, unlike its waves", async () => {
   fetchLatestObservation.mockResolvedValue(skyOk());
 
-  // A lagoon: no wave buoy by design, and an air station all the same, because
+  // A bay: no wave buoy by design, and an air station all the same, because
   // air reaches enclosed water and swell does not.
-  const view = await readLatestAir(
-    "agua-hedionda-lagoon",
-    NOON_PACIFIC_20260817,
-  );
+  const view = await readLatestAir(BAY_BEACH, NOON_PACIFIC_20260817);
 
   expect(view.airStation).not.toBeNull();
   expect(view.skyStation).not.toBeNull();

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -35,10 +35,10 @@ export default defineConfig({
       // purpose, and all four drag these figures down in plain sight rather
       // than quietly.
       thresholds: {
-        statements: 89.6,
-        branches: 89.59,
-        functions: 94.38,
-        lines: 89.43,
+        statements: 89.61,
+        branches: 89.61,
+        functions: 94.42,
+        lines: 89.45,
       },
     },
   },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -35,10 +35,10 @@ export default defineConfig({
       // purpose, and all four drag these figures down in plain sight rather
       // than quietly.
       thresholds: {
-        statements: 89.36,
-        branches: 89.28,
-        functions: 94.27,
-        lines: 89.2,
+        statements: 89.6,
+        branches: 89.59,
+        functions: 94.38,
+        lines: 89.43,
       },
     },
   },


### PR DESCRIPTION
Slices 3 and 4 of `docs/plans/inventory-bounded-by-stations.md`. **Stacked on
#89** — review that first; this PR's diff is against it, and GitHub will
retarget this at `main` when #89 merges.

**The site answers for 41 beaches instead of 73.**

### ADR correction (`863e317`)

Found while measuring the predicate against the committed join. ADR 0011's
consequences were updated from 40 kept to 41 by moving a beach into the wrong
band: the split is 25 bays, 14 in La Jolla and Pacific Beach, 2 in Point Loma
and Ocean Beach, where the ADR said 13 and 3. Children's Pool is the beach the
reclassification moved, and it moved out of the bay group into La Jolla, not
into the band below. One sentence still said forty where the paragraph above it
said forty-one. "No beach survives south of Ocean Beach" was misleading too —
the beach named Ocean Beach is itself cut, the southernmost surviving open-coast
beach is Mission Beach, and the bays run further south than either.

Doc-only, its own commit, no decision changed.

### Slice 3 — the served-inventory predicate (`49657fb`)

`servesBeach` is the second predicate over the inventory, and unlike the first
it is judgement: **a tide station within 10 km, and if a wave buoy is bound at
all, that buoy within 10 km.** Stated that way it subsumes the bay exemption
rather than special-casing beside it — a beach fails when a binding it *has* is
too far, never when a join correctly declined to make one, which is what the
wave join does at a bay and at Children's Pool. 10 km is a named constant, so
changing it is a one-line reviewable edit; at 15 km the site would list 49.

`serviceFault` returns the reason `servesBeach` reads, so the verdict and the
record cannot drift apart. Every excluded beach goes into `beaches.json`'s new
`_excluded` block with the distance that disqualified it, and `document` refuses
to write an inventory with nothing in it.

Two caveats are rewritten rather than left describing the previous inventory:
the one that said the tide distances were large (the beaches that had them are
gone), and the one that named beaches bound to nothing (the predicate removes
them, and `_excluded` says so instead).

Routes and the chooser read the smaller set without changing — a cut slug 404s
because `beachBySlug` returns null, asserted for Harbor Beach.

A finding the plan did not anticipate, recorded as a dated addendum: the
predicate leaves the `no-station` panel states with **no occupant**, because
every beach a join could not bind is now excluded. They stay — the type still
allows null, and the distinction between a permanent fact about a place and a
feed having a bad day is what a reader would lose — and `conditions.test.ts`
reaches them through one synthetic beach added to the real inventory, so every
other test in that file still runs against the shipped data. Collapsing them, or
narrowing `Beach` so the compiler knows a served beach has a station, is a
separate slice; the addendum says why.

### Slice 4 — the exclusion reaches a reader (`6bc5b81`)

A parent looking for Moonlight Beach found a chooser that did not offer it and
no way to tell whether the county never listed it or this site left it out.

`inventoryReach` derives the county's count from the two halves rather than
carrying 73 as a written-down number. `Caveats` renders, **outside** the
disclosures, `This site answers for 41 of the 73 beaches San Diego County
lists.` — the one thing there a reader may need before they have a question —
and puts the 32 names behind their own disclosure, counted in the summary so the
count is visible closed. Each line leads with the beach name and then says how
far its station was.

Rendered against the real data:

```
This site answers for 41 of the 73 beaches San Diego County lists.
Why the other 32 are not here
  A beach is left out rather than answered with a reading measured somewhere
  else — a station further away than we would publish a reading from, or
  coordinates published upstream that cannot be used at all.
  San Onofre State Beach — its tide station 9410230 is 56.6 km away, and this
  site does not publish a reading taken more than 10.0 km from the beach it is
  shown for.
  …
  Imperial Beach pier area — no tide station was bound to it at all: the lower
  endpoint published upstream (32.1327, -117.1332) is outside San Diego County,
  so no station can be joined to it.
```

### Verification

`npm run gate` at `6bc5b81`, with `.next/` removed first:

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

591 → 598 tests. `node scripts/seed-beaches.mjs --check` passes: `beaches.json is
current: 41 beaches, join unchanged.` — the cut set is re-derivable rather than
asserted.

Coverage rose on every axis and the floor rose with it, twice: 89.36/89.28/94.27/89.2
→ 89.61/89.61/94.42/89.45 (statements/branches/functions/lines).

### Judgement calls worth a second opinion

- **Each `_excluded` reason repeats the rule** ("…and this site does not publish
  a reading taken more than 10.0 km from the beach it is shown for") 31 times in
  the rendered list. Kept because every entry then stands alone, which is this
  repo's habit with `unresolved`, and because a reader scanning bold names reads
  one line. Trimming it to the distance alone is a one-line change to
  `serviceFault` plus a re-seed, if you would rather.
- **The reach sentence sits with `Caveats` at the foot of the section**, which is
  what the plan says. Beside the chooser is arguably where someone who cannot
  find their beach is looking. Not moved, because the plan named `Caveats` and
  moving it is a design decision rather than an implementation one.

### What is not here

- **Sky and visibility**, indicted at all 41 surviving beaches and not fixed by
  any tightening of this predicate. Named in the plan's out-of-scope list; still
  has no issue.
- **#86 (LJAC1 water temperature)** stays a deliberate no — a consistent distance
  rule removes water temperature from 23 beaches and adds it to 3. The issue is
  still open and still uncommented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
