### PR TITLE
Put the sighting map slot in the future tense

### DIFF
--- a/src/components/ConditionsSection.test.tsx
+++ b/src/components/ConditionsSection.test.tsx
@@ -80,3 +80,27 @@ test("the slot promises a record of reports, never a survey", () => {
     screen.getByText(/reported by naturalists, not surveyed by us/),
   ).toBeDefined();
 });
+
+/**
+ * The tense is the claim. Named animals, a named window and a named place in
+ * the past tense read as a report of what was found here, and no such report
+ * exists — the map is deferred. On a page whose discipline is that every figure
+ * names its station and nothing unmeasured is asserted, this was the one
+ * sentence a skimming reader could come away believing.
+ *
+ * The three forecast slots in `WeekPanel` do not have the problem because each
+ * describes a product shape — "Swell height and period for each day" — rather
+ * than asserting something about the world. This slot has to read the same way.
+ * The rolling week stays in the copy: a seven-day window is what the product
+ * is (#121), and under "Will show" it describes the map rather than the coast.
+ */
+test("the slot says what the map will show, not what was found", () => {
+  render(<ConditionsSection slug={DEFAULT_BEACH_SLUG} />);
+
+  const slot = screen.getByText(/A map of what people have found here/);
+
+  expect(slot.textContent).toContain(
+    "Will show octopus, nudibranchs, sea hares and leopard sharks logged " +
+      "near this beach in the past week",
+  );
+});

--- a/src/components/ConditionsSection.tsx
+++ b/src/components/ConditionsSection.tsx
@@ -136,7 +136,7 @@ export function ConditionsSection({ slug }: { slug: string }) {
         <ReservedSlot
           emoji="🗺️"
           headline="A map of what people have found here is coming."
-          detail="Octopus, nudibranchs, sea hares and leopard sharks logged near this beach in the past week — reported by naturalists, not surveyed by us."
+          detail="Will show octopus, nudibranchs, sea hares and leopard sharks logged near this beach in the past week — reported by naturalists, not surveyed by us."
         />
       </div>
 


### PR DESCRIPTION
Design review finding 2 (Must Fix), from `.design/conditions-page/DESIGN_REVIEW.md`.

## What changed and why

The map slot's `detail` read:

> Octopus, nudibranchs, sea hares and leopard sharks logged near this beach in the past week — reported by naturalists, not surveyed by us.

Named animals, a named window and a named place, in the past tense, with only the headline above it ("A map of what people have found here **is coming**") marking any of it as illustrative. The map is deferred (#121), so nothing was logged and nobody reported it. On a page whose whole discipline is that every figure names its station and nothing unmeasured is asserted, this was the one sentence a skimming parent could come away believing.

It now reads "**Will show** octopus, …". The three forecast slots in `WeekPanel` never had this problem because each describes a *product shape* — "Swell height and period for each day" — rather than asserting something about the world; this slot now reads the same way.

The rolling week stays. A seven-day window is what the product *is* (#121 is titled "what was found near this beach in the past week"), and governed by "Will show" it describes the map rather than the coast.

One commit, one string, one test.

## Small lane

Prose only, no logic, no data shape, no contract, and it contradicts nothing in `docs/adr/` or `CONTEXT.md` — the small lane per `CLAUDE.md`. No plan file, no slice table, no issue. No open issue covers this finding, so there is no `Closes #`; `DESIGN_REVIEW.md` is the durable record.

## Verification

The test was confirmed red before the fix — the source change stashed, the suite run:

```
 FAIL  src/components/ConditionsSection.test.tsx > the slot says what the map will show, not what was found
AssertionError: expected 'A map of what people have found here …' to contain 'Will show octopus, nudibranchs, sea h…'

Expected: "Will show octopus, nudibranchs, sea hares and leopard sharks logged near this beach in the past week"
Received: "A map of what people have found here is coming.Octopus, nudibranchs, sea hares and leopard sharks logged near this beach in the past week — reported by naturalists, not surveyed by us."

 Test Files  1 failed (1)
      Tests  1 failed | 4 passed (5)
```

`npm run gate` at `90df341`, with `.next/` removed first:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

## Not done here

- Findings 1, 3, 4, 6, 7 and 9 are separate branches and separate PRs, in that order. None of them touch this file.
- Finding 5 (heading scale) is a site-wide decision that needs an ADR; the author has answered it and it will land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
