### PR TITLE
Give each conditions reading a card, and say the shared explanation once

### DIFF
--- a/.design/conditions-page/.gitignore
+++ b/.design/conditions-page/.gitignore
@@ -1,0 +1,1 @@
+screenshots/

--- a/.design/conditions-page/DESIGN_BRIEF.md
+++ b/.design/conditions-page/DESIGN_BRIEF.md
@@ -1,0 +1,314 @@
+# Design Brief: The Conditions Page
+
+Date: 2026-08-24. Feature slug: `conditions-page`.
+
+Covers `/conditions` and `/conditions/[slug]`, which render one section and must
+not drift apart.
+
+**There is no `INFORMATION_ARCHITECTURE.md` in this folder, on purpose.**
+`.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md` is the site's
+single canonical URL-structure document despite its folder name, and this work's
+IA was written into it rather than beside it — closing the `/conditions/<slug>`
+gap filed as #78 in the same pass. A second document defining URL structure is
+the exact drift this repo has already corrected twice, in PR #28 and PR #43.
+
+## Problem
+
+A parent leading a co-op outing decides on Thursday where to take eight children
+on Tuesday. `/conditions` already knows most of what they need — today's lowest
+tide, the swell, the air temperature, the wind, the visibility, and where each
+of those was measured. The information is there and it is honest.
+
+They cannot read it.
+
+Everything on the page is a single 520px column pinned to the left edge, so on
+an ordinary laptop the page uses about a third of its width and leaves the rest
+blank. The numbers that matter are separated from each other by paragraphs of
+10px fine print, so nothing can be compared at a glance — the tide time and the
+wave height are three screens apart in reading order and never appear together.
+The secondary readings are worse off still: wind speed, gust, sky, visibility,
+water temperature and swell period are all dissolved into prose sentences, so
+learning the wind speed means reading a paragraph. Six real measurements are
+invisible because they were written as sentences instead of shown as numbers.
+
+And the page does not look like the site it belongs to. Every other surface
+here is loud — electric yellow, deep purple, ocean blue, heavy black italics,
+rounded cards, big playful glyphs. This one is grey text on cream, no surface,
+no colour, no shape. A parent arriving from the landing page's bright ocean-blue
+teaser lands somewhere that reads like a government form.
+
+The result is that a page built on genuinely careful work — every figure
+attributed, every station named, every distance disclosed — reads as plain and
+secondary, and the honesty that is its whole point reads as clutter.
+
+## Solution
+
+The same information, given the shape it always wanted.
+
+The reader arrives and sees what the page is for and which beach they are
+looking at, side by side, at the top. Immediately beneath, **three cards across
+the full width** answer the question they came with: the lowest tide today, the
+waves and water, the air. Each leads with one big number, says what it means in
+plain words, and then shows its supporting measurements **as labelled figures
+rather than buried in a sentence** — wind and gust here, sky and visibility
+there, each group naming the station that supplied it.
+
+Below that, the page turns from _now_ to _planning_. A **week grid** — days
+across, products down — answers the Thursday-planning-for-Tuesday question that
+today's single reading cannot. It opens with a week of low tides — the same NOAA
+prediction the page already asks for, over a wider window. Rows for the forecasts
+that need new upstream work are labelled slots saying what lands there.
+
+Beside the week, a labelled slot for the **sighting map**: what people have
+actually found near this beach lately. Specified in full and deferred — the
+decisions are recorded in issue #121, and the slot names what is coming.
+
+Finally, in one place rather than repeated three times, the page explains
+itself: what mean lower low water is, why a buoy reading is not the wave at the
+shore, why visibility comes from an airport, what this site does not cover, and
+the standing sentence that none of this is a safety assessment.
+
+Nothing is removed. The honesty layer is not reduced — it is **collected**, so
+it can be read rather than skimmed past, and so the numbers it qualifies can be
+seen.
+
+## Experience Principles
+
+1. **A reading is data; an explanation is prose. They want different widths.**
+   The current page fails because one 520px column serves both, and the prose
+   measure — correct for prose — is what constrains the numbers. Resolving this
+   is what fills the page: figures get cards and grids that genuinely want full
+   width, explanations keep their readable measure. Neither is stretched to fill
+   space; both are finally the shape they were.
+
+2. **Attribution beside the figure, explanation in one place.**
+   The tension is between honesty and legibility, and this page has been
+   resolving it by repeating itself. `TideToday` already argues the right
+   answer — _"the acronym is named once, at the bottom, rather than beside every
+   figure"_ — and then the page does that three separate times. So: which station
+   supplied which number stays visible on the card, because ADR-0010 requires a
+   reader be able to tell. Everything general moves to one block. More honest,
+   not less: given its own space, the safety framing can actually be read
+   instead of being a fragment in 10px type.
+
+3. **Emoji mark categories, never sentences.**
+   The site already has this discipline — `ProgramCards` pairs 🎨 🌿 🌊 📓 🔬 with
+   text labels, always hidden from assistive technology, never in body copy. The
+   tension is that emoji make a page feel alive and also make it feel cheap, and
+   the line between is whether they carry information. So they head cards, label
+   week-grid rows and, later, mark sightings on the map. They do not decorate the
+   `<h1>`, the lead paragraph or the caveats. This also protects the map: a glyph
+   means something specific on this page, so a 🐙 on a coastline reads as an
+   octopus rather than as ornament.
+
+## Aesthetic Direction
+
+- **Philosophy**: **Coastal pop editorial**, inherited unchanged from the landing
+  page — heavy italic Montserrat up to weight 900, electric yellow against deep
+  purple and ocean blue, pill shapes, rounded cards, generous glyphs. Kid-brand
+  energy with print-zine discipline. This page has never expressed it; the work
+  is bringing it into the system, not creating a second one.
+- **The instrument-panel restraint that has to survive it.** This page reports
+  measurements to people taking children into the ocean. Loud is right for
+  chrome — headers, surfaces, glyphs, the week grid's rhythm. It is wrong for
+  the figures themselves, which stay factual and unembellished. Nothing on this
+  page may look like a verdict, a rating or a recommendation, because ADR-0009
+  forbids the site from making one. **A green card would be a lie told in CSS.**
+- **Tone**: Confident and useful. Warm at the edges, exact in the middle. The
+  voice of a local who knows the coast and tells you what the instruments say,
+  including when they say nothing.
+- **Reference points**: The site's own `ProgramCards` — big glyph, bold heading,
+  labelled badges, a real surface. Tide tables and almanacs for the week grid's
+  density. Field-guide plates for the eventual sighting map.
+- **Anti-references**: Surf-report apps, which lead with a computed verdict this
+  site refuses to make. Weather dashboards with gauge widgets and animated
+  gradients. Government data portals — which is what this page currently
+  resembles, and the specific thing being fixed. Anything beige, and anything
+  that implies a rating.
+
+## Existing Patterns
+
+The design system exists and is canonical. This brief extends it and defines no
+new system.
+
+- **Typography**: Montserrat via `next/font/google`, weights 400–900 with
+  italics, loaded once in the root layout as `--font-montserrat`. One family;
+  weight and italics carry all hierarchy. Sizes are tokens: `--text-2xs` 10px
+  through `--text-base` 13px, plus `--text-stat` 36px and the fluid `--text-title`
+  / `--text-card` clamps. Sub-16px body sizes are the template's editorial voice
+  and are kept on purpose.
+- **Colors**: One fixed art-directed palette, no dark mode, by decision. Purple,
+  ocean, pink, yellow, cream, dark, ink, lavender, mist, fog. `--color-fog` is
+  already darkened from the template to clear 5:1 contrast. `--color-pink` and
+  `bg-lavender` have zero uses anywhere in the codebase. **This page does not
+  claim pink.** It was raised as available and the answer was no for now — the
+  colour may be given a role later, by direction rather than by whichever page
+  reaches for it first. An unused palette entry is not an unclaimed one.
+- **Spacing**: `--spacing-gutter` 48px / `--spacing-gutter-sm` 24px,
+  `--spacing-section` 80px / `--spacing-section-sm` 60px. Radii `--radius-tile`
+  12px through `--radius-pill` 99px. `--shadow-card` exists and is barely used.
+- **Components**: `ReservedSlot` (dashed frame, emoji, "coming soon" copy — the
+  standing idiom for decided-but-unbuilt), `PillLink` (five tones, closed list),
+  `Caveats`, `BeachSelector`, the three `*Today` presentational components and
+  their three thin `*Panel` seams.
+- **Conventions that constrain this work**:
+  - **Stops do not apply.** `/conditions` is a routed page; it scrolls normally
+    and has no 540px budget. Only the landing page snaps.
+  - **`TOUCH_TARGET` is `min-h-11`**, 44px below `md` per ADR-0004. Every
+    interactive element composes it.
+  - **Small screens swipe, large screens grid** — stated in `globals.css` and
+    already how the gallery row behaves. The week grid follows it.
+  - **Tailwind source detection is opt-in and scoped to `src/`** (ADR-0006), so
+    a class named in this file compiles nothing. That is deliberate.
+  - **Nothing throws; failures degrade with their reason** (ADR-0013, and the
+    conditions upstream module). Four states stay visibly distinct.
+
+## Component Inventory
+
+| Component                             | Status        | Notes                                                                                                                                                                                                                                                                             |
+| ------------------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ConditionsSection`                   | **Modify**    | The whole restructure lands here: header row, now-band, week grid, map slot, explanation block                                                                                                                                                                                    |
+| `BeachSelector`                       | **Modify**    | Moves into the header row, right-aligned; label promoted from a whisper; pill shape and `noscript` fallback both kept                                                                                                                                                             |
+| `ReadingCard`                         | **New**       | Shared shell for the three now-cards — emoji header, lead figure, plain-language line, stat groups, attribution. Shared rather than three call sites, for the reason `ReservedSlot`'s docstring already gives: the shape is what drifted when six call sites each wrote their own |
+| `StatGroup`                           | **New**       | Labelled figure pairs as a `<dl>`. **Groups by provenance**, so values from two stations can never render as one set                                                                                                                                                              |
+| `ProvenanceLine`                      | **New**       | The one visible attribution line: station · network · distance                                                                                                                                                                                                                    |
+| `TideToday`                           | **Modify**    | Adopts `ReadingCard`; keeps all four states and the height sentence                                                                                                                                                                                                               |
+| `WavesToday`                          | **Modify**    | Adopts `ReadingCard`; period and water temp become stats; keeps `heightWords`                                                                                                                                                                                                     |
+| `WindToday`                           | **Modify**    | Adopts `ReadingCard`; wind/gust and sky/visibility become **two** stat groups with **two** attributions, per ADR-0010                                                                                                                                                             |
+| `TidePanel`, `WavePanel`, `WindPanel` | **Unchanged** | Deliberately the thinnest things in the tree: read, render                                                                                                                                                                                                                        |
+| `WeekGrid`                            | **New**       | Days across, products down. Tolerates ragged row lengths; a product with no forecast is absent, not blank                                                                                                                                                                         |
+| `TideWeek`                            | **New**       | The first live row: a week of lowest lows                                                                                                                                                                                                                                         |
+| `ConditionsNotes`                     | **New**       | The consolidated explanation block — datum, buoy distance, airport visibility, the standing safety sentence                                                                                                                                                                       |
+| `Caveats`                             | **Modify**    | Moves inside `ConditionsNotes`; disclosures and the gate-enforced `unresolved` rendering unchanged                                                                                                                                                                                |
+| `ReservedSlot`                        | **Reused**    | Map slot and forecast-row slots. No change to the component                                                                                                                                                                                                                       |
+| `PillLink`                            | **Reused**    | Links out to authorities in the notes block                                                                                                                                                                                                                                       |
+
+**Library work**: `lib/conditions.ts` gains a read returning a week of lowest
+lows. This **widens the existing CO-OPS request** — today's call asks for
+`nowMs − 1 day` to `nowMs + 1 day`, a three-day window sized so "today" survives
+the timezone boundary, so a week is not already in hand. Same endpoint, same
+parser, same six-hour cache, `endDate` moved out. The day read and the week read
+**share that one request**: separate ranges would mean separate URLs, which Next
+would not dedupe, so the page would make two NOAA calls where it makes one
+today. No new upstream product and no new dependency.
+
+## Key Interactions
+
+**Choosing a beach.** The reader picks from the selector in the header. The
+route changes to `/conditions/<slug>`, and every panel re-reads for that beach.
+Each panel has its own suspense boundary and its own fallback sentence, so a
+slow buoy never holds up the tide time — three agencies, three failure modes.
+The `noscript` list of plain links remains the fallback; a phone with blocked
+scripts must not get a control that silently does nothing.
+
+**Reading a card.** Static. The lead figure, the plain-language line and the
+stat groups are all present without interaction. Nothing important is behind a
+hover, a tooltip or a tap.
+
+**Opening a disclosure.** Failure detail, the reasons a station is missing, the
+excluded-beach list and the unresolved-data list stay in `<details>`. That is
+the existing compromise that lets the caveat list be comprehensive without
+burying the reading, and it does not change.
+
+**A missing reading.** Renders its sentence, never a blank and never a zero.
+The four states stay distinct: a reading, a gap in our request, no station will
+ever exist here, and the station could not be reached just now. The middle two
+look alike and are the two most worth separating.
+
+**Reading the week on a phone.** The grid **transposes rather than scrolls**. At
+`lg` and up each day is a column, seven across. Below that each day is a row,
+seven down. The DOM is **day-major** and identical at every width; only
+`grid-template-columns` changes, so ADR-0005's render-twice rule is not invoked
+and does not need to be.
+
+This deliberately departs from the _"small screens swipe and large screens
+grid"_ line in `globals.css`, and the departure is reasoned rather than
+accidental. That convention was written about the **gallery** — images, where
+swiping is natural — and about the 768–1023 band where the program cards' pills
+wrap. It is not a site-wide law about every grid. A seven-day forecast is a
+**comparison task with few items**, and hidden content is the specific cost that
+matters: a parent planning Tuesday must be able to _see_ Tuesday, not discover
+a scroll affordance concealing it. This is also why weather products
+conventionally scroll hourly data horizontally and list daily data vertically.
+
+Day-major order is additionally the correct screen-reader sequence — _"Monday,
+low tide 6:42 am. Tuesday, low tide 7:20 am"_ — which product-major order would
+not give.
+
+## Responsive Behavior
+
+| Band  | Header row                                         | Now-band         | Week grid                     |
+| ----- | -------------------------------------------------- | ---------------- | ----------------------------- |
+| base  | stacked: `h1`, then lead, then selector full-width | one card per row | seven day-rows, stacked       |
+| `sm`  | stacked                                            | two cards        | seven day-rows                |
+| `md`  | `h1` left, selector right                          | two cards        | seven day-rows                |
+| `lg`+ | `h1` left, selector right                          | three across     | seven day-columns, full width |
+
+Prose blocks — the lead paragraph and the notes block — hold `max-w-130` at
+every width. That cap is correct for reading and is not what was wrong; it was
+wrong only where it constrained figures.
+
+The first screen is designed against a **555px** budget: a 1536×639 viewport at
+125% scaling, less the 84px nav, which is the review machine this repo is
+actually checked on. Moving the selector into the header row reclaims roughly
+103px, which is what puts the now-band above that fold instead of below it. The
+budget is a target for the composition, not a gate — the page scrolls, and
+content that does not fit is arranged, never removed.
+
+## Accessibility Requirements
+
+- **Contrast**: every text/surface pair clears **WCAG AA**, 4.5:1 for body and
+  3:1 for large text. `--color-fog` is already tuned for this and clears 5:1 on
+  mist. Any new surface — including a pink or lavender accent — is checked
+  before it ships, not after.
+- **Emoji are never the only carrier of meaning.** Every glyph is
+  `aria-hidden="true"` with a real text label beside it. A screen reader hears
+  "Waves and water," never "wave emoji."
+- **Stat pairs are a description list.** `<dl>`/`<dt>`/`<dd>`, so the
+  label-to-value relationship is structural rather than visual. This is what
+  makes the two-provenance grouping survive for a non-visual reader, which is
+  precisely what ADR-0010 is protecting.
+- **Headings stay a real outline**: one `<h1>`, an `<h2>` per card and per
+  region, nothing skipped. Each card region keeps its `aria-labelledby`.
+- **Keyboard**: the selector is a native `<select>` and stays one. The week grid
+  transposes rather than scrolls, so it introduces no scroll container and needs
+  no focus stop of its own — one of the reasons that decision is the better one.
+  Nothing on this page is reachable only by pointer.
+- **The caveats chain is already asserted end to end**, and the restructure must
+  keep it green rather than add to it: `lib/caveats.test.ts` binds every
+  `unresolved` entry in every data file to `inventoryCaveats()` in both
+  directions, and `ConditionsSection.test.tsx` asserts every entry it returns
+  reaches the rendered page. Moving `Caveats` inside `ConditionsNotes` is safe
+  because the second test would fail if any caveat stopped rendering.
+- **Touch targets**: `TOUCH_TARGET` on every interactive element below `md`, per
+  ADR-0004. The enlarged selector is the main one.
+- **Motion**: none added. No animated gauges, no counting-up numbers, no
+  transitions carrying meaning.
+- **The `noscript` beach list survives the redesign.** It is not decoration; it
+  is the whole control for a reader without JavaScript.
+
+## Out of Scope
+
+- **The sighting map itself.** Fully specified in **issue #121** and deliberately
+  deferred at the author's request; a `ReservedSlot` ships in its place. This
+  brief covers the slot and the space it occupies, not the map.
+- **Forecast rows needing new upstream work** — gridded NWS temperature, wind and
+  sky (issue #95), and the surf zone forecast. The week grid ships with the tide
+  row live and labelled slots for these. Building them is separate work.
+- **Any computed verdict**: no safety rating, no "good tidepooling today," no
+  best-beach ranking, no colour that encodes a judgement. ADR-0009 governs.
+- **New upstream products, new dependencies, and any map library.** The week's
+  tide row widens a request this page already makes, to the same endpoint with
+  the same parser and the same cache.
+- **The landing-page conditions teaser.** It sits in a 540px stop with its own
+  budget and its own reserved slot. _Noted while working here, not fixed here:_
+  that slot's copy says "Surf, wind and visibility are still to come," which
+  shipped before waves and air did and is now stale.
+- **Dark mode.** One fixed art-directed palette, by decision.
+- **Water quality, marine protected areas, active alerts** — later slices of
+  `docs/plans/conditions-tool.md`.
+- **The `/conditions/[slug]` information-architecture gap** (issue #78). The IA
+  phase that follows this brief may close it; this brief does not.
+- **Changing what any reading means.** No thresholds move, no wording of a
+  measurement changes, no station binding is touched. This is a presentation
+  change over a data layer that is already correct.

--- a/.design/conditions-page/DESIGN_BRIEF.md
+++ b/.design/conditions-page/DESIGN_BRIEF.md
@@ -101,6 +101,15 @@ seen.
    means something specific on this page, so a 🐙 on a coastline reads as an
    octopus rather than as ornament.
 
+   **The animal vocabulary is reserved for sightings, and the panels take
+   environmental glyphs.** 🌊 tide, 🏄 waves and water, 🌡️ air. The tide card was
+   built with 🐚 and it was the wrong call twice over: it renders pale lavender on
+   a pale lavender surface, and more importantly a shell reads as something a
+   child finds, on a page where finding things is about to be what an animal
+   glyph means. #121's roster commits 🐙 🦀 🪸 🐌 ⭐ 🦭 🦈 🦞 🪼 🐢 to that meaning —
+   including 🪸, which is the nearest thing Unicode has to an anemone and is why
+   an anemone cannot head the tide card. A glyph may mean one thing per page.
+
 ## Aesthetic Direction
 
 - **Philosophy**: **Coastal pop editorial**, inherited unchanged from the landing

--- a/.design/conditions-page/TASKS.md
+++ b/.design/conditions-page/TASKS.md
@@ -58,7 +58,7 @@ Establishes the visual direction on one card before three are converted. Slice 2
 is the **aesthetic checkpoint**: stop and look before building the rest on top
 of it.
 
-- [ ] **1. Collect the shared explanation into one block.** New `ConditionsNotes`
+- [x] **1. Collect the shared explanation into one block.** New `ConditionsNotes`
       holding what the three panels each repeat — the datum and what a negative
       tide height means, that a buoy measures open-water swell rather than the
       wave at the shore, that visibility is an airport reading and why, and the
@@ -70,8 +70,13 @@ of it.
       `WavesToday`, `WindToday`, `Caveats`, `ConditionsSection`._
       _Must precede slices 2–4: it is where their shed prose lands._
 
-- [ ] **2. The reading card, proven on the tide.** New `ReadingCard`,
-      `StatGroup` and `ProvenanceLine`, adopted by `TideToday` only. Emoji header
+- [x] **2. The reading card, proven on the tide.** New `ReadingCard` and
+      `ProvenanceLine`, adopted by `TideToday` only. **`StatGroup` is not built
+      here** — the tide card's secondary content is the height _sentence_, which
+      this slice keeps verbatim, so there is nothing for a stat list to hold.
+      Building it now would be a component with no consumer, which is the
+      speculative flexibility this file bans elsewhere. It lands in slice 3,
+      where waves is its first real user. Emoji header
       🐚, lead figure at `--text-stat` (replacing the raw `text-4xl`), the
       plain-language height sentence kept verbatim, and the station line as
       `station · network · distance`. `StatGroup` is a `<dl>`. All four tide
@@ -80,7 +85,8 @@ of it.
       `TideToday` test still passes unmodified. _New: three components. Modifies:
       `TideToday`._ **Aesthetic checkpoint — needs a human look.**
 
-- [ ] **3. Waves adopts the card.** 🌊 header; swell period and water temperature
+- [ ] **3. Waves adopts the card, and brings `StatGroup` with it.** 🌊 header;
+      swell period and water temperature
       become labelled stats instead of clauses in a sentence; `heightWords` keeps
       its plain-language line. The buoy attribution becomes a `ProvenanceLine`,
       keeping the distance disclosure past the existing threshold. **Done when**

--- a/.design/conditions-page/TASKS.md
+++ b/.design/conditions-page/TASKS.md
@@ -1,0 +1,186 @@
+# Build Tasks: The Conditions Page
+
+Generated from: `.design/conditions-page/DESIGN_BRIEF.md`
+Date: 2026-08-24
+
+IA amended in `.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md`
+(closes #78). The sighting map is deferred to PRD #121 and ships as a reserved
+slot here.
+
+## How this list is shaped
+
+**Nine slices, three PRs, cut at dependency boundaries** rather than at layer
+boundaries. Each slice does one nameable thing, leaves the repo working and the
+gates passing, and can be reverted or bisected on its own.
+
+**There is no trailing responsive or accessibility phase, on purpose.** Those
+are horizontal — one layer smeared across the whole feature — and this repo has
+paid for that before: ADR-0004 exists because two design reviews reported the
+nav's touch targets and nothing happened either time. Every slice below ships
+its own breakpoints, its own `aria`, its own contrast and its own tests. A slice
+that needs a follow-up pass to be accessible is not done.
+
+**No `docs/plans/` file, and no issue per slice.** The brief holds the design,
+this file holds the slices and the seams, and #121 holds the map. A fourth
+document would be a third copy of the same decisions with its own drift. Issues
+are skipped for the reason CLAUDE.md gives — these nine are strictly sequential
+and touch the same handful of files, so two people could not pick up two of them
+without colliding. Both omissions get stated in the PR body rather than left to
+look like lapses.
+
+## Test seams
+
+Established seams, reused. Nothing new is invented.
+
+| Layer          | Seam                                                              | Prior art                                    |
+| -------------- | ----------------------------------------------------------------- | -------------------------------------------- |
+| Composition    | Pure function, clock injected as `nowMs`, returns a settled model | `readTodaysLowestLow` in `lib/conditions.ts` |
+| Presentational | Pure component per state, render assertions                       | `TideToday.test.tsx`                         |
+| Panel          | Untouched — read, render, nothing to test                         | `TidePanel.tsx`                              |
+| Section        | Renders the parts, caveats reach the page                         | `ConditionsSection.test.tsx`                 |
+| Data → reader  | Every `unresolved` entry reaches a reader, both directions        | `lib/caveats.test.ts`                        |
+
+**The caveats chain is already asserted end to end and must stay green rather
+than be added to.** `caveats.test.ts` binds data files to `inventoryCaveats()`;
+`ConditionsSection.test.tsx` binds that to the rendered page. Slice 1 moves
+`Caveats` inside a new block, and the second test is what proves nothing was
+dropped.
+
+**jsdom applies no stylesheets** (ADR-0001), so no test here asserts a rendered
+box, a column count or a pixel. Layout claims are verified by a human at the
+review viewport — see _Verification_.
+
+---
+
+## PR A — the reading becomes a card
+
+Establishes the visual direction on one card before three are converted. Slice 2
+is the **aesthetic checkpoint**: stop and look before building the rest on top
+of it.
+
+- [ ] **1. Collect the shared explanation into one block.** New `ConditionsNotes`
+      holding what the three panels each repeat — the datum and what a negative
+      tide height means, that a buoy measures open-water swell rather than the
+      wave at the shore, that visibility is an airport reading and why, and the
+      standing sentence that none of this is a safety assessment. `Caveats` moves
+      inside it unchanged. Each panel keeps its own attribution sentence and
+      sheds only the general prose. **Done when** the explanations render once
+      instead of three times and `ConditionsSection.test.tsx`'s caveat assertion
+      is still green. _New: `ConditionsNotes`. Modifies: `TideToday`,
+      `WavesToday`, `WindToday`, `Caveats`, `ConditionsSection`._
+      _Must precede slices 2–4: it is where their shed prose lands._
+
+- [ ] **2. The reading card, proven on the tide.** New `ReadingCard`,
+      `StatGroup` and `ProvenanceLine`, adopted by `TideToday` only. Emoji header
+      🐚, lead figure at `--text-stat` (replacing the raw `text-4xl`), the
+      plain-language height sentence kept verbatim, and the station line as
+      `station · network · distance`. `StatGroup` is a `<dl>`. All four tide
+      states keep rendering their own sentence — no blanks, no zeros.
+      **Done when** the tide card matches the brief's anatomy and every existing
+      `TideToday` test still passes unmodified. _New: three components. Modifies:
+      `TideToday`._ **Aesthetic checkpoint — needs a human look.**
+
+- [ ] **3. Waves adopts the card.** 🌊 header; swell period and water temperature
+      become labelled stats instead of clauses in a sentence; `heightWords` keeps
+      its plain-language line. The buoy attribution becomes a `ProvenanceLine`,
+      keeping the distance disclosure past the existing threshold. **Done when**
+      period and water temp are readable without reading a sentence, and the
+      no-buoy and unavailable states are unchanged. _Modifies: `WavesToday`._
+
+- [ ] **4. Air adopts the card, with two provenances made visible.** 🌡️ header;
+      **two** `StatGroup`s — wind and gust from the air station, sky and
+      visibility from the sky station — each followed by **its own**
+      `ProvenanceLine`. Grouping by provenance is the point: ADR-0010 requires a
+      reader be able to tell which station supplied which figure, and two
+      adjacent sentences in one grey paragraph technically satisfied that while
+      practically hiding it. "10 miles or more" stays worded that way; it is a
+      ceiling, not a measurement. The two halves still fail independently.
+      **Done when** a reader can attribute every figure without reading prose,
+      and each half renders alone when the other is missing. _Modifies:
+      `WindToday`._
+
+## PR B — the page fills its width
+
+- [ ] **5. The chooser moves into the header row.** `BeachSelector` sits beside
+      the `<h1>`, right-aligned from `md`, stacked below it under that. Label
+      promoted from a whisper to a real one; pill shape kept; `TOUCH_TARGET`
+      composed; the `<noscript>` plain-link list preserved exactly, because it is
+      the entire control for a reader without JavaScript. **Done when** the
+      control is the second thing on the page rather than the fourth, and the
+      `noscript` fallback still lists the full inventory. _Modifies:
+      `BeachSelector`, `ConditionsSection`._
+
+- [ ] **6. The now-band.** The three cards go three-across at `lg`, two at `sm`,
+      one below. Prose blocks — the lead paragraph and the notes — keep
+      `max-w-130`; only the figures leave it. **Done when** the page uses its
+      width and the now-band clears the 555px first screen at the review
+      viewport. _Modifies: `ConditionsSection`._ _Depends on: 2, 3, 4, 5._
+      **Needs a human look at 1536×639.**
+
+- [ ] **7. The sighting map slot.** `ReservedSlot` with 🗺️, naming what lands
+      there and pointing at #121. Sized into the layout it will eventually
+      occupy, so the space is designed rather than discovered. **Done when** the
+      page states what is coming instead of being silent about it. _Reuses:
+      `ReservedSlot` unchanged._ _Depends on: 6._
+
+## PR C — the week
+
+- [ ] **8. A week of lowest lows, from one widened request.**
+      `lib/conditions.ts` gains a read returning one lowest low per day for seven
+      days. **This widens the CO-OPS request rather than re-reading data already
+      in hand** — the existing call asks for `nowMs − 1 day` to `nowMs + 1 day`,
+      a three-day window sized so "today" survives the timezone boundary, and a
+      week is not in it. Same endpoint, same parser, same six-hour cache; the
+      `endDate` moves out, and the lower bound stays at −1 day for the boundary
+      reason it already exists for. **The day read and the week read share that
+      one request**, because separate ranges mean separate URLs, which Next will
+      not dedupe — the page would then make two NOAA calls where it makes one
+      today. Clock injected as `nowMs`; a day the window does not cover is a
+      named absence rather than a gap in an array. **Done when** the seven-day
+      model is asserted against fixed instants — including the day-boundary case
+      the existing tide-day tests already cover — and the page still issues
+      exactly one predictions request per beach. No new upstream product, no new
+      dependency. _Modifies: `lib/conditions.ts`._
+
+- [ ] **9. The week grid.** New `WeekGrid` and `TideWeek`. **Day-major DOM**,
+      identical at every width: seven day-columns at `lg`, seven day-rows below,
+      switched by `grid-template-columns` alone — so ADR-0005's render-twice rule
+      is not invoked. The tide row is live; rows for the gridded NWS forecast
+      (#95) and the surf zone forecast are `ReservedSlot`s naming what lands
+      there. A product with no forecast is **absent, not blank** — wave
+      observations have no forecast and get no empty row. **Done when** a reader
+      can find next Tuesday's low tide on a phone without horizontal scrolling,
+      and the screen-reader order reads day-then-values. _New: `WeekGrid`,
+      `TideWeek`._ _Depends on: 8._
+
+## Verification
+
+Every slice: `npm run gate` green before commit, output pasted in the PR body.
+A claim is not evidence.
+
+Three things the gate cannot assert, checked by a human:
+
+- [ ] **The first screen at 1536×639, 125% scaling** — 555px after the nav. The
+      now-band must land above the fold. Measure on the base branch too before
+      accepting blame for anything.
+- [ ] **Contrast on every new surface**, AA — 4.5:1 body, 3:1 large text.
+      Checked before shipping a surface, not after.
+- [ ] **The aesthetic direction after slice 2**, before three cards are built on
+      top of it.
+
+Remove `.next/` before believing anything about the built stylesheet.
+
+## Review
+
+- [ ] **Design review**: run `/design-review` against the brief once PR B has
+      merged and there is something to look at.
+
+## Deliberately not here
+
+- The sighting map itself — PRD #121, `needs-human`.
+- Gridded NWS forecast rows (#95) and the surf zone forecast. Slice 9 leaves
+  labelled slots for them.
+- The landing-page teaser's stale reserved-slot copy, which says surf and wind
+  are "still to come" after they shipped. Noticed while working here; belongs to
+  its own branch, and goes in the PR body rather than the backlog.
+- Any computed verdict, rating or colour that encodes a judgement. ADR-0009.

--- a/.design/conditions-page/TASKS.md
+++ b/.design/conditions-page/TASKS.md
@@ -77,15 +77,18 @@ of it.
       Building it now would be a component with no consumer, which is the
       speculative flexibility this file bans elsewhere. It lands in slice 3,
       where waves is its first real user. Emoji header
-      🐚, lead figure at `--text-stat` (replacing the raw `text-4xl`), the
+      🌊, lead figure at `--text-stat` (replacing the raw `text-4xl`), the
       plain-language height sentence kept verbatim, and the station line as
-      `station · network · distance`. `StatGroup` is a `<dl>`. All four tide
-      states keep rendering their own sentence — no blanks, no zeros.
+      `station · network · distance`. All four tide
+      states keep rendering their own sentence — no blanks, no zeros. The glyph
+      shipped as 🐚 and was changed to 🌊 at the checkpoint: a shell renders pale
+      on mist, and reads as an animal on a page where animal glyphs are about to
+      mean sightings (#121).
       **Done when** the tide card matches the brief's anatomy and every existing
-      `TideToday` test still passes unmodified. _New: three components. Modifies:
+      `TideToday` test still passes unmodified. _New: two components. Modifies:
       `TideToday`._ **Aesthetic checkpoint — needs a human look.**
 
-- [ ] **3. Waves adopts the card, and brings `StatGroup` with it.** 🌊 header;
+- [x] **3. Waves adopts the card, and brings `StatGroup` with it.** 🏄 header;
       swell period and water temperature
       become labelled stats instead of clauses in a sentence; `heightWords` keeps
       its plain-language line. The buoy attribution becomes a `ProvenanceLine`,
@@ -93,7 +96,7 @@ of it.
       period and water temp are readable without reading a sentence, and the
       no-buoy and unavailable states are unchanged. _Modifies: `WavesToday`._
 
-- [ ] **4. Air adopts the card, with two provenances made visible.** 🌡️ header;
+- [x] **4. Air adopts the card, with two provenances made visible.** 🌡️ header;
       **two** `StatGroup`s — wind and gust from the air station, sky and
       visibility from the sky station — each followed by **its own**
       `ProvenanceLine`. Grouping by provenance is the point: ADR-0010 requires a

--- a/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
+++ b/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
@@ -2,13 +2,14 @@
 
 ## Site Map
 
-Six routes. The landing page keeps a teaser for each program area; the routed
-pages carry the fuller version.
+Six static routes and one dynamic segment beneath one of them. The landing page
+keeps a teaser for each program area; the routed pages carry the fuller version.
 
 - Home `/`
   - Art Classes `/art`
   - Tuesday Co-op `/coop`
   - Conditions `/conditions`
+    - One beach `/conditions/<slug>` — the only dynamic segment on the site
   - Community `/community`
   - Book Now `/book` (utility; not in the nav's link row)
 
@@ -92,6 +93,50 @@ interest-list form under its own heading, without the landing page's teaser
 column — otherwise the "Meet the community" CTA would sit on the page it
 points at.
 
+**`/conditions` has left that shape entirely**, and is the only routed page
+that has. It is a tool rather than a page of copy, and its structure is
+documented under _Conditions_ below.
+
+### Conditions `/conditions` and `/conditions/<slug>` (#78)
+
+**One section, two addresses.** Both routes render the same conditions section;
+the only difference is which beach it is given. That is deliberate and is the
+reason the component exists — two routes rendering two copies of a reading
+would drift, and a reader should not get a different answer depending on which
+URL they arrived at. Both carry the same revalidation interval for the same
+reason.
+
+**`/conditions` opens on a named default beach**, not on whichever beach sorts
+first. The default is chosen for being central, close to its tide station, and
+the beach the National Weather Service means when its surf zone forecast says
+"La Jolla". The page asserts the default is still in the inventory at build
+time, so a rename upstream stops a build rather than rendering a page about
+nothing.
+
+**How a reader reaches a per-beach page.** Only from the conditions page itself.
+The nav links to `/conditions` and nothing links to a slug directly. The beach
+chooser — a grouped `<select>` in the page header — navigates on change, and a
+`<noscript>` list of the same inventory as plain links is the fallback, because
+a family checking the tide on a phone with blocked scripts would otherwise get
+a control that silently does nothing.
+
+**Reading order, top to bottom:**
+
+1. Eyebrow, title and lead — with the **beach chooser on the same row as the
+   title**, right-aligned, because it decides what every figure below it means.
+2. **The now-band**: today's lowest tide, waves and water, air. Three cards
+   across at `lg`, each leading with one figure and carrying its own station
+   attribution.
+3. **The week grid**: days across, products down; a week of lowest lows is its
+   first live row. Transposes to day-rows below `lg` rather than scrolling.
+4. **The sighting map slot** — a reserved slot until #121 is built.
+5. **The notes block**: the datum, why a buoy reading is not the wave at the
+   shore, why visibility is an airport reading, the standing sentence that none
+   of this is a safety assessment, and the caveats and coverage disclosures.
+
+**A slug that does not resolve is a 404.** See _URL Strategy_ for the closed
+slug set and for why nothing under `/conditions/` is prerendered.
+
 ## User Flows
 
 ### Book an art class
@@ -116,6 +161,30 @@ lands on `/art` first; that page's CTA is "Book a class →" → `/book`.
    place with the same-page `#community`.
 4. Fills name, email, kids' ages, interest checkboxes → submits.
 5. Sees the "You're in!" success state (client-side only for now).
+
+### Check conditions for a beach (#78)
+
+1. Parent lands on `/`, clicks "Learn more →" on the conditions teaser, or
+   Conditions in the nav → `/conditions`.
+2. The page opens on the named default beach, already showing readings. There
+   is no empty state to get past and nothing to choose before an answer
+   appears — the default exists so the page always opens on something that can
+   answer.
+3. Reads the now-band for today, or the week grid for the day they are planning
+   for. This is usually a Thursday reading a Tuesday.
+4. Picks a different beach from the chooser in the page header → navigates to
+   `/conditions/<slug>`, and every panel re-reads for that beach.
+5. Compares by repeating step 4. Comparison is sequential rather than
+   side-by-side, which is a known limit of this shape and not an oversight —
+   there is no multi-beach view.
+
+Without JavaScript, step 4 is the `<noscript>` list of plain links instead of
+the chooser, and the flow is otherwise identical.
+
+Dead ends are deliberate and each says which kind it is: a beach the inventory
+does not serve is described in prose on the page rather than linked, and a
+stale or hand-typed slug 404s rather than rendering a page about a beach that
+does not exist.
 
 ## Naming Conventions
 
@@ -159,17 +228,21 @@ lands on `/art` first; that page's CTA is "Book a class →" → `/book`.
   inside the two program pages rather than at one of their own. Adding a
   combined `/schedule` route later would be a genuine IA exercise, and is
   deliberately not one this took.
-- **Dynamic routes** arrived too, in `/conditions/[slug]`, and this document
-  does not describe them anywhere — the sentence you are reading is currently
-  their only mention. That gap belongs to the conditions work rather than to
-  the schedule, and is filed as #78.
+- **Dynamic routes** arrived in `/conditions/[slug]`, and are now described —
+  in _Site Map_, in _The routed pages_, in _User Flows_ and in _URL Strategy_
+  (#78). The pattern they establish is narrow on purpose: a dynamic segment is
+  warranted where one page answers about **one of many interchangeable
+  subjects** the site does not author — the beaches, read from an upstream
+  inventory. It is not warranted for content this site writes, which is why
+  sessions render inside a program page and have no URL of their own.
 - Anything beyond that (a blog, a store, a login) is a new IA exercise.
 
 ## URL Strategy
 
 - Pattern: six static routes — `/`, `/art`, `/coop`, `/conditions`,
-  `/community`, `/book`. The slugs are the short ids the sections carried
-  before the routes existed, not the labels (`/art`, not `/art-classes`).
+  `/community`, `/book` — plus one dynamic segment, `/conditions/<slug>`. The
+  static slugs are the short ids the sections carried before the routes existed,
+  not the labels (`/art`, not `/art-classes`).
 - **One anchor id remains, and it is stable API**: `community`, on the
   `SnapSection` wrapping the interest-list teaser on `/`. Three things point
   at it — the co-op card as `#community`, and `/book` and `/coop` as
@@ -183,4 +256,19 @@ lands on `/art` first; that page's CTA is "Book a class →" → `/book`.
   route instead.
 - Anchor targets clear the sticky nav via `scroll-pt-nav-sm md:scroll-pt-nav`
   on `html`, which subtracts the same tokens the nav sets its height from.
-- No dynamic segments, no query parameters.
+- **One dynamic segment: `/conditions/<slug>`.** The slug set is **closed** — it
+  is exactly the served beaches in `src/data/beaches.json`, and a slug outside
+  that set is a 404 rather than a page apologising about a beach that does not
+  exist. The chooser cannot produce one; a stale link can. Beaches the inventory
+  lists but does not serve are 404s too: they are recorded in the data file's
+  `_excluded` block, which is rendered to the reader as prose on `/conditions`,
+  not as routes.
+- The slug count is deliberately **not written down here.** It is derived from
+  the inventory, which a script rewrites from an upstream resource — the same
+  reasoning `inventoryReach()` uses for declining to hand-maintain a count of
+  somebody else's list.
+- **Nothing under `/conditions/` is prerendered at build.** `generateStaticParams`
+  returns an empty array on purpose, so upstream is asked about a beach the
+  first time a reader actually chooses it, and served from cache afterwards.
+  Upstream load follows real readers rather than the size of the inventory.
+- No query parameters.

--- a/src/components/ConditionsNotes.test.tsx
+++ b/src/components/ConditionsNotes.test.tsx
@@ -1,0 +1,111 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ConditionsNotes } from "./ConditionsNotes";
+
+const ENTRIES = [
+  "beach_type is UNKNOWN upstream for most of these beaches.",
+  "TWC0405 Point Loma does not deliver predictions.",
+];
+
+const REACH = {
+  listed: 73,
+  served: 41,
+  excluded: [
+    {
+      slug: "san-onofre-state-beach",
+      name: "San Onofre State Beach",
+      why: "its tide station 9410230 is 56.6 km away",
+    },
+  ],
+};
+
+/**
+ * The four assertions below moved here from `TideToday` and `WavesToday` when
+ * the shared explanation was collected into one block. They assert the same
+ * properties those tests asserted; only the component that owns them changed.
+ */
+
+test("the datum is named, so a negative tide height is not read as an error", () => {
+  render(<ConditionsNotes entries={ENTRIES} reach={REACH} />);
+
+  expect(screen.getByText(/mean lower low water/)).toBeDefined();
+  expect(
+    screen.getByText(/more of the sand and reef is uncovered/),
+  ).toBeDefined();
+});
+
+test("predictions are named as astronomy rather than as a measurement", () => {
+  render(<ConditionsNotes entries={ENTRIES} reach={REACH} />);
+
+  expect(screen.getByText(/astronomy rather than a measurement/)).toBeDefined();
+});
+
+test("a wave height is attributed as open water, not as the breaking wave", () => {
+  render(<ConditionsNotes entries={ENTRIES} reach={REACH} />);
+
+  expect(
+    screen.getByText(/not the height of the wave breaking at the shore/),
+  ).toBeDefined();
+});
+
+test("the sky is named as an airport reading, and why it is one", () => {
+  render(<ConditionsNotes entries={ENTRIES} reach={REACH} />);
+
+  expect(screen.getByText(/come from an airport/)).toBeDefined();
+  // The clause `WindToday.test.tsx` used to assert, kept verbatim so the
+  // property did not weaken when it changed component.
+  expect(screen.getByText(/only published by airports/)).toBeDefined();
+  expect(screen.getByText(/coastal fog is exactly what changes/)).toBeDefined();
+});
+
+test("the page does not offer any of it as a safety call", () => {
+  render(<ConditionsNotes entries={ENTRIES} reach={REACH} />);
+
+  expect(screen.getByText(/None of it is a safety assessment/)).toBeDefined();
+});
+
+/**
+ * The block renders on every beach, including ones with no sky station and no
+ * buoy, so it must describe how the page works rather than assert that this
+ * shore has any particular reading. "Where they are shown" is the hedge that
+ * makes the airport sentence true at a lagoon.
+ */
+test("it explains the page rather than claiming this beach has these readings", () => {
+  render(<ConditionsNotes entries={ENTRIES} reach={REACH} />);
+
+  expect(screen.getByText(/Where they are shown/)).toBeDefined();
+});
+
+/**
+ * Caveats moved inside this block. `ConditionsSection.test.tsx` asserts the
+ * whole chain from the data files to the page; this one asserts the single link
+ * that moved, so a regression here names the component that broke.
+ */
+test("the caveats it is given still reach the reader from inside it", () => {
+  render(<ConditionsNotes entries={ENTRIES} reach={REACH} />);
+
+  for (const entry of ENTRIES) {
+    expect(screen.getByText(entry)).toBeDefined();
+  }
+  expect(screen.getByText(/41 of the 73 beaches/)).toBeDefined();
+});
+
+test("each note is a term and its explanation, not a run of prose", () => {
+  const { container } = render(
+    <ConditionsNotes entries={ENTRIES} reach={REACH} />,
+  );
+
+  // A description list, so the pairing survives for a reader who cannot see
+  // the bolding that carries it visually.
+  expect(container.querySelectorAll("dt").length).toBe(4);
+  expect(container.querySelectorAll("dd").length).toBe(4);
+});
+
+test("it is a labelled region, so the notes are reachable as a landmark", () => {
+  render(<ConditionsNotes entries={ENTRIES} reach={REACH} />);
+
+  const heading = screen.getByRole("heading", {
+    name: /how to read these numbers/i,
+  });
+  expect(heading).toBeDefined();
+});

--- a/src/components/ConditionsNotes.tsx
+++ b/src/components/ConditionsNotes.tsx
@@ -1,0 +1,104 @@
+/**
+ * What every reading on this page has in common, explained once.
+ *
+ * The three panels each used to end with a paragraph at 10px carrying two
+ * different things: **which station supplied this figure**, and **what the
+ * figure means**. The first is specific to a panel and stays there — ADR-0010
+ * requires that a reader be able to tell which station supplied which number,
+ * and hiding it would be worse than the two lines it costs. The second is the
+ * same explanation three times over, and repeating it is what buried the
+ * numbers between it.
+ *
+ * `TideToday` already argued for this arrangement in its own docstring — "the
+ * acronym is named once, at the bottom, rather than beside every figure" — and
+ * then the page did that once per panel. This is that principle applied at the
+ * scale it was actually about.
+ *
+ * **Nothing was dropped in the move, and one thing changed: the size.** The
+ * explanations were `text-2xs`; here they are `text-sm`. A safety qualification
+ * set in 10px at the tail of an attribution line is technically present and
+ * practically unread, and the whole reason for collecting these is that they
+ * become readable.
+ *
+ * **The wording is general because the block always renders.** A beach with no
+ * sky station still gets the sentence about airports, so it says "where they
+ * are shown" rather than asserting this beach has them. That is a description
+ * of how the page works, not a claim about this shore.
+ *
+ * **Not the standing safety notice.** `docs/plans/conditions-tool.md` reserves a
+ * prominent notice *above* the readings — instruments rather than judgement,
+ * lifeguards and posted signs the authority on the day — for its own slice. This
+ * block collects the qualifications that already existed in the page and adds
+ * none, so that slice still has something to do.
+ */
+
+import type { InventoryReach } from "@/lib/beaches";
+import { Caveats } from "./Caveats";
+
+/** One thing worth understanding about every figure of its kind. */
+const NOTES = [
+  {
+    term: "Tide heights",
+    detail:
+      "Feet above mean lower low water — the average of the lower low tide each day. " +
+      "A negative number means the water drops below that average, so more of the sand " +
+      "and reef is uncovered than usual. Predictions are astronomy rather than a " +
+      "measurement of the water on the day.",
+  },
+  {
+    term: "Wave heights",
+    detail:
+      "The height of the swell in open water, measured at a buoy some distance offshore. " +
+      "That is not the height of the wave breaking at the shore, and nothing here " +
+      "transforms one into the other.",
+  },
+  {
+    term: "Sky and visibility",
+    detail:
+      "Where they are shown, they come from an airport. Cloud and visibility are only " +
+      "published by airports in this county, so that reading is taken further from the " +
+      "water than the temperature beside it — and coastal fog is exactly what changes " +
+      "across that distance.",
+  },
+  {
+    term: "None of it is a safety assessment",
+    detail:
+      "These are readings relayed from public instruments, each shown with the station " +
+      "that supplied it and how far away that station is.",
+  },
+] as const;
+
+export function ConditionsNotes({
+  entries,
+  reach,
+}: {
+  entries: readonly string[];
+  reach: InventoryReach;
+}) {
+  return (
+    <section aria-labelledby="conditions-notes-heading" className="mt-9">
+      <h2
+        id="conditions-notes-heading"
+        className="text-2xs mb-3 font-extrabold tracking-widest text-ocean uppercase"
+      >
+        How to read these numbers
+      </h2>
+
+      {/*
+        A description list rather than paragraphs: each entry is a topic and its
+        explanation, and the pairing is what a reader is scanning for. It also
+        survives for someone who cannot see the bolding.
+      */}
+      <dl className="leading-relaxed max-w-130 text-sm text-fog">
+        {NOTES.map(({ term, detail }) => (
+          <div key={term} className="mb-3">
+            <dt className="font-extrabold text-dark">{term}</dt>
+            <dd>{detail}</dd>
+          </div>
+        ))}
+      </dl>
+
+      <Caveats entries={entries} reach={reach} />
+    </section>
+  );
+}

--- a/src/components/ConditionsSection.tsx
+++ b/src/components/ConditionsSection.tsx
@@ -15,7 +15,7 @@ import {
   inventoryReach,
 } from "@/lib/beaches";
 import { BeachSelector } from "./BeachSelector";
-import { Caveats } from "./Caveats";
+import { ConditionsNotes } from "./ConditionsNotes";
 import { TidePanel } from "./TidePanel";
 import { WavePanel } from "./WavePanel";
 import { WindPanel } from "./WindPanel";
@@ -80,7 +80,12 @@ export function ConditionsSection({ slug }: { slug: string }) {
         <WindPanel slug={slug} />
       </Suspense>
 
-      <Caveats entries={inventoryCaveats()} reach={inventoryReach()} />
+      {/*
+        One block for everything true of every reading — the datum, what a buoy
+        measures, why the sky comes from an airport — plus the caveats, which it
+        renders. The three panels above carry only their own attribution now.
+      */}
+      <ConditionsNotes entries={inventoryCaveats()} reach={inventoryReach()} />
     </section>
   );
 }

--- a/src/components/ProvenanceLine.test.tsx
+++ b/src/components/ProvenanceLine.test.tsx
@@ -1,0 +1,93 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProvenanceLine } from "./ProvenanceLine";
+
+const SOURCE = "La Jolla (Scripps Institution Wharf)";
+
+test("the source and the network are both named", () => {
+  render(<ProvenanceLine source={SOURCE} network="NOAA Tides & Currents" />);
+
+  const line = screen.getByText(/NOAA Tides & Currents/).textContent ?? "";
+  expect(line).toContain(SOURCE);
+  expect(line).toContain("NOAA Tides & Currents");
+});
+
+/**
+ * A near station is credited without a number, which is what the panels did
+ * before and what their own thresholds decide. The line does not invent a
+ * distance when the caller withholds one.
+ */
+test("no distance is shown when the caller withholds one", () => {
+  render(<ProvenanceLine source={SOURCE} network="NOAA Tides & Currents" />);
+
+  expect(screen.queryByText(/km/)).toBeNull();
+});
+
+test("a distance is shown when the caller gives one", () => {
+  render(
+    <ProvenanceLine
+      source={SOURCE}
+      network="NOAA Tides & Currents"
+      distance="about 12 km away"
+    />,
+  );
+
+  expect(screen.getByText(/about 12 km away/)).toBeDefined();
+});
+
+/**
+ * The clause `TideToday` calls "the difference between a prediction for this
+ * shore and the nearest one anybody publishes". A distance alone understates a
+ * station that is far away because nothing nearer exists.
+ */
+test("the reason a distant source was used survives", () => {
+  render(
+    <ProvenanceLine
+      source={SOURCE}
+      network="NOAA Tides & Currents"
+      distance="about 12 km away"
+      note="the nearest open-coast station publishing predictions"
+    />,
+  );
+
+  expect(
+    screen.getByText(/the nearest open-coast station publishing predictions/),
+  ).toBeDefined();
+});
+
+test("no note is rendered when there is nothing to explain", () => {
+  render(
+    <ProvenanceLine
+      source={SOURCE}
+      network="NOAA Tides & Currents"
+      distance="1.4 km away"
+    />,
+  );
+
+  expect(screen.queryByText(/—/)).toBeNull();
+});
+
+/**
+ * A card carrying two sources needs to say which figures each one supplied.
+ * That is ADR-0010's requirement, and the air panel is why this prop exists.
+ */
+test("a label says which figures this source supplied", () => {
+  render(
+    <ProvenanceLine
+      label="Sky and visibility"
+      source="San Diego International"
+      network="NWS"
+      distance="10 km away"
+    />,
+  );
+
+  expect(screen.getByText("Sky and visibility")).toBeDefined();
+});
+
+test("no label is rendered when a card has only one source", () => {
+  const { container } = render(
+    <ProvenanceLine source={SOURCE} network="NOAA Tides & Currents" />,
+  );
+
+  expect(container.querySelector("span")).toBeNull();
+});

--- a/src/components/ProvenanceLine.tsx
+++ b/src/components/ProvenanceLine.tsx
@@ -24,8 +24,17 @@
 type ProvenanceLineProps = {
   /** What the figure names it, ready to print. Never a callsign turned into prose — see #87. */
   source: string;
-  /** Who publishes it, so two readings from two networks are distinguishable. */
-  network: string;
+  /**
+   * Who publishes it, so two readings from two networks are distinguishable.
+   *
+   * Optional because the air panel genuinely does not know. `StationBinding`
+   * carries a name and a distance and no network, and the panel has never named
+   * one — an air station may be on either the NWS or the NDBC network, so there
+   * is no constant to fall back on. Rendering a guess would be worse than
+   * rendering nothing, and threading the field through the view model is a data
+   * change rather than a presentation one.
+   */
+  network?: string | null;
   /** Already worded by the caller, which owns the rounding. `null` withholds it. */
   distance?: string | null;
   /** Why this source and not a nearer one, when there is something to say. */
@@ -36,7 +45,7 @@ type ProvenanceLineProps = {
 
 export function ProvenanceLine({
   source,
-  network,
+  network = null,
   distance = null,
   note = null,
   label = null,
@@ -44,7 +53,8 @@ export function ProvenanceLine({
   return (
     <p className="text-2xs leading-relaxed text-fog">
       {label !== null && <span className="font-extrabold">{label} </span>}
-      {source} · {network}
+      {source}
+      {network !== null ? ` · ${network}` : ""}
       {distance !== null ? ` · ${distance}` : ""}
       {note !== null ? ` — ${note}` : ""}
     </p>

--- a/src/components/ProvenanceLine.tsx
+++ b/src/components/ProvenanceLine.tsx
@@ -1,0 +1,52 @@
+/**
+ * Which instrument answered, who publishes it, and how far away it stands.
+ *
+ * **This is the half of the old attribution paragraph that stayed.** The other
+ * half — what the figure means — went to `ConditionsNotes`, because it was the
+ * same three times. This half differs per beach and must not move: ADR-0010
+ * turns on a reader being able to tell which station supplied which number, and
+ * the air panel names two of them precisely so the two can be compared.
+ *
+ * **Separated rather than written as a sentence.** The three panels each wrote
+ * their own clause — "Predicted for X", "Measured at NDBC buoy Y", "Temperature
+ * and wind measured at Z" — and a reader comparing two stations had to parse
+ * three different sentence shapes to do it. Interpuncts make the same facts
+ * scannable and let two of these stack legibly under one card, which is what the
+ * air panel needs.
+ *
+ * **The note is not decoration.** Some stations are far enough away that the
+ * distance alone understates the situation, and `TideToday` records why that is
+ * disclosed rather than buried: it "is the difference between a prediction for
+ * this shore and the nearest one anybody publishes". A caller passes that
+ * clause here rather than dropping it.
+ */
+
+type ProvenanceLineProps = {
+  /** What the figure names it, ready to print. Never a callsign turned into prose — see #87. */
+  source: string;
+  /** Who publishes it, so two readings from two networks are distinguishable. */
+  network: string;
+  /** Already worded by the caller, which owns the rounding. `null` withholds it. */
+  distance?: string | null;
+  /** Why this source and not a nearer one, when there is something to say. */
+  note?: string | null;
+  /** What these figures are, when a card carries more than one source. */
+  label?: string | null;
+};
+
+export function ProvenanceLine({
+  source,
+  network,
+  distance = null,
+  note = null,
+  label = null,
+}: ProvenanceLineProps) {
+  return (
+    <p className="text-2xs leading-relaxed text-fog">
+      {label !== null && <span className="font-extrabold">{label} </span>}
+      {source} · {network}
+      {distance !== null ? ` · ${distance}` : ""}
+      {note !== null ? ` — ${note}` : ""}
+    </p>
+  );
+}

--- a/src/components/ReadingCard.test.tsx
+++ b/src/components/ReadingCard.test.tsx
@@ -1,0 +1,92 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ReadingCard } from "./ReadingCard";
+
+function card(figure?: string | null) {
+  return (
+    <ReadingCard
+      emoji="🐚"
+      headingId="test-heading"
+      title="Lowest tide today · La Jolla Shores Beach"
+      figure={figure}
+    >
+      <p>the body of the reading</p>
+    </ReadingCard>
+  );
+}
+
+test("the heading names the reading and the beach it is for", () => {
+  render(card("6:24 AM"));
+
+  const heading = screen.getByRole("heading", {
+    name: "Lowest tide today · La Jolla Shores Beach",
+  });
+  expect(heading.id).toBe("test-heading");
+});
+
+test("the region takes its accessible name from that heading", () => {
+  render(card("6:24 AM"));
+
+  const region = screen.getByRole("region", {
+    name: "Lowest tide today · La Jolla Shores Beach",
+  });
+  expect(region).toBeDefined();
+});
+
+/**
+ * The glyph sets the subject at a glance and carries nothing a reader who
+ * cannot see it would lose — the heading beside it says the same thing in
+ * words. This is the pattern `ProgramCards` already follows.
+ */
+test("the emoji is hidden from assistive technology", () => {
+  const { container } = render(card("6:24 AM"));
+
+  const glyph = container.querySelector('[aria-hidden="true"]');
+  expect(glyph?.textContent).toBe("🐚");
+});
+
+test("the leading figure is rendered when there is one", () => {
+  render(card("6:24 AM"));
+
+  expect(screen.getByText("6:24 AM")).toBeDefined();
+});
+
+/**
+ * The state this exists for. `WindToday` refuses to render an empty primary
+ * because "an empty one reads as a fault", and the same is true of a card that
+ * keeps the slot and puts nothing in it — a blank where a number goes is read
+ * as a broken reading rather than as an absent one.
+ */
+test("a card with no figure has no empty slot where one would go", () => {
+  const { container } = render(card(null));
+
+  expect(container.querySelector(".text-stat")).toBeNull();
+});
+
+test("a card given no figure at all behaves the same as one given null", () => {
+  const { container } = render(
+    <ReadingCard emoji="🌊" headingId="h" title="Waves">
+      <p>body</p>
+    </ReadingCard>,
+  );
+
+  expect(container.querySelector(".text-stat")).toBeNull();
+});
+
+test("whatever the reading has to say is rendered beneath", () => {
+  render(card("6:24 AM"));
+
+  expect(screen.getByText("the body of the reading")).toBeDefined();
+});
+
+/**
+ * The figure is the site's `--text-stat`, not a raw Tailwind size. The three
+ * panels each reached for `text-4xl` — the same 36px under a different name,
+ * which is one of the two names waiting to drift from the other.
+ */
+test("the figure uses the design system's stat size", () => {
+  const { container } = render(card("6:24 AM"));
+
+  const figure = container.querySelector(".text-stat");
+  expect(figure?.textContent).toBe("6:24 AM");
+});

--- a/src/components/ReadingCard.tsx
+++ b/src/components/ReadingCard.tsx
@@ -1,0 +1,86 @@
+/**
+ * The shape every reading on this page shares: a glyph, a heading, one figure
+ * that leads, and whatever that particular reading has to say beneath it.
+ *
+ * **Shared rather than written three times.** `ReservedSlot`'s docstring records
+ * why: "the blank line between the headline and the detail is part of the shape,
+ * and it is exactly what drifted while six call sites each wrote their own."
+ * The same drift had already started here — the three panels rendered their
+ * leading figure at `text-4xl`, a raw Tailwind size, while the design system
+ * defines `--text-stat` at the same 36px for exactly this. Two names for one
+ * decision is one of them waiting to be wrong.
+ *
+ * **The surface is `mist`, and that pairing is not a guess.** `globals.css`
+ * records that `--color-fog` was darkened from the template specifically because
+ * the original failed WCAG AA against mist, and the replacement "reads the same
+ * and clears 5:1 everywhere". Fog on mist is the one secondary-text pairing this
+ * repo has already measured, so the card is built on it.
+ *
+ * **Quiet surface, loud chrome.** The site's other cards are saturated purple and
+ * ocean with white type, and that is right for an offer. This is an instrument
+ * reading shown to people taking children into the ocean, and ADR-0009 forbids
+ * the site from making a judgement about it. A card that looked like a verdict
+ * would be making one in CSS. So the colour goes into the glyph and the eyebrow,
+ * and the figure stays dark on light where a number belongs.
+ *
+ * **The figure slot is never empty.** A caller with nothing to lead on passes
+ * null and gets no slot at all, rather than a blank one — an empty space where a
+ * number goes reads as a fault, which is the same reason `WindToday` refuses to
+ * render an empty primary.
+ */
+
+import type { ReactNode } from "react";
+
+type ReadingCardProps = {
+  /** Sets the subject at a glance; hidden from assistive tech, which reads the heading. */
+  emoji: string;
+  /** Ties the heading to the region. Callers own it, because they own the anchor. */
+  headingId: string;
+  /** What this reading is, and which beach it is for. */
+  title: string;
+  /**
+   * The one figure that leads. `null` renders no slot rather than an empty one.
+   */
+  figure?: string | null;
+  /** Everything this particular reading has to say: sentences, stats, disclosures, provenance. */
+  children: ReactNode;
+};
+
+/* leading-none on a decorative glyph, for the reason `ProgramCards` gives:
+   at this size the default line box adds visible height around an emoji that
+   nothing on screen accounts for. */
+const EMOJI = "mb-3 block text-[34px] leading-none";
+
+export function ReadingCard({
+  emoji,
+  headingId,
+  title,
+  figure = null,
+  children,
+}: ReadingCardProps) {
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="rounded-card bg-mist px-6 py-5"
+    >
+      <span aria-hidden="true" className={EMOJI}>
+        {emoji}
+      </span>
+
+      <h2
+        id={headingId}
+        className="text-2xs mb-3 font-extrabold tracking-widest text-ocean uppercase"
+      >
+        {title}
+      </h2>
+
+      {figure !== null && (
+        <p className="text-stat leading-none mb-2 font-black italic">
+          {figure}
+        </p>
+      )}
+
+      {children}
+    </section>
+  );
+}

--- a/src/components/StatGroup.test.tsx
+++ b/src/components/StatGroup.test.tsx
@@ -1,0 +1,92 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatGroup } from "./StatGroup";
+
+test("each figure is shown with the label that says what it is", () => {
+  render(
+    <StatGroup
+      stats={[
+        { label: "Period", value: "6 s" },
+        { label: "Water", value: "74°F" },
+      ]}
+    />,
+  );
+
+  expect(screen.getByText("Period")).toBeDefined();
+  expect(screen.getByText("6 s")).toBeDefined();
+  expect(screen.getByText("Water")).toBeDefined();
+  expect(screen.getByText("74°F")).toBeDefined();
+});
+
+/**
+ * The pairing is the content, so it is structural rather than a visual accident
+ * of one line sitting above another. This is what carries the relationship for
+ * a reader who cannot see the layout, and what lets the air panel's two
+ * provenance groups stay distinguishable without sight.
+ */
+test("labels and figures are paired as a description list", () => {
+  const { container } = render(
+    <StatGroup
+      stats={[
+        { label: "Period", value: "6 s" },
+        { label: "Water", value: "74°F" },
+      ]}
+    />,
+  );
+
+  expect(container.querySelectorAll("dl").length).toBe(1);
+  expect(container.querySelectorAll("dt").length).toBe(2);
+  expect(container.querySelectorAll("dd").length).toBe(2);
+});
+
+/**
+ * The rule this page keeps everywhere: a blank where a measurement goes reads
+ * as a calm sea rather than as a quiet instrument. A buoy publishing waves and
+ * no water temperature is measured, not hypothetical.
+ */
+test("a missing figure states its absence rather than rendering blank", () => {
+  render(<StatGroup stats={[{ label: "Water", value: null }]} />);
+
+  expect(screen.getByText("Water")).toBeDefined();
+  expect(screen.getByText("Not reported")).toBeDefined();
+});
+
+test("a missing figure is never dropped from the list", () => {
+  const { container } = render(
+    <StatGroup
+      stats={[
+        { label: "Period", value: "6 s" },
+        { label: "Water", value: null },
+      ]}
+    />,
+  );
+
+  // Two rows, not one. An omitted row reads as an oversight.
+  expect(container.querySelectorAll("dt").length).toBe(2);
+  expect(container.querySelectorAll("dd").length).toBe(2);
+});
+
+/**
+ * Prominence comes from weight, not size. The token scale jumps 13px to 36px
+ * with nothing between, and the site's direction is that "weight and italics
+ * carry the hierarchy" — so a figure is body-sized and extrabold against the
+ * fog-grey prose around it rather than an off-system size invented here.
+ */
+test("a figure is set heavier than the prose it sits among", () => {
+  const { container } = render(
+    <StatGroup stats={[{ label: "Period", value: "6 s" }]} />,
+  );
+
+  const value = container.querySelector("dd");
+  expect(value?.className).toContain("font-extrabold");
+  expect(value?.className).toContain("text-dark");
+});
+
+test("an absent figure is set apart from a real one, not styled as a value", () => {
+  const { container } = render(
+    <StatGroup stats={[{ label: "Water", value: null }]} />,
+  );
+
+  const value = container.querySelector("dd");
+  expect(value?.className).not.toContain("font-extrabold");
+});

--- a/src/components/StatGroup.tsx
+++ b/src/components/StatGroup.tsx
@@ -1,0 +1,69 @@
+/**
+ * The supporting measurements, as figures rather than as clauses in a sentence.
+ *
+ * **This is the fix for the complaint that started the redesign.** Six real
+ * measurements — swell period, water temperature, wind speed, gust, sky,
+ * visibility — were dissolved into three prose sentences, so learning the wind
+ * speed meant reading a paragraph. They are numbers, and a reader scanning for
+ * one should not have to parse grammar to find it.
+ *
+ * **What did not move is the plain-language line.** `WavesToday`'s docstring is
+ * explicit that "2.6 ft" tells a surfer what they need and tells a parent of an
+ * eight-year-old very little, so the figure keeps its companion sentence. The
+ * stats sit beneath that sentence rather than replacing it. Turning everything
+ * into a table would delete the one thing on the card written for the audience
+ * this site is actually for.
+ *
+ * **A description list, because the pairing is the content.** `dt`/`dd` makes
+ * label-to-value structural rather than a visual accident of one line sitting
+ * above another — which is what carries the relationship for a reader who cannot
+ * see the layout, and is what makes the two-provenance grouping in the air panel
+ * survive at all.
+ *
+ * **A group is one provenance.** Callers with figures from two stations render
+ * two groups with two attributions rather than one group of six, because
+ * ADR-0010 turns on a reader being able to tell which station supplied which
+ * number. One `StatGroup` never spans two sources.
+ *
+ * **Absence is a value, not a gap.** A `null` renders "Not reported" rather than
+ * nothing, for the reason this page states everywhere else: a blank where a
+ * measurement goes is read as a calm sea rather than as a quiet instrument. The
+ * buoy that publishes waves but no water temperature is a measured fact about
+ * that buoy, not a hypothetical.
+ *
+ * **Size is not what makes these prominent — weight is.** The token scale jumps
+ * from 13px to 36px with nothing between, and the site's own direction is that
+ * "weight and italics carry the hierarchy". So a value is body-sized, extrabold
+ * and ink-dark against the fog-grey prose around it, rather than an off-system
+ * size invented here.
+ */
+
+export type Stat = {
+  /** What the figure is. Short: it sets in 10px uppercase. */
+  label: string;
+  /** Already worded and rounded by the caller. `null` states the absence. */
+  value: string | null;
+};
+
+export function StatGroup({ stats }: { stats: readonly Stat[] }) {
+  return (
+    <dl className="mb-3 flex flex-wrap gap-x-7 gap-y-2">
+      {stats.map(({ label, value }) => (
+        <div key={label}>
+          <dt className="text-2xs font-extrabold tracking-widest text-fog uppercase">
+            {label}
+          </dt>
+          <dd
+            className={
+              value === null
+                ? "text-base text-fog italic"
+                : "text-base font-extrabold text-dark"
+            }
+          >
+            {value ?? "Not reported"}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/src/components/TideToday.test.tsx
+++ b/src/components/TideToday.test.tsx
@@ -55,7 +55,13 @@ test("a negative height explains its own minus sign", () => {
   ).toBeDefined();
 });
 
-test("the datum is named once, and predictions are not offered as a safety call", () => {
+/**
+ * The datum and the safety qualification are asserted in
+ * `ConditionsNotes.test.tsx` now. They were the same sentences under all three
+ * panels, so they were collected into one block; what this panel still owes the
+ * reader is which station answered for this beach.
+ */
+test("the station that supplied the prediction is credited here, not elsewhere", () => {
   render(
     <TideToday
       beachName="La Jolla Shores Beach"
@@ -63,8 +69,12 @@ test("the datum is named once, and predictions are not offered as a safety call"
       state={{ kind: "reading", timeLabel: "6:24 AM", feet: 1.368 }}
     />,
   );
-  expect(screen.getByText(/mean lower low water/)).toBeDefined();
-  expect(screen.getByText(/not a safety assessment/)).toBeDefined();
+  // Read off the rendered paragraph rather than matched as a pattern: the
+  // station's name carries parentheses, and building a regex from it turns
+  // them into a capture group that matches a string the page never renders.
+  const attribution = screen.getByText(/Predicted for/).textContent ?? "";
+  expect(attribution).toContain(NEAR_STATION.name);
+  expect(attribution).toContain("NOAA Tides & Currents");
 });
 
 test("a nearby station is credited without a distance", () => {

--- a/src/components/TideToday.test.tsx
+++ b/src/components/TideToday.test.tsx
@@ -72,8 +72,11 @@ test("the station that supplied the prediction is credited here, not elsewhere",
   // Read off the rendered paragraph rather than matched as a pattern: the
   // station's name carries parentheses, and building a regex from it turns
   // them into a capture group that matches a string the page never renders.
-  const attribution = screen.getByText(/Predicted for/).textContent ?? "";
+  const attribution =
+    screen.getByText(/NOAA Tides & Currents/).textContent ?? "";
   expect(attribution).toContain(NEAR_STATION.name);
+  // A plain ampersand reaches the reader. Written `&amp;` in the string
+  // attribute it would have rendered as the entity itself.
   expect(attribution).toContain("NOAA Tides & Currents");
 });
 

--- a/src/components/TideToday.tsx
+++ b/src/components/TideToday.tsx
@@ -34,6 +34,8 @@
  */
 
 import type { TideTodayView } from "@/lib/conditions";
+import { ProvenanceLine } from "./ProvenanceLine";
+import { ReadingCard } from "./ReadingCard";
 
 export type TideTodayProps = TideTodayView;
 
@@ -55,23 +57,16 @@ export function TideToday({ beachName, station, state }: TideTodayProps) {
       : null;
 
   return (
-    <section aria-labelledby="tide-today-heading" className="max-w-130">
-      <h2
-        id="tide-today-heading"
-        className="text-2xs mb-3 font-extrabold tracking-widest text-ocean uppercase"
-      >
-        Lowest tide today · {beachName}
-      </h2>
-
+    <ReadingCard
+      emoji="🐚"
+      headingId="tide-today-heading"
+      title={`Lowest tide today · ${beachName}`}
+      figure={state.kind === "reading" ? state.timeLabel : null}
+    >
       {state.kind === "reading" && (
-        <>
-          <p className="leading-tight mb-2 text-4xl font-black italic">
-            {state.timeLabel}
-          </p>
-          <p className="leading-relaxed mb-4 text-base text-fog">
-            {heightSentence(state.feet)}
-          </p>
-        </>
+        <p className="leading-relaxed mb-4 text-base text-fog">
+          {heightSentence(state.feet)}
+        </p>
       )}
 
       {state.kind === "no-low-today" && (
@@ -116,15 +111,23 @@ export function TideToday({ beachName, station, state }: TideTodayProps) {
         </>
       )}
 
+      {/*
+        The network name carries a plain ampersand rather than `&amp;`: it is a
+        string attribute, and JSX decodes entities in text children but not in
+        those. Written as `&amp;` it would reach the reader verbatim.
+      */}
       {station !== null && (
-        <p className="text-2xs leading-relaxed text-fog">
-          Predicted for {station.name}, NOAA Tides &amp; Currents
-          {distantKm !== null
-            ? ` — the nearest ${station.water === "bay" ? "bay" : "open-coast"} station publishing predictions, about ${distantKm} km away`
-            : ""}
-          .
-        </p>
+        <ProvenanceLine
+          source={station.name}
+          network="NOAA Tides & Currents"
+          distance={distantKm !== null ? `about ${distantKm} km away` : null}
+          note={
+            distantKm !== null
+              ? `the nearest ${station.water === "bay" ? "bay" : "open-coast"} station publishing predictions`
+              : null
+          }
+        />
       )}
-    </section>
+    </ReadingCard>
   );
 }

--- a/src/components/TideToday.tsx
+++ b/src/components/TideToday.tsx
@@ -13,8 +13,11 @@
  * **The datum is explained once, in words.** A tide of -0.4 ft reads as an error
  * to anyone who has not met mean lower low water, and it is the single most
  * useful figure on the page for a tidepooler. So the sign is explained where it
- * appears and the acronym is named once, at the bottom, rather than beside every
- * figure.
+ * appears — `heightSentence` still says what a negative number means — and the
+ * acronym is named once rather than beside every figure. That naming now lives
+ * in `ConditionsNotes`, one block for the whole page, because this panel was
+ * making the argument and then two panels beside it repeated their own version
+ * of it. What stays here is the attribution: which station, and how far.
  *
  * **An absent reading is a sentence, not a blank.** A missing number renders as
  * an explanation a reader can act on, with the upstream detail behind a
@@ -119,9 +122,7 @@ export function TideToday({ beachName, station, state }: TideTodayProps) {
           {distantKm !== null
             ? ` — the nearest ${station.water === "bay" ? "bay" : "open-coast"} station publishing predictions, about ${distantKm} km away`
             : ""}
-          . Heights are feet above mean lower low water, the average of the
-          lower low tide each day. Predictions are astronomy, not a measurement
-          of the water on the day, and they are not a safety assessment.
+          .
         </p>
       )}
     </section>

--- a/src/components/TideToday.tsx
+++ b/src/components/TideToday.tsx
@@ -58,7 +58,7 @@ export function TideToday({ beachName, station, state }: TideTodayProps) {
 
   return (
     <ReadingCard
-      emoji="🐚"
+      emoji="🌊"
       headingId="tide-today-heading"
       title={`Lowest tide today · ${beachName}`}
       figure={state.kind === "reading" ? state.timeLabel : null}

--- a/src/components/WavesToday.test.tsx
+++ b/src/components/WavesToday.test.tsx
@@ -21,8 +21,12 @@ test("a reading leads with the height and puts it in plain words", () => {
   );
 
   expect(screen.getByText("2.6 ft")).toBeDefined();
-  // A height alone tells a surfer what they need and a parent very little.
-  expect(screen.getByText(/about waist high, 5 seconds apart/)).toBeDefined();
+  // A height alone tells a surfer what they need and a parent very little, so
+  // the plain-language companion survives the move to a card. The period left
+  // this sentence and became a figure of its own; what it must not do is stop
+  // being said.
+  expect(screen.getByText(/about waist high/)).toBeDefined();
+  expect(screen.getByText("5 s")).toBeDefined();
 });
 
 test("water temperature comes from the same reading, rounded", () => {
@@ -39,7 +43,9 @@ test("water temperature comes from the same reading, rounded", () => {
       }}
     />,
   );
-  expect(screen.getByText(/The water is 70°F/)).toBeDefined();
+  // Shown as a figure now rather than as the tail of a sentence, and still
+  // rounded: the buoy publishes 69.98 and nobody swims to two decimal places.
+  expect(screen.getByText("70°F")).toBeDefined();
 });
 
 test("a buoy reporting no water temperature says so rather than omitting it", () => {
@@ -56,7 +62,12 @@ test("a buoy reporting no water temperature says so rather than omitting it", ()
       }}
     />,
   );
-  expect(screen.getByText(/reported no water temperature/)).toBeDefined();
+  // A buoy that publishes waves and no water temperature is a measured fact
+  // about that buoy, not a hypothetical. Both figures state their absence
+  // rather than vanishing, because a missing row reads as an oversight and a
+  // blank one reads as a calm sea.
+  expect(screen.getAllByText("Not reported").length).toBe(2);
+  expect(screen.getByText("Water")).toBeDefined();
 });
 
 /**
@@ -79,7 +90,8 @@ test("a nearby buoy is credited without a distance", () => {
       }}
     />,
   );
-  expect(screen.getByText(new RegExp(`NDBC buoy ${NEAR.name}`))).toBeDefined();
+  const line = screen.getByText(/NDBC/).textContent ?? "";
+  expect(line).toContain(NEAR.name);
   expect(screen.queryByText(/km from this beach/)).toBeNull();
 });
 

--- a/src/components/WavesToday.test.tsx
+++ b/src/components/WavesToday.test.tsx
@@ -59,7 +59,13 @@ test("a buoy reporting no water temperature says so rather than omitting it", ()
   expect(screen.getByText(/reported no water temperature/)).toBeDefined();
 });
 
-test("the reading is attributed as open water, not as the breaking wave", () => {
+/**
+ * That an open-water buoy is not the breaking wave is asserted in
+ * `ConditionsNotes.test.tsx` now — it is true at every beach, so it was
+ * collected rather than repeated under each reading. What stays here is the
+ * buoy, and the distance when there is one worth disclosing.
+ */
+test("a nearby buoy is credited without a distance", () => {
   render(
     <WavesToday
       beachName="La Jolla Shores Beach"
@@ -73,9 +79,7 @@ test("the reading is attributed as open water, not as the breaking wave", () => 
       }}
     />,
   );
-  expect(
-    screen.getByText(/not the height of the wave breaking at the shore/),
-  ).toBeDefined();
+  expect(screen.getByText(new RegExp(`NDBC buoy ${NEAR.name}`))).toBeDefined();
   expect(screen.queryByText(/km from this beach/)).toBeNull();
 });
 

--- a/src/components/WavesToday.tsx
+++ b/src/components/WavesToday.tsx
@@ -12,10 +12,12 @@
  * given a plain-language companion. The bands are this site's own wording for
  * published measurements, not a judgement about whether anyone should go in.
  *
- * **A buoy is offshore, and says so.** These are open-water measurements taken
- * some distance out, not the height of the wave breaking at the shore, and no
- * shoaling transform is applied. Where the buoy is far away the distance is
- * given, for the same reason the tide panel gives it.
+ * **A buoy is offshore, and says so — once, for the page.** These are open-water
+ * measurements taken some distance out, not the height of the wave breaking at
+ * the shore, and no shoaling transform is applied. That explanation is the same
+ * on every beach, so it lives in `ConditionsNotes` rather than being repeated
+ * under each reading. What stays here is what differs per beach: which buoy, and
+ * how far away it is when that is far enough to matter.
  */
 
 import type { WavesView } from "@/lib/conditions";
@@ -103,8 +105,6 @@ export function WavesToday({ beachName, buoy, state }: WavesView) {
         <p className="text-2xs leading-relaxed text-fog">
           Measured at NDBC buoy {buoy.name}
           {distantKm !== null ? `, about ${distantKm} km from this beach` : ""}.
-          That is the height of the swell in open water, not the height of the
-          wave breaking at the shore, and it is not a safety assessment.
         </p>
       )}
     </section>

--- a/src/components/WavesToday.tsx
+++ b/src/components/WavesToday.tsx
@@ -21,6 +21,9 @@
  */
 
 import type { WavesView } from "@/lib/conditions";
+import { ProvenanceLine } from "./ProvenanceLine";
+import { ReadingCard } from "./ReadingCard";
+import { StatGroup } from "./StatGroup";
 
 /** Past this, the buoy is far enough away that the reader is owed the number. */
 const DISTANT_BUOY_M = 10_000;
@@ -46,26 +49,45 @@ export function WavesToday({ beachName, buoy, state }: WavesView) {
       : null;
 
   return (
-    <section aria-labelledby="waves-today-heading" className="mt-9 max-w-130">
-      <h2
-        id="waves-today-heading"
-        className="text-2xs mb-3 font-extrabold tracking-widest text-ocean uppercase"
-      >
-        Waves and water · {beachName}
-      </h2>
-
+    <ReadingCard
+      emoji="🏄"
+      headingId="waves-today-heading"
+      title={`Waves and water · ${beachName}`}
+      figure={
+        state.kind === "reading" ? `${state.heightFt.toFixed(1)} ft` : null
+      }
+    >
       {state.kind === "reading" && (
         <>
-          <p className="leading-tight mb-2 text-4xl font-black italic">
-            {state.heightFt.toFixed(1)} ft
+          <p className="leading-relaxed mb-3 text-base text-fog">
+            {heightWords(state.heightFt)}.
           </p>
-          <p className="leading-relaxed mb-4 text-base text-fog">
-            {heightWords(state.heightFt)}
-            {state.periodS !== null ? `, ${state.periodS} seconds apart` : ""}.
-            {state.waterTempF !== null
-              ? ` The water is ${Math.round(state.waterTempF)}°F.`
-              : " The buoy reported no water temperature."}
-          </p>
+          {/*
+            Period and water temperature were clauses in the sentence above.
+            They are measurements, and a reader scanning for the water
+            temperature should not have to read a sentence to find it. The
+            plain-language line stays, because it is the half of this card
+            written for a parent rather than for a surfer.
+
+            A null is rendered as an absence rather than dropped: a buoy that
+            publishes waves and no water temperature is a measured fact about
+            that buoy, and an omitted row would read as an oversight.
+          */}
+          <StatGroup
+            stats={[
+              {
+                label: "Period",
+                value: state.periodS !== null ? `${state.periodS} s` : null,
+              },
+              {
+                label: "Water",
+                value:
+                  state.waterTempF !== null
+                    ? `${Math.round(state.waterTempF)}°F`
+                    : null,
+              },
+            ]}
+          />
         </>
       )}
 
@@ -102,11 +124,14 @@ export function WavesToday({ beachName, buoy, state }: WavesView) {
       )}
 
       {buoy !== null && (
-        <p className="text-2xs leading-relaxed text-fog">
-          Measured at NDBC buoy {buoy.name}
-          {distantKm !== null ? `, about ${distantKm} km from this beach` : ""}.
-        </p>
+        <ProvenanceLine
+          source={`Buoy ${buoy.name}`}
+          network="NDBC"
+          distance={
+            distantKm !== null ? `about ${distantKm} km from this beach` : null
+          }
+        />
       )}
-    </section>
+    </ReadingCard>
   );
 }

--- a/src/components/WindToday.test.tsx
+++ b/src/components/WindToday.test.tsx
@@ -37,21 +37,44 @@ test("the temperature is the panel's largest figure and visibility is not", () =
   // an airport. See ADR 0010.
   render(<WindToday {...panel()} />);
 
-  expect(screen.getByText("71°F").className).toContain("text-4xl");
-  expect(
-    screen.getByText(/Visibility 10 miles or more/).className,
-  ).not.toContain("text-4xl");
+  expect(screen.getByText("71°F").className).toContain("text-stat");
+  expect(screen.getByText("10 miles or more").className).not.toContain(
+    "text-stat",
+  );
 });
 
-test("wind, sky and visibility read as one sentence beneath the temperature", () => {
+test("wind, sky and visibility are figures beneath the temperature, not a sentence", () => {
+  // They were clauses in one paragraph, which meant learning the wind speed
+  // required reading a sentence. Each is a labelled figure now.
   render(<WindToday {...panel()} />);
 
-  // One node, so the order is asserted rather than three presence checks.
-  expect(
-    screen.getByText(
-      /Wind 8 mph from the north-west\. Sky: clear\. Visibility 10 miles or more\./,
-    ),
-  ).toBeDefined();
+  expect(screen.getByText("Wind")).toBeDefined();
+  expect(screen.getByText("8 mph from the north-west")).toBeDefined();
+  expect(screen.getByText("Sky")).toBeDefined();
+  expect(screen.getByText("Clear")).toBeDefined();
+  expect(screen.getByText("Visibility")).toBeDefined();
+  expect(screen.getByText("10 miles or more")).toBeDefined();
+});
+
+/**
+ * ADR-0010's requirement, asserted structurally rather than by reading prose.
+ * The four figures come from two stations at very different distances, and the
+ * grouping is what lets a reader tell which supplied which. One group must
+ * never span both.
+ */
+test("the figures are grouped by the station that supplied them", () => {
+  const { container } = render(<WindToday {...panel()} />);
+
+  const groups = container.querySelectorAll("dl");
+  expect(groups.length).toBe(2);
+
+  const wind = groups[0].textContent ?? "";
+  expect(wind).toContain("Wind");
+  expect(wind).not.toContain("Visibility");
+
+  const sky = groups[1].textContent ?? "";
+  expect(sky).toContain("Visibility");
+  expect(sky).not.toContain("Wind");
 });
 
 test("both stations are named, each with its own distance", () => {
@@ -60,10 +83,13 @@ test("both stations are named, each with its own distance", () => {
   // than one who has to read two lines.
   render(<WindToday {...panel()} />);
 
-  expect(
-    screen.getByText(/Temperature and wind measured at Scripps Pier/),
-  ).toBeDefined();
-  expect(screen.getByText(/Miramar, 10 km away/)).toBeDefined();
+  const air = screen.getByText(/Scripps Pier/).textContent ?? "";
+  expect(air).toContain("Temperature and wind");
+  expect(air).toContain("1.4 km from this beach");
+
+  const sky = screen.getByText(/Miramar/).textContent ?? "";
+  expect(sky).toContain("Sky and visibility");
+  expect(sky).toContain("10 km away");
 });
 
 test("a near station keeps its distance rather than rounding it away", () => {
@@ -86,7 +112,7 @@ test("a near station keeps its distance rather than rounding it away", () => {
 test("the ten-mile ceiling reads as a floor, never as an exact measurement", () => {
   render(<WindToday {...panel()} />);
 
-  expect(screen.getByText(/Visibility 10 miles or more/)).toBeDefined();
+  expect(screen.getByText("10 miles or more")).toBeDefined();
 });
 
 test("a visibility below the ceiling is given as the measurement it is", () => {
@@ -98,7 +124,7 @@ test("a visibility below the ceiling is given as the measurement it is", () => {
     />,
   );
 
-  expect(screen.getByText(/Visibility 8 miles\./)).toBeDefined();
+  expect(screen.getByText("8 miles")).toBeDefined();
 });
 
 test("a visibility under a mile keeps its decimal, being the reading that matters", () => {
@@ -112,7 +138,7 @@ test("a visibility under a mile keeps its decimal, being the reading that matter
     />,
   );
 
-  expect(screen.getByText(/Visibility 0\.3 miles\./)).toBeDefined();
+  expect(screen.getByText("0.3 miles")).toBeDefined();
 });
 
 test("one mile is singular", () => {
@@ -124,7 +150,7 @@ test("one mile is singular", () => {
     />,
   );
 
-  expect(screen.getByText(/Visibility 1 mile\./)).toBeDefined();
+  expect(screen.getByText("1 mile")).toBeDefined();
 });
 
 test("wind is given in plain words, from the direction it blows from", () => {
@@ -132,19 +158,20 @@ test("wind is given in plain words, from the direction it blows from", () => {
   // would reverse every reading on the page.
   render(<WindToday {...panel()} />);
 
-  expect(screen.getByText(/Wind 8 mph from the north-west/)).toBeDefined();
+  expect(screen.getByText("8 mph from the north-west")).toBeDefined();
 });
 
 test("a gust is shown when the station published one", () => {
   render(<WindToday {...panel({ air: { ...AIR, gustMph: 14.2 } })} />);
 
-  expect(screen.getByText(/gusting 14/)).toBeDefined();
+  expect(screen.getByText("Gusting")).toBeDefined();
+  expect(screen.getByText("14 mph")).toBeDefined();
 });
 
 test("wind with no direction is still given as a speed", () => {
   render(<WindToday {...panel({ air: { ...AIR, windDirDegT: null } })} />);
 
-  expect(screen.getByText(/Wind 8 mph\./)).toBeDefined();
+  expect(screen.getByText("8 mph")).toBeDefined();
 });
 
 test("no wind value says so rather than reading as calm", () => {
@@ -155,7 +182,8 @@ test("no wind value says so rather than reading as calm", () => {
     />,
   );
 
-  expect(screen.getByText(/reported no wind speed/)).toBeDefined();
+  expect(screen.getByText("Wind")).toBeDefined();
+  expect(screen.getByText("Not reported")).toBeDefined();
 });
 
 test("a genuine calm is named as calm, not as a missing reading", () => {
@@ -163,7 +191,42 @@ test("a genuine calm is named as calm, not as a missing reading", () => {
     <WindToday {...panel({ air: { ...AIR, windMph: 0, windDirDegT: 0 } })} />,
   );
 
-  expect(screen.getByText(/The wind is calm/)).toBeDefined();
+  expect(screen.getByText("Calm")).toBeDefined();
+});
+
+/**
+ * Regression. The sentence this replaced returned at "The wind is calm" and
+ * never reached its gust clause; the first stats version appended one anyway,
+ * and the live page rendered "Wind: Calm / Gusting: 2 mph" — a card
+ * contradicting itself. Under a knot of wind a gust is instrument noise rather
+ * than weather anybody feels.
+ */
+test("a calm wind reports no gust, however the instrument twitched", () => {
+  render(
+    <WindToday
+      {...panel({
+        air: { ...AIR, windMph: 0.4, windDirDegT: 0, gustMph: 2.1 },
+      })}
+    />,
+  );
+
+  expect(screen.getByText("Calm")).toBeDefined();
+  expect(screen.queryByText("Gusting")).toBeNull();
+});
+
+test("a gust with no wind speed at all is not reported either", () => {
+  // "Not reported / Gusting 14 mph" would be the same contradiction wearing a
+  // different hat: a gust is a property of a wind we do not have.
+  render(
+    <WindToday
+      {...panel({
+        air: { ...AIR, windMph: null, windDirDegT: null, gustMph: 14.2 },
+      })}
+    />,
+  );
+
+  expect(screen.getByText("Not reported")).toBeDefined();
+  expect(screen.queryByText("Gusting")).toBeNull();
 });
 
 test("a missing temperature says so rather than leaving the panel headed by nothing", () => {
@@ -178,9 +241,9 @@ test("a missing temperature says so rather than leaving the panel headed by noth
 test("a station publishing no sky simply goes unsaid", () => {
   render(<WindToday {...panel({ sky: { ...SKY, sky: null } })} />);
 
-  expect(screen.queryByText(/Sky:/)).toBeNull();
+  expect(screen.queryByText("Sky")).toBeNull();
   // Visibility still renders: it is the other half of the same station.
-  expect(screen.getByText(/Visibility 10 miles or more/)).toBeDefined();
+  expect(screen.getByText("10 miles or more")).toBeDefined();
 });
 
 test("an airport publishing no visibility says so rather than rendering blank", () => {
@@ -192,7 +255,8 @@ test("an airport publishing no visibility says so rather than rendering blank", 
     />,
   );
 
-  expect(screen.getByText(/reported no visibility/)).toBeDefined();
+  expect(screen.getByText("Visibility")).toBeDefined();
+  expect(screen.getByText("Not reported")).toBeDefined();
 });
 
 test("a failing sky never takes the temperature down with it", () => {
@@ -212,7 +276,7 @@ test("a failing sky never takes the temperature down with it", () => {
   );
 
   expect(screen.getByText("71°F")).toBeDefined();
-  expect(screen.getByText(/Wind 8 mph/)).toBeDefined();
+  expect(screen.getByText("8 mph from the north-west")).toBeDefined();
   expect(screen.getByText(/returns 404/)).toBeDefined();
   expect(screen.queryByText(/Visibility/)).toBeNull();
 });
@@ -230,9 +294,8 @@ test("a failing temperature never takes the sky down with it", () => {
     />,
   );
 
-  expect(
-    screen.getByText(/Sky: clear\. Visibility 10 miles or more\./),
-  ).toBeDefined();
+  expect(screen.getByText("Clear")).toBeDefined();
+  expect(screen.getByText("10 miles or more")).toBeDefined();
   expect(screen.getByText("No temperature just now")).toBeDefined();
   expect(screen.getByText(/returns 404/)).toBeDefined();
 });
@@ -273,7 +336,7 @@ test("no air station is a permanent fact about the place, with its reason", () =
   expect(screen.getByText(/outside San Diego County/)).toBeDefined();
   // Never invite a reader to retry something that will never work.
   expect(screen.queryByText(/just now/)).toBeNull();
-  expect(screen.queryByText(/Temperature and wind measured at/)).toBeNull();
+  expect(screen.queryByText(/Temperature and wind/)).toBeNull();
 });
 
 test("no sky station leaves the temperature standing on its own", () => {
@@ -291,5 +354,5 @@ test("no sky station leaves the temperature standing on its own", () => {
 
   expect(screen.getByText("71°F")).toBeDefined();
   expect(screen.getByText(/publishes a sky description/)).toBeDefined();
-  expect(screen.queryByText(/Sky and visibility at/)).toBeNull();
+  expect(screen.queryByText(/Sky and visibility/)).toBeNull();
 });

--- a/src/components/WindToday.test.tsx
+++ b/src/components/WindToday.test.tsx
@@ -75,11 +75,13 @@ test("a near station keeps its distance rather than rounding it away", () => {
   expect(screen.getByText(/1\.4 km from this beach/)).toBeDefined();
 });
 
-test("the airport says it is an airport, and why that is the only option", () => {
-  render(<WindToday {...panel()} />);
-
-  expect(screen.getByText(/only published by airports/)).toBeDefined();
-});
+/**
+ * "Why the sky comes from an airport" moved to `ConditionsNotes`, and is
+ * asserted there. It is true at every beach on the site, so it was collected
+ * with the rest of the shared explanation rather than sitting under this one
+ * panel. What this panel still owes the reader — both stations named, each with
+ * its own distance — is asserted above.
+ */
 
 test("the ten-mile ceiling reads as a floor, never as an exact measurement", () => {
   render(<WindToday {...panel()} />);

--- a/src/components/WindToday.tsx
+++ b/src/components/WindToday.tsx
@@ -48,6 +48,9 @@
  */
 
 import type { AirView } from "@/lib/conditions";
+import { ProvenanceLine } from "./ProvenanceLine";
+import { ReadingCard } from "./ReadingCard";
+import { type Stat, StatGroup } from "./StatGroup";
 
 const COMPASS = [
   "north",
@@ -90,30 +93,62 @@ function distanceWords(metres: number): string {
   return `${km < 10 ? km.toFixed(1) : km.toFixed(0)} km`;
 }
 
-/** The wind, as a sentence, or the reason there is not one. */
-function windSentence(air: AirView["air"]): string {
-  if (air.kind !== "reading") return "";
-  if (air.windMph === null) return " The station reported no wind speed.";
-  if (air.windMph < 1) return " The wind is calm.";
-  return (
-    ` Wind ${Math.round(air.windMph)} mph` +
-    (air.windDirDegT !== null
-      ? ` from the ${compassWords(air.windDirDegT)}`
-      : "") +
-    (air.gustMph !== null ? `, gusting ${Math.round(air.gustMph)}` : "") +
-    "."
-  );
+/**
+ * The wind, as figures from the shore station.
+ *
+ * `null` and *absent* mean different things here, and the difference is
+ * deliberate. A null wind speed is a measured absence — the station carries the
+ * field and published nothing — so it renders "Not reported". A gust is omitted
+ * entirely when there is none, because most stations most of the time are not
+ * gusting and a standing "Not reported" would turn ordinary weather into a
+ * column of missing data. That matches what this panel already did: it appended
+ * ", gusting N" only when there was one, and said nothing otherwise.
+ *
+ * **A calm wind reports no gust**, which is the other half of what the sentence
+ * this replaced already did — it returned at "The wind is calm" and never
+ * reached the gust clause. Rendering both produced "Wind: Calm / Gusting: 2 mph"
+ * on the live page, a card contradicting itself. Under a knot of wind, a gust
+ * figure is noise from the instrument rather than weather anybody feels.
+ */
+function windStats(air: Extract<AirView["air"], { kind: "reading" }>): Stat[] {
+  const calm = air.windMph !== null && air.windMph < 1;
+
+  const speed =
+    air.windMph === null
+      ? null
+      : calm
+        ? "Calm"
+        : `${Math.round(air.windMph)} mph` +
+          (air.windDirDegT !== null
+            ? ` from the ${compassWords(air.windDirDegT)}`
+            : "");
+
+  const stats: Stat[] = [{ label: "Wind", value: speed }];
+  if (air.gustMph !== null && !calm && air.windMph !== null) {
+    stats.push({ label: "Gusting", value: `${Math.round(air.gustMph)} mph` });
+  }
+  return stats;
 }
 
-/** Sky then visibility, from the other station, or nothing at all. */
-function skySentence(sky: AirView["sky"]): string {
-  if (sky.kind !== "reading") return "";
-  return (
-    (sky.sky !== null ? ` Sky: ${sky.sky.toLowerCase()}.` : "") +
-    (sky.visibilityMi === null
-      ? " The airport reported no visibility."
-      : ` Visibility ${visibilityWords(sky.visibilityMi, sky.visibilityAtCeiling)}.`)
-  );
+/**
+ * Sky and visibility, as figures from the airport.
+ *
+ * Same distinction, and the same two behaviours this panel already had: a
+ * station publishing no sky simply goes unsaid, while an airport publishing no
+ * visibility says so. The asymmetry is upstream's — a missing sky layer is not
+ * a reading anyone attempted, and a missing visibility is.
+ */
+function skyStats(sky: Extract<AirView["sky"], { kind: "reading" }>): Stat[] {
+  const stats: Stat[] = [];
+  if (sky.sky !== null) stats.push({ label: "Sky", value: sky.sky });
+  stats.push({
+    label: "Visibility",
+    value:
+      sky.visibilityMi === null
+        ? null
+        : visibilityWords(sky.visibilityMi, sky.visibilityAtCeiling),
+  });
+  return stats;
 }
 
 /** The primary slot never renders empty: an empty one reads as a fault. */
@@ -132,23 +167,53 @@ export function WindToday({
   air,
   sky,
 }: AirView) {
-  const secondary = `${windSentence(air)}${skySentence(sky)}`.trim();
-
   return (
-    <section aria-labelledby="wind-today-heading" className="mt-9 max-w-130">
-      <h2
-        id="wind-today-heading"
-        className="text-2xs mb-3 font-extrabold tracking-widest text-ocean uppercase"
-      >
-        Air · {beachName}
-      </h2>
+    <ReadingCard
+      emoji="🌡️"
+      headingId="wind-today-heading"
+      title={`Air · ${beachName}`}
+      figure={temperatureWords(air)}
+    >
+      {/*
+        Two groups, each followed by its own attribution, and that arrangement
+        IS ADR-0010 rather than a layout preference. The four figures come from
+        two stations at very different distances, and a reader who cannot tell
+        which supplied which is worse off than one who reads two lines. As one
+        paragraph of prose the distinction was technically present and
+        practically invisible; grouped, it is the first thing the card shows.
 
-      <p className="leading-tight mb-2 text-4xl font-black italic">
-        {temperatureWords(air)}
-      </p>
+        One StatGroup never spans two sources.
+      */}
+      {air.kind === "reading" && <StatGroup stats={windStats(air)} />}
 
-      {secondary !== "" && (
-        <p className="leading-relaxed mb-4 text-base text-fog">{secondary}</p>
+      {airStation !== null && (
+        <ProvenanceLine
+          label="Temperature and wind"
+          source={airStation.name}
+          distance={
+            airStation.distanceM !== null
+              ? `${distanceWords(airStation.distanceM)} from this beach`
+              : null
+          }
+        />
+      )}
+
+      {sky.kind === "reading" && (
+        <div className="mt-4">
+          <StatGroup stats={skyStats(sky)} />
+        </div>
+      )}
+
+      {skyStation !== null && (
+        <ProvenanceLine
+          label="Sky and visibility"
+          source={skyStation.name}
+          distance={
+            skyStation.distanceM !== null
+              ? `${distanceWords(skyStation.distanceM)} away`
+              : null
+          }
+        />
       )}
 
       {air.kind === "no-station" && (
@@ -191,27 +256,6 @@ export function WindToday({
           <p className="mt-2">{sky.reason}</p>
         </details>
       )}
-
-      <div className="text-2xs leading-relaxed text-fog">
-        {airStation !== null && (
-          <p>
-            Temperature and wind measured at {airStation.name}
-            {airStation.distanceM !== null
-              ? `, ${distanceWords(airStation.distanceM)} from this beach`
-              : ""}
-            .
-          </p>
-        )}
-        {skyStation !== null && (
-          <p>
-            Sky and visibility at {skyStation.name}
-            {skyStation.distanceM !== null
-              ? `, ${distanceWords(skyStation.distanceM)} away`
-              : ""}
-            .
-          </p>
-        )}
-      </div>
-    </section>
+    </ReadingCard>
   );
 }

--- a/src/components/WindToday.tsx
+++ b/src/components/WindToday.tsx
@@ -21,7 +21,10 @@
  *
  * The cost of that decision is a second attribution line, and it is deliberately
  * not hidden: a reader who cannot tell which station supplied which figure is
- * worse off than one who has to read two lines.
+ * worse off than one who has to read two lines. Both lines stay here for that
+ * reason. What left is the explanation of *why* the sky is an airport reading,
+ * which is true of every beach on the site and now sits once in
+ * `ConditionsNotes` instead of under one panel out of three.
  *
  * **Both distances are always shown**, which the single-station version did not
  * do — it hid anything under five kilometres. With two stations named, showing
@@ -205,9 +208,7 @@ export function WindToday({
             {skyStation.distanceM !== null
               ? `, ${distanceWords(skyStation.distanceM)} away`
               : ""}
-            . That is an airport reading rather than one taken at the shore:
-            cloud and visibility are only published by airports, and coastal fog
-            is exactly what changes across that distance.
+            .
           </p>
         )}
       </div>


### PR DESCRIPTION
Refs #122. **PR A of three** — this one makes each reading a card. The page still
uses a third of its width; that is PR B, which depends on these cards existing.

Also closes #78, which asked for a description of `/conditions/[slug]`.

## What changed, by slice

**1 — Collect the shared explanation into one block.** Each panel ended with a
10px paragraph carrying two different things: which station supplied this
figure, and what the figure means. The first differs per beach; the second was
the same explanation written three times, and repeating it between the readings
is most of why the numbers were hard to find. `ConditionsNotes` says each once
for the whole page — the datum, what a buoy measures, why the sky is an airport
reading, and that none of it is a safety assessment.

`TideToday`'s docstring already made this argument — _"the acronym is named once,
at the bottom, rather than beside every figure"_ — and then the page did that
once per panel.

**2 — The reading card, proven on the tide.** `ReadingCard` and `ProvenanceLine`,
adopted by one panel first so the direction could be looked at before two more
were built on it. The surface is `mist`, which is not a guess: `globals.css`
records that `--color-fog` was darkened from the template precisely because the
original failed AA against mist and the replacement "clears 5:1 everywhere".

**3 — Waves adopts the card, and brings `StatGroup`.** Swell period and water
temperature were clauses inside a sentence. Two of the six readings this work
exists to make visible.

**4 — Air adopts the card, with two provenances made visible.** Four figures,
two stations, ten kilometres apart, previously one grey paragraph plus two
attribution lines a reader had to match up. Two `StatGroup`s, each followed by
its own `ProvenanceLine`. One group never spans two sources, and a test asserts
that structurally rather than by matching prose.

## Decisions worth flagging

**The cards are deliberately quieter than `ProgramCards`.** Those are saturated
purple and ocean with white type, which is right for an offer. These are
instrument readings shown to people taking children into the ocean, and ADR-0009
forbids the site from making a judgement about them. A card that looked like a
verdict would be making one in CSS.

**Attributions did not move.** ADR-0010 turns on a reader being able to tell
which station supplied which figure, and the air panel names two precisely so
they can be compared. Only the general explanation was collected.

**`ProvenanceLine`'s network is optional.** `StationBinding` carries a name and a
distance and no network; an air station may be on either the NWS or the NDBC
network, and this panel has never named one. Rendering a guess would be worse
than rendering nothing, and threading the field through the view model is a data
change rather than a presentation one.

**`StatGroup` was planned for slice 2 and built in slice 3.** The tide card's
secondary content is its height sentence, so a stat list there would have been a
component with no consumer — the speculative flexibility CLAUDE.md bans.
`TASKS.md` records the change.

**The tide glyph changed at the checkpoint**, 🐚 to 🌊. The shell rendered pale
lavender on a pale lavender surface, and read as something a child finds on a
page where an animal glyph is about to mean exactly that. #121's roster commits
ten animal glyphs to sightings — 🪸 among them, which is the nearest thing
Unicode has to an anemone and the reason an anemone cannot head the tide card.
Panels take environmental glyphs: 🌊 tide, 🏄 waves, 🌡️ air. Recorded in the
brief as a standing rule.

## A regression this branch introduced and fixed

The wind sentence being replaced returned at "The wind is calm" and never
reached its gust clause. The first stats version appended one regardless, and
the running page rendered **"Wind: Calm / Gusting: 2 mph"** — a card
contradicting itself.

Found by looking at the page, not by a test. Two regression tests now cover it:
a calm wind reports no gust, and neither does a wind speed that was never
reported, a gust being a property of a wind we do not have.

## Tests

Twenty-odd assertions moved from asserting a sentence to asserting a figure, or
moved component when the prose they assert did. Every property survives:

- the datum, the astronomy qualification and the safety line are asserted in
  `ConditionsNotes.test.tsx` in the same words they had in `TideToday` and
  `WavesToday`
- the ten-mile ceiling still reads as a floor; a sub-mile visibility still keeps
  its decimal; one mile is still singular
- a station publishing no sky still goes unsaid, while an airport publishing no
  visibility still says so
- a missing figure renders "Not reported" rather than a blank, because a blank
  where a measurement goes reads as a calm sea

The caveats chain is unchanged and still green end to end: `lib/caveats.test.ts`
binds every `unresolved` entry to `inventoryCaveats()` in both directions, and
`ConditionsSection.test.tsx` binds that to the rendered page. Moving `Caveats`
inside `ConditionsNotes` is safe because that second test would have failed if
any caveat stopped rendering.

## Gate output

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

679 tests, 65 files.

## What I did not do

- **The layout.** The page still uses about a third of its width and the cards
  are full-width and stacked. That is PR B — the chooser moves into the header
  row, the cards go three across, and the map slot lands. It depends on these
  cards existing, which is why it is not in this one.
- **The week grid** — PR C.
- **The sighting map** — specified in #121 and deferred at the author's request.
  A reserved slot for it lands in PR B.
- **No `docs/plans/` file**, and **no issue per slice**. The brief holds the
  design, `TASKS.md` holds the slices and the test seams, and #121 holds the map;
  a fourth document would be a copy with its own drift. The nine slices are
  strictly sequential and touch the same handful of files, so two people could
  not pick up two of them without colliding — the test CLAUDE.md sets for whether
  splitting earns its keep. Both omissions are stated here rather than left to
  look like lapses.

## Noticed, not fixed

The landing page's conditions teaser still carries a reserved slot reading
_"Surf, wind and visibility are still to come."_ That shipped before waves and
air did and is now stale. It belongs to its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
