### PR TITLE
Give the air card its plain-words line, and inline the glyph that pays for it

### DIFF
--- a/src/components/ReadingCard.test.tsx
+++ b/src/components/ReadingCard.test.tsx
@@ -130,3 +130,26 @@ test("a card fills the height of the row it sits in", () => {
 
   expect(container.firstElementChild?.className).toContain("h-full");
 });
+
+/**
+ * The week grid's treatment, adopted here. Its glyph sits inside the `<dt>` —
+ * "🌊 Lowest tide" — where it labels rather than floats, and one page marking
+ * the same product two ways was the inconsistency. The 34px block plus its
+ * 12px margin cost 46px per card for a mark that carries nothing a reader
+ * without it would lose.
+ */
+test("the glyph labels the heading rather than taking a line of its own", () => {
+  const { container } = render(card("6:24 AM"));
+
+  const heading = screen.getByRole("heading", { name: "Lowest tide today" });
+
+  expect(heading.textContent).toContain("🐚");
+  // Still hidden, so the accessible name stays the words alone. The assertion
+  // above and this one together are the contract: visible beside the label,
+  // absent from the name.
+  expect(heading.querySelector('[aria-hidden="true"]')?.textContent).toBe("🐚");
+
+  // The block it replaced carried the one raw arbitrary size in a component
+  // whose docstring makes the case against exactly that.
+  expect(container.innerHTML).not.toContain("text-[34px]");
+});

--- a/src/components/ReadingCard.tsx
+++ b/src/components/ReadingCard.tsx
@@ -23,6 +23,15 @@
  * would be making one in CSS. So the colour goes into the glyph and the eyebrow,
  * and the figure stays dark on light where a number belongs.
  *
+ * **The glyph labels the heading rather than floating above it.** It was a 34px
+ * block with a 12px margin on a line of its own -- 46px per card, in every card
+ * -- for a mark that carries nothing a reader would lose. `WeekGrid` puts its
+ * glyph inside the `<dt>`, "🌊 Lowest tide", where it labels rather than floats,
+ * and that is the better of the two: one page should not mark a product two
+ * ways. Recovering the row is also where the first screen's spare height is,
+ * and it takes `text-[34px]` with it -- the one raw arbitrary size in the
+ * component whose own docstring argues against exactly that.
+ *
  * **The figure slot is never empty.** A caller with nothing to lead on passes
  * null and gets no slot at all, rather than a blank one — an empty space where a
  * number goes reads as a fault, which is the same reason `WindToday` refuses to
@@ -66,11 +75,6 @@ type ReadingCardProps = {
   children: ReactNode;
 };
 
-/* leading-none on a decorative glyph, for the reason `ProgramCards` gives:
-   at this size the default line box adds visible height around an emoji that
-   nothing on screen accounts for. */
-const EMOJI = "mb-3 block text-[34px] leading-none";
-
 export function ReadingCard({
   emoji,
   headingId,
@@ -87,15 +91,11 @@ export function ReadingCard({
       aria-label={context !== null ? `${title} · ${context}` : title}
       className="rounded-card flex h-full flex-col bg-mist px-6 py-4"
     >
-      <span aria-hidden="true" className={EMOJI}>
-        {emoji}
-      </span>
-
       <h2
         id={headingId}
         className="text-2xs mb-3 font-extrabold tracking-widest text-ocean uppercase"
       >
-        {title}
+        <span aria-hidden="true">{emoji}</span> {title}
       </h2>
 
       {figure !== null && (

--- a/src/components/WindToday.test.tsx
+++ b/src/components/WindToday.test.tsx
@@ -356,3 +356,115 @@ test("no sky station leaves the temperature standing on its own", () => {
   expect(screen.getByText(/publishes a sky description/)).toBeDefined();
   expect(screen.queryByText(/Sky and visibility/)).toBeNull();
 });
+
+/**
+ * The brief's card anatomy: "leads with one big number, says what it means in
+ * plain words, and then shows its supporting measurements". The tide and waves
+ * cards shipped with the line and this one did not, so nothing below the lead
+ * figure aligned across the band and three instances of one component read as
+ * three different layouts.
+ */
+test("the card says what its figures mean in plain words", () => {
+  render(<WindToday {...panel()} />);
+
+  // 71°F and 8 mph, restated. Never advice: ADR-0009 forbids a verdict, so a
+  // Beaufort-style "a gentle breeze" is available and "a good day for it" is
+  // not.
+  expect(screen.getByText("Mild, with a gentle breeze.")).toBeDefined();
+});
+
+test("a calm wind is calm in the words and in the figure", () => {
+  render(
+    <WindToday {...panel({ air: { ...AIR, windMph: 0.4, gustMph: 2 } })} />,
+  );
+
+  expect(screen.getByText("Mild, with no wind.")).toBeDefined();
+  expect(screen.getByText("Calm")).toBeDefined();
+  // One threshold read by both. Two would let the card say "no wind" above
+  // "Gusting 2 mph", which is the contradiction the gust rule already exists
+  // to stop.
+  expect(screen.queryByText("Gusting")).toBeNull();
+});
+
+test("either figure alone still makes a sentence", () => {
+  // The two halves of this card fail separately, and so does each field a
+  // station publishes: a station carrying a temperature and no wind is a
+  // measured absence rather than an outage.
+  const { unmount } = render(
+    <WindToday {...panel({ air: { ...AIR, windMph: null, gustMph: null } })} />,
+  );
+  expect(screen.getByText("Mild.")).toBeDefined();
+  unmount();
+
+  render(<WindToday {...panel({ air: { ...AIR, airTempF: null } })} />);
+  expect(screen.getByText("A gentle breeze.")).toBeDefined();
+});
+
+test("no line at all when neither figure arrived", () => {
+  render(
+    <WindToday
+      {...panel({
+        air: { ...AIR, airTempF: null, windMph: null, gustMph: null },
+      })}
+    />,
+  );
+
+  // A blank sentence is the same mistake as a blank primary: it reads as a
+  // fault rather than as an absence, and this card already refuses one.
+  expect(screen.getByText("No temperature reading")).toBeDefined();
+  expect(screen.queryByText(/^(Cold|Chilly|Cool|Mild|Warm|Hot)/)).toBeNull();
+  expect(screen.queryByText(/breeze|no wind/)).toBeNull();
+});
+
+/**
+ * The bands themselves, which are the whole of what these two lines say. They
+ * are this site's own wording for published figures rather than a standard, so
+ * nothing upstream asserts them and this is the only place they are pinned.
+ */
+test("every temperature band has its own word", () => {
+  const bands: [number, string][] = [
+    [48, "Cold"],
+    [55, "Chilly"],
+    [64, "Cool"],
+    [71, "Mild"],
+    [79, "Warm"],
+    [90, "Hot"],
+  ];
+
+  for (const [airTempF, word] of bands) {
+    const { unmount } = render(
+      <WindToday
+        {...panel({ air: { ...AIR, airTempF, windMph: null, gustMph: null } })}
+      />,
+    );
+
+    expect(screen.getByText(`${word}.`)).toBeDefined();
+    unmount();
+  }
+});
+
+test("every wind band has its own words", () => {
+  const bands: [number, string][] = [
+    [0.4, "No wind."],
+    [2, "Barely any wind."],
+    [6, "A light breeze."],
+    [11, "A gentle breeze."],
+    [16, "A moderate breeze."],
+    [22, "A fresh breeze."],
+    [28, "A strong breeze."],
+    [40, "A hard wind."],
+  ];
+
+  // Read with no temperature, so the wind is the whole sentence and reaches
+  // the capitalising branch the clause form never does.
+  for (const [windMph, words] of bands) {
+    const { unmount } = render(
+      <WindToday
+        {...panel({ air: { ...AIR, airTempF: null, windMph, gustMph: null } })}
+      />,
+    );
+
+    expect(screen.getByText(words)).toBeDefined();
+    unmount();
+  }
+});

--- a/src/components/WindToday.tsx
+++ b/src/components/WindToday.tsx
@@ -52,6 +52,15 @@ import { ProvenanceLine } from "./ProvenanceLine";
 import { ReadingCard } from "./ReadingCard";
 import { type Stat, StatGroup } from "./StatGroup";
 
+/**
+ * Under a knot the wind is calm. Named once because two readers disagree
+ * otherwise: `windStats` prints "Calm" and suppresses the gust here, and
+ * `windWords` says "no wind" -- a card that said "no wind" above "Gusting
+ * 2 mph" would be contradicting itself, which is the bug the gust rule was
+ * written to stop.
+ */
+const CALM_MPH = 1;
+
 const COMPASS = [
   "north",
   "north-east",
@@ -111,7 +120,7 @@ function distanceWords(metres: number): string {
  * figure is noise from the instrument rather than weather anybody feels.
  */
 function windStats(air: Extract<AirView["air"], { kind: "reading" }>): Stat[] {
-  const calm = air.windMph !== null && air.windMph < 1;
+  const calm = air.windMph !== null && air.windMph < CALM_MPH;
 
   const speed =
     air.windMph === null
@@ -160,6 +169,85 @@ function temperatureWords(air: AirView["air"]): string {
     : `${Math.round(air.airTempF)}°F`;
 }
 
+/**
+ * The air temperature in plain words.
+ *
+ * Descriptive rather than advisory, for the reason `WavesToday`'s `heightWords`
+ * gives about its own bands: this site relays measurements and does not decide
+ * whether anybody should go. "Warm" restates 76 °F; "a good day for it" would
+ * be a verdict, and ADR-0009 forbids the site from making one. That ADR's own
+ * wording is the licence for this line -- "facts get described in plain
+ * language" -- and the boundary it draws is inference, not description.
+ *
+ * The bands are this site's own wording for a published figure. Nothing
+ * upstream publishes them and they are not a standard.
+ */
+function warmthWord(fahrenheit: number): string {
+  if (fahrenheit < 52) return "Cold";
+  if (fahrenheit < 60) return "Chilly";
+  if (fahrenheit < 68) return "Cool";
+  if (fahrenheit < 75) return "Mild";
+  if (fahrenheit < 84) return "Warm";
+  return "Hot";
+}
+
+/**
+ * The wind in plain words, in the Beaufort scale's register.
+ *
+ * Miles per hour is the figure on this card that most needs translating: a
+ * parent reads 76 °F without help and reads 11 mph without knowing whether
+ * that is windy. So the wind earns a clause even though the temperature leads,
+ * the same way `TideToday`'s sentence explains the height while the figure is
+ * the time.
+ *
+ * `CALM_MPH` rather than a second threshold, so this and `windStats` cannot
+ * come to different conclusions about the same reading.
+ */
+function windWords(mph: number): string {
+  if (mph < CALM_MPH) return "no wind";
+  if (mph < 4) return "barely any wind";
+  if (mph < 8) return "a light breeze";
+  if (mph < 13) return "a gentle breeze";
+  if (mph < 19) return "a moderate breeze";
+  if (mph < 25) return "a fresh breeze";
+  if (mph < 32) return "a strong breeze";
+  return "a hard wind";
+}
+
+/**
+ * What this card's figures mean, in one line.
+ *
+ * The brief specifies this line as card anatomy in three places -- "leads with
+ * one big number, says what it means in plain words" under Solution, "emoji
+ * header, lead figure, plain-language line, stat groups, attribution" in
+ * `ReadingCard`'s inventory row, and "the lead figure, the plain-language line
+ * and the stat groups are all present without interaction" under Key
+ * Interactions. Two of the three cards shipped with it: `TASKS.md` slices 2 and
+ * 3 each preserve their card's line explicitly and slice 4 does not mention
+ * one, which is where this card's was dropped. Without it nothing below the
+ * lead figure aligned across the band, so three instances of one component read
+ * as three different layouts.
+ *
+ * Temperature leads because it is this card's figure; the wind follows as a
+ * clause. Either half alone still makes a sentence, because the field each
+ * station publishes can be absent on its own.
+ *
+ * `null` rather than an empty line when neither arrived. `ReadingCard` refuses
+ * to render an empty primary because "an empty one reads as a fault", and a
+ * blank sentence is the same mistake one row down.
+ */
+function plainWords(
+  air: Extract<AirView["air"], { kind: "reading" }>,
+): string | null {
+  const warmth = air.airTempF === null ? null : warmthWord(air.airTempF);
+  const wind = air.windMph === null ? null : windWords(air.windMph);
+
+  if (warmth !== null && wind !== null) return `${warmth}, with ${wind}.`;
+  if (warmth !== null) return `${warmth}.`;
+  if (wind === null) return null;
+  return `${wind[0].toUpperCase()}${wind.slice(1)}.`;
+}
+
 export function WindToday({
   beachName,
   airStation,
@@ -167,6 +255,8 @@ export function WindToday({
   air,
   sky,
 }: AirView) {
+  const words = air.kind === "reading" ? plainWords(air) : null;
+
   return (
     <ReadingCard
       emoji="🌡️"
@@ -175,6 +265,21 @@ export function WindToday({
       context={beachName}
       figure={temperatureWords(air)}
     >
+      {/*
+        The plain-words line every card on this page is specified to carry, and
+        the one this card shipped without. Measured row tops across the band:
+        tide and waves align on all seven rows, and air matched for three and
+        then diverged, because where the others say what the number means it
+        went straight from 76°F to WIND.
+
+        A restatement, never advice. ADR-0009 forbids this site a verdict, so a
+        Beaufort-style "a light breeze" is available and "a good day for it" is
+        not.
+      */}
+      {words !== null && (
+        <p className="leading-relaxed mb-3 text-base text-fog">{words}</p>
+      )}
+
       {/*
         Two groups, each followed by its own attribution, and that arrangement
         IS ADR-0010 rather than a layout preference. The four figures come from


### PR DESCRIPTION
Design review findings **7** (Should Fix) and **9** (Could Improve), from `.design/conditions-page/DESIGN_REVIEW.md`. Coupled by arithmetic and shipped together: finding 7 costs the tallest card ~35px and finding 9 gives back ~46px.

## What changed and why

### 1. `2ecb059` — the glyph labels the heading (finding 9)

`ReadingCard` set its glyph as `mb-3 block text-[34px] leading-none` — a 34px block plus a 12px margin, on a line of its own, in every card. `WeekGrid` puts its glyph inside the `<dt>` ("🌊 Lowest tide") where it labels rather than floats, and that is the better of the two: one page should not mark the same product two ways, and 🏄 and 🌡️ already mean the same thing in a live card and its reserved row.

The glyph stays `aria-hidden` inside the heading, so the accessible name is still the words alone — the existing `getByRole("heading", { name: "Lowest tide today" })` test holds that and passes unchanged.

**It takes `text-[34px]` with it.** That was the one raw arbitrary size in a component whose own docstring argues against exactly that ("Two names for one decision is one of them waiting to be wrong"), which is **finding 10** closed as a byproduct rather than as its own change.

### 2. `97af6e7` — the air card gets its line (finding 7)

The brief specifies the plain-language line as card anatomy in three places — *"leads with one big number, says what it means in plain words"* (Solution), *"emoji header, lead figure, plain-language line, stat groups, attribution"* (`ReadingCard`'s inventory row), and *"the lead figure, the plain-language line and the stat groups are all present without interaction"* (Key Interactions). `TASKS.md` slices 2 and 3 each preserve their card's line explicitly and slice 4 does not mention one, which is where this card's was dropped. **A spec deviation, not an open question** — the review's Corrections section says so directly.

**"Mild, with a light breeze."** Both registers, as you asked. Temperature leads because it is the card's figure; the wind follows as a clause because mph is the number here that most needs plain words — a parent reads 74°F without help and reads 7 mph without knowing whether that is windy. Either half alone still makes a sentence, because each station's fields can be absent independently, and neither arriving renders no line rather than an empty one (the same rule that already stops `ReadingCard` rendering an empty primary).

**A restatement, never advice.** ADR-0009 forbids the site a verdict, and its own wording is the licence for the line: *"Facts get described in plain language"*, with the boundary drawn at inference, not description. So a Beaufort-style "a light breeze" is available and "a good day for it" is not.

`CALM_MPH` names the one-knot threshold `windStats` already used, now that a second reader of it exists. Two thresholds would let the card print "no wind" above "Gusting 2 mph" — the contradiction the gust rule was written to stop.

## Verification

### Measured in Chromium at 1536×639, `.next/` removed, `next dev`

The review's arithmetic holds to the pixel. Baseline from the review at `67e3c46`: the now-band ran **354–648** against a 639px fold, nine pixels over.

| | Before (review) | After |
|---|---|---|
| Now-band | 354 – **648** | 354 – **637** |
| Band height | 294px | **283px** |
| Page height | 2171px | 2161px |

−46px for the glyph row, +35px for the line, **net −11px**. The band now closes **two pixels inside the fold**, as a byproduct of a composition change rather than as a target — which is what the review's "the nine pixels" section argued for over trimming a margin.

**Finding 7's actual defect — the rows no longer diverge.** Measured row tops, all three cards:

```
                    heading  figure  sentence  stat label  provenance
Lowest tide today     370     397      441        476         523
Waves and water       370     397      441        476         523
Air                   370     397      441        476         523
```

Previously air matched for three rows and then diverged, because where the others say what the number means it went straight from the figure to WIND.

No horizontal overflow at 375 (`scrollWidth` 375 = `clientWidth` 375).

### Gates

Both new tests confirmed red first. `ReadingCard.tsx` stashed:

```
 FAIL  src/components/ReadingCard.test.tsx > the glyph labels the heading rather than taking a line of its own
AssertionError: expected 'Lowest tide today' to contain '🐚'
 Test Files  1 failed (1)
      Tests  1 failed | 11 passed (12)
```

`WindToday.tsx` stashed:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/components/WindToday.test.tsx > the card says what its figures mean in plain words
 FAIL  src/components/WindToday.test.tsx > a calm wind is calm in the words and in the figure
 FAIL  src/components/WindToday.test.tsx > either figure alone still makes a sentence
 Test Files  1 failed (1)
      Tests  3 failed | 25 passed (28)
```

**The coverage floor caught a real gap on the way through** — the first pass tested three bands and left eleven untested, and the gate failed at `branches 89.27% < 89.7%`. Both band tables are now pinned test-by-test, which is the right coverage anyway: the bands are this site's own wording and nothing upstream asserts them.

`npm run gate` at `97af6e7`, with `.next/` removed first (and separately green at `2ecb059`):

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

## One thing to look at

**The inlined glyph renders at 10px**, inheriting the heading's `text-2xs`. That is the week grid's `<dt>` treatment adopted straight, which is what finding 9 asked for, and it reads as a mark rather than an illustration. It is the one judgement in this PR a gate cannot make. If it is too quiet at card scale, the fix is a size on the span rather than a return to the block — and it would want a token, not another `text-[34px]`.

## Not done here, and merge order

- **`WindToday.tsx` overlaps two other open PRs.** Merge order for the series: finding 1 (#134), finding 6 (#136), then this one. The provenance lines in the measurements above still read "1.4 km from this beach" and "10 km away" because this branch is cut from `main` and does not carry #136 — that is finding 6's fix, not this one's.
- **Finding 5** (heading scale) is answered and lands separately as an ADR plus the size step.
- Findings 8 and 11–13 were not in scope for this pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
