### PR TITLE
Mark shipped plans historical, and stop maintaining them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,16 @@ A decision that will outlive this task (a dependency choice, a data format, a
 threading contract) also gets a short ADR in `docs/adr/`: context, decision,
 consequences. One page maximum.
 
-The plan file is the record of what was decided. Amend it with dated addenda
-when the plan changes; never rewrite history in it.
+The plan file is the record of what was decided. **While the work is in
+flight**, amend it with dated addenda when the plan changes; never rewrite
+history in it.
+
+**When the work merges, the plan stops being maintained.** Mark it historical
+in the same PR — see [`docs/plans/README.md`](docs/plans/README.md) for the
+note and the reasoning. After that it is a dated record, not a description of
+the code: it is not amended again, and it drifting from the code is expected
+rather than a defect to file. If a decision inside it is still binding, that
+decision belongs in an ADR, which is the thing that is kept current.
 
 ### 5. Split it into issues, when that earns its keep
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,10 +102,10 @@ change that reaches this lane.** Write one when the work will not finish in one
 sitting, or when it turns on a choice between approaches someone will question
 later. Both are knowable before you start; "how many slices is it" is not, and
 by the time you can count them you have already done the thinking the file was
-meant to hold. Otherwise the issue and the PR body are
-the durable record, and a plan file is a third copy of them that can go stale
-on its own — which is what `docs/plans/` currently costs: it is the largest
-body of prose in this repository and it describes code that has since moved.
+meant to hold. Otherwise the issue and the PR body are the durable record, and
+a plan file is a third copy of them that can go stale on its own — which is
+what `docs/plans/` currently costs: it is the largest body of prose in this
+repository and it describes code that has since moved.
 
 When you skip it, say so in the PR body and say why, so the omission is a
 decision rather than a lapse.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -1,0 +1,45 @@
+# Plans
+
+A plan is written **before** the work, as its own first commit, and describes
+what someone intended to build and why. Once the work ships, that intent does
+not change — but the code keeps moving, so the plan starts describing something
+that is no longer there.
+
+**That is expected, and it is not a defect.** A shipped plan is a dated record,
+like a receipt. The code is the truth about what the code does.
+
+## Every plan says which it is
+
+Each file carries a note under its title:
+
+> **Historical.** Planned 2026-08-14, shipped in PR #32 on 2026-08-14.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
+A plan still being worked carries no such note. Today every plan here is
+historical; nothing is in flight.
+
+## What that means in practice
+
+- **A historical plan is not edited again.** No addenda, no corrections, no
+  bringing it up to date. Editing it would make it neither a record of what was
+  decided nor a description of the code — the worst of both.
+- **A historical plan drifting from the code is not a bug.** Do not open an
+  issue for it. Issue #103 was exactly that: a plan naming three functions that
+  no longer existed, reported as a defect, and answered with an addendum that
+  made the file longer without making anything truer.
+- **If a decision in a plan is still binding, it belongs in an ADR.** ADRs are
+  short, few, and maintained. `docs/adr/` is where you look for what is still
+  true; `docs/plans/` is where you look for why someone once thought so.
+- **The rejected options are the part worth keeping.** That is why these files
+  are marked rather than deleted — "considered and rejected" is expensive to
+  reconstruct and is the first thing anyone re-litigates.
+
+## Writing a new one
+
+See `CLAUDE.md`. Not every change needs a plan; this directory is already the
+largest body of prose in the repository, and a plan that duplicates its issue
+and its PR body is a third copy that goes stale on its own.
+
+When your work merges, add the historical note as part of the merge, so the
+next reader knows what they are holding.

--- a/docs/plans/adr-number-gate.md
+++ b/docs/plans/adr-number-gate.md
@@ -1,5 +1,9 @@
 # A gate that each ADR number names one decision (issue #109)
 
+> **Historical.** Planned 2026-08-20, shipped in PR #110 on 2026-08-20.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Date: 2026-08-20.
 
 ## Problem, from the user's point of view

--- a/docs/plans/art-program-page-copy.md
+++ b/docs/plans/art-program-page-copy.md
@@ -1,5 +1,9 @@
 # The art page says what the classes are and what they cost
 
+> **Historical.** Planned 2026-08-19, shipped in PR #99 on 2026-08-19.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 ## Problem, from the reader's point of view
 
 A parent lands on `/art` in the weeks before the fall term. The page tells them

--- a/docs/plans/assert-built-stylesheet.md
+++ b/docs/plans/assert-built-stylesheet.md
@@ -1,5 +1,9 @@
 # Plan: a gate row that asserts the built stylesheet
 
+> **Historical.** Planned 2026-08-14, shipped in PR #32 on 2026-08-14.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Status: agreed 2026-08-14. Issue #23. Follow-up from PR #22 (issue #15).
 
 ## The problem, from the point of view of someone working here

--- a/docs/plans/charter-claim-withdrawn.md
+++ b/docs/plans/charter-claim-withdrawn.md
@@ -1,5 +1,9 @@
 # The site stops claiming charter-fund eligibility (issue #104)
 
+> **Historical.** Planned 2026-08-20, shipped in PR #112 on 2026-08-20.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Date: 2026-08-20.
 
 ## Problem, from the parent's point of view

--- a/docs/plans/coastal-air-observations.md
+++ b/docs/plans/coastal-air-observations.md
@@ -1,5 +1,9 @@
 # Air at the shore, not at the airport
 
+> **Historical.** Planned 2026-08-18, shipped in PR #82 on 2026-08-18.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Issue #80. ADR `docs/adr/0010-two-provenances-in-the-air-panel.md` records the
 decision this plan reverses.
 

--- a/docs/plans/conditions-tool.md
+++ b/docs/plans/conditions-tool.md
@@ -1,5 +1,9 @@
 # The conditions tool, built in this repo (issue #48)
 
+> **Historical.** Planned 2026-08-17, shipped in PR #49 on 2026-08-17.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Date: 2026-08-17.
 
 ## Problem, from the reader's point of view

--- a/docs/plans/design-doc-drift.md
+++ b/docs/plans/design-doc-drift.md
@@ -1,5 +1,9 @@
 # The design docs describe a site that no longer exists
 
+> **Historical.** Planned 2026-08-15, shipped in PR #43 on 2026-08-15.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Covers issues #26 (`DESIGN_BRIEF.md`) and #27 (`INFORMATION_ARCHITECTURE.md`).
 One decision applied to two documents; a shared plan is what stops them being
 resolved differently.

--- a/docs/plans/direct-test-drive-casing.md
+++ b/docs/plans/direct-test-drive-casing.md
@@ -1,5 +1,9 @@
 # Direct test scripts: normalize the cwd drive-letter casing (issue #5)
 
+> **Historical.** Planned 2026-08-12, shipped in PR #8 on 2026-08-12.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Date: 2026-08-12.
 
 ## Problem, from the user's point of view

--- a/docs/plans/gallery-aspect-rhythm.md
+++ b/docs/plans/gallery-aspect-rhythm.md
@@ -1,5 +1,9 @@
 # Gallery aspect rhythm and the two-stop grid
 
+> **Historical.** Planned 2026-08-14, shipped in PR #39 on 2026-08-14.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Issue #19. The design decisions in this file were taken with the repo owner in
 an interview on 2026-08-14; where a decision was theirs rather than derived,
 this file says so.

--- a/docs/plans/gallery-row-gutter.md
+++ b/docs/plans/gallery-row-gutter.md
@@ -1,5 +1,9 @@
 # The gallery row's gutter, and where its controls belong
 
+> **Historical.** Planned 2026-08-17, shipped in PR #46 on 2026-08-17.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Issue #45. Branch `issue-45-gallery-row-gutter`.
 
 Confirms and widens the code reading filed as #45: the row does rest past its

--- a/docs/plans/gate-command.md
+++ b/docs/plans/gate-command.md
@@ -1,5 +1,9 @@
 # Plan: one command that runs every gate
 
+> **Historical.** Planned 2026-08-11, shipped in PR #1 on 2026-08-11.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Status: agreed 2026-08-11.
 
 ## The problem, from the point of view of someone working here

--- a/docs/plans/gate-drive-casing.md
+++ b/docs/plans/gate-drive-casing.md
@@ -1,5 +1,9 @@
 # Gate hardening: normalize the cwd drive-letter casing (issue #4)
 
+> **Historical.** Planned 2026-08-12, shipped in PR #6 on 2026-08-12.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Date: 2026-08-12.
 
 ## Problem, from the user's point of view

--- a/docs/plans/ia-doc-routed-structure.md
+++ b/docs/plans/ia-doc-routed-structure.md
@@ -1,5 +1,9 @@
 # IA doc describes the routed structure
 
+> **Historical.** Planned 2026-08-14, shipped in PR #28 on 2026-08-14.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Issue: [#25](https://github.com/cweber12/wild-coast-kids/issues/25).
 
 ## Problem, from the reader's point of view

--- a/docs/plans/inventory-bounded-by-stations.md
+++ b/docs/plans/inventory-bounded-by-stations.md
@@ -1,5 +1,9 @@
 # The inventory is bounded by the stations that can serve it
 
+> **Historical.** Planned 2026-08-19, shipped in PR #89 on 2026-08-19.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 ADR `docs/adr/0011-inventory-bounded-by-station-networks.md` records the decision
 this plan implements. Relates to #86, which this plan's measurement closed as a
 no.

--- a/docs/plans/nav-pages-scaffolding.md
+++ b/docs/plans/nav-pages-scaffolding.md
@@ -1,5 +1,9 @@
 # Nav pages and scaffolding
 
+> **Historical.** Planned 2026-08-12, shipped in PR #10 on 2026-08-12.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 ## Problem, from the user's point of view
 
 Everything a visitor can reach lives on the single landing page. The nav's

--- a/docs/plans/nav-touch-targets.md
+++ b/docs/plans/nav-touch-targets.md
@@ -1,5 +1,9 @@
 # Nav touch targets
 
+> **Historical.** Planned 2026-08-14, shipped in PR #33 on 2026-08-14.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Issue: #18. Supersedes nothing; builds on `docs/adr/0003-nav-in-document-flow.md`.
 
 ## Problem, from the user's point of view

--- a/docs/plans/scope-gates-to-this-checkout.md
+++ b/docs/plans/scope-gates-to-this-checkout.md
@@ -1,5 +1,9 @@
 # Plan: keep the gates inside this checkout
 
+> **Historical.** Planned 2026-08-14, shipped in PR #34 on 2026-08-14.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Status: agreed 2026-08-14. Issues #31 and #29 (the same defect, filed twice).
 
 ## The problem, from the point of view of someone working here

--- a/docs/plans/section-snapping.md
+++ b/docs/plans/section-snapping.md
@@ -1,5 +1,9 @@
 # Landing page section snapping
 
+> **Historical.** Planned 2026-08-13, shipped in PR #14 on 2026-08-13.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 ## Problem, from the user's point of view
 
 The landing page is six self-contained pieces of content read as one long

--- a/docs/plans/session-schedule-from-supabase.md
+++ b/docs/plans/session-schedule-from-supabase.md
@@ -1,5 +1,9 @@
 # The session schedule comes from Supabase
 
+> **Historical.** Planned 2026-08-18, shipped in PR #79 on 2026-08-18.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Issue: [#74](https://github.com/cweber12/wild-coast-kids/issues/74).
 
 ## Problem, from the reader's point of view

--- a/docs/plans/shared-module-deepening.md
+++ b/docs/plans/shared-module-deepening.md
@@ -1,5 +1,9 @@
 # Shared module deepening
 
+> **Historical.** Planned 2026-08-12, shipped in PR #12 on 2026-08-13.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 ## Problem, from the user's point of view
 
 Two things a visitor meets today are wrong, and both come from one cause:

--- a/docs/plans/stop-height-threshold.md
+++ b/docs/plans/stop-height-threshold.md
@@ -1,5 +1,9 @@
 # Landing page stops: a height threshold
 
+> **Historical.** Planned 2026-08-15, shipped in PR #41 on 2026-08-15.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 Status: agreed 2026-08-15. Issue #37. Follow-up from `section-snapping.md`,
 which designed the stops against a window nobody re-measured.
 

--- a/docs/plans/wild-coast-kids-landing.md
+++ b/docs/plans/wild-coast-kids-landing.md
@@ -1,5 +1,9 @@
 # Wild Coast Kids landing page
 
+> **Historical.** Planned 2026-08-11, shipped in PR #3 on 2026-08-12.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
 ## Problem, from the user's point of view
 
 A homeschool parent who hears about Wild Coast Kids has nowhere to look it up.


### PR DESCRIPTION
The archiving change, as discussed. `docs/plans/` is the largest body of prose
in the repository and it describes code that has since moved.

**The problem is not that the plans are stale.** It is that a shipped plan and a
live one sit in the same directory in the same format, so a reader cannot tell
which they are holding. #103 was exactly that: a shipped plan naming three
functions that no longer existed, reported as a defect, answered with an
addendum that made the file longer without making anything truer.

## What changed

**1. Every plan carries a note under its title.**

```
# Plan: one command that runs every gate

> **Historical.** Planned 2026-08-11, shipped in PR #1 on 2026-08-11.
> It records what was intended then, not what the code does now, and is not
> maintained. See [`README.md`](README.md).
```

Inserted after the H1 rather than replacing anything, because the existing
headers come in four different shapes (`Status:`, `Date:`, `Issue:`, and none
at all).

**2. `docs/plans/README.md`** carries the convention: a historical plan is not
edited again, its drift is not a bug worth filing, and a decision still binding
belongs in an ADR — the thing that *is* kept current. The rejected options are
why these are marked rather than deleted; "considered and rejected" is expensive
to reconstruct and is the first thing anyone re-litigates.

**3. CLAUDE.md's addenda rule now applies only while work is in flight.** It
previously said to amend a plan with dated addenda whenever the plan changes,
with no end date. Now the plan stops being maintained when the work merges.

## The PR numbers are derived, not typed

For each plan: the commit that added it, then the first merge on `main`
containing that commit. 20 of 22 resolved that way.

The other two landed by **rebase**, so no merge commit contains them. Found via
`gh pr list --search` and verified with `gh pr view --json files` that each PR
actually touches that plan file:

- `assert-built-stylesheet` → PR #32 "Assert the built stylesheet in a gate row"
- `nav-touch-targets` → PR #33 "Bring the nav's touch targets to 44px below md"

Those two are the only hand-entered values, and they are commented as such in
the script.

## All 22 are historical, and I checked the one that looked otherwise

Nothing is in flight — the only open PR is #117, which has no plan file.

`nav-touch-targets` looked like a live plan because issue **#30** is still open
about `PillLink` being ~41px. It is not: that plan's _Out of scope_ says
"**`PillLink`'s ~41px** … Filed separately", which is #30. The plan shipped
exactly as written.

## Gates

```
$ npm run gate
GATE EXIT: 0
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

The first attempt failed on `gate-scope`'s ESLint hook timing out at 60s —
**issue #62, the flake #117 fixes.** Zero timeouts elsewhere, 636 tests passed,
only the suite's `beforeAll` hook died. A capped run isolates it cleanly:

```
$ npx vitest run --coverage --maxWorkers=4
 Test Files  61 passed (61)
      Tests  639 passed (639)
   Duration  29.50s (… environment 65.88s)
```

against `environment 879s` on the uncapped run that failed. That is #117's
diagnosis reproducing on a branch that does not have its fix.

## Order of merging

**Merge #117 first.** Both PRs edit `CLAUDE.md` — #117 near the top of step 4,
this one at the bottom — so whichever lands second may want a trivial rebase. I
kept them apart deliberately, but they are adjacent.

More practically, #117 is what stops the gate flaking, and this branch just
spent two gate runs demonstrating why that matters.

## What this does not do

- **No plan is deleted or moved.** Marked, not archived into a subdirectory —
  the header is what stops the misreading; a directory move is cosmetic on top.
- **Nothing about `.design/`.** DESIGN_BRIEF and INFORMATION_ARCHITECTURE are
  live specs that genuinely must stay current, so "mark it historical" is not
  available to them. Two of the three open `documentation` issues are those
  files (#52, #78). That is the harder half and it is untouched here.
- **No existing addenda removed.** The ones already written stay; they are part
  of the record now.
