### PR TITLE
Give PillLink the 44px touch target below md

### DIFF
--- a/docs/adr/0004-touch-target-sizes.md
+++ b/docs/adr/0004-touch-target-sizes.md
@@ -83,3 +83,9 @@ preference is the part most likely to be re-litigated.
 about 41px, across eleven call sites (issue #30). The standard is adopted
 knowing one shared component already violates it, rather than being narrowed
 until everything passes.
+
+_2026-08-23: that exception is closed. `PillLink` composes the shared floor
+with `md:min-h-0`, under the visible-shape clause above, and `TONES` is
+unchanged (issue #30). The paragraph stands as written because it records the
+trade that was made on adoption, not the state of the code today. The decision
+is unamended._

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,11 +1,12 @@
 import { NavLink } from "./NavLink";
 import { Placeholder } from "./Placeholder";
+import { TOUCH_TARGET } from "./touchTarget";
 
-// 44px, per ADR-0004. Named once and composed by every interactive element in
-// the bar, because the failure this repo has is drift -- a link added later
-// without it -- and one name is one place to be wrong. The gate can assert
-// that an element refers to this; it cannot assert the rendered box (ADR-0001).
-const TOUCH_TARGET = "flex min-h-11 items-center";
+// Every interactive element in the bar composes the shared floor, because the
+// failure this repo has is drift -- a link added later without it. The
+// constant carries the number only; `flex items-center` is the nav's own
+// layout, and PillLink needs a different one. See touchTarget.ts.
+const NAV_TARGET = `${TOUCH_TARGET} flex items-center`;
 
 const SECTION_LINKS = [
   { href: "/art", label: "Art Classes" },
@@ -46,7 +47,7 @@ export function Nav() {
           <NavLink
             key={href}
             href={href}
-            className={`${TOUCH_TARGET} group px-1.5 text-[9px] font-extrabold tracking-wider whitespace-nowrap text-dark uppercase md:px-0 md:text-2xs`}
+            className={`${NAV_TARGET} group px-1.5 text-[9px] font-extrabold tracking-wider whitespace-nowrap text-dark uppercase md:px-0 md:text-2xs`}
           >
             <span className="border-b-2 border-transparent pb-0.5 transition-colors duration-fast group-hover:border-yellow group-aria-[current=page]:border-yellow">
               {label}
@@ -60,7 +61,7 @@ export function Nav() {
           floor (ADR-0004). */}
       <NavLink
         href="/book"
-        className={`${TOUCH_TARGET} rounded-pill shrink-0 bg-yellow px-3.5 text-2xs font-black tracking-[0.06em] whitespace-nowrap text-ink md:min-h-0 md:px-5.5 md:py-2.25 md:text-xs`}
+        className={`${NAV_TARGET} rounded-pill shrink-0 bg-yellow px-3.5 text-2xs font-black tracking-[0.06em] whitespace-nowrap text-ink md:min-h-0 md:px-5.5 md:py-2.25 md:text-xs`}
       >
         Book Now →
       </NavLink>

--- a/src/components/PillLink.test.tsx
+++ b/src/components/PillLink.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { PillLink } from "./PillLink";
+import { TOUCH_TARGET } from "./touchTarget";
 
 test("the destination reaches the rendered link", () => {
   render(
@@ -69,4 +70,34 @@ test("every pill shares one geometry", () => {
   // 2px narrower each side, so the border lands the outer box in the same
   // place as the solid pill's.
   expect(outline("link").className).toContain("px-6.5 py-2.75");
+});
+
+test("every pill clears the touch-target floor below md, and only below md", () => {
+  // ADR-0004: 44px on touch. text-sm carries no paired line-height, so the
+  // padding in TONES came to ~41px on its own (#30). The floor is asserted on
+  // both kinds of tone because the solid and outline paddings differ -- the
+  // shared min-height is what lands them on the same outer box, so a tone
+  // that lost it would break the pairing the test above exists to hold.
+  //
+  // md:min-h-0 is half the contract, not a detail: the pill is a visible
+  // shape, and 44px at md would grow the capsule on desktop compositions
+  // that are finished. Asserting it is what stops the fix spreading upward.
+  //
+  // Per ADR-0001 jsdom applies no stylesheets, so this proves the class is
+  // referenced, not that the box measures 44px. That stays a human check.
+  for (const tone of ["yellow", "outline-light"] as const) {
+    const { getByRole, unmount } = render(
+      <PillLink href="/book" tone={tone}>
+        {tone}
+      </PillLink>,
+    );
+
+    expect(getByRole("link").className).toContain(TOUCH_TARGET);
+    expect(getByRole("link").className).toContain("md:min-h-0");
+    // inline-flex, not the nav's flex: three call sites put a pill in a bare
+    // block container, where a block-level box would fill the width and stop
+    // being a pill at all.
+    expect(getByRole("link").className).toContain("inline-flex items-center");
+    unmount();
+  }
 });

--- a/src/components/PillLink.tsx
+++ b/src/components/PillLink.tsx
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 
+import { TOUCH_TARGET } from "./touchTarget";
+
 export type PillTone =
   "yellow" | "purple" | "ocean" | "outline-light" | "outline-dark";
 
@@ -41,7 +43,16 @@ export function PillLink({ href, tone, children }: PillLinkProps) {
   return (
     <Link
       href={href}
-      className={`rounded-pill inline-block text-sm ${TONES[tone]}`}
+      // The 44px floor below md (ADR-0004): text-sm carries no paired
+      // line-height, so the capsule measured 43.14px solid and 42.34px
+      // outline in Chrome -- both under the floor. min-h takes both to
+      // exactly 44 there without touching TONES, because the box is
+      // border-box; above md they keep the heights they already had.
+      // md:min-h-0 because the pill is a visible shape, not just a hit area:
+      // growing it above md is a redesign, and it already clears the 24px
+      // pointer floor. inline-flex, not the nav's flex, keeps the pill
+      // inline-level; items-center centres the label in the taller box.
+      className={`rounded-pill ${TOUCH_TARGET} inline-flex items-center text-sm md:min-h-0 ${TONES[tone]}`}
     >
       {children}
     </Link>

--- a/src/components/touchTarget.ts
+++ b/src/components/touchTarget.ts
@@ -1,0 +1,19 @@
+/**
+ * 44px, per ADR-0004: the touch-target floor below `md`.
+ *
+ * The number, and nothing else. The failure this repo has is drift -- an
+ * interactive element added later without the floor -- and one name is one
+ * place to be wrong. Display stays with the caller because it is genuinely
+ * per-context: a nav link is a `flex` row item, a pill is `inline-flex` and
+ * has to stay inline-level or it fills its container. A constant carrying
+ * `flex` could not serve both, and spelling the number twice to serve the
+ * second is the drift this exists to stop.
+ *
+ * Composing it does not prove the rendered box is 44px -- jsdom applies no
+ * stylesheets (ADR-0001) -- so tests assert that an element refers to the
+ * standard, and a human confirms it holds.
+ *
+ * Elements that are a visible shape add `md:min-h-0`: growing them above `md`
+ * is a redesign, and they already clear the 24px pointer floor there.
+ */
+export const TOUCH_TARGET = "min-h-11";


### PR DESCRIPTION
Closes #30.

`PillLink` rendered under ADR-0004's 44px touch floor below `md`. Three slices: share the number, apply it, close the ADR's record of the exception.

## What changed

**1. `Narrow TOUCH_TARGET to the number and share it`** — `TOUCH_TARGET` was `"flex min-h-11 items-center"`, private to `Nav.tsx`. It becomes `"min-h-11"` in a new `src/components/touchTarget.ts`; `Nav` composes `${TOUCH_TARGET} flex items-center` locally. Answering the issue's (a)/(b) question with (a), reasoning in [this comment](https://github.com/cweber12/wild-coast-kids/issues/30#issuecomment-5388618553). Pure refactor: no rendered class list changes, which is why `Nav.test.tsx`'s "every target carries the 44px touch target" stays green untouched.

It needed a home outside `Nav.tsx` — `PillLink` importing from `Nav` inverts the dependency, since `PillLink` is a leaf used by eleven sites and `Nav` does not use it. That new module is the one new abstraction here.

**2. `Give PillLink the 44px touch target below md`** — `inline-block` → `${TOUCH_TARGET} inline-flex items-center md:min-h-0`. `TONES` untouched. None of the eleven call sites change.

**3. `Close ADR-0004's PillLink exception`** — its last paragraph said in the present tense that `PillLink` violates the standard. One dated line appended; the paragraph itself stays, because "adopted knowing one shared component already violates it" records the trade made on 2026-08-14 and stays true. No Status-line change — unlike ADR-0011's amendment, nothing about this decision changed.

## The issue's measurement was off by ~1.3px

Measured in Chrome, not derived: the pre-fix capsule is **43.14px** (solid) and **42.34px** (outline), not the ~41px the issue and ADR-0004 both cite. The issue assumed Montserrat's normal line-height gives ~14.6px of text box at 12px; measured it is ~16.34px. The direction is unchanged — `--text-sm` has no paired `--text-sm--line-height`, the fallback is what makes the capsule short, and it lands under 44 — so the fix is the same. Only the number was wrong. The code comment and commit message carry the measured figures.

## Measured before/after

`next start` on this branch, driven in Chrome. Widths are real viewports via a same-origin iframe — `resize_window` cannot shrink a maximised window. The "before" state restores the exact pre-fix class list, plus the `.inline-block{display:inline-block}` rule by hand: this build no longer emits it (nothing in `src/` uses that class any more), and without it the probe silently fell back to `display:inline`, where `min-height` does not apply at all. First run of this measurement was wrong for exactly that reason.

**At `md` and above — every delta is zero.**

| width | pill heights | 11 section heights | document height |
|---|---|---|---|
| 768px | identical | identical | 3826 → 3826 |
| 1536px | identical | identical | 4980 → 4980 |

`md:min-h-0` computes to `0px` at both, confirmed directly.

**At 375px — all eight landing-page pills reach exactly 44.00px.**

| tone | before | after | delta |
|---|---|---|---|
| solid (`py-3.25`) | 43.14px | 44.00px | +0.86 |
| outline (`py-2.75` + 2px border) | 42.34px | 44.00px | +1.66 |

Section growth 1.6–2.6px; whole document 4905 → 4911 (+6px). The other three call sites, at 375px / 1536px: `/art` 43.14 → 44.00 / unchanged, `/book` 43.14 → 44.00 / unchanged, `/coop` 43.14 → 44.00 / unchanged.

Pill **widths are identical** at every width, so nothing re-wraps. The hero CTA row and the program-card rows already wrapped to two lines at 375px on `main`; that is unchanged.

A side effect worth naming: below `md` the two tones now land on *exactly* the same outer box (44.00 = 44.00), where on `main` they were 0.8px apart.

## Gate

Run at this HEAD, after `rm -rf .next` (a stale build cache hides Tailwind source changes):

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

The new test was confirmed red against the unfixed component before being made green:

```
FAIL  src/components/PillLink.test.tsx > every pill clears the touch-target floor below md, and only below md
AssertionError: expected 'rounded-pill inline-block text-sm bg-…' to contain 'min-h-11'

Expected: "min-h-11"
Received: "rounded-pill inline-block text-sm bg-yellow px-7 py-3.25 font-black text-ink"
```

The four existing `PillLink` tests stayed green in that run — including the `px-7 py-3.25` / `px-6.5 py-2.75` assertions, which is the evidence this leaves the solid/outline pairing alone.

## Still needs a human

Whether a 44px capsule **sits right** at 375px in the hero's wrapped CTA row and on the program cards. The numbers above say nothing moved that shouldn't; they cannot say the composition still reads well. Issue stays `needs-human` and I have not merged.

## Not done, and why

- **No plan file.** The issue body already holds the problem, the seam, the rejected alternatives and the out-of-scope list; a `docs/plans/` file would be a third copy that can go stale on its own.
- **Dropped `justify-center`** from the issue's prescribed `inline-flex items-center justify-center`. All eleven parents leave the pill shrink-to-fit, so there is never free space on the main axis and the rule could never apply. Confirmed by measurement: pill widths are content-sized at every viewport.
- **Out of scope, untouched:** anything at `md` and above, a size axis or `className` escape hatch on `PillLink`, the interest-list form's controls.

## Noticed, not filed

`PillLink`'s `TONES` doc comment says the solid and outline paddings are set "so their outer boxes match". Above `md` they do not quite — 43.14px vs 42.34px, ~0.8px apart, because `font-black` and `font-bold` resolve to faces with different metrics. Pre-existing, unchanged by this PR, and invisible at these sizes. Mentioning it rather than opening a row for it.
