### PR TITLE
Say what the art classes are and what they cost

### DIFF
--- a/docs/plans/art-program-page-copy.md
+++ b/docs/plans/art-program-page-copy.md
@@ -1,0 +1,192 @@
+# The art page says what the classes are and what they cost
+
+## Problem, from the reader's point of view
+
+A parent lands on `/art` in the weeks before the fall term. The page tells them
+the media — watercolors, ink, collage, printmaking — and that full class details
+are on their way. It does not tell them what a class costs, how often classes
+run, how many kids are in one, or what makes this different from any other art
+class in the county.
+
+So the page cannot be decided on. A parent who is interested has to join the
+interest list and wait, which is the right CTA for someone who has already
+decided and the wrong one for someone still deciding.
+
+Art is the program opening first — fall 2026 — and the schedule below the copy
+is already wired to Supabase and waiting on rows. What is missing is not
+machinery. It is the words.
+
+## Solution
+
+`/art` states the program's story and its pricing.
+
+- **Why it is different**: the work starts from the kids' own interest; every
+  class includes art history; the class is skill-focused rather than everyone
+  copying one result; technique and foundations are taught so that creative
+  freedom has something to stand on; the skills go home with the kid.
+- **What you get**: a weekly small-group class, capped at ten.
+- **What it costs**: drop-in $20, a 6-pack for $100, a 12-pack for $200.
+
+The schedule below keeps doing what it already does — the published upcoming
+sessions, or the reserved slot when there are none — and its slot stops
+promising pricing, because pricing is now above it.
+
+## Relationship to what already shipped
+
+The schedule on this page came from `session-schedule-from-supabase.md` and is
+unchanged by this work. No migration, no new query, no change to
+`src/lib/sessions.ts` or `src/components/SessionSchedule.tsx`.
+
+**One earlier assumption is refined rather than reversed.** A comment in
+`src/app/art/page.test.tsx` reads:
+
+> Prices vary from one class to the next, which is why they live on the row
+> rather than in page copy, and why the schedule is where a parent finds them.
+
+That was a reasonable reading when the only thing known about art pricing was
+that `price_cents` existed. The program's actual pricing is tiered and identical
+across every weekly session, so it describes the **program**, not any one date.
+
+Both remain true, and that is the point:
+
+- **Program-level tiers are page copy.** They cannot be expressed on a session
+  row at all — "6 classes for $100" is not a price for one class.
+- **`price_cents` stays on the row and still renders.** A one-off workshop
+  priced differently from the standing tiers still says so on its own line.
+- **Standing weekly sessions carry `price_cents = null`**, which already means
+  "not priced here, which is not the same as free" — the distinction was written
+  into `src/lib/sessions.ts` before there was a case for it, and this is the
+  case.
+
+So this slice is additive. The existing assertion that a `4500` row renders
+`$45` stays green and stays correct.
+
+## Implementation decisions
+
+- **The tiers are copy on the page, not rows in the database.** The argument in
+  full is under _Considered and rejected_. The short version: a pack is not a
+  price for a session, the tiers are the same for every session, and programs
+  are already hardcoded — `ProgramCards.tsx` is a bespoke design and the
+  `program` column is a foreign key to code, not to a table. Program-level facts
+  living in code is the established pattern here, not a new one.
+
+- **Weekly only. The monthly themed class is not mentioned.** It has a
+  description and no price, and a described package with no price generates
+  email rather than signups. It lands when it has a number.
+
+- **No new shared component unless a second caller appears.** `/coop` has no
+  pricing and is not opening this term. A pricing block used once belongs in the
+  page that uses it, and extracting it before there is a second caller is
+  speculative flexibility.
+
+- **The eyebrow keeps saying "Group & Private".** Private classes are still
+  offered; this slice adds the group pricing and does not remove anything.
+
+- **No change to `ProgramCards.tsx`.** Its art card copy and badges may want a
+  look — "Outdoors" on a studio class is worth questioning — but the landing
+  page's card is a different surface with a 520px height budget set by issue
+  #37, and touching it here would be a second thing in one slice.
+
+- **The reserved slot's copy narrows to the schedule.** It currently reads
+  "Schedule & pricing coming soon." Once the page states pricing, a slot
+  promising pricing is stale — and a reserved slot that promises what has
+  already arrived is exactly the drift the component was extracted to stop.
+
+## Test seams
+
+The existing one. `src/app/art/page.test.tsx` renders the page and asserts what
+a reader sees; this work adds assertions to it and changes two that name the
+slot's old copy.
+
+| Seam                                        | What it covers                                   |
+| ------------------------------------------- | ------------------------------------------------ |
+| `render(await Art())`                       | The differentiator copy is present and reachable |
+| `render(await Art())`                       | Each tier and its price renders                  |
+| `render(await Art())`                       | The cap of ten is stated                         |
+| `render(await Art())`                       | The slot no longer promises pricing              |
+| `render(await Art())` (existing, unchanged) | A priced session still renders its own price     |
+
+No new seam is needed and none is proposed. This is page copy: the thing that
+can be wrong is what the page says, and the render test is where that is
+asserted. Extracting a pure function to hold three prices would add a seam
+without adding a question it can answer.
+
+The prices are asserted **as strings a reader sees** — `$20`, `$100`, `$200` —
+not as constants imported from the module under test. A test that imports the
+number it asserts cannot fail when the number is wrong.
+
+## Slices
+
+1. **The plan** — this file.
+2. **The program's story.** Replace the single intro paragraph with the
+   differentiators. Copy and its assertions.
+3. **The packages and pricing.** The weekly small group, its cap, and the three
+   tiers.
+4. **The reserved slot narrows.** Its headline and detail stop promising
+   pricing; the two assertions naming the old copy move with it.
+
+Slice 4 depends on slice 3 — the slot can only stop promising pricing once the
+page supplies it.
+
+## Verification
+
+`npm run gate` before each commit, and its output in the PR body.
+
+`npm run check:db` is **not** run and is not relevant: no migration, no schema
+change, and no new column read.
+
+## Considered and rejected
+
+**Put the tiers in the database.** Rejected on three counts. A pack spans
+sessions, so `price_cents` — one integer on one row — cannot express one at all;
+representing a purchased balance and its consumption needs tables that do not
+exist, and that should not be designed before a term has been sold. The tiers
+are identical across every weekly session, so putting them on each row stores
+the same three numbers once per date and invites them to disagree. And it would
+need a migration and a `check:db` assertion to ship a paragraph of text.
+
+The cost of this rejection is real and worth naming: **Lena cannot change a
+price without a deploy.** That is acceptable because a price change is not a
+routine edit — it happens at most once a term, it is a decision worth reviewing
+before it is public, and the schedule rows that _do_ change weekly remain
+editable in Studio with no deploy. If price edits ever become frequent, that is
+the signal to revisit, and the revisit is cheap: the page reads from somewhere
+else instead.
+
+**Add a `packages` or `pricing_tiers` table now.** Rejected as premature. The
+pricing model has never met a customer; it opens in weeks and will change. A
+schema built for an untested price list gets built twice. The tiers are three
+numbers in a paragraph until a term has run.
+
+**Model the monthly themed class alongside the weekly one.** Rejected for now —
+no price, and no confirmation it runs this fall.
+
+**Extract a `PricingTiers` component.** Rejected: one caller. It becomes a
+component when `/coop` or a second program needs it.
+
+**Reword the art card on the landing page in the same pass.** Rejected as a
+second thing in one slice. Filed as a follow-up rather than folded in.
+
+## Out of scope
+
+- The schedule itself, `src/lib/sessions.ts`, and the sessions table. Untouched.
+- Entering fall session rows. Data entry in Supabase Studio, not code, and
+  blocked on dates and a location that are not decided.
+- The monthly themed class, until it has a price.
+- The class location, which is undecided and which the schedule rows carry
+  per-session anyway.
+- Booking, RSVP, capacity enforcement, accounts and packs. `/book` keeps its
+  reserved slot and its interest-list CTA.
+- `ProgramCards.tsx`.
+- `/coop`, which is not the program opening first.
+
+## Open questions
+
+- **Does this decision want an ADR?** "Program-level pricing is copy; per-session
+  pricing is data" will outlive this task and will be re-litigated, which is the
+  test CLAUDE.md sets. Argued here in full rather than in `docs/adr/` because it
+  refines an assumption rather than establishing a new contract. Worth a second
+  opinion at review.
+- **What does the monthly themed class cost?** Blocks including it.
+- **Where do classes meet?** Undecided. Carried per-session on the row, so it
+  does not block this page.

--- a/src/app/art/page.test.tsx
+++ b/src/app/art/page.test.tsx
@@ -23,10 +23,24 @@ test("the art page exposes its landmark, heading and reserved slots", async () =
   const heading = screen.getByRole("heading", { level: 1 });
   expect(heading.textContent).toContain("Art");
 
-  expect(screen.getByText(/schedule & pricing coming soon/i)).toBeDefined();
+  expect(screen.getByText(/fall dates coming soon/i)).toBeDefined();
   expect(
     screen.getByRole("img", { name: "Student artwork gallery" }),
   ).toBeDefined();
+});
+
+// The slot stands in for the schedule and nothing else. It promised pricing
+// while pricing had nowhere to live; pricing now has a section of its own, and
+// a reserved slot that promises what has already arrived is the exact drift the
+// component was extracted to stop.
+test("the reserved slot no longer promises pricing", async () => {
+  render(await Art());
+
+  expect(screen.getByText(/fall dates coming soon/i)).toBeDefined();
+  expect(screen.queryByText(/pricing coming soon/i)).toBeNull();
+
+  // ...while the page still states the prices themselves.
+  expect(screen.getByText("$20")).toBeDefined();
 });
 
 test("the page CTA routes to the booking page", async () => {
@@ -130,9 +144,10 @@ test("an unreachable schedule is reported to the server log", async () => {
   );
 });
 
-// The half of the reserved slot's promise this slice can keep. Prices vary from
-// one class to the next, which is why they live on the row rather than in page
-// copy, and why the schedule is where a parent finds them.
+// A session that carries its own price still shows it. The standing weekly
+// tiers are page copy — a pack spans sessions and cannot live on a row — but
+// that did not remove `price_cents`, and a one-off priced differently from the
+// tiers says so here. Both readings are live at once, deliberately.
 test("published art sessions show their times and their prices", async () => {
   vi.stubEnv("SUPABASE_URL", "https://abcdefghijklmnopqrst.supabase.co");
   vi.stubEnv("SUPABASE_ANON_KEY", "sb_publishable_test");
@@ -164,7 +179,7 @@ test("published art sessions show their times and their prices", async () => {
   ).toBeDefined();
   expect(screen.getByText("$45")).toBeDefined();
   expect(screen.getByText("Studio — North Park")).toBeDefined();
-  expect(screen.queryByText(/schedule & pricing coming soon/i)).toBeNull();
+  expect(screen.queryByText(/fall dates coming soon/i)).toBeNull();
 });
 
 // Art's accent is purple where the co-op's is ocean, and the component derives

--- a/src/app/art/page.test.tsx
+++ b/src/app/art/page.test.tsx
@@ -76,6 +76,50 @@ test("the approach list is named by its own heading", async () => {
   expect(region.getAttribute("aria-labelledby")).toBe(heading.id);
 });
 
+// The prices are asserted as the strings a reader sees. Importing TIERS and
+// asserting against it would pass whatever the numbers were.
+test("the art page states all three pricing tiers", async () => {
+  render(await Art());
+
+  expect(
+    screen.getByRole("heading", { level: 2, name: "Packages & pricing" }),
+  ).toBeDefined();
+
+  expect(
+    screen.getByRole("heading", { level: 3, name: "Drop-in" }),
+  ).toBeDefined();
+  expect(screen.getByText("$20")).toBeDefined();
+
+  expect(
+    screen.getByRole("heading", { level: 3, name: "6-pack" }),
+  ).toBeDefined();
+  expect(screen.getByText("$100")).toBeDefined();
+
+  expect(
+    screen.getByRole("heading", { level: 3, name: "12-pack" }),
+  ).toBeDefined();
+  expect(screen.getByText("$200")).toBeDefined();
+});
+
+// Class size and the shared-pack rule are the two facts a parent asks about
+// that no session row carries.
+test("the art page states the class cap and that packs are shared", async () => {
+  render(await Art());
+
+  expect(screen.getByText(/capped at ten kids/i)).toBeDefined();
+  expect(
+    screen.getByText(/siblings can draw from the same one/i),
+  ).toBeDefined();
+});
+
+// The monthly themed class has no price yet, and a named package without a
+// number generates email rather than signups.
+test("the art page does not advertise the monthly class yet", async () => {
+  render(await Art());
+
+  expect(screen.queryByText(/monthly/i)).toBeNull();
+});
+
 test("an unreachable schedule is reported to the server log", async () => {
   const error = vi.spyOn(console, "error").mockImplementation(() => {});
 

--- a/src/app/art/page.test.tsx
+++ b/src/app/art/page.test.tsx
@@ -37,6 +37,45 @@ test("the page CTA routes to the booking page", async () => {
   ).toBe("/book");
 });
 
+// The page has to answer "what is this?" before a parent has any use for
+// "when is it?". These assert the answer is on the page at all — the wording
+// will be revised, but a page that silently loses it should fail.
+test("the art page says what makes the program different", async () => {
+  render(await Art());
+
+  const approach = screen.getByRole("heading", {
+    level: 2,
+    name: "What makes it different",
+  });
+  expect(approach).toBeDefined();
+
+  expect(
+    screen.getByRole("heading", { level: 3, name: "Skills, not copies" }),
+  ).toBeDefined();
+  expect(
+    screen.getByRole("heading", { level: 3, name: "Art history every class" }),
+  ).toBeDefined();
+  expect(
+    screen.getByText(/creative freedom needs something to stand on/i),
+  ).toBeDefined();
+});
+
+// The list is a labelled region rather than a bare `ul`, so a screen reader
+// reaches it from the landmark menu instead of having to scroll into it.
+test("the approach list is named by its own heading", async () => {
+  render(await Art());
+
+  const heading = screen.getByRole("heading", {
+    level: 2,
+    name: "What makes it different",
+  });
+  const region = screen.getByRole("region", {
+    name: "What makes it different",
+  });
+
+  expect(region.getAttribute("aria-labelledby")).toBe(heading.id);
+});
+
 test("an unreachable schedule is reported to the server log", async () => {
   const error = vi.spyOn(console, "error").mockImplementation(() => {});
 

--- a/src/app/art/page.tsx
+++ b/src/app/art/page.tsx
@@ -172,16 +172,18 @@ export default async function Art() {
             ))}
           </ul>
         </section>
-        {/* The schedule fills the slot that promised session times and pricing.
-            Charter-fund details are page copy still to be written, not data, so
-            the slot's wording keeps naming them while it stands in. */}
+        {/* The slot promises only what is still missing. Pricing moved onto the
+            page above, so a slot still naming it would be promising what has
+            already arrived — the drift ReservedSlot was extracted to stop.
+            Charter-fund copy is genuinely unwritten and is a separate slice; it
+            is not the schedule's to promise either way. */}
         <div className="grid gap-4 md:grid-cols-2">
           <SessionSchedule
             result={schedule}
             program="art"
             emoji="🎨"
-            headline="Schedule & pricing coming soon."
-            detail="Session times, group and private options, and charter-fund details land here."
+            headline="Fall dates coming soon."
+            detail="Class times and where we meet land here as the fall schedule is set."
           />
           <Placeholder
             label="Student artwork gallery"

--- a/src/app/art/page.tsx
+++ b/src/app/art/page.tsx
@@ -13,8 +13,42 @@ export const metadata: Metadata = {
 /** Per request, and for the reasons given in full on `/coop`. */
 export const dynamic = "force-dynamic";
 
-/** Ties the approach list to its heading; the two cannot drift apart. */
+/** Tie each list to its heading; the two cannot drift apart. */
 const APPROACH_HEADING_ID = "art-approach-heading";
+const PRICING_HEADING_ID = "art-pricing-heading";
+
+/**
+ * What the weekly small-group class costs.
+ *
+ * Copy, not `price_cents`. A pack spans sessions, so a column holding one
+ * integer per session cannot express one; and these three numbers are the same
+ * for every weekly session, which makes them a fact about the program rather
+ * than about any date. A session that is priced differently still says so on
+ * its own row — see `docs/plans/art-program-page-copy.md`.
+ *
+ * Written as the strings a reader sees rather than as cents run through
+ * `formatPrice`. There is no arithmetic here to get wrong, and a test that
+ * imported the number it asserts could not fail when the number is wrong.
+ *
+ * The monthly themed class is deliberately absent until it has a price.
+ */
+const TIERS = [
+  {
+    name: "Drop-in",
+    price: "$20",
+    detail: "One class, whenever it suits. No commitment.",
+  },
+  {
+    name: "6-pack",
+    price: "$100",
+    detail: "Six classes, one of them free.",
+  },
+  {
+    name: "12-pack",
+    price: "$200",
+    detail: "Twelve classes, two of them free. The best value per class.",
+  },
+];
 
 /**
  * What a parent is actually choosing between, in the program's own terms.
@@ -102,6 +136,37 @@ export default async function Art() {
                 <h3 className="leading-display mb-1.5 text-base font-black italic">
                   {title}
                 </h3>
+                <p className="leading-relaxed text-sm text-fog">{detail}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+        {/* Pricing sits between the pitch and the dates: a parent who wants in
+            asks the cost before they ask which Tuesday. */}
+        <section aria-labelledby={PRICING_HEADING_ID} className="mb-12">
+          <h2
+            id={PRICING_HEADING_ID}
+            className="text-2xs mb-3 font-extrabold tracking-widest text-purple uppercase"
+          >
+            Packages &amp; pricing
+          </h2>
+          <p className="leading-relaxed mb-4 max-w-130 text-base text-fog">
+            A weekly small-group class, capped at ten kids, starting fall 2026.
+            Come once, or save with a pack — packs are shared, so siblings can
+            draw from the same one.
+          </p>
+          <ul className="grid gap-3 md:grid-cols-3">
+            {TIERS.map(({ name, price, detail }) => (
+              <li
+                key={name}
+                className="rounded-tile border-[1.5px] border-lavender bg-white/60 p-5"
+              >
+                <h3 className="text-2xs mb-2 font-extrabold tracking-widest text-purple uppercase">
+                  {name}
+                </h3>
+                <p className="leading-display mb-1.5 text-stat font-black italic">
+                  {price}
+                </p>
                 <p className="leading-relaxed text-sm text-fog">{detail}</p>
               </li>
             ))}

--- a/src/app/art/page.tsx
+++ b/src/app/art/page.tsx
@@ -13,6 +13,49 @@ export const metadata: Metadata = {
 /** Per request, and for the reasons given in full on `/coop`. */
 export const dynamic = "force-dynamic";
 
+/** Ties the approach list to its heading; the two cannot drift apart. */
+const APPROACH_HEADING_ID = "art-approach-heading";
+
+/**
+ * What a parent is actually choosing between, in the program's own terms.
+ *
+ * Copy rather than data, and staying that way: these describe the standing
+ * offer, not any one session, and `public.sessions` deliberately holds nothing
+ * about a program. See `docs/plans/art-program-page-copy.md`.
+ */
+const APPROACH = [
+  {
+    title: "Led by the kids",
+    detail:
+      "What we make starts from what they are curious about that week, not from a lesson plan that ignores them.",
+  },
+  {
+    title: "Art history every class",
+    detail:
+      "Real artists and real movements, told the way a kid will actually remember them.",
+  },
+  {
+    title: "Skills, not copies",
+    detail:
+      "Nobody leaves with the same picture. Everyone leaves with the same technique.",
+  },
+  {
+    title: "Foundations first",
+    detail:
+      "Technique and fundamentals, because creative freedom needs something to stand on.",
+  },
+  {
+    title: "It goes home with them",
+    detail:
+      "Skills that work at the kitchen table on a Tuesday, not only at ours.",
+  },
+  {
+    title: "Confidence, not just craft",
+    detail:
+      "Knowing how to begin is what makes a kid keep going after the class ends.",
+  },
+];
+
 export default async function Art() {
   const schedule = await fetchSessions("art");
 
@@ -32,14 +75,38 @@ export default async function Art() {
         </h1>
         <p className="leading-relaxed mb-9 max-w-130 text-base text-fog">
           Watercolors, ink, collage, printmaking — inspired by the coast and
-          whatever sparks curiosity. Every session is different, and full class
-          details are on their way.
+          whatever sparks curiosity. Every class teaches a real technique, and
+          nobody goes home with the same picture.
         </p>
         <div className="mb-12">
           <PillLink href="/book" tone="purple">
             Book a class →
           </PillLink>
         </div>
+        {/* The half of the page a parent decides on. It sits above the schedule
+            because "what is this?" comes before "when is it?" — a parent who has
+            not been sold yet has no use for a list of dates. */}
+        <section aria-labelledby={APPROACH_HEADING_ID} className="mb-12">
+          <h2
+            id={APPROACH_HEADING_ID}
+            className="text-2xs mb-3 font-extrabold tracking-widest text-purple uppercase"
+          >
+            What makes it different
+          </h2>
+          <ul className="grid gap-3 md:grid-cols-2">
+            {APPROACH.map(({ title, detail }) => (
+              <li
+                key={title}
+                className="rounded-tile border-[1.5px] border-lavender bg-white/60 p-5"
+              >
+                <h3 className="leading-display mb-1.5 text-base font-black italic">
+                  {title}
+                </h3>
+                <p className="leading-relaxed text-sm text-fog">{detail}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
         {/* The schedule fills the slot that promised session times and pricing.
             Charter-fund details are page copy still to be written, not data, so
             the slot's wording keeps naming them while it stands in. */}


### PR DESCRIPTION
Art opens fall 2026 and `/art` could not be decided on. It named the media
and promised details were coming; it said nothing about class size, price,
or what separates this from any other art class in the county.

Plan: `docs/plans/art-program-page-copy.md`.

## What changed, by slice

| Commit | Slice |
| --- | --- |
| 38dc928 | The plan |
| 6c0d353 | Six blocks saying what makes the program different |
| a0ba927 | Packages & pricing — three tiers, the cap of ten, shared packs |
| ec2aba2 | The reserved slot narrows to the dates it stands in for |

**No schema change, no migration, no new dependency.** `src/lib/sessions.ts`
and `SessionSchedule.tsx` are untouched.

## The one decision worth reviewing

**Program-level pricing is copy; per-session pricing stays data.**

The tiers are drop-in $20, 6-pack $100, 12-pack $200. A pack spans sessions,
so `price_cents` — one integer on one row — cannot express one at all. The
three numbers are also identical for every weekly session, which makes them a
fact about the *program*, not about any date.

This refines rather than reverses the earlier reading recorded in a comment in
`art/page.test.tsx` ("prices vary from one class to the next, which is why they
live on the row"). Both are live now:

- standing weekly sessions carry `price_cents = null`, which already meant
  "not priced here, which is not the same as free"
- a one-off priced differently still renders its own price — the existing
  `$45` assertion is unchanged and still passing

The cost is stated in the plan and is real: **Lena cannot change a price
without a deploy.** Judged acceptable because a price change happens at most
once a term and is worth reviewing before it is public, while the rows that
change weekly stay editable in Studio. If price edits become frequent, that is
the signal to revisit.

`docs/plans/art-program-page-copy.md` has the rejected alternatives, including
a `pricing_tiers` table (premature — the model has not met a customer) and
extracting a `PricingTiers` component (one caller).

**Open question for review:** whether this decision wants its own ADR. Argued
in the plan rather than `docs/adr/` because it refines an assumption rather
than establishing a new contract. Happy to add one.

## Gate output

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

Run before each of the four commits; the above is the run at `ec2aba2`.
`npm run check:db` was **not** run and is not relevant — no migration, no
schema change, no new column read.

## Verified beyond the gate

- Rendered `/art` on the dev server and confirmed every new string reaches the
  HTML, and that "monthly" appears nowhere.
- Screenshotted at 1536×639 and 390×844. The approach list is two columns and
  the tiers three on desktop; both stack cleanly on mobile with no overflow.
- **Mutation-checked the new slot assertions**: reverted the headline and
  confirmed two tests fail. One pre-existing assertion queried the old slot
  copy to prove the slot was gone when sessions render — left alone it would
  have passed whatever the page did, since that string no longer exists
  anywhere. It now names the new copy and fails when it should.

## What I did not do

- **The monthly themed class is not on the page.** It has a description and no
  price; a named package without a number generates email rather than signups.
  A test asserts it stays out so it cannot be half-added later. It lands when
  it has a figure.
- **Charter-fund copy.** Removed from the slot's detail line, because it was
  only riding along there while the slot was the page's one stand-in, and it is
  not the schedule's to promise. The copy itself is still unwritten — worth its
  own issue.
- **`ProgramCards.tsx` untouched.** Its art card still says "Every session is
  different" and badges "Outdoors", both of which may want a look against this
  new copy. Different surface, 520px height budget from #37, separate slice.
- **No Lighthouse pass.** The page has meaningfully more content now; worth
  running, but it was not part of this work.
- **Fall session rows are not entered.** Data entry in Supabase Studio, blocked
  on dates and a location that are not decided yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
