### PR TITLE
Size and name the week's reserved band

### DIFF
--- a/src/components/ReservedSlot.test.tsx
+++ b/src/components/ReservedSlot.test.tsx
@@ -40,3 +40,24 @@ test("the tone follows the surface the slot sits on", () => {
   expect(light.firstElementChild?.className).toContain("border-lavender");
   expect(ocean.firstElementChild?.className).toContain("border-white/20");
 });
+
+test("the density follows what the slot stands in for", () => {
+  const { container: section } = render(
+    <ReservedSlot emoji="🗓️" headline="Soon." detail="Here." />,
+  );
+  const { container: row } = render(
+    <ReservedSlot emoji="🏄" headline="Soon." detail="Here." density="row" />,
+  );
+
+  // The default is the section density, and that is the half of this variant
+  // that matters most: five of the six call sites hold open a whole section
+  // and none of them names a density, so none of them may move.
+  expect(section.firstElementChild?.className).toContain("py-12");
+  expect(row.firstElementChild?.className).toContain("py-5");
+  expect(row.firstElementChild?.className).not.toContain("py-12");
+
+  // The glyph is the other half. 48px of emoji plus 96px of padding is most of
+  // why three row-scale slots measured taller than the seven days above them.
+  expect(section.querySelector("span")?.className).toContain("text-5xl");
+  expect(row.querySelector("span")?.className).toContain("text-2xl");
+});

--- a/src/components/ReservedSlot.tsx
+++ b/src/components/ReservedSlot.tsx
@@ -7,6 +7,8 @@ type ReservedSlotProps = {
   detail: string;
   /** `ocean` for slots sitting on the ocean-blue section; `light` elsewhere. */
   tone?: "light" | "ocean";
+  /** How much room the slot holds open. The list is closed on purpose. */
+  density?: "section" | "row";
 };
 
 const TONES = {
@@ -21,26 +23,57 @@ const TONES = {
 };
 
 /**
+ * How much vertical room a slot takes, which follows from what it stands in
+ * for rather than from a style preference.
+ *
+ * `section` is the original and stays the default. `px-8 py-12` with a 48px
+ * glyph is right for a slot holding open a whole section — a schedule, a
+ * scheduler embed, the conditions tool — and it is what five of the six call
+ * sites want, so none of them changes.
+ *
+ * `row` is for a slot standing in for one row of a grid that already exists
+ * around it. At section density the week's three reserved forecasts measured
+ * 244px against 128px of live week above them: three dashed boxes physically
+ * larger than the seven days they annotate, and 21% of the page given to
+ * products that do not exist yet. Nothing about the copy or the frame was
+ * wrong. The padding and the glyph were sized for a different job, and reusing
+ * them unchanged in a small space is the one place this component's reuse cost
+ * something.
+ */
+const DENSITIES = {
+  section: { room: "px-8 py-12", glyph: "mb-3.5 text-5xl" },
+  row: { room: "px-5 py-5", glyph: "mb-2 text-2xl" },
+};
+
+/**
  * A labeled stand-in for content that is decided but not yet built — a
  * schedule, a scheduler embed, the conditions tool.
  *
  * The copy arrives as props rather than children on purpose: the blank line
  * between the headline and the detail is part of the shape, and it is
  * exactly what drifted while six call sites each wrote their own.
+ *
+ * Two closed lists and no third axis. Tone picks the surface; density picks
+ * how much room the slot holds open. Neither takes a className, for the reason
+ * `PillLink` gives about its own tones: an escape hatch puts geometry back in
+ * the interface, which is what left the call sites writing their own in the
+ * first place.
  */
 export function ReservedSlot({
   emoji,
   headline,
   detail,
   tone = "light",
+  density = "section",
 }: ReservedSlotProps) {
   const { frame, text } = TONES[tone];
+  const { room, glyph } = DENSITIES[density];
 
   return (
     <div
-      className={`rounded-box border-2 border-dashed px-8 py-12 text-center ${frame}`}
+      className={`rounded-box border-2 border-dashed text-center ${room} ${frame}`}
     >
-      <span aria-hidden="true" className="mb-3.5 block text-5xl">
+      <span aria-hidden="true" className={`block ${glyph}`}>
         {emoji}
       </span>
       <p className={`leading-normal text-sm ${text}`}>

--- a/src/components/WeekGrid.test.tsx
+++ b/src/components/WeekGrid.test.tsx
@@ -145,3 +145,18 @@ test("the week is a region a reader can navigate to by its heading", () => {
   expect(section?.getAttribute("aria-labelledby")).toBe("week-heading");
   expect(screen.getByText("The week ahead").id).toBe("week-heading");
 });
+
+/** The slot's own box, reached through the copy the caller gave it. */
+function reservedSlot() {
+  return screen.getByText(/A wave forecast is coming/).closest("div");
+}
+
+test("the week's reserved slots take the row density, not the section one", () => {
+  renderGrid({ reserved: RESERVED });
+
+  // 244px of dashed box against 128px of live week was the finding.
+  // `ReservedSlot` owns the numbers; what this asserts is that the grid asks
+  // for the density sized to a row rather than reusing the section default.
+  expect(reservedSlot()?.className).toContain("py-5");
+  expect(reservedSlot()?.className).not.toContain("py-12");
+});

--- a/src/components/WeekGrid.test.tsx
+++ b/src/components/WeekGrid.test.tsx
@@ -160,3 +160,17 @@ test("the week's reserved slots take the row density, not the section one", () =
   expect(reservedSlot()?.className).toContain("py-5");
   expect(reservedSlot()?.className).not.toContain("py-12");
 });
+
+test("the reserved band says it belongs to the week above it", () => {
+  renderGrid({ reserved: RESERVED });
+
+  // Without this the three dashed panels read as a separate thing sitting
+  // below the table rather than as rows the week is waiting for. The band
+  // stays where it is: a reserved product has no cells, so it cannot be a row
+  // until it exists, and one inside the `<ol>` would print seven times.
+  expect(
+    screen.getByText(
+      "Each of these will join the week above as a row of its own.",
+    ),
+  ).toBeDefined();
+});

--- a/src/components/WeekGrid.test.tsx
+++ b/src/components/WeekGrid.test.tsx
@@ -174,3 +174,15 @@ test("the reserved band says it belongs to the week above it", () => {
     ),
   ).toBeDefined();
 });
+
+test("the reserved band steps at the same width the days do", () => {
+  renderGrid({ reserved: RESERVED });
+
+  // The day blocks are `lg:grid-cols-7`, so at `sm` the live week is stacked
+  // full-width. Three slots side by side from 640px gave roughly 26 characters
+  // over five ragged lines at 768 -- the page's own responsive logic
+  // disagreeing with itself in adjacent bands of the same section.
+  const band = reservedSlot()?.parentElement;
+  expect(band?.className).toContain("lg:grid-cols-3");
+  expect(band?.className).not.toContain("sm:grid-cols-3");
+});

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -197,7 +197,15 @@ export function WeekGrid({
           <p className="leading-relaxed mb-3 max-w-130 text-base text-fog">
             Each of these will join the week above as a row of its own.
           </p>
-          <div className="grid gap-3 sm:grid-cols-3">
+          {/*
+            `lg:grid-cols-3`, matching the days above rather than stepping a
+            breakpoint earlier. The day blocks stay one column until `lg`, so
+            at `sm` the live week was stacked full-width while these three sat
+            side by side at 216px each -- roughly 26 characters over five
+            ragged lines. The week said 768 was narrow and the slots said it
+            was wide, in adjacent bands of the same section.
+          */}
+          <div className="grid gap-3 lg:grid-cols-3">
             {reserved.map((slot) => (
               <ReservedSlot key={slot.headline} {...slot} density="row" />
             ))}

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -172,10 +172,18 @@ export function WeekGrid({
         </ol>
       )}
 
+      {/*
+        `density="row"` rather than the section default. At section density
+        these three slots measured 244px against 128px of live week above
+        them -- three dashed boxes physically larger than the seven days they
+        annotate, because `ReservedSlot` was built to hold open a whole section
+        and was reused here unchanged. It records why its own numbers are what
+        they are; what this asks for is the density sized to a row.
+      */}
       {reserved.length > 0 && (
         <div className="grid gap-3 sm:grid-cols-3">
           {reserved.map((slot) => (
-            <ReservedSlot key={slot.headline} {...slot} />
+            <ReservedSlot key={slot.headline} {...slot} density="row" />
           ))}
         </div>
       )}

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -181,11 +181,28 @@ export function WeekGrid({
         they are; what this asks for is the density sized to a row.
       */}
       {reserved.length > 0 && (
-        <div className="grid gap-3 sm:grid-cols-3">
-          {reserved.map((slot) => (
-            <ReservedSlot key={slot.headline} {...slot} density="row" />
-          ))}
-        </div>
+        <>
+          {/*
+            The band says what it is. Nothing tied it to the grid above, so a
+            reader had no way to tell that a wave forecast lands *in* the week
+            rather than in a box of its own -- three dashed panels under a
+            table read as a separate thing that happens to sit below it.
+
+            A sentence is the whole fix, and the band stays where it is. A
+            reserved product is one fact about a feed rather than seven facts
+            about seven days: `ReservedRow` carries no `cells`, so there is
+            nothing to put in a day-block until the product exists, and moving
+            one into the `<ol>` would print its headline seven times.
+          */}
+          <p className="leading-relaxed mb-3 max-w-130 text-base text-fog">
+            Each of these will join the week above as a row of its own.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {reserved.map((slot) => (
+              <ReservedSlot key={slot.headline} {...slot} density="row" />
+            ))}
+          </div>
+        </>
       )}
     </section>
   );


### PR DESCRIPTION
Design review findings **3** and **4** (Should Fix), from `.design/conditions-page/DESIGN_REVIEW.md`. One piece of work on one band, three slices.

## What changed and why

### 1. `e4a79b1` — a density axis on `ReservedSlot` (finding 3, proportion)

`ReservedSlot` was built to hold open a whole section — its docstring names "a schedule, a scheduler embed, the conditions tool" — so it carries `px-8 py-12` and a `text-5xl` glyph. The week grid reused it unchanged for three forecast rows, where 96px of vertical padding plus a 48px glyph are sized for a different job. Measured at 1536: the three slots were **244px against 128px of live week** above them, part of a 503px unbroken run of dashed boxes, 21% of the page.

A closed density list with a default, the same shape as the `tone` list beside it:

```
section: { room: "px-8 py-12", glyph: "mb-3.5 text-5xl" }   // default, unchanged
row:     { room: "px-5 py-5",  glyph: "mb-2 text-2xl" }
```

**The five call sites outside the week band name no density and none of them moves** — `book`, `community`, the landing-page `Conditions` teaser, `SessionSchedule`, and this page's own map slot. Only `WeekGrid` asks for `row`. No `className` escape hatch on the new axis, for the reason `PillLink` gives about its tones: an escape hatch puts geometry back in the interface, which is the drift this component was extracted to stop.

Padding drops 96px → 40px and the glyph 48px → 24px. **The rendered total is not restated here because it was not re-measured** — per ADR-0001 jsdom asserts no pixel, and layout claims are a human check at the review viewport. What the tests assert is that the grid asks for the row density and that the default is untouched.

### 2. `32a56cd` — the band names itself (finding 3, belonging)

Nothing tied the band to the grid, so a reader could not tell that a wave forecast lands *in* the week rather than in a box of its own. Added: *"Each of these will join the week above as a row of its own."*

**The band stays where it is.** `DESIGN_REVIEW.md`'s Corrections section supersedes the version of finding 3 in PR #130's merged body, and the types agree with the file: `ReservedRow` carries only `{emoji, headline, detail}` where `WeekRow` carries `cells` keyed by date, because a product with no forecast is one fact about a feed rather than seven facts about seven days. A reserved slot inside the `<ol>` would print its headline seven times; one given empty `cells` would render nowhere. The two distinct types were the author encoding exactly this.

### 3. `807bbff` — the band steps where the days step (finding 4)

`sm:grid-cols-3` → `lg:grid-cols-3`. The day blocks are `lg:grid-cols-7`, so at 768 the live week was stacked full-width while three slots sat side by side at 216px each — roughly 26 characters of centred prose over five ragged lines. The week said 768 was narrow and the slots said it was wide, in adjacent bands of the same section.

## Process

Full lane. Three slices rather than one commit: each is nameable in a sentence, each has its own test, and each is separately revertible — the density could stand without the label, and finding 4 is a different finding that happens to touch an adjacent line. Gates were run and are green at **each** of the three commits.

**No plan file:** one sitting, and `DESIGN_REVIEW.md` plus the docstrings hold the rationale and the rejected alternative (moving the slots into the `<ol>`). **No issue:** none exists for these findings, so no `Closes #`.

## Verification

All four new tests confirmed red first — `ReservedSlot.tsx` and `WeekGrid.tsx` stashed, tests left in place:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/components/ReservedSlot.test.tsx > the density follows what the slot stands in for
AssertionError: expected 'rounded-box border-2 border-dashed px…' to contain 'py-5'
 FAIL  src/components/WeekGrid.test.tsx > the reserved band says it belongs to the week above it
TestingLibraryElementError: Unable to find an element with the text: Each of these will join the week above as a row of its own.
 FAIL  src/components/WeekGrid.test.tsx > the reserved band steps at the same width the days do
AssertionError: expected 'grid gap-3 sm:grid-cols-3' to contain 'lg:grid-cols-3'
 FAIL  src/components/WeekGrid.test.tsx > the week's reserved slots take the row density, not the section one
AssertionError: expected 'rounded-box border-2 border-dashed px…' to contain 'py-5'
 Test Files  2 failed (2)
      Tests  4 failed | 14 passed (18)
```

`npm run gate` at `807bbff`, with `.next/` removed first (and separately green at `e4a79b1` and `32a56cd`):

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

`py-5` and `text-2xl` are both present in the built stylesheet, so the density variant compiles rather than resolving to nothing (ADR-0006's reading).

## Not done here

- **The slots were not moved into the `<ol>`.** See slice 2 above — the types forbid it, and the review's Corrections section says so explicitly.
- **The band's rendered height was not re-measured.** Worth a look at the review viewport before merge; the arithmetic is above.
- No file conflicts with the other PRs in this series — this one touches only `ReservedSlot.tsx` and `WeekGrid.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
