### PR TITLE
Withdraw the charter-fund claim until copy explains it

### DIFF
--- a/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
+++ b/.design/wild-coast-kids-landing/DESIGN_BRIEF.md
@@ -4,8 +4,7 @@
 
 A homeschool parent in San Diego hears about Wild Coast Kids and wants to answer
 three questions fast: what is this (art classes and an outdoor co-op), is it for
-my kid (K–8, charter-fund eligible), and how do I get in (book a class, join the
-interest list). Today there is nothing to point them at — the co-op exists in
+my kid (K–8), and how do I get in (book a class, join the interest list). Today there is nothing to point them at — the co-op exists in
 conversations and a style template, not on the web.
 
 ## Solution
@@ -89,7 +88,7 @@ tree rather than believed.
 | Conditions         | `Conditions.tsx`         | Ocean-blue section with a reserved slot for the tool                                     |
 | InterestListTeaser | `InterestListTeaser.tsx` | The landing page's interest-list section, wrapping the form                              |
 | InterestListForm   | `InterestListForm.tsx`   | Interest-list form; client-side success state only                                       |
-| QuoteStats         | `QuoteStats.tsx`         | Parent quotes + K–8 / Charter stat tiles; closes the page                                |
+| QuoteStats         | `QuoteStats.tsx`         | Parent quotes + the K–8 stat tile; closes the page                                       |
 | SnapSection        | `SnapSection.tsx`        | One stop: owns its height and surface, and the padding its content drops                 |
 | Footer             | `Footer.tsx`             | Dark bar, logo, program summary. Rendered by `layout.tsx`, so it is on every route       |
 | PillLink           | `PillLink.tsx`           | The site's CTA shape, in five closed tones                                               |
@@ -285,6 +284,24 @@ since changed things it still stated as current.
   overflow survived review; the `md`–`lg` band it described has had no stops
   since 2026-08-15, and the two-up step it called a regression was a deliberate
   choice recorded in the plan before the code was written.
+
+### 2026-08-20 (the charter claim is withdrawn)
+
+The brief opened by naming "charter-fund eligible" as half of the answer to
+"is it for my kid", and the Component Inventory described `QuoteStats` as
+carrying "K–8 / Charter stat tiles". Both are corrected above.
+
+The site asserted charter-fund eligibility in seven places and explained it
+nowhere — the copy that would have explained it was never written, and the
+facts to write it from are not in the repository. Rather than invent a claim
+about public money, the claim was withdrawn until the copy exists. `QuoteStats`
+now carries one tile, not two.
+
+This is expected to reverse. The route back, and the reason a replacement
+statistic was not invented to fill the space, are in
+`docs/plans/charter-claim-withdrawn.md` (issue #104). Three tests assert the
+claim stays absent in the meantime, so restoring it means deleting a test that
+says why it went.
 
 ## Out of Scope
 

--- a/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
+++ b/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
@@ -48,10 +48,11 @@ page. See _URL Strategy_ for the anchors that were retired.
    the conversion core; everything above earns attention for it.
 4. **Conditions** — differentiator teaser; placeholder until the tool exists.
 5. **Community form** — the catch-all conversion for anyone not ready to book.
-6. **Quote + stats** — social proof and the two facts parents filter on
-   (K–8, charter eligible). It closes the page by decision, not by leftover
-   ordering: it was fourth until the sections became snap stops
-   (`docs/plans/section-snapping.md`).
+6. **Quote + stats** — social proof and the one fact parents filter on (K–8).
+   It was two facts until the charter claim was withdrawn on 2026-08-20 (issue
+   #104, `docs/plans/charter-claim-withdrawn.md`). It closes the page by
+   decision, not by leftover ordering: it was fourth until the sections became
+   snap stops (`docs/plans/section-snapping.md`).
 
 Six items, and they are the six `SnapSection`s of `src/app/page.tsx` in order.
 
@@ -69,8 +70,10 @@ wordmark banner. Decided in the brief; not deferred.
 `/art`, `/coop`, `/conditions`, `/community` and `/book` share one shape: an
 eyebrow line, an italic title, a lead paragraph, at most one CTA, then
 reserved slots where real content lands. They were structural shells
-throughout, by decision in `docs/plans/nav-pages-scaffolding.md`; photos, the
-booking scheduler and charter-fund details still are.
+throughout, by decision in `docs/plans/nav-pages-scaffolding.md`; photos and
+the booking scheduler still are. Charter-fund details are not among them: the
+claim they would have explained was withdrawn rather than reserved, so there is
+no slot standing in for it (issue #104).
 
 **The schedule is no longer among them.** `/art` and `/coop` render their own
 program's upcoming sessions in the slot that was reserved for one, read from
@@ -116,14 +119,14 @@ lands on `/art` first; that page's CTA is "Book a class →" → `/book`.
 
 ## Naming Conventions
 
-| Concept             | Label in UI      | Notes                                         |
-| ------------------- | ---------------- | --------------------------------------------- |
-| The art program     | Art Classes      | Never "art program" or "lessons"              |
-| The outdoor program | Tuesday Co-op    | Day is part of the name                       |
-| The signup form     | Community        | Nav label; form heading is "Stay in the loop" |
-| The surf/tide tool  | Conditions       | Singular section, plural word                 |
-| Funding note        | Charter eligible | Exact phrase, used in tags and stats          |
-| Age range           | K–8              | En dash, no spaces                            |
+| Concept             | Label in UI      | Notes                                                 |
+| ------------------- | ---------------- | ----------------------------------------------------- |
+| The art program     | Art Classes      | Never "art program" or "lessons"                      |
+| The outdoor program | Tuesday Co-op    | Day is part of the name                               |
+| The signup form     | Community        | Nav label; form heading is "Stay in the loop"         |
+| The surf/tide tool  | Conditions       | Singular section, plural word                         |
+| Funding note        | Charter eligible | Withdrawn 2026-08-20 (#104); the phrase if it returns |
+| Age range           | K–8              | En dash, no spaces                                    |
 
 ## Component Reuse Map
 

--- a/docs/plans/charter-claim-withdrawn.md
+++ b/docs/plans/charter-claim-withdrawn.md
@@ -1,0 +1,138 @@
+# The site stops claiming charter-fund eligibility (issue #104)
+
+Date: 2026-08-20.
+
+## Problem, from the parent's point of view
+
+The site tells a parent the programs are charter-fund eligible in seven places
+and gives them nowhere to read what that means. PR #99 narrowed `/art`'s
+reserved slot to the dates it stands in for, which was right — charter copy was
+only riding along because the slot was the page's one stand-in — but it left
+the claim asserted everywhere and explained nowhere.
+
+A parent who filters on charter funding is the parent most likely to act on the
+claim, and there is nothing for them to act on. "Charter eligible" answers none
+of the questions that decide whether their family can actually use it: which
+charters, whether Wild Coast Kids is an approved vendor, and what they have to
+do.
+
+## Decision
+
+**Withdraw the claim until there is copy that explains it.** Chosen by the
+program's owner on 2026-08-20, over the two alternatives below.
+
+This is deliberately reversible and expected to reverse. The claim is not
+believed to be false — the program is understood to be charter-fund eligible —
+so this is not a correction. It is declining to assert something the site
+cannot yet support.
+
+### Considered and rejected
+
+- **Write the charter-fund section now.** The preferred outcome and the reason
+  #104 was labelled `needs-human`. Rejected because the facts do not exist in
+  this repository to write it from. `docs/reference/art-program.md` is the
+  document that exists precisely to hold supplied domain knowledge — it was
+  committed on 2026-08-19 because "none of it is derivable from the code" — and
+  it covers the pricing model, the pack decisions and five open questions
+  without mentioning charter funding once. Writing the copy would mean
+  inventing a factual claim about public money, which CLAUDE.md's rule against
+  inventing what cannot be confirmed exists to prevent.
+- **Keep the claim and route to the interest list.** A line on `/art` saying
+  the funding is worth asking about, promising no specifics, pointing at the
+  interest list the whole site already uses. Cheapest, and closes the gap
+  today. Rejected by the owner: it still asserts eligibility, and a parent who
+  has to ask what a claim means has been sold a question rather than an answer.
+
+### The cost, stated plainly
+
+Charter families are a segment the site was deliberately courting, and the
+phrase is what let them self-identify. Removing it will cost some of those
+signups until the copy exists. That is the price of not making a funding claim
+the site cannot explain, and it is why this plan records how the claim comes
+back rather than treating the removal as an end state.
+
+## What changes
+
+Seven shipped surfaces assert it. #104 named three; these are all of them.
+
+| Where                                | Today                               | After                               |
+| ------------------------------------ | ----------------------------------- | ----------------------------------- |
+| `src/app/layout.tsx:23`              | metadata: "Charter fund eligible."  | sentence dropped                    |
+| `src/app/art/page.tsx:10`            | metadata: ", charter fund eligible" | clause dropped                      |
+| `src/components/Hero.tsx:31`         | "Charter fund eligible."            | sentence dropped                    |
+| `src/components/Marquee.tsx:9`       | phrase in the strip                 | phrase dropped, seven remain        |
+| `src/components/ProgramCards.tsx:56` | yellow badge on the art card        | badge dropped, "All levels" remains |
+| `src/components/Footer.tsx:15`       | "Charter Eligible · K–8"            | "K–8"                               |
+| `src/components/QuoteStats.tsx:45`   | purple stat tile                    | tile dropped; see below             |
+
+**The QuoteStats tile is the only one that leaves a hole.** It is one of two
+tiles in a `md:grid-cols-2`, so removing it leaves a half-width tile beside
+nothing. The grid drops to a single full-width tile rather than gaining a
+replacement statistic: inventing a new claim to fill the space would be the
+same mistake in a different colour. If the pair is wanted back, that is a copy
+decision and a one-line change.
+
+The stale comment at `src/app/art/page.tsx:178` — "Charter-fund copy is
+genuinely unwritten and is a separate slice" — is corrected in the same slice,
+because it now describes a decision that has been taken.
+
+## Test seams
+
+Four existing assertions pin the exact strings and change with the code:
+`Footer.test.tsx:10`, `Marquee.test.tsx:8`, `QuoteStats.test.tsx:21-22`.
+`Marquee.test.tsx` uses the phrase only as a probe for "every phrase appears
+twice", so it moves to another phrase and keeps its subject.
+
+**Three guards assert the claim stays gone**, following the idiom already in
+`src/app/art/page.test.tsx` for the monthly themed class — "asserts it stays
+absent, so it cannot be half-added later":
+
+- `src/app/page.test.tsx` — covers Hero, Marquee, ProgramCards and QuoteStats
+  in one assertion, since the landing page renders all four.
+- `src/components/Footer.test.tsx` — the footer is in `layout.tsx`, so no page
+  test reaches it.
+- `src/app/art/page.test.tsx` — covers `/art`.
+
+The guards are what make this reversible on purpose rather than by accident:
+whoever restores the claim has to delete a test that says why it went, which is
+the moment to check the copy exists.
+
+## Documentation
+
+Two design documents describe the claim and go stale. The repo already has a
+convention for each, set by `docs/plans/design-doc-drift.md`:
+
+- **`DESIGN_BRIEF.md`** — body states what is true now, dated addenda are the
+  change log. Body updated, addendum added.
+- **`INFORMATION_ARCHITECTURE.md`** — corrected in place, no addendum. It has
+  no addenda today and inventing the pattern for one document while retiring it
+  in the other would leave two conventions.
+
+Left alone as historical records, per CLAUDE.md's rule against rewriting
+history: `TASKS.md` (a completed-task log), `docs/plans/wild-coast-kids-landing.md`
+(a plan), and the `DESIGN_BRIEF.md` addenda already there.
+
+## How the claim comes back
+
+Not by re-adding the phrase. The facts land in `docs/reference/art-program.md`
+first — which charters or vendor systems, whether Wild Coast Kids is an
+approved vendor, and what a parent actually does — because that is the file
+for supplied knowledge that is not derivable from the code. Copy is written
+from it, and the guards come out in the same slice that adds the copy.
+
+## Out of scope
+
+- Writing any charter-fund copy. That is the whole reason #104 is `needs-human`
+  and the facts are not available.
+- No ADR. The state is explicitly temporary and expected to reverse; ADRs here
+  record decisions meant to hold.
+- `/coop`, `/book` and `/community`, which never carried the claim.
+- The interest-list flow, untouched.
+
+## Slices
+
+| #   | Slice                          | Delivers                                                                  |
+| --- | ------------------------------ | ------------------------------------------------------------------------- |
+| 0   | Write this plan down           | This file                                                                 |
+| 1   | Withdraw the claim from the UI | Seven surfaces, four updated assertions, three absence guards             |
+| 2   | Correct the design docs        | `DESIGN_BRIEF.md` body + addendum, `INFORMATION_ARCHITECTURE.md` in place |

--- a/docs/plans/charter-claim-withdrawn.md
+++ b/docs/plans/charter-claim-withdrawn.md
@@ -66,11 +66,16 @@ Seven shipped surfaces assert it. #104 named three; these are all of them.
 | `src/components/QuoteStats.tsx:45`   | purple stat tile                    | tile dropped; see below             |
 
 **The QuoteStats tile is the only one that leaves a hole.** It is one of two
-tiles in a `md:grid-cols-2`, so removing it leaves a half-width tile beside
-nothing. The grid drops to a single full-width tile rather than gaining a
-replacement statistic: inventing a new claim to fill the space would be the
-same mistake in a different colour. If the pair is wanted back, that is a copy
-decision and a one-line change.
+tiles in a `md:grid-cols-2`. No replacement statistic is invented to fill the
+space — that would be the same mistake in a different colour — so the question
+is only what the survivor does with the room.
+
+The grid keeps `md:grid-cols-2` and the remaining tile keeps the width it has
+always had, sitting under the left-hand quote. Dropping the column was tried
+first and rejected on the rendered page: it stretches the tile to the full
+1425px section width with "K–8" in the leftmost eighth, which reads as
+something deleted rather than as one stat. Half-width, the tile is unchanged
+from what shipped and the empty column lines up with the quote above it.
 
 The stale comment at `src/app/art/page.tsx:178` — "Charter-fund copy is
 genuinely unwritten and is a separate slice" — is corrected in the same slice,

--- a/docs/plans/charter-claim-withdrawn.md
+++ b/docs/plans/charter-claim-withdrawn.md
@@ -120,6 +120,10 @@ approved vendor, and what a parent actually does — because that is the file
 for supplied knowledge that is not derivable from the code. Copy is written
 from it, and the guards come out in the same slice that adds the copy.
 
+That question is now recorded there, as open question 6. A plan under
+`docs/plans/` is where a task is worked out; the reference doc is where someone
+asking what is still unknown about the program actually looks.
+
 ## Out of scope
 
 - Writing any charter-fund copy. That is the whole reason #104 is `needs-human`
@@ -131,8 +135,9 @@ from it, and the guards come out in the same slice that adds the copy.
 
 ## Slices
 
-| #   | Slice                          | Delivers                                                                  |
-| --- | ------------------------------ | ------------------------------------------------------------------------- |
-| 0   | Write this plan down           | This file                                                                 |
-| 1   | Withdraw the claim from the UI | Seven surfaces, four updated assertions, three absence guards             |
-| 2   | Correct the design docs        | `DESIGN_BRIEF.md` body + addendum, `INFORMATION_ARCHITECTURE.md` in place |
+| #   | Slice                           | Delivers                                                                  |
+| --- | ------------------------------- | ------------------------------------------------------------------------- |
+| 0   | Write this plan down            | This file                                                                 |
+| 1   | Withdraw the claim from the UI  | Seven surfaces, four updated assertions, three absence guards             |
+| 2   | Correct the design docs         | `DESIGN_BRIEF.md` body + addendum, `INFORMATION_ARCHITECTURE.md` in place |
+| 3   | Record what would bring it back | `docs/reference/art-program.md` open question 6                           |

--- a/docs/reference/art-program.md
+++ b/docs/reference/art-program.md
@@ -116,8 +116,9 @@ sensitive data the site would hold as far from any ledger as possible.
 
 ## 6. Open questions
 
-None of these blocks the first term. All of them change the schema, so they want
-answers before a pack system is built rather than after.
+None of these blocks the first term. The first four change the schema and want
+answers before a pack system is built rather than after; the last two block
+page copy instead, and cost nothing but the answer.
 
 1. **Do credits expire?** If so, on what clock — purchase date, or term end?
    Easy to add up front, awkward to add to balances already sold.
@@ -127,6 +128,12 @@ answers before a pack system is built rather than after.
 4. **Does a drop-in purchase create an account?** If not, a parent who drops in
    twice and then buys a pack has two identities and a split history.
 5. **What does the monthly themed class cost?** Blocks putting it on the site.
+6. **How does charter funding actually work here?** Which charters or vendor
+   systems, whether Wild Coast Kids is an approved vendor yet, and what a parent
+   has to do. The site claimed charter-fund eligibility in seven places and
+   explained it nowhere, so the claim was withdrawn on 2026-08-20 rather than
+   invented around — issue #104, `docs/plans/charter-claim-withdrawn.md`. These
+   answers are what brings it back.
 
 ## 7. The wider PRD set
 

--- a/src/app/art/page.test.tsx
+++ b/src/app/art/page.test.tsx
@@ -216,3 +216,13 @@ test("the art schedule carries the art accent", async () => {
       .className,
   ).toContain("text-purple");
 });
+
+// /art is where the charter copy would have lived, and PR #99 left the page
+// with none while the rest of the site still claimed eligibility. The claim
+// went (#104); this asserts the page does not start asserting it again without
+// the copy. See docs/plans/charter-claim-withdrawn.md.
+test("the art page makes no funding claim it cannot explain", async () => {
+  const { container } = render(await Art());
+
+  expect(container.textContent).not.toMatch(/charter|fund eligible/i);
+});

--- a/src/app/art/page.tsx
+++ b/src/app/art/page.tsx
@@ -7,7 +7,7 @@ import { fetchSessions } from "@/lib/sessions";
 export const metadata: Metadata = {
   title: "Art Classes",
   description:
-    "Watercolors, ink, collage and printmaking for K–8 kids, inspired by the San Diego coast. Group and private sessions, charter fund eligible.",
+    "Watercolors, ink, collage and printmaking for K–8 kids, inspired by the San Diego coast. Group and private sessions.",
 };
 
 /** Per request, and for the reasons given in full on `/coop`. */
@@ -175,8 +175,10 @@ export default async function Art() {
         {/* The slot promises only what is still missing. Pricing moved onto the
             page above, so a slot still naming it would be promising what has
             already arrived — the drift ReservedSlot was extracted to stop.
-            Charter-fund copy is genuinely unwritten and is a separate slice; it
-            is not the schedule's to promise either way. */}
+            Charter-fund copy is still unwritten, and the claim it would have
+            explained has been withdrawn from the site until it exists (#104,
+            docs/plans/charter-claim-withdrawn.md). Not the schedule's to
+            promise either way. */}
         <div className="grid gap-4 md:grid-cols-2">
           <SessionSchedule
             result={schedule}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
     template: "%s — Wild Coast Kids",
   },
   description:
-    "Art classes and a Tuesday outdoor co-op for K–8 kids, rooted in the San Diego coast. Charter fund eligible.",
+    "Art classes and a Tuesday outdoor co-op for K–8 kids, rooted in the San Diego coast.",
 };
 
 export default function RootLayout({ children }: LayoutProps<"/">) {

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -43,3 +43,15 @@ test("the parent quotes close the page, below the interest list", () => {
     form.compareDocumentPosition(quote) & Node.DOCUMENT_POSITION_FOLLOWING,
   ).toBeTruthy();
 });
+
+// Hero, Marquee, ProgramCards and QuoteStats all asserted charter-fund
+// eligibility, and the site explained it nowhere. The claim was withdrawn
+// until copy exists (#104, docs/plans/charter-claim-withdrawn.md). This is one
+// assertion rather than four because the landing page renders all four; the
+// footer, which carried it too, sits in layout.tsx and is guarded in
+// Footer.test.tsx.
+test("the landing page makes no funding claim", () => {
+  const { container } = render(<Home />);
+
+  expect(container.textContent).not.toMatch(/charter|fund eligible/i);
+});

--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -7,5 +7,17 @@ test("the footer is a contentinfo landmark carrying the wordmark", () => {
 
   const footer = screen.getByRole("contentinfo");
   expect(footer.textContent).toContain("Wild Coast Kids");
-  expect(footer.textContent).toContain("Charter Eligible · K–8");
+  expect(footer.textContent).toContain("K–8");
+});
+
+// The footer sits in layout.tsx, so no page test reaches it — this is the only
+// guard on the site-wide line. It said "Charter Eligible · K–8" until the claim
+// was withdrawn (#104, docs/plans/charter-claim-withdrawn.md); it comes back
+// with the copy that explains it, not before.
+test("the footer makes no funding claim", () => {
+  render(<Footer />);
+
+  expect(screen.getByRole("contentinfo").textContent).not.toMatch(
+    /charter|fund/i,
+  );
 });

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,7 +12,7 @@ export function Footer() {
       <p className="text-2xs leading-loose font-extrabold tracking-wider text-white/25 uppercase md:text-right">
         Art Classes · Tuesday Co-op
         <br />
-        Charter Eligible · K–8
+        K–8
       </p>
     </footer>
   );

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -28,8 +28,7 @@ export function Hero() {
         </h1>
         {/* white/90, up from the template's /70: 4.79:1 vs a failing 3.60:1 */}
         <p className="leading-relaxed mb-6 max-w-80 text-base text-white/90">
-          Art classes and outdoor co-op rooted in the California coast. Charter
-          fund eligible.
+          Art classes and outdoor co-op rooted in the California coast.
         </p>
         <div className="flex flex-wrap gap-3">
           {/* Routes, not anchors: both program cards now share one snap

--- a/src/components/Marquee.test.tsx
+++ b/src/components/Marquee.test.tsx
@@ -5,7 +5,7 @@ import { Marquee } from "./Marquee";
 test("every phrase appears twice in the DOM for the seamless loop", () => {
   render(<Marquee />);
 
-  expect(screen.getAllByText("Charter Eligible")).toHaveLength(2);
+  expect(screen.getAllByText("Art Classes")).toHaveLength(2);
   expect(screen.getAllByText("K–8")).toHaveLength(2);
 });
 

--- a/src/components/Marquee.tsx
+++ b/src/components/Marquee.tsx
@@ -6,7 +6,6 @@ const PHRASES = [
   "Nature Journal",
   "Hikes",
   "Science",
-  "Charter Eligible",
   "San Diego",
   "K–8",
 ];

--- a/src/components/ProgramCards.tsx
+++ b/src/components/ProgramCards.tsx
@@ -52,9 +52,6 @@ export function ProgramCards() {
               whatever sparks curiosity. Every session is different.
             </p>
             <div className="mb-5.5 flex flex-wrap gap-2">
-              <span className="rounded-pill bg-yellow px-[13px] py-[5px] text-2xs font-extrabold tracking-wide text-ink">
-                Charter eligible
-              </span>
               <span className="rounded-pill bg-white/15 px-[13px] py-[5px] text-2xs font-extrabold tracking-wide text-white">
                 All levels
               </span>

--- a/src/components/QuoteStats.test.tsx
+++ b/src/components/QuoteStats.test.tsx
@@ -13,13 +13,20 @@ test("both parent quotes are reachable, each with its attribution", () => {
   expect(screen.getAllByText(/— Parent, Wild Coast Kids/i)).toHaveLength(2);
 });
 
-test("both stat tiles state the facts parents filter on", () => {
+test("the stat tile states the fact parents filter on", () => {
   render(<QuoteStats />);
 
   expect(screen.getByText("K–8")).toBeDefined();
   expect(screen.getByText("All ages welcome")).toBeDefined();
-  expect(screen.getByText("Charter ✓")).toBeDefined();
-  expect(screen.getByText("Fund eligible programs")).toBeDefined();
+});
+
+// The second tile claimed charter-fund eligibility the site could not explain
+// anywhere, and went with the rest of that claim (#104). It comes back with
+// the copy, not before — see docs/plans/charter-claim-withdrawn.md.
+test("the closing section makes no funding claim", () => {
+  const { container } = render(<QuoteStats />);
+
+  expect(container.textContent).not.toMatch(/charter|fund/i);
 });
 
 test("the closing section carries no divider at all", () => {

--- a/src/components/QuoteStats.tsx
+++ b/src/components/QuoteStats.tsx
@@ -35,10 +35,12 @@ export function QuoteStats() {
       </div>
       {/* One tile, not two. The charter tile was the second, and it went with
           the rest of the claim (#104, docs/plans/charter-claim-withdrawn.md).
-          The grid loses its md:grid-cols-2 rather than gaining a replacement
-          statistic: inventing a claim to fill the space is the same mistake
-          that emptied it. */}
-      <div className="mt-10 grid gap-3 md:gap-4">
+          The grid keeps md:grid-cols-2 so the survivor stays the width it has
+          always been: dropping the column instead stretches "K–8" across the
+          full section, which reads as a deletion rather than as one stat. No
+          replacement statistic — inventing a claim to fill the space is the
+          same mistake that emptied it. */}
+      <div className="mt-10 grid gap-3 md:grid-cols-2 md:gap-4">
         <div className="rounded-thumb bg-yellow px-6 py-5">
           <p className="text-stat leading-none mb-1 font-black text-ink italic">
             K–8

--- a/src/components/QuoteStats.tsx
+++ b/src/components/QuoteStats.tsx
@@ -33,20 +33,17 @@ export function QuoteStats() {
           </figure>
         ))}
       </div>
-      <div className="mt-10 grid gap-3 md:grid-cols-2 md:gap-4">
+      {/* One tile, not two. The charter tile was the second, and it went with
+          the rest of the claim (#104, docs/plans/charter-claim-withdrawn.md).
+          The grid loses its md:grid-cols-2 rather than gaining a replacement
+          statistic: inventing a claim to fill the space is the same mistake
+          that emptied it. */}
+      <div className="mt-10 grid gap-3 md:gap-4">
         <div className="rounded-thumb bg-yellow px-6 py-5">
           <p className="text-stat leading-none mb-1 font-black text-ink italic">
             K–8
           </p>
           <p className="text-xs font-bold text-black/50">All ages welcome</p>
-        </div>
-        <div className="rounded-thumb bg-purple px-6 py-5">
-          <p className="text-stat leading-none mb-1 font-black text-yellow italic">
-            Charter ✓
-          </p>
-          <p className="text-xs font-bold text-white/60">
-            Fund eligible programs
-          </p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Closes #104

The site asserted charter-fund eligibility in seven places and explained it
nowhere. The claim is withdrawn until copy exists.

**#104 is `needs-human` and the human decision is what this implements.** The
issue asked for charter-fund copy; the facts to write it are not in this
repository, so the choice put to the owner was write it / point at the interest
list / stop claiming it. **Stop claiming it** was chosen on 2026-08-20.

Reasoning, the rejected options and the route back are in
`docs/plans/charter-claim-withdrawn.md`.

## Why the copy could not just be written

`docs/reference/art-program.md` exists precisely to hold supplied domain
knowledge — its header says it was committed "because none of it is derivable
from the code". It covers the pricing model, the pack decisions and five open
questions, and does not mention charter funding once. Writing the section would
have meant inventing a factual claim about public money.

## Seven surfaces, not three

#104 named three. These are all of them, verified against the tree:

| Where                                | Was                                 | Now                                 |
| ------------------------------------ | ----------------------------------- | ----------------------------------- |
| `src/app/layout.tsx:23`              | metadata: "Charter fund eligible."  | sentence dropped                    |
| `src/app/art/page.tsx:10`            | metadata: ", charter fund eligible" | clause dropped                      |
| `src/components/Hero.tsx:31`         | "Charter fund eligible."            | sentence dropped                    |
| `src/components/Marquee.tsx:9`       | phrase in the strip                 | dropped, seven phrases remain       |
| `src/components/ProgramCards.tsx:56` | yellow badge on the art card        | dropped, "All levels" remains       |
| `src/components/Footer.tsx:15`       | "Charter Eligible · K–8"            | "K–8"                               |
| `src/components/QuoteStats.tsx:45`   | purple stat tile                    | dropped, one tile remains           |

## I changed my mind after looking at the page

The plan first said the stat grid should drop `md:grid-cols-2` so the surviving
tile went full width. Rendered, that stretches the tile across the full 1425px
section with "K–8" in the leftmost eighth — it reads as something deleted
rather than as one stat.

The grid keeps its column instead, so the tile is exactly the size it shipped
at, under the left-hand quote. The plan is corrected rather than left standing
(`ea46094`). No replacement statistic was invented to fill the empty column;
that would be the same mistake in a different colour.

## Guards, so it cannot come back half-done

Three tests assert the claim stays absent, following the idiom already used for
the unpriced monthly class in `src/app/art/page.test.tsx`:

- `src/app/page.test.tsx` — one assertion covering Hero, Marquee, ProgramCards
  and QuoteStats, since the landing page renders all four
- `src/components/Footer.test.tsx` — the footer is in `layout.tsx`, beyond any
  page test
- `src/app/art/page.test.tsx` — `/art`

Checked for teeth by re-adding the badge to `ProgramCards.tsx`, which turned the
landing guard red:

```
--- mutated: charter badge re-added ---
   × the landing page makes no funding claim 12ms
 FAIL  src/app/page.test.tsx > the landing page makes no funding claim
      Tests  1 failed | 4 passed (5)
```

Whoever restores the claim has to delete a test that says why it went, which is
the moment to check the copy exists.

## Verified in the running app, not only in tests

Against `localhost:3001`:

```
landing: { charterAnywhereOnPage: false,
           metaDescription: "Art classes and a Tuesday outdoor co-op for K–8
                             kids, rooted in the San Diego coast." }
/art:    { charterOnArt: false, badgesOnPage: [],
           artMeta: "...Group and private sessions." }
```

## Documentation

Two design docs described the claim as shipped copy. Each is corrected the way
`docs/plans/design-doc-drift.md` decided for it — the brief's body states what
is true now plus a dated addendum, the IA doc is corrected in place with no
addendum. The IA's Naming Conventions row is kept rather than deleted: the
phrase was a vocabulary decision and is the phrase to use if the claim returns.

`TASKS.md` and `docs/plans/wild-coast-kids-landing.md` keep their mentions —
a completed-task log and a plan, both records of a day rather than specs.

The outstanding question is recorded as open question 6 in
`docs/reference/art-program.md`, because someone asking what is still unknown
about the program reads the reference doc, not a plan file.

## Gates

```
$ npm run gate

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

Coverage floor unchanged: the removed JSX and the new tests both sit in files
already fully covered.

## Housekeeping

The issue title was `C:/Program Files/Git/art no longer says…` — Git Bash MSYS
path mangling of `/art`. Fixed via PowerShell, since Bash would have mangled the
fix the same way.

## What this does not do

- **No charter-fund copy.** The facts are not available; that is the whole
  reason #104 is `needs-human`.
- **No ADR.** The state is explicitly temporary and expected to reverse.
- **No replacement statistic** in the freed column.
- **Nothing on `/coop`, `/book` or `/community`**, which never carried it.

## Worth your judgement

Removing the phrase costs the self-identification signal for charter families,
who were a segment the site was deliberately courting. The plan states that cost
rather than pretending the removal is free. If you would rather have the interim
line pointing at the interest list after all, that is a small follow-up and the
guards are what would need relaxing.
