### PR TITLE
Lay the notes in columns, each keeping its own measure

### DIFF
--- a/src/components/ConditionsNotes.test.tsx
+++ b/src/components/ConditionsNotes.test.tsx
@@ -149,3 +149,38 @@ test("the block's heading takes the region rank", () => {
   // referred to, not that 34px renders. That stays a human check.
   expect(heading.className).not.toContain("text-2xs");
 });
+
+/**
+ * Finding 8 of the conditions-page design review. As a single column this block
+ * was 520px of prose in a 1440px section, leaving 920px blank beside it for its
+ * full height — the complaint the brief opens with, reproduced in the page's own
+ * closing section. The notes are independent of one another, so columns cost a
+ * reader nothing to scan.
+ *
+ * The cap moves from the list to each note, which is what the review's "each
+ * still capped at its own measure" requires: on a very wide screen the columns
+ * stop growing rather than pulling the lines back out to the 83 characters they
+ * measured before.
+ *
+ * Per ADR-0001 jsdom applies no stylesheets, so this proves the classes are
+ * referenced, not that three columns render. The measurements are in the PR.
+ */
+test("the notes lay out in columns, each keeping its own measure", () => {
+  const { container } = render(
+    <ConditionsNotes entries={ENTRIES} reach={REACH} />,
+  );
+
+  const list = container.querySelector("dl");
+
+  expect(list?.className).toContain("md:grid-cols-2");
+  expect(list?.className).toContain("xl:grid-cols-3");
+
+  // On the list the cap would hold the whole grid inside 520px and put the
+  // three columns back into the one ribbon this replaces.
+  expect(list?.className).not.toContain("max-w-130");
+  const notes = Array.from(list?.children ?? []);
+  expect(notes.length).toBeGreaterThan(0);
+  for (const note of notes) {
+    expect(note.className).toContain("max-w-130");
+  }
+});

--- a/src/components/ConditionsNotes.tsx
+++ b/src/components/ConditionsNotes.tsx
@@ -85,10 +85,30 @@ export function ConditionsNotes({
         A description list rather than paragraphs: each entry is a topic and its
         explanation, and the pairing is what a reader is scanning for. It also
         survives for someone who cannot see the bolding.
+
+        Columns rather than one stacked ribbon, and the cap moves from the list
+        to each note. As a single column this block was 520px of prose in a
+        1440px section, leaving 920px blank beside it for its full height -- the
+        complaint the brief opens with, reproduced in the page's own closing
+        section. The notes are independent of each other, so columns cost the
+        reader nothing to scan.
+
+        It also reads better rather than merely narrower. Measured at 520px the
+        lines ran 83-84 characters at every width, which is past a comfortable
+        measure; three columns at 1536 set to about 74 and two at 768 to about
+        52. The brief's principle is that prose keeps its measure and is not
+        stretched to fill space, and `max-w-130` per note is what holds that --
+        on a very wide screen the columns stop growing rather than pulling the
+        lines back out to 83.
+
+        Two steps, matching the now-band's `sm:grid-cols-2 lg:grid-cols-3`
+        rhythm rather than inventing one. `lg:grid-cols-3` alone would put three
+        columns at 1024 where each is 288px, about 47 characters, and this ramp
+        never takes prose below roughly 52.
       */}
-      <dl className="leading-relaxed max-w-130 text-sm text-fog">
+      <dl className="leading-relaxed text-sm text-fog md:grid md:grid-cols-2 md:gap-x-8 xl:grid-cols-3">
         {NOTES.map(({ term, detail }) => (
-          <div key={term} className="mb-3">
+          <div key={term} className="mb-3 max-w-130">
             <dt className="font-extrabold text-dark">{term}</dt>
             <dd>{detail}</dd>
           </div>


### PR DESCRIPTION
Design review finding 8 (Should Fix), from `.design/conditions-page/DESIGN_REVIEW.md`.

> **Stacked on #140.** That PR sets the note count, which is the entire input to this layout, so this branch is cut from it and targets it. GitHub will retarget this to `main` when #140 merges. Merge #140 first.

## What changed

As a single column, `ConditionsNotes` was 520px of prose in a 1440px section — 920px blank beside it for its full height, which is the complaint the brief opens with, reproduced in the page's own closing section. The notes now lay out `md:grid-cols-2 xl:grid-cols-3`, with `max-w-130` moved from the list onto each note.

## Two places I departed from the review's fix clause, both deliberate

**1. Three columns, not the two it prescribes.** The clause says *"lay the four notes two-up from `lg`"* — written when this block had four notes. #140 moved the safety entry out to the standing notice, so there are three. Two-up now gives a ragged 2+1 **and** still leaves 368px blank at 1536. The direction survives (fill the width, each note keeps its measure); the count is re-derived from the content that is actually there.

**2. `md`/`xl`, not `lg`.** `lg:grid-cols-3` alone puts three columns at 1024 where each is 288px — about 47 characters, the thin end. The two-step ramp never takes prose below ~52 and matches the now-band's own `sm:grid-cols-2 lg:grid-cols-3` rhythm rather than inventing one.

## The measurement reframes the finding

The review argued this as wasted space. It is also a **readability** fix, which the review did not claim and I would not have known without measuring:

| Width | Section h before → after | Chars/line before → after |
|---|---|---|
| 768 | 533 → **512** | 83–84 → **51** |
| 1024 | 541 → **454** | 83–84 → **71–72** |
| 1280 | 546 → **361** | 83–84 → **59–61** |
| 1536 | 546 → **340** | 83–84 → **71–75** |

83–84 characters is past a comfortable measure at every width, so the single column was *already* harder to read than columns are. The `<dl>` now spans the full section width at every step above `md`. The cap on each note is what stops a very wide screen pulling the lines back out to 83.

## Not done here, and it is now more visible

**`Caveats` is still a 520×134 ribbon below the columns**, so roughly 920×134 of the section stays empty — down from 920×546, a ~75% reduction, but not zero. Making the notes wider makes that ribbon *more* conspicuous, not less, so I want to be explicit rather than let it read as an oversight.

I left it on two grounds rather than on scope alone:

- The finding's own reasoning is that "the four notes are independent". `Caveats` is not a set of independent items — it is one continuous disclosure: a coverage sentence, then two `<details>`.
- **Functional, not just editorial:** a `<details>` expanding inside a grid column reflows its whole row and shifts the sibling beside it. Stacked, they expand predictably downward. Two-up disclosures would trade a real behaviour for a visual one.

The brief also says explanations are "neither stretched to fill space", so a narrower closing block is not itself a violation. If you disagree, it is a small follow-up — say the word and I will file or do it.

## Process

Full lane, one slice. **No plan file** — one sitting, and `DESIGN_REVIEW.md` plus the component's docstring hold the reasoning, including why the prescribed count changed. **No issue** — one slice, nothing to parallelise. **No ADR** — a page-local layout decision under an existing brief principle.

## Verification

Confirmed red first — `ConditionsNotes.tsx` stashed, test left in place:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/components/ConditionsNotes.test.tsx > the notes lay out in columns, each keeping its own measure
AssertionError: expected 'leading-relaxed max-w-130 text-sm tex…' to contain 'md:grid-cols-2'
 Test Files  1 failed (1)
      Tests  1 failed | 10 passed (11)
```

Measured in Chromium at four widths, `.next/` removed, `next dev` — the before/after table above is that run. Per ADR-0001 the test asserts the classes are referenced; the column count and the measure are the browser's evidence.

`npm run gate` at `834281d`, `.next/` removed first:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
