### PR TITLE
Rank a region heading above a card heading (ADR-0014)

### DIFF
--- a/docs/adr/0014-region-headings-outrank-card-headings.md
+++ b/docs/adr/0014-region-headings-outrank-card-headings.md
@@ -1,0 +1,107 @@
+# 0014 — A region heading outranks a card heading, in the display register
+
+Date: 2026-08-24. Status: accepted.
+
+## Context
+
+Twelve of the thirteen headings on `/conditions` render at 10px. Measured: the
+`<h1>` is 56px, and every other heading on the page — the three card `<h2>`s,
+the two region `<h2>`s and the seven day `<h3>`s — is
+`text-2xs font-extrabold tracking-widest text-ocean uppercase`, identical to
+each other and to the stat labels and the provenance lines beside them.
+`--text-2xs` is the smallest token in the system and `--text-base` body is 13px,
+so a heading is smaller than the text it introduces.
+
+The consequence is that "The week ahead" (a region), "Air" (a card inside it)
+and "Tue, Aug 25" (a day inside that) are typographically indistinguishable. The
+DOM outline is correct and nothing is skipped — this is purely visual — but the
+page has **two visual type levels where its outline has four**. Reported as
+finding 5 of `.design/conditions-page/DESIGN_REVIEW.md`.
+
+**The brief names the lever and it does not reach.** `DESIGN_BRIEF.md`'s
+typography section says "One family; weight and italics carry all hierarchy",
+so weight and italics are what a fix should try first. Both are already spent:
+every heading here is `font-extrabold` and non-italic, 800 → 900 at 10px
+uppercase is close to imperceptible, and italics at 10px uppercase with
+`tracking-widest` reads as a rendering fault rather than as emphasis.
+
+**Size is not a departure from the brief.** The brief's own `<h1>` uses
+`--text-title` and its `--text-stat` figures use a size token, so the system
+already differentiates by size wherever the difference has to be seen.
+
+**The site has two heading registers, and it has never written the rule down.**
+That is the actual gap, and it is why this is an ADR rather than a page fix.
+
+- **Display register** — `font-black italic`, a size token, `leading-display`.
+  `ConditionsSection`'s `<h1>`, `community`'s and `InterestListTeaser`'s and
+  `GallerySection`'s `<h2>`s (`--text-title`), `ProgramCards`' card titles
+  (`--text-card`), `QuoteStats`' pull quote (`--text-quote`).
+- **Label register** — `text-2xs font-extrabold tracking-widest uppercase` in an
+  accent colour. Card headings, day headings, stat labels, provenance lines,
+  eyebrows — and also five region `<h2>`s: two on `/art`, one in
+  `SessionSchedule`, two on `/conditions`.
+
+So a region heading has been written both ways depending on which page reached
+for it first, which is the drift `PillLink` and `ReservedSlot` were both
+extracted to stop, one layer up. Two of those pages already invert: `/art`'s
+`<h3>` is display-register at 13px under a label-register `<h2>` at 10px, and
+`SessionSchedule`'s `<h3>` is display-register at 18px under the same. A child
+heading outranks its parent in both.
+
+## Decision
+
+**A region heading is display register. A card heading and a day heading stay
+label register.**
+
+A region heading takes `--text-quote`: `text-quote leading-display mb-4
+font-black italic`, inheriting its colour as the `<h1>` does. Named once, as
+`REGION_HEADING` in `src/components/headingRank.ts`, because a rank asserted in
+two places is one of them waiting to drift — the argument `touchTarget.ts`
+already makes about a number.
+
+That gives `/conditions` three visual levels — 56 / 34 / 10 at 1536, 32 / 20 /
+10 at 375 — against four outline levels. Card and day headings stay identical
+to each other deliberately: the review grouped them, and a card `<h2>` and the
+day `<h3>` inside its sibling grid are not competing for the same glance.
+
+**`--text-quote` and not `--text-card`**, which is the other unused mid token.
+`--text-card` is `clamp(30px, 3vw, 44px)` against the `<h1>`'s
+`clamp(32px, 5vw, 56px)`: 44 against 56 at 1536, and **30 against 32 at 375**,
+where a region heading would all but equal the page title. `--text-quote` is
+`clamp(20px, 2.8vw, 34px)` — 34 against 56, and 20 against 32. Clear at both
+ends of the clamp, which is the property that matters, since a rank that holds
+only on a desktop is not a rank.
+
+**No new colour pair.** A region heading inherits the same ink on the same cream
+the `<h1>` already uses, so the brief's rule that any new surface is checked
+before it ships is not engaged. At 34px and 20px it is large text besides,
+needing 3:1 rather than 4.5:1.
+
+## Consequences
+
+`/conditions` gains the middle level its outline always had. The two region
+headings there change; nothing else on that page moves.
+
+**Three region headings are knowingly left in the label register** — `/art`'s
+"What makes it different" and "Packages & pricing", and `SessionSchedule`'s
+"Upcoming sessions". They are outside the brief this decision was taken under,
+they each carry a different accent colour, and converting them is a visible
+change to two finished compositions that wants its own look. This ADR is what
+they are converted _against_ when someone does it, and recording the omission
+here is the point: the alternative is a rule that quietly means "on the page
+where it was written".
+
+**The heading inversion on those two pages is not fixed by this.** `/art` and
+`SessionSchedule` each render a display-register `<h3>` under a label-register
+`<h2>`, so a child outranks its parent. Converting the parents closes it;
+until then the defect stands and is recorded rather than filed.
+
+**The gate cannot check a rank.** jsdom applies no stylesheets (ADR-0001), so
+tests assert that a region heading composes `REGION_HEADING` and that a card
+heading does not. That 34px reads as outranking 10px is a human check at the
+review viewport, which is the same compromise ADR-0004 records for the touch
+target.
+
+The part most likely to be re-litigated is using three levers where the brief
+names two. The honest answer is that the two it names were tried and cannot
+move: this page had already spent both before the question was asked.

--- a/src/components/ConditionsNotes.test.tsx
+++ b/src/components/ConditionsNotes.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ConditionsNotes } from "./ConditionsNotes";
+import { REGION_HEADING } from "./headingRank";
 
 const ENTRIES = [
   "beach_type is UNKNOWN upstream for most of these beaches.",
@@ -108,4 +109,23 @@ test("it is a labelled region, so the notes are reachable as a landmark", () => 
     name: /how to read these numbers/i,
   });
   expect(heading).toBeDefined();
+});
+
+/**
+ * ADR-0014: a region heading is display register, so it outranks the card and
+ * day headings inside the page. This block introduces one of the page's two
+ * regions and rendered at 10px — the smallest token in the system, and smaller
+ * than the 13px body it introduces.
+ */
+test("the block's heading takes the region rank", () => {
+  render(<ConditionsNotes entries={ENTRIES} reach={REACH} />);
+
+  const heading = screen.getByRole("heading", {
+    name: "How to read these numbers",
+  });
+
+  expect(heading.className).toBe(REGION_HEADING);
+  // Per ADR-0001 jsdom applies no stylesheets, so this proves the rank is
+  // referred to, not that 34px renders. That stays a human check.
+  expect(heading.className).not.toContain("text-2xs");
 });

--- a/src/components/ConditionsNotes.tsx
+++ b/src/components/ConditionsNotes.tsx
@@ -34,6 +34,7 @@
 
 import type { InventoryReach } from "@/lib/beaches";
 import { Caveats } from "./Caveats";
+import { REGION_HEADING } from "./headingRank";
 
 /** One thing worth understanding about every figure of its kind. */
 const NOTES = [
@@ -79,10 +80,7 @@ export function ConditionsNotes({
     // No top margin: the now-band above carries the gap. Spacing on both is
     // counted twice, which is the failure `SnapSection`'s docstring records.
     <section aria-labelledby="conditions-notes-heading">
-      <h2
-        id="conditions-notes-heading"
-        className="text-2xs mb-3 font-extrabold tracking-widest text-ocean uppercase"
-      >
+      <h2 id="conditions-notes-heading" className={REGION_HEADING}>
         How to read these numbers
       </h2>
 

--- a/src/components/WeekGrid.test.tsx
+++ b/src/components/WeekGrid.test.tsx
@@ -1,5 +1,6 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { REGION_HEADING } from "./headingRank";
 import { WeekGrid, type WeekDay, type WeekRow } from "./WeekGrid";
 
 const DAYS: WeekDay[] = [
@@ -144,4 +145,23 @@ test("the week is a region a reader can navigate to by its heading", () => {
   const section = container.querySelector("section");
   expect(section?.getAttribute("aria-labelledby")).toBe("week-heading");
   expect(screen.getByText("The week ahead").id).toBe("week-heading");
+});
+
+/**
+ * ADR-0014, asserted where both ranks render inside one component. "The week
+ * ahead" is a region and "Tue, Aug 18" is a day inside it, and the two were
+ * `text-2xs font-extrabold tracking-widest text-ocean uppercase` apiece —
+ * indistinguishable, on a page whose outline has four levels.
+ */
+test("the week's heading outranks the day headings inside it", () => {
+  const { container } = renderGrid();
+
+  const region = screen.getByRole("heading", { name: "The week ahead" });
+  expect(region.className).toBe(REGION_HEADING);
+
+  // The other half of the rank: the label register stays where it is. A day
+  // heading moving with the region would restore the flat scale one level down.
+  const day = container.querySelector("h3");
+  expect(day?.className).toContain("text-2xs");
+  expect(day?.className).not.toContain("text-quote");
 });

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -37,6 +37,7 @@
  */
 
 import type { ReactNode } from "react";
+import { REGION_HEADING } from "./headingRank";
 import { ReservedSlot } from "./ReservedSlot";
 
 /** One column of the week. */
@@ -106,10 +107,7 @@ export function WeekGrid({
 }: WeekGridProps) {
   return (
     <section aria-labelledby={headingId}>
-      <h2
-        id={headingId}
-        className="text-2xs mb-3 font-extrabold tracking-widest text-ocean uppercase"
-      >
+      <h2 id={headingId} className={REGION_HEADING}>
         {title}
       </h2>
 

--- a/src/components/headingRank.ts
+++ b/src/components/headingRank.ts
@@ -1,0 +1,30 @@
+/**
+ * A region heading, in the site's display register. See ADR-0014.
+ *
+ * The site writes headings two ways. The **display register** is
+ * `font-black italic` at a size token with `leading-display` -- the `<h1>`,
+ * `ProgramCards`' card titles, `QuoteStats`' pull quote. The **label register**
+ * is `text-2xs font-extrabold tracking-widest uppercase` in an accent colour --
+ * card headings, day headings, stat labels, provenance lines, eyebrows. A
+ * region heading had been written both ways depending on which page reached
+ * for it first, which left `/conditions` rendering a region, a card inside it
+ * and a day inside that at the same 10px.
+ *
+ * `--text-quote` rather than `--text-card`, the other unused mid token: card
+ * clamps to 30px at 375 against the `<h1>`'s 32px, where a region heading would
+ * all but equal the page title. Quote is 20px there and 34px at 1536, clear at
+ * both ends of the clamp -- and a rank that holds only on a desktop is not a
+ * rank.
+ *
+ * The colour is inherited rather than set, as the `<h1>` inherits it: no new
+ * text-on-surface pair, so nothing here is owed a contrast measurement the
+ * page has not already taken.
+ *
+ * Named once because a rank asserted in two places is one of them waiting to
+ * drift, which is the argument `touchTarget.ts` makes about a number. It does
+ * not prove the rendered rank -- jsdom applies no stylesheets (ADR-0001) -- so
+ * tests assert that a region heading refers to this and a card heading does
+ * not, and a human confirms the rank is visible.
+ */
+export const REGION_HEADING =
+  "text-quote leading-display mb-4 font-black italic";


### PR DESCRIPTION
Design review finding **5** (Should Fix), from `.design/conditions-page/DESIGN_REVIEW.md`. This is the one the review called a genuinely open decision; you answered **region outranks card**, so it lands as an ADR plus the change.

## What changed and why

Measured: the `<h1>` is 56px and **twelve of the other thirteen headings are 10px** — `text-2xs font-extrabold tracking-widest text-ocean uppercase`, identical to each other and to the stat labels and provenance lines beside them. `--text-2xs` is the smallest token in the system and `--text-base` body is 13px, so a heading was smaller than the text it introduced. "The week ahead" (a region), "Air" (a card inside it) and "Tue, Aug 25" (a day inside that) were indistinguishable: **two visual levels where the outline has four.** The DOM outline was correct and nothing was skipped.

### The brief's lever, tried first

`DESIGN_BRIEF.md` says *"One family; weight and italics carry all hierarchy"*, and the review's own Corrections section exists because a published fix skipped naming it. Both are already spent here: every heading on the page is `font-extrabold` and non-italic, 800 → 900 at 10px uppercase is close to imperceptible, and italics at 10px uppercase with `tracking-widest` reads as a rendering fault rather than as emphasis. The brief's `<h1>` and `--text-stat` both differentiate by size, so size is not a departure from the system.

### What I found that the review did not

**The site already has two heading registers and has never written the rule down** — that is the actual gap, and it is why this is an ADR rather than a page fix.

- **Display** — `font-black italic` at a size token with `leading-display`: the `<h1>`, `community`/`InterestListTeaser`/`GallerySection`'s `<h2>`s (`--text-title`), `ProgramCards`' card titles (`--text-card`), `QuoteStats`' pull quote (`--text-quote`).
- **Label** — `text-2xs font-extrabold tracking-widest uppercase` in an accent: card headings, day headings, stat labels, provenance lines, eyebrows — **and five region `<h2>`s**: two on `/art`, one in `SessionSchedule`, two on `/conditions`.

So a region heading has been written both ways depending on which page reached for it first. My first read was that `/conditions` was the outlier; it is not, which is what makes this genuinely site-wide rather than a page fix wearing an ADR.

### The decision

A region heading is display register at `--text-quote`. Card and day headings stay label register, together — the review grouped them, and a card `<h2>` and the day `<h3>` in its sibling grid do not compete for the same glance. Three visual levels against four outline levels, which is what the review's fix clause asked for.

**`--text-quote`, not `--text-card`** — the other unused mid token. `--text-card` is `clamp(30px, 3vw, 44px)` against the `<h1>`'s `clamp(32px, 5vw, 56px)`: 44 vs 56 at 1536, but **30 vs 32 at 375**, where a region heading would all but equal the page title. A rank that holds only on a desktop is not a rank.

`REGION_HEADING` in the new `src/components/headingRank.ts` — **flagging this as a new abstraction** per `CLAUDE.md`. Two call sites is thin, but the thing being shared is a *rank*, and a rank asserted in two places is one of them waiting to drift. Same argument `touchTarget.ts` makes about a number.

No new colour pair: a region heading inherits the same ink on the same cream the `<h1>` already uses, so nothing here is owed a contrast measurement the page has not taken.

## Verification

### Measured in Chromium, `.next/` removed, `next dev` — both ends of the clamp

```
--- 1536x639 ---                          --- 375x812 ---
  H1   56px 900 italic  Check conditions…   H1   32px 900 italic  Check conditions…
  H2   10px 800 normal  Lowest tide today   H2   10px 800 normal  Lowest tide today
  H2   10px 800 normal  Waves and water     H2   10px 800 normal  Waves and water
  H2   10px 800 normal  Air                 H2   10px 800 normal  Air
  H2   34px 900 italic  The week ahead      H2   20px 900 italic  The week ahead
  H3   10px 800 normal  Today · Mon, Aug 24 H3   10px 800 normal  Today · Mon, Aug 24
  H3   10px 800 normal  Tue, Aug 25         H3   10px 800 normal  Tue, Aug 25
  no horizontal overflow: true              no horizontal overflow: true
```

56 / 34 / 10 and 32 / 20 / 10. Both region headings hold one line at both widths — "How to read these numbers" is 327×20 at 375 and 1440×34 at 1536.

**`text-quote` emits real CSS**, which is the ADR-0006 reading and the specific false pass a className test cannot see:

```
text-quote      -> .text-quote{font-size:var(--text-quote)}
leading-display -> .leading-display{--tw-leading:var(--leading-display);line-height:var(--leading-display)}
```

### Gates

Both new tests confirmed red first — the two component sources stashed:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/components/ConditionsNotes.test.tsx > the block's heading takes the region rank
AssertionError: expected 'text-2xs mb-3 font-extrabold tracking…' to be 'text-quote leading-display mb-4 font-…'
 FAIL  src/components/WeekGrid.test.tsx > the week's heading outranks the day headings inside it
AssertionError: expected 'text-2xs mb-3 font-extrabold tracking…' to be 'text-quote leading-display mb-4 font-…'
 Test Files  2 failed (2)
      Tests  2 failed | 20 passed (22)
```

`npm run gate` at `f3d91e5`, with `.next/` removed first:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

ADR number 0014 was re-derived, not assumed: 0001–0013 are on `main` and no open branch carries a `docs/adr/` file that `main` does not.

## Not done here — please read this part

**Three region headings are knowingly left in the label register**, and this is recorded in the ADR's Consequences rather than fixed: `/art`'s "What makes it different" and "Packages & pricing", and `SessionSchedule`'s "Upcoming sessions". They are outside the brief this decision was taken under, they each carry a different accent colour, and converting them changes two finished compositions in ways that want their own look.

**That leaves a real defect standing on two other pages.** `/art:136` renders a display-register `<h3>` at 13px under a label-register `<h2>` at 10px, and `SessionSchedule:94` renders one at 18px under the same — **a child heading outranking its parent** in both. Converting the parents under ADR-0014 closes it. I have recorded this in the ADR and here rather than opening an issue, per `CLAUDE.md`; say the word if you want it filed.

**One test I did not write.** The rank the ADR names is region > *card*, and the negative half of that would belong in `ReadingCard.test.tsx` — which PR #137 already appends to, so a second append is a conflict for little gain. `WeekGrid.test.tsx` asserts the equivalent inside one component: the region `<h2>` takes the rank and the day `<h3>` does not.

**Merge order.** This touches `WeekGrid.tsx` (the `<h2>`, near the top) which PR #135 also touches (the reserved band, at the bottom) — different regions, but merge #135 first. It touches `ConditionsNotes.tsx`, which nothing else in the series does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
