### PR TITLE
Give the Supabase ADR a number of its own

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 
 # Supabase — read-only public data, protected by Row Level Security. These two
 # would be safe in a browser, and deliberately never reach one: nothing
-# client-side talks to Supabase (ADR-0008), so they carry no NEXT_PUBLIC_
+# client-side talks to Supabase (ADR-0013), so they carry no NEXT_PUBLIC_
 # prefix. That is not only about exposure. A NEXT_PUBLIC_ value is inlined at
 # build time, so changing one in Vercel does nothing until the next deploy;
 # these are read at runtime and take effect on the next request.

--- a/docs/adr/0013-supabase-reads-over-plain-fetch.md
+++ b/docs/adr/0013-supabase-reads-over-plain-fetch.md
@@ -1,6 +1,7 @@
-# 0008 — Supabase is read over plain fetch, and a failed read degrades
+# 0013 — Supabase is read over plain fetch, and a failed read degrades
 
-Date: 2026-08-18. Status: accepted.
+Date: 2026-08-18. Status: accepted. Filed as 0008 and renumbered on
+2026-08-20: 0008 already named the gallery decision (#102).
 
 ## Context
 
@@ -100,7 +101,7 @@ rebuilt — which is exactly the state this project's Preview environment was in
 That directly contradicts the reason these routes render dynamically at all: a
 change should be live on the next request. Unprefixed, both the data and the
 configuration behave that way. The cost is that a future client component
-wanting Supabase directly would need the names changed back, and ADR-0008's
+wanting Supabase directly would need the names changed back, and ADR-0013's
 own advice is that such a component is the moment to adopt the SDK anyway.
 
 Validating at the boundary is cheap insurance bought after the fact rather than

--- a/docs/plans/session-schedule-from-supabase.md
+++ b/docs/plans/session-schedule-from-supabase.md
@@ -93,7 +93,7 @@ Three defects in the source document are corrected here rather than copied:
   auth, storage, realtime and functions to use none of them. An injected `fetch`
   is a cleaner seam than a mocked module, and Next's own fetch handling applies
   to it. If auth or RSVP ever lands, adopting the SDK is contained behind this
-  one module. Recorded as ADR-0008.
+  one module. Recorded as ADR-0013.
 
 - **The routes render dynamically.** `.github/workflows/gate.yml` passes no
   `env` and no `secrets`, and the gate table runs `npm run build`. A page that
@@ -225,7 +225,7 @@ Each leaves the repo working and the gates green.
 
 | #   | Slice                                                          | Delivers                                                                                    |
 | --- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| 0   | Write this plan down                                           | This file, plus ADR-0008 on reading Supabase over plain fetch                               |
+| 0   | Write this plan down                                           | This file, plus ADR-0013 on reading Supabase over plain fetch                               |
 | 1   | The sessions table, and a command that proves it               | `supabase/migrations/0001_sessions.sql`, `npm run check:db`, `CONTEXT.md` gains **Session** |
 | 2   | `/coop` lists its published sessions                           | `src/lib/sessions.ts`, `SessionSchedule`, `/coop` async, coverage floor re-derived          |
 | 3   | `/art` lists its sessions, with price                          | `/art` async, price rendering, coverage floor re-derived                                    |
@@ -335,7 +335,7 @@ after a question about how the Supabase variables were labelled in Vercel:
 (`SUPABASE_URL` / `SUPABASE_ANON_KEY`, no `NEXT_PUBLIC_` prefix).
 
 It is not a tidying pass. A `NEXT_PUBLIC_` value is substituted into the build
-output rather than read at run time — measured, not assumed; see ADR-0008 —
+output rather than read at run time — measured, not assumed; see ADR-0013 —
 which would have made two of this project's existing problems unfixable without
 a redeploy: the malformed Production URL, and a Preview environment that had no
 Supabase variables at all and would have inlined `undefined` into every build.

--- a/scripts/db-check.mjs
+++ b/scripts/db-check.mjs
@@ -14,7 +14,7 @@
 /**
  * Every column the site expects, and no others. Checked as a set: a renamed
  * column fails here rather than surfacing later as an empty schedule, which is
- * the job a generated type would otherwise do (ADR-0008).
+ * the job a generated type would otherwise do (ADR-0013).
  */
 export const EXPECTED_COLUMNS = [
   "id",
@@ -227,7 +227,7 @@ const INVALID = {
  * does that — so the two can be tested apart.
  *
  * `fetch` arrives as a dependency rather than an import, so the tests drive
- * this with a stub instead of intercepting a module (ADR-0008).
+ * this with a stub instead of intercepting a module (ADR-0013).
  *
  * It writes. Two probe rows go in under the service role, get read back through
  * the anon key to prove RLS, and are deleted in a `finally`. Leftovers from a


### PR DESCRIPTION
Closes #102

`docs/adr/0008-supabase-reads-over-plain-fetch.md` becomes
`docs/adr/0013-supabase-reads-over-plain-fetch.md`, so each ADR number names
one decision. The gallery ADR keeps 0008 and is untouched.

One slice, one commit: the rename, the file's own H1 and self-reference, and
the six citations that meant Supabase.

## Two departures from what the issue specifies

**0013, not the 0012 the issue prescribes.** `0012-sky-and-visibility-kept-knowingly.md`
landed on 19 Aug — the same day #102 was written — so 0012 was taken by the
time the issue was read. 0013 is the next free number, and the issue's own
reasoning points there: taking the next free number rather than restoring
chronological order is what makes this the small edit.

**Six Supabase citations, not five.** The issue's list misses
`.env.example:6`, which explains the absent `NEXT_PUBLIC_` prefix by citing
the ADR. It is included.

One addition the issue does not call for: the renumber is recorded in the
file's date line. Commit messages and closed PRs cite ADR-0008 meaning
Supabase and cannot be rewritten, so without a note the number changes under
those readers silently.

## Evidence

Every surviving `ADR-0008` resolves to the gallery ADR:

```
$ git grep -n "ADR-0008"
.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md:45:   position whatever its padding is (ADR-0008). The marquee it sits beneath is
CONTEXT.md:72:whatever the padding is (ADR-0008). It names what it drives with
docs/plans/design-doc-drift.md:147:**#45 closed and ADR-0008 landed, so the pager is part of what the prose must
docs/plans/gallery-row-gutter.md:176:1. This plan, and ADR-0008.
src/components/GalleryPager.test.tsx:40:  // the assertion that keeps ADR-0008 from being undone by a stray absolute:
src/components/GalleryRow.test.tsx:87:  // the row's left and right edges. That arrangement is what ADR-0008 removed:
src/components/GalleryRow.tsx:18: * outside the artwork rather than on this row's edges (ADR-0008). The
src/components/GallerySection.test.tsx:66:  // Where the pair sits is the whole of ADR-0008, and it is the one part of
src/components/useGalleryPaging.ts:19: * together in the DOM (ADR-0008), so the two need something to share. That is
```

Every `ADR-0013` resolves to the Supabase ADR:

```
$ git grep -n "ADR-0013"
.env.example:6:# client-side talks to Supabase (ADR-0013), so they carry no NEXT_PUBLIC_
docs/adr/0013-supabase-reads-over-plain-fetch.md:103:wanting Supabase directly would need the names changed back, and ADR-0013's
docs/plans/session-schedule-from-supabase.md:96:  one module. Recorded as ADR-0013.
docs/plans/session-schedule-from-supabase.md:228:| 0   | Write this plan down                                           | This file, plus ADR-0013 on reading Supabase over plain fetch                               |
docs/plans/session-schedule-from-supabase.md:338:output rather than read at run time — measured, not assumed; see ADR-0013 —
scripts/db-check.mjs:17: * the job a generated type would otherwise do (ADR-0013).
scripts/db-check.mjs:230: * this with a stub instead of intercepting a module (ADR-0013).
```

No link breaks — the two references that name a full ADR filename both point
at the gallery ADR, and every `docs/adr/NNNN-*.md` path referenced in a
tracked file resolves to a file that exists.

## Gates

```
$ npm run gate

> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  test
  PASS  build
  PASS  stylesheet
```

## What this does not do

**No regression test, and the gate proves nothing about this change** — it
passed with the duplicate present too. The regression test for this bug is a
gate row asserting ADR numbers are unique, which is a new script plus a row
in `scripts/gates.mjs` and its own test: a separate slice with its own
justification, so it is filed rather than smuggled in here. Without it, the
collision recurs the next time two ADRs are written in the same week, which
is exactly how this one happened.

**Nothing outside the working tree is corrected.** Commit messages, closed
PRs and #102 itself still say ADR-0008 meaning Supabase. The date-line note
is the only mitigation available.
