### PR TITLE
Stop the gate flaking, and give CLAUDE.md a small-change lane

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,12 +24,18 @@ process over a two-line copy fix produces a plan file, a slice table and a PR
 body longer than the diff. That is the process working as written, which is the
 problem it is worth having a second lane for.
 
-**Take the small lane when all three hold:**
+**Take the small lane when both hold:**
 
-- it changes no behaviour a test could assert — copy, comments, docs — **or**
-  it is one file and roughly twenty lines or fewer;
-- it introduces no dependency, abstraction, data format or contract;
+- the change is confined to prose — page copy, comments, documentation — and
+  touches no logic, no data shape and no contract;
 - it contradicts nothing recorded in `docs/adr/` or `CONTEXT.md`.
+
+Not a line count. Five lines inside `src/lib/sessions.ts` are riskier than
+sixty lines of page copy, and a rule counting lines would route both wrongly.
+The question is what kind of thing changed, not how much of it.
+
+Page copy is prose and takes this lane, but it is still behaviour a reader
+sees: it ships with a test like anything else.
 
 **The small lane is:** branch, do it, run the gate, one commit, short PR that
 says what changed and why. **No plan file. No slice table. No confirmation
@@ -92,9 +98,11 @@ exists only in a transcript gets rebuilt slightly differently every time
 someone returns to it.
 
 **A plan file is for work that is hard to hold in your head, not for every
-change that reaches this lane.** Write one when the work runs to more than two
-or three slices, when it turns on a decision someone will re-litigate, or when
-it will be picked up across sessions. Otherwise the issue and the PR body are
+change that reaches this lane.** Write one when the work will not finish in one
+sitting, or when it turns on a choice between approaches someone will question
+later. Both are knowable before you start; "how many slices is it" is not, and
+by the time you can count them you have already done the thinking the file was
+meant to hold. Otherwise the issue and the PR body are
 the durable record, and a plan file is a third copy of them that can go stale
 on its own — which is what `docs/plans/` currently costs: it is the largest
 body of prose in this repository and it describes code that has since moved.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,9 +17,37 @@ this file itself.
 
 ---
 
+## Pick the lane first
+
+Two lanes. Most work is the full one below; some is not, and running the full
+process over a two-line copy fix produces a plan file, a slice table and a PR
+body longer than the diff. That is the process working as written, which is the
+problem it is worth having a second lane for.
+
+**Take the small lane when all three hold:**
+
+- it changes no behaviour a test could assert — copy, comments, docs — **or**
+  it is one file and roughly twenty lines or fewer;
+- it introduces no dependency, abstraction, data format or contract;
+- it contradicts nothing recorded in `docs/adr/` or `CONTEXT.md`.
+
+**The small lane is:** branch, do it, run the gate, one commit, short PR that
+says what changed and why. **No plan file. No slice table. No confirmation
+step.** Behaviour changes still ship with a test; the gates still all run and
+still have to be green. Nothing about verification relaxes — only the
+paperwork.
+
+If you are partway in and any of the three stops holding, stop and switch
+lanes. Discovering a change was bigger than it looked is normal; finishing it
+in the wrong lane is not.
+
+**Anything else takes the full lane below**, and the guide is size on the way
+in, not confidence. Two files that must change together is the full lane even
+if each is small.
+
 ## How to work: confirm, plan, branch, slice, PR
 
-Follow this for any task beyond a one-line fix.
+The full lane. Follow this for any task the small lane above does not take.
 
 ### 1. Confirm understanding before doing anything
 
@@ -63,6 +91,17 @@ The conversation that produced the plan is not durable. Write the plan to
 exists only in a transcript gets rebuilt slightly differently every time
 someone returns to it.
 
+**A plan file is for work that is hard to hold in your head, not for every
+change that reaches this lane.** Write one when the work runs to more than two
+or three slices, when it turns on a decision someone will re-litigate, or when
+it will be picked up across sessions. Otherwise the issue and the PR body are
+the durable record, and a plan file is a third copy of them that can go stale
+on its own — which is what `docs/plans/` currently costs: it is the largest
+body of prose in this repository and it describes code that has since moved.
+
+When you skip it, say so in the PR body and say why, so the omission is a
+decision rather than a lapse.
+
 The write-up states the problem and the solution _from the user's point of
 view_, the implementation decisions, the **test seams**, and what is out of
 scope. Say what was considered and rejected, and why — the rejected options are
@@ -105,8 +144,12 @@ commit directly to it.
 
 - Name the branch after the issue: `issue-<number>-<short-slug>`.
 - One issue per branch. Work that "was right there" belongs to a different
-  branch and a different issue, even when it is two lines. If you notice it,
-  file an issue for it and move on.
+  branch, even when it is two lines. Do not do it here.
+- **Noticing something is not the same as filing an issue for it.** Say it in
+  the PR body and move on. Open a tracker entry only when it is a real defect
+  someone would want to find later, or when it needs a decision before it can
+  be worked. A backlog that grows a row every time anyone looks at anything
+  stops being a list of what to do next.
 - Do not start an issue whose blocker has not merged. The blocker's code is the
   ground the slices stand on, and rebasing half-finished work onto a moved
   blocker is how a verified slice quietly stops being verified.

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -19,6 +19,23 @@ export default defineConfig({
     // vitest's defaults wholesale, and dropping node_modules while fixing this
     // would trade one kind of foreign test file for another.
     exclude: [...configDefaults.exclude, "**/.claude/**"],
+    // Vitest sizes its fork pool from the CPU count. On a 24-core machine that
+    // is ~23 jsdom environments competing for one disk, and per-test work then
+    // misses the 5s default timeout — tests fail for being starved rather than
+    // wrong. Four consecutive runs of one unchanged commit gave 3, 9 and 22
+    // timeouts and then a pass, with a different set of files each time and not
+    // one assertion among them (issue #114).
+    //
+    // Capping at 4 is not a throttle. It is *faster*: the whole suite in 26s
+    // against 114s, setup 11s against 525s, because the extra workers bought
+    // contention rather than parallelism. `ubuntu-latest` gives 4 vCPU, so CI
+    // is unchanged and a local run is now the same shape as the CI run — which
+    // is what CLAUDE.md asks for when the two disagree.
+    //
+    // Raise it only with numbers. The failure mode is silent until it is loud:
+    // more workers look faster and are not, then start failing tests that are
+    // not wrong.
+    maxWorkers: 4,
     coverage: {
       provider: "v8",
       include: ["src/**/*.{ts,tsx}", "scripts/**/*.mjs"],


### PR DESCRIPTION
Closes #114

Two commits, both about the friction rather than the product. They are on one
branch rather than two because between them they are ~60 lines, and two PRs
with two CI waits would be more of exactly the thing they exist to reduce.

## 1. Cap vitest at four workers (`561f7fa`)

Vitest sizes its fork pool from the CPU count. On a 24-core machine that is
~23 jsdom environments competing for one disk, and per-test work then misses
the 5s default timeout — tests fail for being starved, not for being wrong.

**The cap makes the suite 4× faster.** It was never a throttle:

| | wall | setup | environment | result |
| --- | --- | --- | --- | --- |
| default pool (~23 workers) | 114.36s | 525.45s | 1035.19s | 22 files failed |
| **`maxWorkers: 4`** | **26.28s** | **11.11s** | **67.03s** | **61 files, 639 tests, all pass** |

The extra workers were buying contention, not parallelism.

`ubuntu-latest` gives 4 vCPU, so CI is unchanged — and a local run is now the
same shape as the CI run, which is what CLAUDE.md asks for when the two
disagree.

**Verified by repetition, which is what a flake needs rather than a test:**

```
run 1: exit=0 timeouts=0
run 2: exit=0 timeouts=0
run 3: exit=0 timeouts=0
```

Three consecutive full gate runs, all seven rows green, zero timeouts. For
contrast, the four runs on the previous branch that produced #114 gave 3, 9 and
22 timeouts and then a pass, with a different set of files each time.

This also looks like the general case of **#62**, which records `gate-scope`
timing out at 5s "under load" and blames ESLint's lazy config. `gate-scope` was
in the failing set alongside twenty-one files that have nothing to do with
ESLint. Worth deciding whether #62 closes into this.

## 2. A lane in CLAUDE.md for small changes (`d0c1c92`)

Requested after the observation that everything in this repo takes a long time.
The measurements behind that:

| | lines |
| --- | --- |
| App code (`src/`, non-test) | 5,047 |
| **Prose (`.md`)** | **8,596** |
| — of which `docs/plans/` | 5,350 across 22 files |

`docs/plans/` is larger than the application. **11 of the last 50 merges changed
no code at all**, and three of the five issues worked on 2026-08-20 were defects
in the written record rather than in the site.

Three changes, all paperwork, **none touching verification** — the gates all
still run and behaviour changes still ship with a test:

- **A small lane**, entered on three stops that must all hold: changes no
  behaviour a test could assert (copy, comments, docs) or is one file and ~20
  lines; introduces no dependency, abstraction, format or contract; contradicts
  no ADR or `CONTEXT.md`. Then: branch, do it, gate, one commit, short PR. No
  plan file, no slice table, no confirmation step. Switch lanes if a stop stops
  holding partway in.
- **Plan files scoped** to work that is hard to hold in your head — more than
  two or three slices, a decision someone will re-litigate, or work spanning
  sessions. Otherwise the issue and PR body are the record, and the plan file is
  a third copy that goes stale separately. Skipping it has to be said out loud
  in the PR body.
- **Noticing ≠ filing.** Say it in the PR body; open a tracker entry only for a
  real defect or something needing a decision. I have been filing one for every
  observation, which is how a backlog stops being a list of what to do next.

**The thresholds are guesses.** "~20 lines", "two or three slices" — I made
those up to be concrete, not because they are right. Argue with them; this half
of the PR is a draft.

## Gates

```
$ npm run gate
GATE EXIT: 0
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

## What this does not do

- **Nothing about the doc-drift coupling itself.** The plan-file rule is scoped
  going forward, but the 22 existing plan files stay. Archiving merged plans, or
  folding them into ADRs, is the larger question and not this PR's.
- **#62 not closed**, pending your call on whether it folds into #114.
- **No change to the gate table, the coverage floor, or any test.**
