### PR TITLE
Correct the session-schedule plan's test seams

### DIFF
--- a/docs/plans/session-schedule-from-supabase.md
+++ b/docs/plans/session-schedule-from-supabase.md
@@ -345,3 +345,53 @@ Taken before slice 2 because it was cheapest there: no application code read the
 variables yet, only `check-db.mjs` named them.
 
 The slice order is therefore 0, 1, **runtime config**, 2, 3, 4.
+
+### 2026-08-20 — three of the six test seams name code that does not exist
+
+The Test seams table above (lines 190–197) was agreed before slice 1 and never
+revisited. Three of its six rows name things that were never written under
+those names. The table is left standing, because it is the record of what was
+agreed; this says what shipped instead. The same correction applies to the two
+other places the body names `getSessions`, at lines 78 and 207.
+
+**`getSessions(program, deps)` is `fetchSessions(program, now)`.** There is no
+`deps` parameter. The function reads `SUPABASE_URL` and `SUPABASE_ANON_KEY`
+from the environment itself, and takes an optional `now` for the
+upcoming-sessions filter. `getSessions` appears nowhere in `src/` or
+`scripts/` — only in this file.
+
+**The `fetch` stub is the global one, not an injection.**
+`src/lib/sessions.test.ts` does `vi.stubGlobal("fetch", fetchMock)`. This was a
+deliberate reversal rather than drift: the 2026-08-18 amendment to ADR-0013
+records that Next instruments `fetch` itself — caching, revalidation, and the
+`no-store` that `force-dynamic` applies — so a module holding an injected
+function has no guarantee it was handed the instrumented one. That makes the
+injected seam one that can lie. The ADR was amended; this table was not.
+`scripts/db-check.mjs` still injects its `fetch`, for the reason the amendment
+gives: it is a command-line script with no Next instrumentation to preserve.
+
+**`formatSessionWhen(session)` was never written.** The composition lives in an
+unexported `when()` inside `SessionSchedule.tsx`, so it is not a seam. The
+helper that module does export is `formatPrice(cents)`, which this table never
+mentioned.
+
+**What was actually lost is less than the list suggests.** The
+`America/Los_Angeles` rendering that `formatSessionWhen` was meant to isolate
+_is_ tested as a pure function against fixed instants — just not where the
+table looked. `when()` delegates to `localDayOf` and `localTimeOf` in
+`src/lib/pacific-time.ts`, and `src/lib/pacific-time.test.ts` asserts both,
+including the exact `"Tue, Sep 8"` this feature renders and the evening instant
+that is already the next day in UTC. That is a better seam than the one
+proposed: it is shared with the conditions tool and the tide day, so one set of
+assertions holds for all three rather than one per feature.
+
+What is reachable only by rendering is the single line that joins them,
+`day · start – end`, and `SessionSchedule.test.tsx:40` covers it by asserting
+`"Tue, Sep 8 · 10:00 AM – 1:00 PM"` from a fixed UTC input. There is no
+coverage hole, and extracting a `formatSessionWhen` today would isolate a
+template literal. No code changes for this; the record was the thing that was
+wrong.
+
+One row is understated rather than wrong: `SessionSchedule({ result })` also
+takes `program`, `emoji`, `headline` and `detail`, and the reserved-slot branch
+is driven by all of them.


### PR DESCRIPTION
Closes #103

A dated addendum to `docs/plans/session-schedule-from-supabase.md` recording
that three of the six Test seams rows name code that was never written under
those names. 50 insertions, 0 deletions — the table itself is left standing, as
CLAUDE.md requires of a plan.

## Verified, not transcribed

Every claim in #103 checked against the tree:

| Plan row                          | Reality                                                                     |
| --------------------------------- | --------------------------------------------------------------------------- |
| `sessionsUrl(base, program, now)` | exists — `src/lib/sessions.ts:101`                                          |
| `parseSessions(body)`             | exists — `src/lib/sessions.ts:179`                                          |
| `getSessions(program, deps)`      | **no such function.** `fetchSessions(program, now = new Date())` at `:227`, no `deps`; reads env itself. `getSessions` occurs only in this plan, at 78, 194, 207 |
| `SessionSchedule({ result })`     | exists — `SessionSchedule.tsx:60`, though it takes five props, not one       |
| `formatSessionWhen(session)`      | **never existed.** `when()` is private at `SessionSchedule.tsx:54`; the exported helper is `formatPrice` at `:42` |
| `npm run check:db`                | exists                                                                      |

"Injected `fetch` stub — no `vi.mock`" → `sessions.test.ts:46` does
`vi.stubGlobal("fetch", fetchMock)`.

## One correction to the issue

**#103's "what was lost" is overstated**, and I did not carry it into the
addendum. It says the date logic "can only be exercised by rendering a
component". It cannot:

`when()` delegates to `localDayOf` / `localTimeOf` in `src/lib/pacific-time.ts`,
both exported and directly asserted in `src/lib/pacific-time.test.ts` —
including the exact instant this feature renders (`localDayOf(Date.UTC(2026, 8,
8, 17, 0))` → `"Tue, Sep 8"`, line 45) and the evening that is already the next
day in UTC (line 51). That is a *better* seam than the table proposed: it is
shared with the conditions tool and the tide day, so one set of assertions
holds for all three.

Only the line joining them — `day · start – end` — is render-only, and
`SessionSchedule.test.tsx:40` asserts it. Extracting a `formatSessionWhen`
today would isolate a template literal.

This matters because the addendum is the durable record: an overstated loss
there would justify a refactor nobody needs. No code changes in this PR.

## Also worth noting

One of the three is a **deliberate reversal, not drift**. ADR-0013's
2026-08-18 amendment moved the seam to the global `fetch` because Next
instruments `fetch` itself, so a module handed an injected function has no
guarantee it got the instrumented one. The ADR was amended; the table was not.
(`scripts/db-check.mjs` still injects, for the reason that amendment gives.)

#103 cites this as "ADR-0008" — correct when it was filed on 2026-08-19, stale
since #102 renumbered that ADR to 0013. The addendum cites 0013.

## Gates

```
$ npm run gate

> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

## What this does not do

- **No edit to the table, or to lines 78 and 207.** They are the record of what
  was agreed before slice 1. The addendum names them instead.
- **No code changes.** There is no coverage hole; the record was what was wrong.
- **No `formatSessionWhen` extracted.** It would isolate a template literal, and
  the timezone logic already has a shared seam with tests.
