### PR TITLE
Bring the art card's copy in line with /art

### DIFF
--- a/docs/plans/art-program-page-copy.md
+++ b/docs/plans/art-program-page-copy.md
@@ -190,3 +190,28 @@ second thing in one slice. Filed as a follow-up rather than folded in.
 - **What does the monthly themed class cost?** Blocks including it.
 - **Where do classes meet?** Undecided. Carried per-session on the row, so it
   does not block this page.
+
+## Addendum — 2026-08-20: the card was looked at, and the budget did not bind
+
+_Out of scope_ above defers `ProgramCards.tsx` with two reasons: that touching
+it would be a second thing in one slice, and that the landing card has "a 520px
+height budget set by issue #37". The first reason was right and is why the work
+became #105. The second does not hold, and is corrected here rather than left
+for the next person to inherit.
+
+`min-h-[520px]` is a floor, not a ceiling, and the two cards sit in a
+`md:grid-cols-2` grid that equalises their heights. The co-op card is the taller
+of the two — it carries a four-tile activities grid — so it sets the height and
+the art card renders with slack. Measured at 1536px on 2026-08-20: both cards
+531px, co-op content 475px, art content 354px. **121px of that card was empty**,
+visible as bare purple below the CTAs.
+
+So the premise that "anything added has to come out of something else" was not
+true of this card. #105 spent 20px of the 121px — one line of paragraph — and
+both cards stayed at 531px with the section unchanged at 611px.
+
+This does not generalise. The slack exists because the co-op card is taller, so
+it would vanish if the co-op card lost its activities grid, and it never existed
+for the co-op card at all. The lesson is narrower than "there is room": it is
+that the budget has to be measured against the sibling card rather than assumed
+from the `min-h`.

--- a/src/components/ProgramCards.test.tsx
+++ b/src/components/ProgramCards.test.tsx
@@ -27,6 +27,36 @@ test("each card's CTA points where its flow goes", () => {
   expect(learnMore).toEqual(["/art", "/coop"]);
 });
 
+// The card links to /book, so what a class costs is the most decision-relevant
+// fact on the page it points at, and it said nothing about it until #105. The
+// number is TIERS[0].price in src/app/art/page.tsx; they are duplicated
+// literals and #113 is open about single-sourcing them.
+test("the art card names what a class costs", () => {
+  render(<ProgramCards />);
+
+  expect(screen.getByText("$20 drop-in")).toBeDefined();
+});
+
+// The card predated /art's copy and claimed "Every session is different",
+// which is the weaker half of what the page claims: the technique is shared
+// and only the results differ (#105). This pins the claim, not the wording
+// around it, so the sentence can be edited without the test dictating prose.
+test("the art card carries the page's claim, not its opposite", () => {
+  render(<ProgramCards />);
+
+  const art = screen.getByText(/watercolors, ink, collage/i);
+  expect(art.textContent).toMatch(/nobody goes home with the same picture/i);
+  expect(art.textContent).not.toMatch(/every session is different/i);
+});
+
+// The co-op is the outdoor program; art is studio work "inspired by the
+// coast", which is not the same claim (#105).
+test("the art card does not claim to be outdoors", () => {
+  render(<ProgramCards />);
+
+  expect(screen.queryByText("Outdoors")).toBeNull();
+});
+
 test("the co-op card lists all four activities", () => {
   render(<ProgramCards />);
 

--- a/src/components/ProgramCards.tsx
+++ b/src/components/ProgramCards.tsx
@@ -47,16 +47,31 @@ export function ProgramCards() {
             <p className="mb-3.5 text-xs font-extrabold tracking-wider text-yellow uppercase">
               In-person · Group & Private · K–8
             </p>
+            {/* Both sentences are `/art`'s lead paragraph, word for word. The
+                card is the teaser for that page, so when the page's emphasis
+                moves the card follows — it said "Every session is different"
+                until #105, which reads as the weaker half of what the page
+                actually claims: the technique is shared and only the results
+                differ. Keep the two in step; they are duplicated literals, and
+                nothing enforces it (#113). */}
             <p className="leading-normal mb-4.5 max-w-[340px] text-sm text-white/90">
               Watercolors, ink, collage, printmaking — inspired by the coast and
-              whatever sparks curiosity. Every session is different.
+              whatever sparks curiosity. Every class teaches a real technique,
+              and nobody goes home with the same picture.
             </p>
+            {/* "Outdoors" was here until #105. The co-op is the outdoor
+                program; this one is studio work "inspired by the coast", which
+                is not the same claim. The entry price replaces it rather than
+                joining it, because the card is the one surface that linked to
+                `/book` while saying nothing about what a class costs.
+                `$20` is `TIERS[0].price` in `src/app/art/page.tsx` — the
+                source of truth, and the other half of #113. */}
             <div className="mb-5.5 flex flex-wrap gap-2">
               <span className="rounded-pill bg-white/15 px-[13px] py-[5px] text-2xs font-extrabold tracking-wide text-white">
                 All levels
               </span>
               <span className="rounded-pill bg-white/15 px-[13px] py-[5px] text-2xs font-extrabold tracking-wide text-white">
-                Outdoors
+                $20 drop-in
               </span>
             </div>
             <div className="flex flex-wrap gap-3">


### PR DESCRIPTION
Closes #105

The art card's copy and badges predated `/art`'s copy and had drifted three
ways. All three are fixed, using copy that already exists rather than new copy.

**#105 is `needs-human`, and the reading was yours to choose.** Three options
were put up — match `/art` verbatim, a shorter sentence, or spend more of the
card's spare room. **Match `/art` verbatim** was chosen on 2026-08-20.

| Defect (#105)                    | Fix                                                                      |
| -------------------------------- | ------------------------------------------------------------------------ |
| "Every session is different"     | replaced by `/art`'s lead paragraph, word for word                       |
| "Outdoors" badge on a studio class | replaced by the entry price, so the badge row stays at two              |
| No price signal                  | `$20 drop-in`, from `TIERS[0].price` on the page the card links to       |

Nothing here is invented: the paragraph is `/art`'s, the price is `TIERS`'s.
Verified by comparing the two files rather than by eye —

```
card: Watercolors, ink, collage, printmaking — inspired by the coast and whatever sparks curiosity. Every class teaches a real technique, and nobody goes home with the same picture.
page: Watercolors, ink, collage, printmaking — inspired by the coast and whatever sparks curiosity. Every class teaches a real technique, and nobody goes home with the same picture.
VERBATIM MATCH: true
```

## The height constraint does not bind, and that is measured

#105 says "the card has a 520px height budget from #37 … Anything added has to
come out of something else — that is why this was not folded into PR #99."

That is not true of this card. `min-h-[520px]` is a floor, not a ceiling, and
the two cards sit in a `md:grid-cols-2` grid that equalises their heights. The
co-op card carries a four-tile activities grid and is the taller of the two, so
it sets the height and **the art card renders with 121px of slack** — visible as
bare purple below its CTAs.

Measured at 1536px, before and after:

| | art card | art content | co-op card | co-op content | section |
| --- | --- | --- | --- | --- | --- |
| before | 531 | 354 | 531 | 475 | 611 |
| after  | 531 | **374** | 531 | 475 | 611 |

The new line costs 20px of the 121px. **No height changes at all** — both cards
stay 531px, the section stays 611px, 100px of slack remains.

`docs/plans/art-program-page-copy.md` gets a dated addendum correcting the claim,
including why it does not generalise: the slack is a consequence of the co-op
card being taller, not a property of the layout, and the co-op card has none.

## Tests

Three, one per defect, pinning the claim rather than the prose so the sentence
can still be edited:

- the art card names what a class costs
- the art card carries the page's claim, not its opposite
- the art card does not claim to be outdoors

Checked for teeth by restoring the pre-#105 copy, which turned exactly those
three red and left the four existing tests green:

```
--- mutated back to the pre-#105 copy ---
   × the art card names what a class costs
   × the art card carries the page's claim, not its opposite
   × the art card does not claim to be outdoors
      Tests  3 failed | 4 passed (7)
```

## Gates

```
$ npm run gate
GATE EXIT: 0
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

**Read that with #114 in mind.** Three earlier runs of this same commit failed
— 3, 9 and 22 test timeouts, a different random set each time, not one
assertion among them, every file passing in isolation. `npx vitest run
--maxWorkers=4` passes 639/639 with zero timeouts. Vitest sizes its pool from
the CPU count and this machine has 24 cores; the workers starve each other past
the 5s timeout. **#114 is filed with the evidence.** This PR is unaffected — its
own three tests passed in every run, failing or not.

## Follow-ups filed

- **#113** — the card and `/art` now duplicate both the lead paragraph and the
  price as literals, and nothing enforces either. Change `TIERS[0].price` and
  the card keeps a stale badge while every gate stays green. Duplication is not
  new (the first sentence was already verbatim in both files), but the price
  duplication is. Four options, no obvious winner, so `needs-human`.
- **#114** — the gate flake above.

## Housekeeping

The issue body read "says nothing about 0 drop-in" — `$20` eaten by shell
expansion when the issue was filed, the same class of mangling as #104's title.
Corrected to `$20`.

## What this does not do

- **No single-sourcing** of the shared copy — that is #113 and a design call.
- **No change to the co-op card**, which #105 does not raise.
- **No new statistic** in the card's remaining 100px of slack; the option to
  spend it was offered and not taken.
