### PR TITLE
The standing safety notice, above the readings

### DIFF
--- a/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
+++ b/.design/wild-coast-kids-landing/INFORMATION_ARCHITECTURE.md
@@ -123,7 +123,10 @@ a control that silently does nothing.
 **Reading order, top to bottom:**
 
 1. Eyebrow, title and lead — with the **beach chooser on the same row as the
-   title**, right-aligned, because it decides what every figure below it means.
+   title**, right-aligned, because it decides what every figure below it means,
+   and the **standing safety notice** above the chooser in that same column:
+   instruments rather than a judgement, lifeguards and the posted signs the
+   authority on the day. ADR-0009 turns on it sitting around the readings.
 2. **The now-band**: today's lowest tide, waves and water, air. Three cards
    across at `lg`, each leading with one figure and carrying its own station
    attribution.
@@ -131,8 +134,9 @@ a control that silently does nothing.
    first live row. Transposes to day-rows below `lg` rather than scrolling.
 4. **The sighting map slot** — a reserved slot until #121 is built.
 5. **The notes block**: the datum, why a buoy reading is not the wave at the
-   shore, why visibility is an airport reading, the standing sentence that none
-   of this is a safety assessment, and the caveats and coverage disclosures.
+   shore, why visibility is an airport reading, and the caveats and coverage
+   disclosures. The safety framing is not here — it is the standing notice in
+   item 1, because it is not a note about how to read a figure.
 
 **A slug that does not resolve is a 404.** See _URL Strategy_ for the closed
 slug set and for why nothing under `/conditions/` is prerendered.

--- a/docs/plans/conditions-tool.md
+++ b/docs/plans/conditions-tool.md
@@ -702,3 +702,59 @@ the seam the caveats gate already walks. As with #70 it holds the sentence still
 and not the ocean: a gate must not fetch `realtime2`, so nothing in CI notices if
 NDBC changes what these stations publish. The measurement above is the evidence;
 the test only stops the claim reverting silently.
+
+### 2026-08-25 — slice 9 splits, and where the standing notice actually goes
+
+**Slice 9 ships in two parts, and this is the first.** As written it is three
+things: active alerts, the surf zone forecast relayed verbatim, and the standing
+notice. The first two need upstream products this repo does not read yet; the
+notice needs none, and it is what three documents are queued behind — this
+plan's _Presentation_ section, `DESIGN_BRIEF.md`'s Solution paragraph, and
+finding 13 of `.design/conditions-page/DESIGN_REVIEW.md`, which says the entry
+under "How to read these numbers" "may move anyway" when this lands. ADR-0009's
+argument for building the tool here rather than embedding it rests on this
+notice existing, so shipping it alone is worth more than holding it for a feed.
+
+**The placement was decided by measurement, because two documents disagreed.**
+_Presentation_ above says "Above the readings, a standing notice". The brief
+designs the first screen against a 555px budget and spent a whole slice — moving
+the chooser into the header row, worth about 103px — buying the now-band its
+place above that fold. Measured on `main` at `e00b163`, the band runs **354–637
+against a 639px fold**: two pixels of slack. Anything above the readings is paid
+for out of that.
+
+Three placements were built and measured at 1536×639, same copy in each:
+
+| Placement                            | Notice  | Now-band    | Air card's second attribution | Cost  |
+| ------------------------------------ | ------- | ----------- | ----------------------------- | ----- |
+| Its own line above the band          | 354–401 | 417–**700** | 666–684, fully below the fold | +63px |
+| Header row, above the chooser        | 164–258 | 379–**662** | 628–646, cut mid-line         | +25px |
+| Its own line, lead paragraph trimmed | 354–401 | 417–**700** | 666–684                       | +63px |
+
+**Taken: the header row, above the chooser.** It is cheap for a reason rather
+than by trick — the row is `md:items-end`, so the right column is bottom-aligned
+to a taller left column and 85px sits empty in it. The notice fills waste, which
+is what the brief means by content that "is arranged, never removed". It also
+lands at y164, level with the eyebrow and higher up the page than the literal
+placement's y354, and it pairs sensibly with the control beneath it: the chooser
+decides what every figure means, the notice says what every figure is.
+
+**What that costs, named so it is a trade rather than a discovery.** The notice
+sets to 288px over four lines rather than to the page's prose measure, and a
+reader may parse it as a caption for the chooser rather than for the page. The
+literal placement was rejected on one specific loss: at 417–700 the air card's
+second attribution falls at 666, entirely below the fold, and ADR-0010 turns on
+a reader being able to compare the two stations' distances.
+
+**The third row is recorded because it was wrong.** Trimming "Know before you
+go." from the lead paragraph was expected to buy back a line and did not — the
+paragraph sets to two lines either way, so that variant measured identically to
+the first. The sentence stays.
+
+**The safety entry leaves `ConditionsNotes` rather than being said twice.** The
+notice carries everything that entry carried and adds the clause ADR-0009 names
+and the entry never had: that lifeguards and the posted signs are the authority
+on the day. That resolves finding 13 of the design review — "None of it is a
+safety assessment" is not a note about how to read a number — and leaves the
+block with three notes, which is an input to that review's finding 8 rather than
+a decision taken here.

--- a/src/components/ConditionsNotes.test.tsx
+++ b/src/components/ConditionsNotes.test.tsx
@@ -59,10 +59,22 @@ test("the sky is named as an airport reading, and why it is one", () => {
   expect(screen.getByText(/coastal fog is exactly what changes/)).toBeDefined();
 });
 
-test("the page does not offer any of it as a safety call", () => {
+/**
+ * The property this block used to hold, kept as a negative now that it has
+ * moved — the same way the airport clause was kept verbatim when it arrived
+ * here from `WindToday.test.tsx`. The standing notice in `ConditionsSection`
+ * asserts it positively and adds the clause ADR-0009 names, and this block
+ * saying it too would be the page stating one thing twice.
+ */
+test("the safety framing is not repeated here, it is above the readings", () => {
   render(<ConditionsNotes entries={ENTRIES} reach={REACH} />);
 
-  expect(screen.getByText(/None of it is a safety assessment/)).toBeDefined();
+  expect(screen.queryByText(/None of it is a safety assessment/)).toBeNull();
+  // Three notes, not four, and the three that stay are all about reading a
+  // figure -- which is what the heading above them promises.
+  expect(screen.getByText("Tide heights")).toBeDefined();
+  expect(screen.getByText("Wave heights")).toBeDefined();
+  expect(screen.getByText("Sky and visibility")).toBeDefined();
 });
 
 /**
@@ -97,9 +109,17 @@ test("each note is a term and its explanation, not a run of prose", () => {
   );
 
   // A description list, so the pairing survives for a reader who cannot see
-  // the bolding that carries it visually.
-  expect(container.querySelectorAll("dt").length).toBe(4);
-  expect(container.querySelectorAll("dd").length).toBe(4);
+  // the bolding that carries it visually. Asserted as a pairing rather than as
+  // two independent counts: a note that lost its `<dd>` is the failure this
+  // catches, and the count alone would not see it.
+  const terms = container.querySelectorAll("dt");
+  const details = container.querySelectorAll("dd");
+
+  expect(terms.length).toBe(details.length);
+  // Three since the safety framing became a standing notice above the
+  // readings. The named-term assertions elsewhere in this file are what stop a
+  // note being dropped silently; this number only tracks them.
+  expect(terms.length).toBe(3);
 });
 
 test("it is a labelled region, so the notes are reachable as a landmark", () => {

--- a/src/components/ConditionsNotes.tsx
+++ b/src/components/ConditionsNotes.tsx
@@ -25,11 +25,14 @@
  * are shown" rather than asserting this beach has them. That is a description
  * of how the page works, not a claim about this shore.
  *
- * **Not the standing safety notice.** `docs/plans/conditions-tool.md` reserves a
- * prominent notice *above* the readings — instruments rather than judgement,
- * lifeguards and posted signs the authority on the day — for its own slice. This
- * block collects the qualifications that already existed in the page and adds
- * none, so that slice still has something to do.
+ * **Not the standing safety notice, which now exists.** That slice has landed:
+ * `ConditionsSection` carries it in the header row, above the chooser, saying
+ * that these are instruments rather than a judgement and that lifeguards and
+ * the posted signs are the authority on the day. The entry this block used to
+ * carry — "None of it is a safety assessment" — went with it rather than being
+ * said twice, and it was never a note about how to read a number, which is the
+ * heading it sat under. Three notes rather than four for that reason, not
+ * because one was dropped.
  */
 
 import type { InventoryReach } from "@/lib/beaches";
@@ -60,12 +63,6 @@ const NOTES = [
       "published by airports in this county, so that reading is taken further from the " +
       "water than the temperature beside it — and coastal fog is exactly what changes " +
       "across that distance.",
-  },
-  {
-    term: "None of it is a safety assessment",
-    detail:
-      "These are readings relayed from public instruments, each shown with the station " +
-      "that supplied it and how far away that station is.",
   },
 ] as const;
 

--- a/src/components/ConditionsSection.test.tsx
+++ b/src/components/ConditionsSection.test.tsx
@@ -104,3 +104,38 @@ test("the slot says what the map will show, not what was found", () => {
       "near this beach in the past week",
   );
 });
+
+/**
+ * The standing notice ADR-0009 rests on. That decision rejects an embed partly
+ * because inside a frame "the host page is asserting something it does not
+ * control", and this sentence is the assertion — so the page not carrying it
+ * would make a shipped ADR untrue rather than merely leave a gap.
+ *
+ * Both halves are asserted because the entry this replaced only had the first.
+ * `docs/plans/conditions-tool.md` names the second: lifeguards and posted signs
+ * on the day are the authority.
+ */
+test("the page says these are instruments and not a safety assessment", () => {
+  render(<ConditionsSection slug={DEFAULT_BEACH_SLUG} />);
+
+  expect(
+    screen.getByText(/readings from public instruments, not a safety/),
+  ).toBeDefined();
+  expect(
+    screen.getByText(/Lifeguards and the signs posted at the beach are the/),
+  ).toBeDefined();
+});
+
+/**
+ * Said once. The notes block carried "None of it is a safety assessment" as the
+ * fourth of four entries under "How to read these numbers", where it was
+ * neither prominent nor a note about how to read a number. It moved rather than
+ * being duplicated, which is what this asserts end to end: the section renders
+ * `ConditionsNotes` for real, so a regression there fails here.
+ */
+test("the safety framing is stated once, above the readings", () => {
+  render(<ConditionsSection slug={DEFAULT_BEACH_SLUG} />);
+
+  expect(screen.queryByText(/None of it is a safety assessment/)).toBeNull();
+  expect(screen.getAllByText(/not a safety assessment/)).toHaveLength(1);
+});

--- a/src/components/ConditionsSection.tsx
+++ b/src/components/ConditionsSection.tsx
@@ -58,7 +58,30 @@ export function ConditionsSection({ slug }: { slug: string }) {
           </p>
         </div>
 
-        <div className="mt-7 md:mt-0">
+        {/*
+          The standing notice ADR-0009 turns on: that decision rejects an embed
+          partly because "the host page is asserting something it does not
+          control", and this sentence is the assertion. It said less than this
+          and sat fourth of four at the bottom of a 2171px page until now.
+
+          Here rather than in a band of its own above the readings, and the
+          reason is measured. The row is `md:items-end`, so this column is
+          bottom-aligned to a taller one and 85px sat empty in it; the notice
+          fills waste and costs the first screen 25px, where a band above the
+          readings cost 63px and put the air card's second attribution below
+          the fold. ADR-0010 turns on those two distances being comparable at a
+          glance. See the 2026-08-25 addendum in docs/plans/conditions-tool.md
+          for the three placements and their numbers.
+
+          Above the chooser, not below it, so it is read before the control
+          rather than as a footnote to it.
+        */}
+        <div className="mt-7 md:mt-0 md:w-72">
+          <p className="leading-relaxed mb-4 text-base text-fog">
+            These are readings from public instruments, not a safety assessment.
+            Lifeguards and the signs posted at the beach are the authority on
+            the day.
+          </p>
           <BeachSelector groups={groups} current={slug} />
         </div>
       </div>


### PR DESCRIPTION
Slice 9 of `docs/plans/conditions-tool.md`, split — the standing notice ships without active alerts or the surf zone forecast, which need upstream products this repo does not read yet.

## Why this one

**ADR-0009's argument for building the tool here rather than embedding it rests on this notice existing:**

> The safety framing this content needs — a standing notice that these are instrument readings and not a safety assessment, and that lifeguards and posted signs are the authority on the day — has to sit around the readings. Inside a frame, the host page is asserting something it does not control.

The page has never carried that assertion. What it had was **"None of it is a safety assessment"**, fourth of four entries in a notes block at the bottom of a 2218px page, saying nothing about lifeguards or posted signs. Three documents were queued behind this: the plan's _Presentation_ section, the brief's Solution paragraph, and design-review finding 13.

## The placement was measured, because two documents disagreed

`conditions-tool.md` says *"Above the readings, a standing notice."* The brief spent a whole slice — moving the chooser into the header row, ~103px — buying the now-band its place above the 639px fold, where it closed at **637**. Two pixels of slack, so anything above the readings is paid for out of that.

Three placements were built and measured at 1536×639, same copy in each:

| Placement | Notice | Now-band | Air card's 2nd attribution | Cost |
|---|---|---|---|---|
| Its own line above the band | 354–401 | 417–**700** | 666–684, fully below the fold | +63px |
| **Header row, above the chooser** | **164–258** | **379–662** | **628–646, cut mid-line** | **+25px** |
| Its own line, lead paragraph trimmed | 354–401 | 417–**700** | 666–684 | +63px |

**Taken: the header row.** Cheap for a reason rather than by trick — the row is `md:items-end`, so that column is bottom-aligned to a taller one and **85px sat empty in it**. The notice fills waste, which is what the brief means by content that "is arranged, never removed". It also lands at y164, level with the eyebrow and higher up the page than the literal placement's y354, and it pairs sensibly with the control beneath it: the chooser decides what every figure means, the notice says what every figure *is*.

**The literal placement was rejected on one specific loss**, not on the total: at 417–700 the air card's second attribution falls at 666, entirely below the fold, and ADR-0010 turns on a reader being able to compare the two stations' distances at a glance.

**The third row is in the table because I was wrong about it.** I proposed trimming "Know before you go." from the lead to pay for the literal placement. It buys nothing — the paragraph sets to two lines either way, so that variant measured identically to the first. The sentence stays.

**The risk I flagged did not materialise.** I was worried a notice directly above "CHOOSE A BEACH" would read as a caption for the chooser. On screen it does not: the notice is prose and the chooser's label is a 10px uppercase eyebrow, and the `mb-4` between them is enough. Worth your eye anyway — it is the one judgement here a gate cannot make.

## The entry it replaces moves rather than repeating

`ConditionsNotes` drops to three notes. This also settles **design-review finding 13** — "None of it is a safety assessment" was never a note about how to read a number, which is the heading it sat under. Its test becomes the negative, the way the airport clause was kept verbatim when it moved out of `WindToday.test.tsx`.

Side effect worth knowing for finding 8: the notes block is now **three** notes, so laying it two-up from `lg` is a 3-note decision rather than a 4-note one.

## Two things I touched that were not the feature

- **`ConditionsNotes`' docstring said the standing notice was reserved for its own slice** so "that slice still has something to do". That slice is this one, so the paragraph is now false and is rewritten.
- **`INFORMATION_ARCHITECTURE.md`** is the site's canonical structure document and enumerates both blocks by their contents. Moving an element it lists without updating it is the doc drift `docs/plans/design-doc-drift.md` exists about.
- **A hardcoded `dt`/`dd` count of `4`** in `ConditionsNotes.test.tsx`, under a test named "each note is a term and its explanation, not a run of prose". The number was incidental to that property, so it now asserts the pairing (`terms.length === details.length`) plus a count that tracks the notes. Flagging it because a bare number change in a test can read as a test bent to fit.

## Process

Full lane. **No new plan file** — `docs/plans/conditions-tool.md` is the plan for this work, still in flight, and has a documented dated-addenda convention; `CLAUDE.md` says to amend it rather than start a third copy. The decision landed as its own first commit, the way that plan's own PR A landed. **No ADR** — ADR-0009 already governs the requirement and the placement is page-local. **No issue** — one slice.

## Verification

All four tests confirmed red first — `ConditionsSection.tsx` and `ConditionsNotes.tsx` stashed:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/components/ConditionsNotes.test.tsx > the safety framing is not repeated here, it is above the readings
AssertionError: expected <dt …(1)></dt> to be null
 FAIL  src/components/ConditionsNotes.test.tsx > each note is a term and its explanation, not a run of prose
AssertionError: expected 4 to be 3
 FAIL  src/components/ConditionsSection.test.tsx > the page says these are instruments and not a safety assessment
TestingLibraryElementError: Unable to find an element with the text: /readings from public instruments, not a safety/
 FAIL  src/components/ConditionsSection.test.tsx > the safety framing is stated once, above the readings
AssertionError: expected <dt …(1)></dt> to be null
```

Measured in Chromium, `.next/` removed, `next dev`:

```
=== 1536x639 ===
notice 164–258 (288px wide), before the chooser: yes
band 379–662  (fold 639)
air's 2nd attribution 628–646
page 2166px · overflow false · "safety assessment" appears 1×

=== 768x1024 ===
notice 183–277 (288px wide), before the chooser: yes
band 398–978 · air's 2nd attribution 926–962
page 3631px · overflow false · "safety assessment" appears 1×

=== 375x812 ===
notice 459–529 (327px wide), before the chooser: yes
band 650–1448 · air's 2nd attribution 1396–1432
page 4396px · overflow false · "safety assessment" appears 1×
```

The page got **shorter**, 2218 → 2166: removing the note saved more than the notice added. "safety assessment" appears exactly once in the rendered DOM at every width, and the notice precedes the chooser in document order at all three — so a screen reader meets it before the control.

`npm run gate` at `70542e5`, `.next/` removed first:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

## Not done here

- **The rest of slice 9** — active alerts and the surf zone forecast relayed verbatim. Both need upstream products; the addendum records the split.
- **Design-review finding 8** (the notes block two-up from `lg`) is the natural next one, and it wanted this first so the block only gets designed once.
- No conflicts with anything — every other PR in this series is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
