### PR TITLE
Stamp the generated date where the beaches are

### DIFF
--- a/scripts/generated-date.mjs
+++ b/scripts/generated-date.mjs
@@ -1,0 +1,41 @@
+/**
+ * The date to stamp on a data file, for the seeding scripts next door.
+ *
+ * One date function and nothing else. It lives on its own because two scripts
+ * write a `generated` field now -- the beach inventory and the station probe --
+ * and a date filed under either of them would be copied by whoever was writing
+ * the other. That copy is what this file exists to prevent: `seed-beaches.mjs`
+ * stamped UTC for months while `probe-observation-stations.mjs` stamped
+ * Pacific, so the sibling tables disagreed by a day (issue #85).
+ *
+ * `src/lib/pacific-time.ts` is the same idea for the site, and is deliberately
+ * not imported here: these scripts run under node unbuilt, so they cannot read
+ * TypeScript. The zone is spelled the same in both places on purpose.
+ */
+
+/** The zone the data files describe, and declare in their own `time_zone`. */
+const DATA_TIME_ZONE = "America/Los_Angeles";
+
+/**
+ * The calendar date an instant falls on where the beaches are, as `YYYY-MM-DD`.
+ *
+ * `new Date().toISOString().slice(0, 10)` gives the UTC date, so any run after
+ * 5pm Pacific stamps tomorrow: the file claims to have been generated on a day
+ * that has not started in the county it describes.
+ *
+ * `en-CA` is used for its format rather than its locale -- it yields
+ * ISO-ordered parts, so nothing has to be reassembled and no month/day
+ * ambiguity can creep in. `Intl` carries the daylight-saving rules, which is
+ * the part nobody should hand-roll.
+ *
+ * @param {Date} now
+ * @returns {string}
+ */
+export function generatedDate(now) {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: DATA_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+}

--- a/scripts/generated-date.test.mjs
+++ b/scripts/generated-date.test.mjs
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { generatedDate } from "./generated-date.mjs";
+
+describe("generatedDate", () => {
+  it("is the date where the beaches are, not where the clock is", () => {
+    // 01:59 UTC on the 19th is 18:59 on the 18th in San Diego. This is the case
+    // that was observed wrong: a file stamped a day that had not started in the
+    // county it describes.
+    expect(generatedDate(new Date("2026-08-19T01:59:22Z"))).toBe("2026-08-18");
+  });
+
+  it("agrees with UTC when the two are the same day", () => {
+    expect(generatedDate(new Date("2026-08-18T16:00:00Z"))).toBe("2026-08-18");
+  });
+
+  it("follows the offset across daylight saving, not a fixed seven hours", () => {
+    // Pacific is UTC-8 in January, so 07:30 UTC is still the previous evening,
+    // where UTC-7 would have rolled over. A hand-rolled offset gets exactly one
+    // of these two cases right.
+    expect(generatedDate(new Date("2026-01-19T07:30:00Z"))).toBe("2026-01-18");
+    expect(generatedDate(new Date("2026-07-19T07:30:00Z"))).toBe("2026-07-19");
+  });
+});

--- a/scripts/probe-observation-stations.mjs
+++ b/scripts/probe-observation-stations.mjs
@@ -45,6 +45,7 @@
 
 import { readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
+import { generatedDate } from "./generated-date.mjs";
 
 const NWS_POINTS = "https://api.weather.gov/points";
 const NWS_OBSERVATIONS = "https://api.weather.gov/stations";
@@ -461,24 +462,6 @@ export function buildTable(stations) {
   return table;
 }
 
-/**
- * Today's date where the beaches are, not where the clock is.
- *
- * `new Date().toISOString().slice(0, 10)` -- which is what `seed-beaches.mjs`
- * uses -- stamps the UTC date, so any run after 5pm Pacific records tomorrow.
- * The file would claim to have been generated on a day that had not started in
- * the county it describes, and would read a day newer than the sibling tables
- * probed beside it. The zone is the one `beaches.json` already declares.
- */
-export function probeDate(now) {
-  return new Intl.DateTimeFormat("en-CA", {
-    timeZone: "America/Los_Angeles",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).format(now);
-}
-
 export function document(table, now = new Date()) {
   const rows = Object.values(table);
   const count = (predicate) => rows.filter(predicate).length;
@@ -490,7 +473,7 @@ export function document(table, now = new Date()) {
 
   return {
     version: "0.2.0",
-    generated: probeDate(now),
+    generated: generatedDate(now),
     _provenance:
       `Measured by scripts/probe-observation-stations.mjs; re-runnable and diffable with ` +
       `--check. National Weather Service candidates are the union of ` +

--- a/scripts/probe-observation-stations.test.mjs
+++ b/scripts/probe-observation-stations.test.mjs
@@ -11,7 +11,6 @@ import {
   nwsCapabilities,
   nwsStationListUrls,
   parseActiveStations,
-  probeDate,
   probeNdbc,
   probeNws,
   tableRow,
@@ -371,18 +370,10 @@ describe("the boxes", () => {
 });
 
 describe("the generated date", () => {
-  it("is the date where the beaches are, not where the clock is", () => {
-    // 01:59 UTC on the 19th is 18:59 on the 18th in San Diego. Stamping the UTC
-    // date -- which seed-beaches.mjs still does -- makes any evening run claim a
-    // day that has not started in the county the file describes, and makes this
-    // table read a day newer than the sibling tables probed beside it.
-    expect(probeDate(new Date("2026-08-19T01:59:22Z"))).toBe("2026-08-18");
-  });
-
-  it("agrees with UTC when the two are the same day", () => {
-    expect(probeDate(new Date("2026-08-18T16:00:00Z"))).toBe("2026-08-18");
-  });
-
+  // The date itself is generated-date.mjs's, and asserted in its own suite next
+  // door -- including the daylight-saving case neither caller can see. What is
+  // this table's business is that the document stamps that date and not the
+  // machine's: 01:59 UTC on the 19th is 18:59 on the 18th in San Diego.
   it("is what the document records", () => {
     const table = buildTable([
       {

--- a/scripts/seed-beaches.mjs
+++ b/scripts/seed-beaches.mjs
@@ -30,6 +30,7 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { distanceMetres } from "./geo.mjs";
+import { generatedDate } from "./generated-date.mjs";
 import { bindAirStation } from "./air-join.mjs";
 import { bindTideStation } from "./tide-join.mjs";
 import { bindWaveBuoy } from "./wave-join.mjs";
@@ -392,7 +393,7 @@ export function servesBeach(beach, toleranceM = SERVICE_TOLERANCE_M) {
   return serviceFault(beach, toleranceM) === null;
 }
 
-export function document(built) {
+export function document(built, now = new Date()) {
   const beaches = built.filter((beach) => servesBeach(beach));
   const excluded = built
     .filter((beach) => !servesBeach(beach))
@@ -431,7 +432,7 @@ export function document(built) {
 
   return {
     version: "0.2.0",
-    generated: new Date().toISOString().slice(0, 10),
+    generated: generatedDate(now),
     time_zone: "America/Los_Angeles",
     _provenance:
       `Seeded from the Beach Detail Information resource of "Beach Advisories (Postings and ` +

--- a/scripts/seed-beaches.test.mjs
+++ b/scripts/seed-beaches.test.mjs
@@ -611,4 +611,17 @@ describe("document", () => {
     expect(second).toEqual(first);
     expect(new Set(first).size).toBe(first.length);
   });
+
+  it("stamps the date where the beaches are, not where the clock is", () => {
+    // 01:59 UTC on the 19th is 18:59 on the 18th in San Diego. Stamping the UTC
+    // date made any run after 5pm Pacific claim a day that had not started in
+    // the county this file describes, and read a day ahead of the station
+    // tables probed beside it. The zone is the one the document itself
+    // declares two lines below the stamp.
+    const built = build([row()], STATIONS, BUOYS, WEATHER);
+
+    expect(document(built, new Date("2026-08-19T01:59:22Z")).generated).toBe(
+      "2026-08-18",
+    );
+  });
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -36,9 +36,9 @@ export default defineConfig({
       // than quietly.
       thresholds: {
         statements: 89.61,
-        branches: 89.61,
+        branches: 89.63,
         functions: 94.42,
-        lines: 89.45,
+        lines: 89.46,
       },
     },
   },


### PR DESCRIPTION
Closes #85.

## What changed

One slice, one commit.

`seed-beaches.mjs` stamped `generated: new Date().toISOString().slice(0, 10)`,
which is the UTC date. San Diego is UTC-7 in summer, so any run after 5pm
Pacific recorded tomorrow — a day that had not started in the county the file
describes, and a day ahead of the station tables probed beside it.

`probe-observation-stations.mjs` already had the fix as a local `probeDate`.
Rather than copy it, the function moves to a new **`scripts/generated-date.mjs`**
and both scripts import it. That home is `geo.mjs`'s precedent applied
literally: two callers need it, so it gets its own file rather than a `utils`
bag or a place under whichever caller wrote it first. Its unit tests moved with
it into `scripts/generated-date.test.mjs`, and gained the daylight-saving case
that neither caller can see (07:30 UTC is the previous day in January and the
same day in July, so a hand-rolled seven-hour offset gets exactly one of them
right).

Each caller keeps only the assertion that is its own business — that the
document it builds stamps *that* date and not the machine's. Making
`document(built, now = new Date())` injectable is what makes that assertible
without faking the clock, and it matches the probe's existing signature.

## The test, and watching it fail

The regression test went in first, against the unfixed `document`:

```
 FAIL  scripts/seed-beaches.test.mjs > document > stamps the date where the beaches are, not where the clock is
AssertionError: expected '2026-08-20' to be '2026-08-18' // Object.is equality

Expected: "2026-08-18"
Received: "2026-08-20"
```

Worth noting what it received. The test injects 01:59 UTC on the 19th — 18:59
on the 18th in San Diego — and the old code ignored the injected instant
entirely and stamped the machine's UTC clock, which had *already rolled over to
the 20th* while it was still the evening of the 19th in San Diego. The bug
reproduced itself inside its own failure message.

## Gate

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

## Coverage

Measured on `main` and again on this branch, same command:

| | before | after |
|---|---|---|
| statements | 89.61 | 89.61 |
| branches | 89.61 | **89.63** |
| functions | 94.42 | 94.42 |
| lines | 89.45 | **89.46** |

Branches and lines rose, so the floor in `vitest.config.mts` is raised to what
the run actually achieves. Nothing was lowered.

## What I did not do

- **No `src/data/` file is touched, and `node scripts/seed-beaches.mjs` was not
  run.** Back-dating the `generated` values already committed is out of scope
  per the issue: they record when those files were written, which is what they
  are for, and rewriting them would invent a measurement date. The next real
  seed will stamp Pacific on its own.
- **`src/lib/pacific-time.ts` is not imported and not touched.** It has
  `localDateOf`, the same idea for the site, but these scripts run under node
  unbuilt and cannot read TypeScript. The duplicated zone string across that
  boundary is called out in the new module's header rather than left to be
  rediscovered.
- No ADR. Where a shared function lives inside `scripts/` is not a decision that
  outlives the task, and the issue named the precedent to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
