### PR TITLE
Compose the 44px touch-target floor on every disclosure

### DIFF
--- a/src/components/Caveats.test.tsx
+++ b/src/components/Caveats.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { Caveats } from "./Caveats";
+import { DISCLOSURE_TARGET } from "./disclosure";
 
 const ENTRIES = [
   "beach_type is UNKNOWN upstream for most of these beaches.",
@@ -96,4 +97,26 @@ test("the uncertainty disclosure is absent when there is nothing to disclose", (
     screen.queryByText("What we are unsure about in this data"),
   ).toBeNull();
   expect(screen.getByText(/answers for 41 of the 73/)).toBeDefined();
+});
+
+/**
+ * ADR-0004's 44px floor, on the elements that were the last thing on this page
+ * under it. A `<summary>` is background-less, so it takes the floor at every
+ * breakpoint and carries no `md:min-h-0` -- see `disclosure.ts` for why the
+ * display is left alone and why the padding is part of the composition.
+ *
+ * Every summary the component can render rather than a named one, because the
+ * failure this repo has is drift: a disclosure added later without the floor.
+ * Per ADR-0001 jsdom applies no stylesheets, so this proves the class is
+ * referenced, not that the box measures 44px. That stays a human check.
+ */
+test("both disclosures compose the touch-target floor", () => {
+  const { container } = render(<Caveats entries={ENTRIES} reach={REACH} />);
+
+  const summaries = [...container.querySelectorAll("summary")];
+
+  expect(summaries).toHaveLength(2);
+  for (const summary of summaries) {
+    expect(summary.className).toContain(DISCLOSURE_TARGET);
+  }
 });

--- a/src/components/Caveats.tsx
+++ b/src/components/Caveats.tsx
@@ -26,6 +26,7 @@
  */
 
 import type { InventoryReach } from "@/lib/beaches";
+import { DISCLOSURE_TARGET } from "./disclosure";
 
 export function Caveats({
   entries,
@@ -43,7 +44,9 @@ export function Caveats({
 
       {reach.excluded.length > 0 && (
         <details className="mt-3">
-          <summary>Why the other {reach.excluded.length} are not here</summary>
+          <summary className={DISCLOSURE_TARGET}>
+            Why the other {reach.excluded.length} are not here
+          </summary>
           <p className="leading-relaxed mt-3">
             A beach is left out rather than answered with a reading measured
             somewhere else — a station further away than we would publish a
@@ -62,7 +65,9 @@ export function Caveats({
 
       {entries.length > 0 && (
         <details className="mt-3">
-          <summary>What we are unsure about in this data</summary>
+          <summary className={DISCLOSURE_TARGET}>
+            What we are unsure about in this data
+          </summary>
           <ul className="leading-relaxed mt-3">
             {entries.map((entry) => (
               <li key={entry} className="mb-3">

--- a/src/components/TideToday.test.tsx
+++ b/src/components/TideToday.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { TideToday } from "./TideToday";
+import { DISCLOSURE_TARGET } from "./disclosure";
 
 const NEAR_STATION = {
   name: "La Jolla (Scripps Institution Wharf)",
@@ -198,4 +199,51 @@ test("drift is called out as a bug here rather than a problem at the station", (
   expect(
     screen.getByText(/a bug here rather than a problem at the station/),
   ).toBeDefined();
+});
+
+/**
+ * ADR-0004's 44px floor, on the elements that were the last thing on this page
+ * under it. A `<summary>` is background-less, so it takes the floor at every
+ * breakpoint and carries no `md:min-h-0` -- see `disclosure.ts` for why the
+ * display is left alone and why the padding is part of the composition.
+ *
+ * Every summary the component can render rather than a named one, because the
+ * failure this repo has is drift: a disclosure added later without the floor.
+ * Per ADR-0001 jsdom applies no stylesheets, so this proves the class is
+ * referenced, not that the box measures 44px. That stays a human check.
+ */
+test("every disclosure this card can render composes the touch-target floor", () => {
+  const renders = [
+    render(
+      <TideToday
+        beachName="Imperial Beach pier area"
+        station={null}
+        state={{
+          kind: "no-station",
+          reason: "no tide station could be joined to this beach",
+        }}
+      />,
+    ),
+    render(
+      <TideToday
+        beachName="La Jolla Shores Beach"
+        station={NEAR_STATION}
+        state={{
+          kind: "unavailable",
+          detail: "NOAA returned HTTP 503 for station 9410230.",
+          drift: false,
+        }}
+      />,
+    ),
+  ];
+
+  const summaries = renders.flatMap((r) => [
+    ...r.container.querySelectorAll("summary"),
+  ]);
+
+  // Both degraded states, so neither disclosure can be the one that was missed.
+  expect(summaries).toHaveLength(2);
+  for (const summary of summaries) {
+    expect(summary.className).toContain(DISCLOSURE_TARGET);
+  }
 });

--- a/src/components/TideToday.tsx
+++ b/src/components/TideToday.tsx
@@ -34,6 +34,7 @@
  */
 
 import type { TideTodayView } from "@/lib/conditions";
+import { DISCLOSURE_TARGET } from "./disclosure";
 import { ProvenanceLine } from "./ProvenanceLine";
 import { ReadingCard } from "./ReadingCard";
 import { StatGroup } from "./StatGroup";
@@ -107,7 +108,7 @@ export function TideToday({ beachName, station, state }: TideTodayProps) {
             is not different, we simply have no published figure for it.
           </p>
           <details className="mb-4 text-sm text-fog">
-            <summary>Why not</summary>
+            <summary className={DISCLOSURE_TARGET}>Why not</summary>
             <p className="mt-2">{state.reason}</p>
           </details>
         </>
@@ -121,7 +122,7 @@ export function TideToday({ beachName, station, state }: TideTodayProps) {
             printed tide table.
           </p>
           <details className="mb-4 text-sm text-fog">
-            <summary>What went wrong</summary>
+            <summary className={DISCLOSURE_TARGET}>What went wrong</summary>
             <p className="mt-2">{state.detail}</p>
             {state.drift && (
               <p className="mt-2">

--- a/src/components/WavesToday.test.tsx
+++ b/src/components/WavesToday.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { WavesToday } from "./WavesToday";
+import { DISCLOSURE_TARGET } from "./disclosure";
 
 const NEAR = { name: "Scripps Nearshore", distanceM: 1400 };
 const FAR = { name: "Point Loma South", distanceM: 34_159 };
@@ -170,4 +171,53 @@ test("drift is named as a bug here rather than a problem at the buoy", () => {
   expect(
     screen.getByText(/a bug here rather than a problem at the buoy/),
   ).toBeDefined();
+});
+
+/**
+ * ADR-0004's 44px floor, on the elements that were the last thing on this page
+ * under it. A `<summary>` is background-less, so it takes the floor at every
+ * breakpoint and carries no `md:min-h-0` -- see `disclosure.ts` for why the
+ * display is left alone and why the padding is part of the composition.
+ *
+ * Every summary the component can render rather than a named one, because the
+ * failure this repo has is drift: a disclosure added later without the floor.
+ * Per ADR-0001 jsdom applies no stylesheets, so this proves the class is
+ * referenced, not that the box measures 44px. That stays a human check.
+ */
+test("every disclosure this card can render composes the touch-target floor", () => {
+  const renders = [
+    render(
+      <WavesToday
+        beachName="Kellogg Park"
+        buoy={null}
+        state={{
+          kind: "no-buoy",
+          reason: "every wave buoy sits on the open coast",
+        }}
+      />,
+    ),
+    render(
+      <WavesToday
+        beachName="La Jolla Shores Beach"
+        buoy={NEAR}
+        state={{
+          kind: "unavailable",
+          detail: "NDBC 46254's newest observation is 214 minutes old.",
+          drift: false,
+        }}
+      />,
+    ),
+  ];
+
+  const summaries = renders.flatMap((r) => [
+    ...r.container.querySelectorAll("summary"),
+  ]);
+
+  // The no-buoy "Why not" is the one the review measured at 279x17; the
+  // unavailable disclosure eighteen lines below it in the source is the one a
+  // fix scoped to what rendered that day would have left behind.
+  expect(summaries).toHaveLength(2);
+  for (const summary of summaries) {
+    expect(summary.className).toContain(DISCLOSURE_TARGET);
+  }
 });

--- a/src/components/WavesToday.tsx
+++ b/src/components/WavesToday.tsx
@@ -21,6 +21,7 @@
  */
 
 import type { WavesView } from "@/lib/conditions";
+import { DISCLOSURE_TARGET } from "./disclosure";
 import { ProvenanceLine } from "./ProvenanceLine";
 import { ReadingCard } from "./ReadingCard";
 import { StatGroup } from "./StatGroup";
@@ -99,7 +100,7 @@ export function WavesToday({ beachName, buoy, state }: WavesView) {
             than a fault. Every wave buoy sits out on the open coast.
           </p>
           <details className="mb-4 text-sm text-fog">
-            <summary>Why not</summary>
+            <summary className={DISCLOSURE_TARGET}>Why not</summary>
             <p className="mt-2">{state.reason}</p>
           </details>
         </>
@@ -112,7 +113,7 @@ export function WavesToday({ beachName, buoy, state }: WavesView) {
             shortly.
           </p>
           <details className="mb-4 text-sm text-fog">
-            <summary>What went wrong</summary>
+            <summary className={DISCLOSURE_TARGET}>What went wrong</summary>
             <p className="mt-2">{state.detail}</p>
             {state.drift && (
               <p className="mt-2">

--- a/src/components/WindToday.test.tsx
+++ b/src/components/WindToday.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { WindToday } from "./WindToday";
+import { DISCLOSURE_TARGET } from "./disclosure";
 
 /** Scripps Pier: what La Jolla Shores now reads for temperature and wind. */
 const PIER = { name: "Scripps Pier", distanceM: 1_381 };
@@ -355,4 +356,60 @@ test("no sky station leaves the temperature standing on its own", () => {
   expect(screen.getByText("71°F")).toBeDefined();
   expect(screen.getByText(/publishes a sky description/)).toBeDefined();
   expect(screen.queryByText(/Sky and visibility/)).toBeNull();
+});
+
+/**
+ * ADR-0004's 44px floor, on the elements that were the last thing on this page
+ * under it. A `<summary>` is background-less, so it takes the floor at every
+ * breakpoint and carries no `md:min-h-0` -- see `disclosure.ts` for why the
+ * display is left alone and why the padding is part of the composition.
+ *
+ * Every summary the component can render rather than a named one, because the
+ * failure this repo has is drift: a disclosure added later without the floor.
+ * Per ADR-0001 jsdom applies no stylesheets, so this proves the class is
+ * referenced, not that the box measures 44px. That stays a human check.
+ */
+test("every disclosure this card can render composes the touch-target floor", () => {
+  // Four of the ten on this page are here, because the two halves fail
+  // separately and each has both a no-station and an unavailable disclosure.
+  const renders = [
+    render(
+      <WindToday
+        {...panel({
+          airStation: null,
+          skyStation: null,
+          air: { kind: "no-station", reason: "no station near enough" },
+          sky: {
+            kind: "no-station",
+            reason: "nothing near here publishes sky",
+          },
+        })}
+      />,
+    ),
+    render(
+      <WindToday
+        {...panel({
+          air: {
+            kind: "unavailable",
+            detail: "NDBC LJAC1 returns 404 for realtime2.",
+            drift: false,
+          },
+          sky: {
+            kind: "unavailable",
+            detail: "NWS KNKX returns 404 for its latest observation.",
+            drift: false,
+          },
+        })}
+      />,
+    ),
+  ];
+
+  const summaries = renders.flatMap((r) => [
+    ...r.container.querySelectorAll("summary"),
+  ]);
+
+  expect(summaries).toHaveLength(4);
+  for (const summary of summaries) {
+    expect(summary.className).toContain(DISCLOSURE_TARGET);
+  }
 });

--- a/src/components/WindToday.tsx
+++ b/src/components/WindToday.tsx
@@ -48,6 +48,7 @@
  */
 
 import type { AirView } from "@/lib/conditions";
+import { DISCLOSURE_TARGET } from "./disclosure";
 import { ProvenanceLine } from "./ProvenanceLine";
 import { ReadingCard } from "./ReadingCard";
 import { type Stat, StatGroup } from "./StatGroup";
@@ -219,14 +220,18 @@ export function WindToday({
 
       {air.kind === "no-station" && (
         <details className="mb-4 text-sm text-fog">
-          <summary>Why there is no temperature or wind</summary>
+          <summary className={DISCLOSURE_TARGET}>
+            Why there is no temperature or wind
+          </summary>
           <p className="mt-2">{air.reason}</p>
         </details>
       )}
 
       {air.kind === "unavailable" && (
         <details className="mb-4 text-sm text-fog">
-          <summary>Why there is no temperature or wind</summary>
+          <summary className={DISCLOSURE_TARGET}>
+            Why there is no temperature or wind
+          </summary>
           <p className="mt-2">{air.detail}</p>
           {air.drift && (
             <p className="mt-2">
@@ -239,7 +244,9 @@ export function WindToday({
 
       {sky.kind === "unavailable" && (
         <details className="mb-4 text-sm text-fog">
-          <summary>Why there is no sky or visibility</summary>
+          <summary className={DISCLOSURE_TARGET}>
+            Why there is no sky or visibility
+          </summary>
           <p className="mt-2">{sky.detail}</p>
           {sky.drift && (
             <p className="mt-2">
@@ -253,7 +260,9 @@ export function WindToday({
 
       {sky.kind === "no-station" && (
         <details className="mb-4 text-sm text-fog">
-          <summary>Why there is no sky or visibility</summary>
+          <summary className={DISCLOSURE_TARGET}>
+            Why there is no sky or visibility
+          </summary>
           <p className="mt-2">{sky.reason}</p>
         </details>
       )}

--- a/src/components/disclosure.ts
+++ b/src/components/disclosure.ts
@@ -1,0 +1,38 @@
+import { TOUCH_TARGET } from "./touchTarget";
+
+/**
+ * A `<summary>` grown to the touch-target floor without losing its marker.
+ *
+ * Every disclosure on the conditions page measured 17px tall -- `text-sm` at
+ * Montserrat's normal line-height, and nothing else. They were the only
+ * interactive elements on that page under 44px, and the design review that
+ * found them is the third to report a touch target here. ADR-0004 exists
+ * because the first two were filed as style notes and nothing happened.
+ *
+ * **The display is deliberately left alone.** `Nav` composes the floor with
+ * `flex` and `PillLink` with `inline-flex`, and either one here would take the
+ * disclosure triangle with it: the marker comes from the UA stylesheet's
+ * `display: list-item` on `<summary>`, so any other display removes the one
+ * thing that says the element opens. This is the per-context display choice
+ * `touchTarget.ts` says stays with the caller -- it is just that here the
+ * choice is to make none.
+ *
+ * **The padding is not decoration.** `min-h-11` alone pins a 17px line to the
+ * top of a 44px box and leaves 27px of blank under it, which reads as a
+ * spacing bug rather than as a target. ADR-0004's reason for growing
+ * background-less elements at every breakpoint is that the growth is
+ * *invisible*, and that is only true when it is balanced. `py-3` puts 12px
+ * either side of the line for 41px and the floor lifts it to 44, so both parts
+ * do real work: padding alone would satisfy the number by accident, which is
+ * exactly the drift `touchTarget.ts` exists to stop.
+ *
+ * **No `md:min-h-0`.** ADR-0004: an element with no background takes 44px at
+ * every breakpoint, because the box growing is invisible and there is nothing
+ * to buy by restricting it. That clause is what separates a summary from
+ * `PillLink`, which is a visible shape and does carry the opt-out.
+ *
+ * Composing this does not prove the rendered box is 44px -- jsdom applies no
+ * stylesheets (ADR-0001) -- so tests assert that every summary a component can
+ * render refers to the standard, and a human confirms it holds.
+ */
+export const DISCLOSURE_TARGET = `${TOUCH_TARGET} py-3`;


### PR DESCRIPTION
Design review finding 1 (Must Fix), from `.design/conditions-page/DESIGN_REVIEW.md`.

## What changed and why

Measured at 375: "Why the other 32 are not here" and "What we are unsure about in this data" are 327×17, and "Why not" inside the waves card is 279×17. `TOUCH_TARGET` (`min-h-11`, 44px) exists at `src/components/touchTarget.ts` and is composed by `Nav`, `PillLink` and `BeachSelector` — the `<summary>` elements composed nothing. They were the only interactive elements on this page below 44px, and this is the **third** design review to report a touch target in this repo. ADR-0004 exists precisely because the first two were filed as style notes and nothing happened either time.

**All ten `<summary>` elements, not the three that were measured.** The measured three are the ones that happened to render on the reviewed beach; the other seven are the same bare element in a state that beach was not in — including `WavesToday`'s "What went wrong", eighteen lines below the "Why not" that *was* measured, in the same file. Fixing one and not the other is the drift `touchTarget.ts` exists to stop. Breakdown: 2 in `Caveats`, 2 in `TideToday`, 2 in `WavesToday`, 4 in `WindToday`.

**New: `src/components/disclosure.ts`**, exporting `DISCLOSURE_TARGET = min-h-11 py-3`. Ten call sites is where a shared name earns its keep, and a summary needs two decisions the bare number does not carry:

- **The display is deliberately left alone.** `Nav` composes the floor with `flex` and `PillLink` with `inline-flex`. Either one here removes the disclosure triangle — the marker comes from the UA stylesheet's `display: list-item` on `<summary>`, so any other display takes away the one thing that says the element opens. This *is* the per-context display choice `touchTarget.ts` says stays with the caller; here the choice is to make none.
- **`py-3` is not decoration.** `min-h-11` alone pins a 17px line to the top of a 44px box and leaves 27px of blank beneath it, which reads as a spacing bug. ADR-0004's stated reason for growing background-less elements at every breakpoint is that the growth is *invisible* — only true when it is balanced. 12 + 17 + 12 = 41px, and the floor lifts that to 44, so both parts do real work. Padding sized to reach 44 on its own would satisfy the number by accident, which is the failure mode ADR-0004 calls out by name.
- **No `md:min-h-0`.** ADR-0004: "Where an element has no background, it takes 44px at every breakpoint — the box growing is invisible, so there is nothing to buy by restricting it." That clause is what separates a summary from `PillLink`, which is a visible shape and does carry the opt-out.

No browser test, per your steer and ADR-0001: jsdom applies no stylesheets, so the tests assert that **every** summary a component can render *refers to* the standard — the `PillLink.test.tsx:95` idiom. Each asserts a count as well, so it cannot pass vacuously if a disclosure stops rendering. The 44px box itself stays a human check, which is what ADR-0004 already says it is.

## Process

Full lane. **No plan file:** one sitting, and `DESIGN_REVIEW.md` plus `disclosure.ts`'s own docstring already hold the problem, the rationale and the rejected alternatives — a `docs/plans/` file would be a third copy free to go stale. **No issue:** none exists for this finding, so there is no `Closes #`.

## Verification

All four new tests confirmed red first — the four component sources stashed, tests and `disclosure.ts` left in place:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/components/Caveats.test.tsx > both disclosures compose the touch-target floor
AssertionError: expected '' to contain 'min-h-11 py-3'
 FAIL  src/components/TideToday.test.tsx > every disclosure this card can render composes the touch-target floor
AssertionError: expected '' to contain 'min-h-11 py-3'
 FAIL  src/components/WavesToday.test.tsx > every disclosure this card can render composes the touch-target floor
AssertionError: expected '' to contain 'min-h-11 py-3'
 FAIL  src/components/WindToday.test.tsx > every disclosure this card can render composes the touch-target floor
AssertionError: expected '' to contain 'min-h-11 py-3'
 Test Files  4 failed (4)
      Tests  4 failed | 49 passed (53)
```

`npm run gate` at `9209440`, with `.next/` removed first:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

## Not done here, and merge order

- **`WindToday.tsx` and `WavesToday.tsx` are also touched by two later PRs** in this series — finding 6 (`ProvenanceLine` owns the distance suffix) and findings 7+9 (the air card's plain-words line, glyph inlined). They edit different regions of those files. Merge order is this PR, then finding 6, then findings 7+9; anything else risks a conflict that has no meaning.
- Noticed, not filed: nothing here. The disclosures were the whole finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
