### PR TITLE
Name the sky and air stations in the glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -118,3 +118,27 @@ something to put in its place. It shows readings and forecasts relayed from
 public sources, attributed and timestamped — never a judgement this site makes
 about whether conditions are safe.
 _Avoid_: weather, forecast, surf report
+
+**Observation station**:
+One of the stations in `src/data/observation-stations.json` — 62 of them, across
+the National Weather Service's network and NDBC's. The table is read by two
+joins with different filters, so it is named for neither of them. Until it was
+renamed it was `weather-stations.json`, and the sky join beside it was
+`weather-join.mjs`; ADRs and plan files written before the rename still name
+those paths, and are left as the dated records they are.
+_Avoid_: weather station, met station
+
+**Sky station**:
+The observation station a beach reads for sky and visibility. Always an airport
+METAR, because in this county only airports publish those two values — so it is
+the furthest-away reading on the page, and the panel says so rather than
+letting it pass as a measurement at the shore.
+_Avoid_: weather station, the beach's weather
+
+**Air station**:
+The observation station a beach reads for air temperature and wind. Usually not
+the same station as its sky station, and much nearer: requiring one station to
+supply all four values let the scarcest of them, sky, decide where the
+temperature was measured, which put an inland reading on a coastal beach
+(ADR-0010).
+_Avoid_: weather station, wind station


### PR DESCRIPTION
Follow-up to #93, and the answer to the loose end it left: ADRs 0010 and 0011
and three plan files still name `weather-stations.json` and `weather-join.mjs`.

**The paths are not chased.** Plan files are dated records and `CLAUDE.md`
forbids rewriting their history; ADRs could be amended in place, but a rename is
not a decision change and it would be the same edit repeated five times.

Instead the mapping goes where this repo says shared words live. `CONTEXT.md` is
"the words the code, the copy, the issues and the plans all use for the same
things", with an `_Avoid_` convention for exactly this — and it turned out to
have **no station vocabulary at all**. One entry, `Conditions`, covered the whole
tool. That gap predates #84 and is what makes the stale paths a navigation
problem rather than a cosmetic one: a reader following a path from an old ADR has
nowhere to look the word up.

Three entries:

- **Observation station** — the table and why it is named for neither join. It
  names both old paths deliberately, so a grep for the name a stale ADR uses
  lands here.
- **Sky station** — always an airport METAR, the furthest reading on the page.
- **Air station** — usually a different and much nearer station, with the
  ADR-0010 reasoning for why the two are separate at all.

Each carries `_Avoid_: weather station`, which is the word `#84` removed from
every identifier and which `CONTEXT.md`'s own `Conditions` entry already listed
under `_Avoid_`.

### Verification

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

Documentation only — no code, no data, no behaviour. `CONTEXT.md` sits outside
the `src/` directory Tailwind scans, which `CLAUDE.md`'s project-invariants
section names explicitly, so prose here cannot reach the built stylesheet; the
`stylesheet` row confirms it.

### Not done

- **The rest of the station vocabulary.** `Tide station`, `wave buoy`, `water
  class`, `sheltered`, and the served/excluded distinction from #90 are all still
  absent from the glossary. Deliberately out of scope — this slice closes the gap
  #84 opened, and adding eight entries to a thirteen-entry glossary in one pass
  is a different change with a different argument.
- **No issue.** One slice, one commit, no blocker to name; `CLAUDE.md` says to
  skip the issue when it does not earn its keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
