### PR TITLE
Let ProvenanceLine word the distance, not its callers

### DIFF
--- a/src/components/ProvenanceLine.test.tsx
+++ b/src/components/ProvenanceLine.test.tsx
@@ -23,16 +23,33 @@ test("no distance is shown when the caller withholds one", () => {
   expect(screen.queryByText(/km/)).toBeNull();
 });
 
-test("a distance is shown when the caller gives one", () => {
+/**
+ * The caller hands over a rounded number and this component writes the
+ * sentence. Handing out the wording as well produced four phrasings of one
+ * fact across three components -- "about N km away", "about N km from this
+ * beach", "N km from this beach" and "N km away" -- two of them twenty lines
+ * apart in the same file. The rounding stays with the caller, where each
+ * threshold has its reason recorded.
+ */
+test("the caller gives a number and this line words it", () => {
   render(
     <ProvenanceLine
       source={SOURCE}
       network="NOAA Tides & Currents"
-      distance="about 12 km away"
+      distanceKm="12"
     />,
   );
 
-  expect(screen.getByText(/about 12 km away/)).toBeDefined();
+  expect(screen.getByText(/about 12 km from this beach/)).toBeDefined();
+});
+
+test("the caller's rounding survives verbatim", () => {
+  // "4.7" and "12" are decisions made upstream: the air panel keeps a decimal
+  // under ten kilometres precisely so a 1.4 km station and a 10.4 km one stay
+  // comparable, and this line must not round that away again.
+  render(<ProvenanceLine source={SOURCE} distanceKm="4.7" />);
+
+  expect(screen.getByText(/about 4\.7 km from this beach/)).toBeDefined();
 });
 
 /**
@@ -45,7 +62,7 @@ test("the reason a distant source was used survives", () => {
     <ProvenanceLine
       source={SOURCE}
       network="NOAA Tides & Currents"
-      distance="about 12 km away"
+      distanceKm="12"
       note="the nearest open-coast station publishing predictions"
     />,
   );
@@ -60,7 +77,7 @@ test("no note is rendered when there is nothing to explain", () => {
     <ProvenanceLine
       source={SOURCE}
       network="NOAA Tides & Currents"
-      distance="1.4 km away"
+      distanceKm="1.4"
     />,
   );
 
@@ -77,7 +94,7 @@ test("a label says which figures this source supplied", () => {
       label="Sky and visibility"
       source="San Diego International"
       network="NWS"
-      distance="10 km away"
+      distanceKm="10"
     />,
   );
 

--- a/src/components/ProvenanceLine.tsx
+++ b/src/components/ProvenanceLine.tsx
@@ -14,6 +14,18 @@
  * scannable and let two of these stack legibly under one card, which is what the
  * air panel needs.
  *
+ * **The distance is worded here, and rounded by the caller.** Those are two
+ * decisions and they were handed out as one. `distance` arrived "already
+ * worded by the caller", which is right for the rounding -- `TideToday`'s 5 km
+ * threshold, `WavesToday`'s 10 km one and `WindToday`'s sub-10 km decimal each
+ * have a reason recorded where they are made -- and wrong for the phrasing,
+ * which drifted immediately into four wordings of one fact across three
+ * components. On `fiesta-island`, where air and sky bind to the same station,
+ * one card printed "San Diego Airport · 4.7 km from this beach" and "San Diego
+ * Airport · 4.7 km away" 80px apart. So this takes the number and prints the
+ * sentence: same drift `ReadingCard` and `ReservedSlot` both cite in their
+ * docstrings as the reason to share a component at all.
+ *
  * **The note is not decoration.** Some stations are far enough away that the
  * distance alone understates the situation, and `TideToday` records why that is
  * disclosed rather than buried: it "is the difference between a prediction for
@@ -35,8 +47,16 @@ type ProvenanceLineProps = {
    * change rather than a presentation one.
    */
   network?: string | null;
-  /** Already worded by the caller, which owns the rounding. `null` withholds it. */
-  distance?: string | null;
+  /**
+   * How far the station stands, in kilometres and already rounded. `null`
+   * withholds it, which is what a caller under its own threshold does.
+   *
+   * The number and nothing else: a string rather than a number so the caller's
+   * rounding survives verbatim, since "4.7" and "12" are decisions made
+   * upstream for reasons recorded there. Everything around it -- the hedge,
+   * the unit and the reference point -- belongs to this component.
+   */
+  distanceKm?: string | null;
   /** Why this source and not a nearer one, when there is something to say. */
   note?: string | null;
   /** What these figures are, when a card carries more than one source. */
@@ -46,7 +66,7 @@ type ProvenanceLineProps = {
 export function ProvenanceLine({
   source,
   network = null,
-  distance = null,
+  distanceKm = null,
   note = null,
   label = null,
 }: ProvenanceLineProps) {
@@ -55,7 +75,7 @@ export function ProvenanceLine({
       {label !== null && <span className="font-extrabold">{label} </span>}
       {source}
       {network !== null ? ` · ${network}` : ""}
-      {distance !== null ? ` · ${distance}` : ""}
+      {distanceKm !== null ? ` · about ${distanceKm} km from this beach` : ""}
       {note !== null ? ` — ${note}` : ""}
     </p>
   );

--- a/src/components/TideToday.test.tsx
+++ b/src/components/TideToday.test.tsx
@@ -103,7 +103,7 @@ test("a nearby station is credited without a distance", () => {
       state={{ kind: "reading", timeLabel: "6:24 AM", feet: 1.368 }}
     />,
   );
-  expect(screen.queryByText(/km away/)).toBeNull();
+  expect(screen.queryByText(/km from this beach/)).toBeNull();
 });
 
 test("a distant station discloses how far away it is", () => {
@@ -116,7 +116,7 @@ test("a distant station discloses how far away it is", () => {
   );
   // 57 km up the coast is the difference between a prediction for this shore and
   // the nearest one anybody publishes, so it is said where the number is given.
-  expect(screen.getByText(/57 km away/)).toBeDefined();
+  expect(screen.getByText(/about 57 km from this beach/)).toBeDefined();
   expect(
     screen.getByText(/nearest open-coast station publishing predictions/),
   ).toBeDefined();

--- a/src/components/TideToday.tsx
+++ b/src/components/TideToday.tsx
@@ -142,7 +142,7 @@ export function TideToday({ beachName, station, state }: TideTodayProps) {
         <ProvenanceLine
           source={station.name}
           network="NOAA Tides & Currents"
-          distance={distantKm !== null ? `about ${distantKm} km away` : null}
+          distanceKm={distantKm}
           note={
             distantKm !== null
               ? `the nearest ${station.water === "bay" ? "bay" : "open-coast"} station publishing predictions`

--- a/src/components/WavesToday.tsx
+++ b/src/components/WavesToday.tsx
@@ -128,9 +128,7 @@ export function WavesToday({ beachName, buoy, state }: WavesView) {
         <ProvenanceLine
           source={`Buoy ${buoy.name}`}
           network="NDBC"
-          distance={
-            distantKm !== null ? `about ${distantKm} km from this beach` : null
-          }
+          distanceKm={distantKm}
         />
       )}
     </ReadingCard>

--- a/src/components/WindToday.test.tsx
+++ b/src/components/WindToday.test.tsx
@@ -85,11 +85,11 @@ test("both stations are named, each with its own distance", () => {
 
   const air = screen.getByText(/Scripps Pier/).textContent ?? "";
   expect(air).toContain("Temperature and wind");
-  expect(air).toContain("1.4 km from this beach");
+  expect(air).toContain("about 1.4 km from this beach");
 
   const sky = screen.getByText(/Miramar/).textContent ?? "";
   expect(sky).toContain("Sky and visibility");
-  expect(sky).toContain("10 km away");
+  expect(sky).toContain("about 10 km from this beach");
 });
 
 test("a near station keeps its distance rather than rounding it away", () => {
@@ -98,7 +98,7 @@ test("a near station keeps its distance rather than rounding it away", () => {
   // tells a reader why the sky is less local than the temperature.
   render(<WindToday {...panel()} />);
 
-  expect(screen.getByText(/1\.4 km from this beach/)).toBeDefined();
+  expect(screen.getByText(/about 1\.4 km from this beach/)).toBeDefined();
 });
 
 /**
@@ -355,4 +355,28 @@ test("no sky station leaves the temperature standing on its own", () => {
   expect(screen.getByText("71°F")).toBeDefined();
   expect(screen.getByText(/publishes a sky description/)).toBeDefined();
   expect(screen.queryByText(/Sky and visibility/)).toBeNull();
+});
+
+/**
+ * The finding as a reader met it. On `fiesta-island` both halves bind to the
+ * same station, so one card printed "San Diego Airport · 4.7 km from this
+ * beach" and "San Diego Airport · 4.7 km away" 80px apart: the identical fact,
+ * phrased two ways, on one card. `ProvenanceLine` owns the wording now, so two
+ * lines can only differ where the facts differ.
+ */
+test("one station bound to both halves is worded the same way twice", () => {
+  const AIRPORT = { name: "San Diego Airport", distanceM: 4_700 };
+
+  render(
+    <WindToday {...panel({ airStation: AIRPORT, skyStation: AIRPORT })} />,
+  );
+
+  const lines = screen
+    .getAllByText(/San Diego Airport/)
+    .map((line) => line.textContent ?? "");
+
+  expect(lines).toHaveLength(2);
+  for (const line of lines) {
+    expect(line).toContain("San Diego Airport · about 4.7 km from this beach");
+  }
 });

--- a/src/components/WindToday.tsx
+++ b/src/components/WindToday.tsx
@@ -82,15 +82,22 @@ function visibilityWords(miles: number, atCeiling: boolean): string {
 }
 
 /**
- * How far the station is, in words.
+ * How far the station is, in kilometres, rounded.
  *
  * A decimal under ten kilometres because that is the range these two bindings
  * differ across: an air station at 1.4 km and a sky station at 10.4 km is the
  * whole point, and rounding the first to "1 km" throws away the comparison.
+ *
+ * The number only. This panel used to append the unit and a reference point
+ * too, and it wrote two different ones twenty lines apart -- "from this beach"
+ * for the air station and "away" for the sky station, which on a beach whose
+ * two halves bind to the same station printed the identical fact two ways on
+ * one card. `ProvenanceLine` owns that wording now; the rounding stays here,
+ * where the reason for it is.
  */
-function distanceWords(metres: number): string {
+function roundedKm(metres: number): string {
   const km = metres / 1000;
-  return `${km < 10 ? km.toFixed(1) : km.toFixed(0)} km`;
+  return km < 10 ? km.toFixed(1) : km.toFixed(0);
 }
 
 /**
@@ -191,9 +198,9 @@ export function WindToday({
         <ProvenanceLine
           label="Temperature and wind"
           source={airStation.name}
-          distance={
+          distanceKm={
             airStation.distanceM !== null
-              ? `${distanceWords(airStation.distanceM)} from this beach`
+              ? roundedKm(airStation.distanceM)
               : null
           }
         />
@@ -209,9 +216,9 @@ export function WindToday({
         <ProvenanceLine
           label="Sky and visibility"
           source={skyStation.name}
-          distance={
+          distanceKm={
             skyStation.distanceM !== null
-              ? `${distanceWords(skyStation.distanceM)} away`
+              ? roundedKm(skyStation.distanceM)
               : null
           }
         />


### PR DESCRIPTION
Design review finding 6 (Should Fix), from `.design/conditions-page/DESIGN_REVIEW.md`.

## What changed and why

The same fact — how far a station stands — was written four ways across three components:

| Component | Rendered |
|---|---|
| `TideToday` | `about N km away` |
| `WavesToday` | `about N km from this beach` |
| `WindToday` (air) | `N km from this beach` |
| `WindToday` (sky) | `N km away` |

The last two are twenty lines apart in the same file. On `fiesta-island`, where both halves of the air card bind to the same station, one card printed "San Diego Airport · 4.7 km from this beach" and "San Diego Airport · 4.7 km away" **80px apart** — the identical fact, phrased two ways, on one card.

`ProvenanceLine` centralised the interpunct ordering and left `distance` *"already worded by the caller, which owns the rounding."* That is two decisions handed out as one. The rounding genuinely belongs to the caller and stays there — `TideToday`'s 5 km threshold, `WavesToday`'s 10 km one and `WindToday`'s sub-10 km decimal each have a documented reason at the place they are made. The **phrasing** does not belong to the caller, and it drifted immediately — the same drift `ReadingCard` and `ReservedSlot` both cite in their docstrings as the reason to share a component at all.

`distance?: string` → `distanceKm?: string`, rendered as **`about {n} km from this beach`**. Two wording calls, both stated so they can be argued with:

- **"about"** — three of the four phrasings already said it, and a great-circle distance from a beach's published point to a station's is an approximation at any precision. It applies equally to both air-card stations, so it costs nothing the comparison needs.
- **"from this beach"** over "away" — a distance disclosure is only useful once it names its reference point, and the air card names two stations at once. The two call sites that reasoned hardest about distance (`WavesToday`'s threshold, `WindToday`'s air/sky comparison) already used it.

A `string` rather than a `number` so the caller's rounding survives verbatim: "4.7" and "12" are upstream decisions, and a number would re-open one of them here.

`WindToday`'s `distanceWords` becomes `roundedKm` — it keeps the sub-10 km decimal, which is the documented half ("an air station at 1.4 km and a sky station at 10.4 km is the whole point"), and loses the unit and the reference point, which were not.

## Process

Full lane, **one slice**: the prop rename, the render and all four call sites have to move together or `typecheck` fails, so there is no intermediate state that leaves the repo working. **No plan file** — one sitting, and the rationale now sits in `ProvenanceLine`'s own docstring where the next reader will find it. **No issue**, so no `Closes #`.

## Verification

Confirmed red first — the four component sources stashed, tests left in place:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/components/WindToday.test.tsx > both stations are named, each with its own distance
AssertionError: expected 'Temperature and wind Scripps Pier · 1…' to contain 'about 1.4 km from this beach'
 FAIL  src/components/WindToday.test.tsx > a near station keeps its distance rather than rounding it away
 FAIL  src/components/WindToday.test.tsx > one station bound to both halves is worded the same way twice
AssertionError: expected 'Temperature and wind San Diego Airpor…' to contain 'San Diego Airport · about 4.7 km from…'
 Test Files  1 failed (1)
      Tests  3 failed | 22 passed (25)
```

The third of those is the finding itself as a regression test: it renders the `fiesta-island` shape — one station bound to both halves — and asserts the two provenance lines are worded identically, so the two lines can only differ where the facts do.

`npm run gate` at `0fb565d`, with `.next/` removed first:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

## Not done here, and merge order

- **No threshold moved and no rounding changed.** The 5 km, 10 km and sub-10 km decimal all render exactly the numbers they did. Only the words around them changed.
- **`WindToday.tsx` and `WavesToday.tsx` overlap two other open PRs** in this series. Merge order: finding 1 (touch targets, #134), then this one, then findings 7+9. They edit different regions, but that order avoids conflicts that carry no meaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
