### PR TITLE
Fail the gate when two ADRs share a number

### DIFF
--- a/docs/plans/adr-number-gate.md
+++ b/docs/plans/adr-number-gate.md
@@ -1,0 +1,121 @@
+# A gate that each ADR number names one decision (issue #109)
+
+Date: 2026-08-20.
+
+## Problem, from the user's point of view
+
+Two unrelated decisions were both filed as ADR-0008 — where the gallery's
+paging controls sit (17 Aug) and how the site reads Supabase (18 Aug). For two
+days the number that decisions are cited by pointed at two documents, and the
+fourteen bare `ADR-0008` references in the repo were indistinguishable. Three
+test files carry a comment about keeping ADR-0008 from being undone; someone
+following one had a 5-in-14 chance of opening the wrong document. Fixed in
+#102 by renumbering the Supabase ADR to 0013.
+
+Nothing stops the next one. The evidence that this is structural rather than
+bad luck:
+
+- Both halves were written in the same week, by an agent, on separate
+  branches. A number is chosen by looking at `docs/adr/`, and two branches open
+  at once see the same highest number. Neither branch could observe the other.
+- `npm run gate` passed for the entire two days the duplicate existed. The
+  gate had nothing to say about it, so CI could not be the thing that noticed.
+- It was found by a manual audit a day later. That is the only reason it was
+  found at all.
+
+A collision is cheapest to fix in the hour it is created and most expensive
+once citations accumulate — #102 touched seven files to undo two days of it.
+
+## Decision
+
+A `adr-numbers` gate row asserting that every ADR is identified by exactly one
+number. Three properties, one verdict:
+
+1. **Every file in `docs/adr/` is named `NNNN-slug.md`.** The directory is a
+   numbered series; a file in it without a number is either a mistake or a
+   decision nobody made.
+2. **No number appears twice.** The #102 regression.
+3. **Each file's `# NNNN` heading declares its own number.** See below.
+
+The failure names both files and the number they share, because the fix
+requires knowing which two documents collided.
+
+The gate reports; it never edits. Renumbering rewrites citations across the
+repo and the choice of which document moves is a judgement — #102 moved
+Supabase because the gallery had the number first. `docs/adr/` is an input
+here, and CLAUDE.md's read-only rule applies.
+
+### The heading is checked too
+
+#109 left this open. It is included.
+
+During #102 the file was renamed and its `# 0008 —` heading edited by hand as
+a separate step. A filename-only check passes a document that has been renamed
+but still announces itself as 0008 — the same class of defect, a number naming
+the wrong thing, and the heading is what a reader sees first.
+
+The match is on the number alone (`^#\s*(\d{4})`), not the separator or the
+title. All thirteen ADRs today read `# NNNN — Title`, but pinning the em-dash
+would make the gate a style rule and fail an ordinary title edit. The number
+is the part that must agree; the prose is not the gate's business.
+
+### Test seams
+
+The split ADR-0002 established, and that `built-css.mjs` / `check-built-css.mjs`
+already follow: the part that can be wrong is pure and unit-tested, the part
+that touches the filesystem is thin.
+
+- `adrNumber(filename)`, `headingNumber(text)` — pure parsers, called directly.
+- `auditAdrs(entries)` — the verdict, over a list of `{ file, number, heading }`.
+  Every failure mode is reachable from a literal array, so the duplicate case
+  is tested without a duplicate existing in the tree.
+- `readAdrs(root)`, `checkAdrNumbers(root)` — the filesystem walk, tested
+  against a temp directory as `built-css.test.mjs` does, so the walk is
+  exercised for real rather than mocked.
+- `scripts/check-adr-numbers.mjs` — entry plumbing only, deliberately
+  untested, and named as such in the coverage note below.
+
+The regression test for #102 is `auditAdrs` rejecting two files that share a
+number. A `mustFail` gate row cannot serve here: `mustFail` runs a command, and
+there is no duplicate left in the tree for it to fail on. Manufacturing one to
+satisfy the mechanism would mean committing the bug back.
+
+### Considered and rejected
+
+- **Leave it to review.** This is what happened. Both halves of #102 were
+  reviewed and merged; neither reviewer could see the other branch.
+- **A script that renumbers automatically.** It would have to rewrite citations
+  in seven files and pick which document moves. Both are judgement, and a gate
+  that edits its own input violates the read-only rule.
+- **Check the filename only.** Cheaper by three lines, and passes exactly the
+  stale-heading state #102 had to fix by hand.
+- **Also assert the slug matches the title.** Titles are prose and get edited;
+  slugs are stable because renaming a file breaks links. Coupling them would
+  fail the gate on ordinary copy edits and teach people to work around it.
+- **Number `docs/plans/` too.** Plans are not cited by number — they are cited
+  by filename, and nothing in the repo refers to "plan 0007". There is no
+  collision to prevent.
+
+## Coverage
+
+`vitest.config.mts` includes `scripts/**/*.mjs`, so both new files count.
+`check-adr-numbers.mjs` sits at 0% by design, joining `run-gates.mjs`,
+`run-vitest.mjs`, `check-built-css.mjs` and `check-db.mjs`. That grows the
+untested denominator, which is reason 1 of the two the config admits. The floor
+is re-derived from what the run actually achieves and the commit names the
+uncovered statements.
+
+## Out of scope
+
+- Renumbering anything. #102 did that; every number is unique today.
+- Any check on ADR content, status, or date.
+- The `ADR-0008` references in commit messages and closed pull requests that
+  mean Supabase. Those cannot be rewritten; the note in the date line of
+  `0013-supabase-reads-over-plain-fetch.md` is the whole mitigation.
+
+## Slices
+
+| #   | Slice                | Delivers                                                                                                  |
+| --- | -------------------- | --------------------------------------------------------------------------------------------------------- |
+| 0   | Write this plan down | This file                                                                                                 |
+| 1   | The gate             | `adr-numbers.mjs`, `check-adr-numbers.mjs`, `adr-numbers.test.mjs`, the `gates.mjs` row, floor re-derived |

--- a/scripts/adr-numbers.mjs
+++ b/scripts/adr-numbers.mjs
@@ -1,0 +1,205 @@
+/**
+ * Every ADR is identified by exactly one number — the `adr-numbers` gate row.
+ *
+ * Two unrelated decisions were both filed as ADR-0008 for two days (#102), and
+ * the fourteen bare `ADR-0008` citations in the repo could not be told apart.
+ * Nothing observed it: both halves were written on separate branches that
+ * could not see each other, and the gate had nothing to say. See
+ * docs/plans/adr-number-gate.md.
+ *
+ * The verdict is a pure function over a list, so the duplicate case is tested
+ * without a duplicate existing in the tree. Only `findAdrs` and
+ * `checkAdrNumbers` touch the filesystem (ADR-0002, the same split as
+ * built-css.mjs).
+ *
+ * This reports; it never renumbers. Which of two colliding documents moves is
+ * a judgement — #102 moved Supabase because the gallery had the number first —
+ * and it rewrites citations across the repo. `docs/adr/` is an input.
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/** Where the decisions live, relative to the repo root. */
+export const ADR_ROOT = "docs/adr";
+
+/**
+ * `0008-gallery-controls-outside-the-artwork.md` — four digits, then a slug.
+ * The slug is not inspected: its casing and wording are style, and a gate that
+ * polices them fails an ordinary rename for no benefit.
+ */
+const FILENAME = /^(\d{4})-.+\.md$/;
+
+/**
+ * `# 0008 — The gallery's paging controls sit outside the artwork`.
+ *
+ * The number alone. All thirteen ADRs spell the separator as an em dash today,
+ * but pinning it would make this a style rule and fail a title edit that got
+ * the number right.
+ */
+const HEADING = /^#\s*(\d{4})\b/;
+
+/**
+ * @typedef {object} Adr
+ * @property {string} file     Path as read, so a failure can be acted on.
+ * @property {string|null} number   From the filename; null when it has none.
+ * @property {string|null} heading  From the `# NNNN` line; null when it has none.
+ */
+
+/**
+ * @typedef {object} Audit
+ * @property {boolean} ok
+ * @property {string[]} lines  What to print, whether it passed or failed.
+ */
+
+/**
+ * The number a filename claims, or null if it is not shaped like an ADR.
+ *
+ * @param {string} filename  A bare name, not a path.
+ * @returns {string|null}
+ */
+export function adrNumber(filename) {
+  return FILENAME.exec(filename)?.[1] ?? null;
+}
+
+/**
+ * The number the first heading declares, or null if the document opens with
+ * something other than `# NNNN`.
+ *
+ * Only the first line is read. A `# 0008` deeper in the prose is a citation
+ * inside the document, not the document announcing itself.
+ *
+ * @param {string} text  The whole file.
+ * @returns {string|null}
+ */
+export function headingNumber(text) {
+  // `split` always yields at least one element, `""` for empty input, so the
+  // first line needs no fallback and a `?? ""` here would be a branch no test
+  // could ever reach.
+  return HEADING.exec(text.split("\n", 1)[0])?.[1] ?? null;
+}
+
+/**
+ * Read every expectation against the ADRs found on disk.
+ *
+ * @param {Adr[]} adrs
+ * @returns {Audit}
+ */
+export function auditAdrs(adrs) {
+  // An empty docs/adr/ means the walk found nothing where the decisions are
+  // meant to be — a moved directory, or a typo in ADR_ROOT. Passing would make
+  // this row green for exactly the state in which it is checking nothing.
+  if (adrs.length === 0) {
+    return {
+      ok: false,
+      lines: [`FAIL  no ADRs found in ${ADR_ROOT}/ — is the directory there?`],
+    };
+  }
+
+  const lines = [];
+  const failed = new Set();
+
+  const fail = (file, message) => {
+    failed.add(file);
+    lines.push(`FAIL  ${message}`);
+  };
+
+  const numbered = adrs.filter((adr) => adr.number !== null);
+
+  for (const adr of adrs) {
+    if (adr.number === null) {
+      fail(adr.file, `${adr.file} is not named NNNN-slug.md`);
+    }
+  }
+
+  // Grouped rather than compared pairwise so a number claimed three times is
+  // reported once, naming all three, instead of as three overlapping pairs.
+  const byNumber = new Map();
+  for (const adr of numbered) {
+    byNumber.set(adr.number, [...(byNumber.get(adr.number) ?? []), adr.file]);
+  }
+
+  for (const [number, files] of [...byNumber].sort()) {
+    if (files.length > 1) {
+      // Both names, because fixing it means choosing which one moves, and that
+      // choice needs to see what the other document is about.
+      for (const file of files) failed.add(file);
+      lines.push(`FAIL  ${number} names ${files.length}: ${files.join(", ")}`);
+    }
+  }
+
+  for (const adr of numbered) {
+    if (adr.heading === null) {
+      fail(adr.file, `${adr.file} does not open with "# ${adr.number}"`);
+    } else if (adr.heading !== adr.number) {
+      // The state a filename-only check passes: renamed, heading not yet
+      // caught up. #102 fixed exactly this by hand.
+      fail(
+        adr.file,
+        `${adr.file} opens with "# ${adr.heading}" — renamed but not retitled?`,
+      );
+    }
+  }
+
+  // Only what nothing failed on, and after the failures rather than among
+  // them. A colliding file listed as `ok` three lines below its own FAIL
+  // reads as though it were the fine one of the two.
+  for (const adr of numbered) {
+    if (!failed.has(adr.file)) lines.push(`ok    ${adr.number}  ${adr.file}`);
+  }
+
+  return { ok: failed.size === 0, lines };
+}
+
+/**
+ * Every ADR directly in `directory`, in a stable order, with its first line.
+ *
+ * Flat and markdown-only on purpose: the series is flat, and a stray asset
+ * beside it is not a numbering question. Anything skipped says so in the
+ * output rather than vanishing. A missing directory yields none, which
+ * `auditAdrs` fails on.
+ *
+ * @param {string} directory
+ * @returns {{ adrs: Adr[], skipped: string[] }}
+ */
+export function findAdrs(directory) {
+  if (!existsSync(directory)) return { adrs: [], skipped: [] };
+
+  const adrs = [];
+  const skipped = [];
+
+  for (const entry of readdirSync(directory, { withFileTypes: true }).sort(
+    (a, b) => a.name.localeCompare(b.name),
+  )) {
+    const path = join(directory, entry.name);
+
+    if (!entry.isFile() || !entry.name.endsWith(".md")) {
+      skipped.push(path);
+      continue;
+    }
+
+    adrs.push({
+      file: path,
+      number: adrNumber(entry.name),
+      heading: headingNumber(readFileSync(path, "utf8")),
+    });
+  }
+
+  return { adrs, skipped };
+}
+
+/**
+ * @param {string} directory
+ * @returns {Audit}
+ */
+export function checkAdrNumbers(directory) {
+  const { adrs, skipped } = findAdrs(directory);
+  const { ok, lines } = auditAdrs(adrs);
+
+  return {
+    ok,
+    lines: [
+      ...skipped.map((path) => `note  ${path} not read, not markdown`),
+      ...lines,
+    ],
+  };
+}

--- a/scripts/adr-numbers.test.mjs
+++ b/scripts/adr-numbers.test.mjs
@@ -1,0 +1,266 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  adrNumber,
+  auditAdrs,
+  checkAdrNumbers,
+  findAdrs,
+  headingNumber,
+} from "./adr-numbers.mjs";
+
+/** An ADR as `findAdrs` yields it, so tests can break one field at a time. */
+const adr = (number, overrides = {}) => ({
+  file: `docs/adr/${number}-a-decision.md`,
+  number,
+  heading: number,
+  ...overrides,
+});
+
+const temporary = [];
+
+/** A throwaway ADR directory, so the filesystem walk is tested for real. */
+const adrDirectory = (files) => {
+  const root = mkdtempSync(join(tmpdir(), "adr-numbers-"));
+  temporary.push(root);
+  for (const [name, contents] of Object.entries(files)) {
+    const full = join(root, name);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, contents);
+  }
+  return root;
+};
+
+afterEach(() => {
+  for (const root of temporary.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("adrNumber", () => {
+  test("reads the four digits a filename opens with", () => {
+    expect(adrNumber("0008-gallery-controls-outside-the-artwork.md")).toBe(
+      "0008",
+    );
+  });
+
+  // Leading zeros are part of the identifier: ADR-0008 is how it is cited, and
+  // a number parsed to 8 would collide with nothing and sort wrongly.
+  test("keeps the leading zeros rather than parsing a value", () => {
+    expect(adrNumber("0012-sky-and-visibility.md")).toBe("0012");
+  });
+
+  test("rejects a name with no number", () => {
+    expect(adrNumber("README.md")).toBeNull();
+  });
+
+  test("rejects a number that is not four digits", () => {
+    expect(adrNumber("12-too-short.md")).toBeNull();
+    expect(adrNumber("00012-too-long.md")).toBeNull();
+  });
+
+  test("rejects a number with no slug after it", () => {
+    expect(adrNumber("0008.md")).toBeNull();
+  });
+});
+
+describe("headingNumber", () => {
+  test("reads the number the first heading declares", () => {
+    expect(
+      headingNumber("# 0008 — The gallery's paging controls sit outside\n"),
+    ).toBe("0008");
+  });
+
+  // The separator is not the gate's business, so a title punctuated any other
+  // way still reads. Pinning the em dash would fail an ordinary copy edit.
+  test("does not care how the number is separated from the title", () => {
+    expect(headingNumber("#0008: a decision\n")).toBe("0008");
+  });
+
+  // A document citing another ADR in its prose is the common case, and reading
+  // past the first line would take that citation for the document's own number.
+  test("ignores a number in a heading further down", () => {
+    expect(headingNumber("# 0013 — Supabase\n\n## See also\n\n# 0008\n")).toBe(
+      "0013",
+    );
+  });
+
+  test("is null when the document does not open with a number", () => {
+    expect(headingNumber("# Supabase is read over plain fetch\n")).toBeNull();
+  });
+});
+
+describe("auditAdrs", () => {
+  test("passes when every number is unique and matches its heading", () => {
+    const { ok, lines } = auditAdrs([adr("0001"), adr("0002"), adr("0003")]);
+    expect(ok).toBe(true);
+    expect(lines).toHaveLength(3);
+  });
+
+  // The #102 regression. Two unrelated decisions were filed as 0008 for two
+  // days and every gate stayed green; this is the assertion that goes red.
+  test("fails when two files share a number, naming both", () => {
+    const { ok, lines } = auditAdrs([
+      { ...adr("0008"), file: "docs/adr/0008-gallery-controls.md" },
+      { ...adr("0008"), file: "docs/adr/0008-supabase-reads.md" },
+    ]);
+
+    expect(ok).toBe(false);
+    expect(lines).toContainEqual(
+      expect.stringContaining("docs/adr/0008-gallery-controls.md"),
+    );
+    expect(lines).toContainEqual(
+      expect.stringContaining("docs/adr/0008-supabase-reads.md"),
+    );
+  });
+
+  // Found by running the row against a real duplicate: both files were named
+  // in the FAIL and then listed again as `ok` further down, which reads as
+  // though one of the two were the fine one.
+  test("does not also list a colliding file as ok", () => {
+    const { lines } = auditAdrs([
+      { ...adr("0008"), file: "docs/adr/0008-gallery-controls.md" },
+      { ...adr("0008"), file: "docs/adr/0008-supabase-reads.md" },
+      adr("0009"),
+    ]);
+
+    expect(lines.filter((line) => line.startsWith("ok"))).toEqual([
+      expect.stringContaining("0009"),
+    ]);
+  });
+
+  test("reports a number claimed three times once, not as three pairs", () => {
+    const { ok, lines } = auditAdrs([
+      { ...adr("0008"), file: "a.md" },
+      { ...adr("0008"), file: "b.md" },
+      { ...adr("0008"), file: "c.md" },
+    ]);
+
+    expect(ok).toBe(false);
+    expect(lines.filter((line) => line.startsWith("FAIL"))).toHaveLength(1);
+  });
+
+  // The state a filename-only check passes: #102 renamed the file and edited
+  // its `# 0008` heading as two separate steps.
+  test("fails when the heading disagrees with the filename", () => {
+    const { ok, lines } = auditAdrs([adr("0013", { heading: "0008" })]);
+
+    expect(ok).toBe(false);
+    expect(lines).toContainEqual(
+      expect.stringContaining('opens with "# 0008"'),
+    );
+  });
+
+  test("fails when a document opens with no number at all", () => {
+    const { ok } = auditAdrs([adr("0013", { heading: null })]);
+    expect(ok).toBe(false);
+  });
+
+  test("fails a file in the directory that is not named NNNN-slug.md", () => {
+    const { ok, lines } = auditAdrs([
+      { file: "docs/adr/notes.md", number: null, heading: null },
+    ]);
+
+    expect(ok).toBe(false);
+    expect(lines).toContainEqual(expect.stringContaining("docs/adr/notes.md"));
+  });
+
+  // Not a skip: an empty result means the walk found nothing where the
+  // decisions are meant to be, and green would mean the row checked nothing.
+  test("fails on an empty directory rather than passing vacuously", () => {
+    expect(auditAdrs([]).ok).toBe(false);
+  });
+});
+
+describe("findAdrs", () => {
+  test("reads each ADR's number and heading off the disk", () => {
+    const root = adrDirectory({
+      "0001-test-runner.md": "# 0001 — Vitest as the test runner\n",
+      "0002-gate-runner.md": "# 0002 — A Node script with a table\n",
+    });
+
+    expect(findAdrs(root).adrs).toEqual([
+      {
+        file: join(root, "0001-test-runner.md"),
+        number: "0001",
+        heading: "0001",
+      },
+      {
+        file: join(root, "0002-gate-runner.md"),
+        number: "0002",
+        heading: "0002",
+      },
+    ]);
+  });
+
+  test("orders by name, so a failure reads the same way twice", () => {
+    const root = adrDirectory({
+      "0003-c.md": "# 0003\n",
+      "0001-a.md": "# 0001\n",
+      "0002-b.md": "# 0002\n",
+    });
+
+    expect(findAdrs(root).adrs.map((found) => found.number)).toEqual([
+      "0001",
+      "0002",
+      "0003",
+    ]);
+  });
+
+  // Reported rather than dropped: a stray asset is not a numbering question,
+  // but a directory that quietly ignores files is how the next one hides.
+  test("names what it did not read instead of ignoring it", () => {
+    const root = adrDirectory({
+      "0001-a.md": "# 0001\n",
+      "diagram.png": "not markdown",
+    });
+
+    const { adrs, skipped } = findAdrs(root);
+    expect(adrs).toHaveLength(1);
+    expect(skipped).toEqual([join(root, "diagram.png")]);
+  });
+
+  test("yields nothing for a directory that is not there", () => {
+    expect(findAdrs(join(tmpdir(), "adr-numbers-absent")).adrs).toEqual([]);
+  });
+});
+
+describe("checkAdrNumbers", () => {
+  test("passes a well-formed directory", () => {
+    const root = adrDirectory({
+      "0001-a.md": "# 0001 — A decision\n",
+      "0002-b.md": "# 0002 — Another decision\n",
+    });
+
+    expect(checkAdrNumbers(root).ok).toBe(true);
+  });
+
+  test("fails a directory holding the #102 collision", () => {
+    const root = adrDirectory({
+      "0008-gallery-controls.md": "# 0008 — Controls outside the artwork\n",
+      "0008-supabase-reads.md": "# 0008 — Supabase over plain fetch\n",
+    });
+
+    const { ok, lines } = checkAdrNumbers(root);
+    expect(ok).toBe(false);
+    expect(lines).toContainEqual(expect.stringContaining("0008 names 2"));
+  });
+
+  test("carries what was skipped into the output it prints", () => {
+    const root = adrDirectory({
+      "0001-a.md": "# 0001\n",
+      "diagram.png": "not markdown",
+    });
+
+    expect(checkAdrNumbers(root).lines).toContainEqual(
+      expect.stringContaining("diagram.png"),
+    );
+  });
+
+  // The gate's real subject. If this ever goes red, two decisions are sharing
+  // a number in the repo right now.
+  test("passes the repository's own ADRs", () => {
+    expect(checkAdrNumbers("docs/adr").ok).toBe(true);
+  });
+});

--- a/scripts/check-adr-numbers.mjs
+++ b/scripts/check-adr-numbers.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+/**
+ * The `adr-numbers` gate row: asserts each ADR number names one decision.
+ *
+ * Entry-point plumbing only — resolve, print, exit. Everything that decides
+ * the verdict lives in adr-numbers.mjs, where it is unit-tested against a temp
+ * directory (ADR 0002, same split as check-built-css.mjs).
+ */
+import { ADR_ROOT, checkAdrNumbers } from "./adr-numbers.mjs";
+
+const { ok, lines } = checkAdrNumbers(ADR_ROOT);
+
+console.log(lines.join("\n"));
+process.exit(ok ? 0 : 1);

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -22,6 +22,10 @@ export const GATES = [
   { name: "format", command: "npm run format:check" },
   { name: "lint", command: "npm run lint" },
   { name: "typecheck", command: "npm run typecheck" },
+  // Reads only the working tree, so it sits above the expensive rows and fails
+  // in milliseconds. Two decisions shared ADR-0008 for two days while every
+  // gate stayed green (#102). See docs/plans/adr-number-gate.md.
+  { name: "adr-numbers", command: "node scripts/check-adr-numbers.mjs" },
   // Runs with coverage so the floor in vitest.config.mts is enforced here:
   // Vitest exits non-zero when a threshold is missed, which is the third way
   // CLAUDE.md says this command must fail.

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -31,14 +31,14 @@ export default defineConfig({
       //   2. covered code was deleted, which pulls the whole-project ratio
       //      toward the 0% plumbing even though no test was lost.
       // Nothing is excluded to flatter the number: run-gates.mjs,
-      // run-vitest.mjs, check-built-css.mjs and check-db.mjs sit at 0% on
-      // purpose, and all four drag these figures down in plain sight rather
-      // than quietly.
+      // run-vitest.mjs, check-built-css.mjs, check-db.mjs and
+      // check-adr-numbers.mjs sit at 0% on purpose, and all five drag these
+      // figures down in plain sight rather than quietly.
       thresholds: {
-        statements: 89.61,
-        branches: 89.63,
-        functions: 94.42,
-        lines: 89.46,
+        statements: 89.89,
+        branches: 89.7,
+        functions: 94.64,
+        lines: 89.71,
       },
     },
   },


### PR DESCRIPTION
Closes #109

An `adr-numbers` gate row asserting that every ADR is identified by exactly
one number. #102 renumbered the duplicate; this closes the hole that made it.

Two slices: the plan (`docs/plans/adr-number-gate.md`), then the gate.

## What it asserts

One property in three parts — every file in `docs/adr/` is named
`NNNN-slug.md`, no number appears twice, and each file's heading declares its
own number. The failure names both colliding files, because fixing it means
choosing which one moves and that needs to see what the other document is
about.

It reports and never renumbers. Which document moves is a judgement (#102
moved Supabase because the gallery had the number first) and the fix rewrites
citations across the repo. `docs/adr/` is an input.

## The decision #109 left open

**The heading is checked too.** #102 renamed the file and edited its
`# 0008 —` heading as two separate steps; a filename-only check passes the
state in between, where the document is called 0013 and still announces
itself as 0008. Only the number is matched, not the separator or the title,
so an ordinary copy edit cannot fail this.

## Evidence

Both failure modes driven end to end against the real `docs/adr/`, not only
against fixtures:

```
$ printf '# 0008 — A second decision filed under a taken number\n' > docs/adr/0008-a-colliding-decision.md
$ node scripts/check-adr-numbers.mjs; echo "EXIT: $?"
FAIL  0008 names 2: docs\adr\0008-a-colliding-decision.md, docs\adr\0008-gallery-controls-outside-the-artwork.md
ok    0001  docs\adr\0001-test-runner.md
...
EXIT: 1
```

```
$ sed -i '1s/# 0013/# 0008/' docs/adr/0013-supabase-reads-over-plain-fetch.md
$ node scripts/check-adr-numbers.mjs; echo "EXIT: $?"
FAIL  docs\adr\0013-supabase-reads-over-plain-fetch.md opens with "# 0008" — renamed but not retitled?
ok    0001  docs\adr\0001-test-runner.md
...
EXIT: 1
```

The tests were checked for teeth by mutation rather than assumed. Disabling
the duplicate check (`files.length > 1` → `> 99`) turned exactly three red and
left the other 21 green; disabling the heading comparison turned exactly one
red:

```
--- mutated: duplicate detection disabled ---
     × fails when two files share a number, naming both
     × reports a number claimed three times once, not as three pairs
     × fails a directory holding the #102 collision
      Tests  3 failed | 21 passed (24)

--- mutated: heading check disabled ---
     × fails when the heading disagrees with the filename
      Tests  1 failed | 23 passed (24)
```

## Two defects the end-to-end run found

Both were invisible to the unit tests as first written, and are now pinned:

- **Colliding files were listed as `ok` below their own FAIL**, reading as
  though one of the two were the fine one. `ok` lines are now emitted only for
  files nothing failed on, and after the failures rather than among them.
- **`headingNumber` carried a `?? ""` fallback that `split` makes
  unreachable** — `"".split("\n", 1)` is `[""]`, so the first element is always
  a string. Removed rather than left as a branch no test could reach; that is
  what recovered the branch-coverage figure.

## Coverage

Re-derived **upward** on all four metrics — 89.61→89.89 statements,
89.63→89.70 branches, 94.42→94.64 functions, 89.46→89.71 lines. This is
reason 1 in `vitest.config.mts`: the denominator grew by
`check-adr-numbers.mjs`, entry plumbing at 0% joining the four already named
there. `adr-numbers.mjs`, which holds everything that can be wrong, is at 100%
on all four.

## Gates

```
$ npm run gate

> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

## What this does not do

- **No `mustFail` row.** `mustFail` runs a command and there is no duplicate
  left in the tree to fail on; manufacturing one would mean committing the bug
  back. The regression lives in `auditAdrs` rejecting two files that share a
  number.
- **Slug and title are not policed.** Titles are prose and get edited; slugs
  are stable because renaming breaks links. Coupling them would fail the gate
  on ordinary copy edits.
- **`docs/plans/` is not numbered.** Plans are cited by filename; nothing
  refers to "plan 0007", so there is no collision to prevent.
- **Non-markdown files in `docs/adr/` are reported, not failed.** A stray
  asset is not a numbering question, but the output names what it did not read
  rather than dropping it silently.
