### PR TITLE
Give the week grid an edge, an alignment, and no glyphs

### DIFF
--- a/.design/conditions-page/DESIGN_REVIEW-2026-08-25.md
+++ b/.design/conditions-page/DESIGN_REVIEW-2026-08-25.md
@@ -12,6 +12,12 @@ Reviewed URL: `http://localhost:3000/conditions/la-jolla-shores-beach`
 > overwritten. Where a note below reverses something that file recommended, it
 > says so.
 
+> **Findings 1–4 have been acted on; see the addendum at the foot of this file
+> before following any _Fix:_ clause above.** Two of them were answered
+> differently from what is written here, and finding 3's fix in particular was
+> built and rejected. Findings 5–8 are still open and are the brief for the work
+> that follows.
+
 ## Screenshots Captured
 
 | Screenshot                                                                | Breakpoint       | What it shows                                      |
@@ -63,6 +69,12 @@ own backing_, not to the card, and the fix is four lines.
 
 ### 1. Radius is being chosen by token name, not by the size of the box it lands on
 
+> Half superseded 2026-08-25 by PR #142. The reading card's radius was not
+> reduced and did not need to be: this finding's own argument is that the corner
+> was all you could see _because_ `bg-mist` sits at 1.10:1 against the page, and
+> the card is now `bg-dark` at 16:1, where 24px reads as intended. **The week
+> day cell is untouched and this finding stands for it in full.**
+
 **(note 1 — "the cards with large border radius are tacky")**
 
 Measured radii and boxes on the rendered page:
@@ -109,6 +121,10 @@ part with nothing in it but corners.
 
 ### 2. Every glyph on real data is 10px; the only big glyphs on the page are in empty boxes
 
+> Shipped 2026-08-25 in PR #142, by the position this finding proposed. The
+> glyph is 30px on the figure's row and costs no height at all — better than the
+> 8px this predicted, because a 30px glyph fits inside the 36px figure line.
+
 **(note 2 — "I liked the large emojis better")**
 
 Measured, every `aria-hidden` glyph inside `<main>`:
@@ -146,6 +162,15 @@ it is asserting the decision being changed, so it gets rewritten in the same
 commit.
 
 ### 3. 🐚 and 💨 cannot sit on the mist card as-is — an ocean chip is what makes the swap possible
+
+> **Superseded 2026-08-25 by PR #142. Do not follow the _Fix:_ below.** The
+> vocabulary shipped — 🐚 tide, 🏄 waves, 💨 air — but the ocean chip was built,
+> reviewed and rejected: a badge behind each glyph read as decoration applied to
+> the card rather than as part of it, and it cost 8px per card. The card itself
+> went `bg-dark` instead, which carries the pale glyphs for nothing and fixes
+> finding 1's cause as a side effect. The chip table below is still a correct
+> measurement of glyphs on backings; it is the conclusion drawn from it that was
+> wrong. See ADR-0015, which is the maintained record.
 
 **(note 3 — "tide should be a shell and air should be the wind; adjust
 background if necessary")**
@@ -240,6 +265,12 @@ arguing 🌊-over-🐚 needs rewriting, not deleting) and
 ## Should Fix
 
 ### 4. The page renders in three background tones and two of the brand's colours never appear
+
+> Partly answered 2026-08-25 by PR #142: the three reading cards are `bg-dark`
+> and their eyebrows `text-yellow`, which is the first brand colour to reach
+> this page. The measurement below describes the page before that. Everything
+> outside the now-band — the week grid, the reserved slots, the notes — is
+> unchanged and the finding stands for it.
 
 **(note: "more fun")**
 
@@ -373,3 +404,58 @@ four dashed boxes carrying the page's biggest marks contribute to the first.
 - **The waves glyph was raised and settled.** I flagged 🏄 as a human figure in an
   otherwise environmental set and suggested 🌊; the surfer stays, by your call.
   Finding 3 is written to the decided set and notes what it saves.
+
+---
+
+## Addendum, 2026-08-25 — what PR #142 shipped, and what it changed here
+
+Written while the work is in flight, per `CLAUDE.md`. The findings above are a
+dated record of the page as it was and are not rewritten; this says what
+happened to each of them. When the remaining work merges, this file gets the
+historical note that `docs/plans/README.md` describes and stops being amended.
+
+| Finding                                   | Status                                                                                                |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 1 · Radius by token name                  | **Half done.** Reading card resolved by its new surface, not by a radius change. Week cell untouched. |
+| 2 · Every live glyph is 10px              | **Done.** 30px on the figure's row, at no height cost.                                                |
+| 3 · 🐚 and 💨 need a backing              | **Done differently.** Vocabulary shipped; the ocean chip was rejected.                                |
+| 4 · Three pale tones, no brand colour     | **Partly done.** Now-band only.                                                                       |
+| 5 · Ragged week cells                     | Open.                                                                                                 |
+| 6 · 🏖️ on a rip-current product           | Open.                                                                                                 |
+| 7 · Week as a matrix                      | Open, and still needs a decision before it can be worked.                                             |
+| 8 · 19% of the page is dashed placeholder | Open.                                                                                                 |
+
+### The two things this review got wrong
+
+**The chip.** Finding 3 concluded that because 🐚 and 💨 are pale, the _glyph_
+needed a saturated backing, and specified a 44px `bg-ocean` chip. That was
+built and rejected on sight: it reads as a badge stuck onto the card. The
+premise was right and the conclusion was one level too low — what needed to be
+dark was the card, not a shape behind the glyph. Darkening the card also
+removed finding 1's cause on the same element, which the chip did not.
+
+The general shape of the error is worth keeping: the review measured a glyph
+against seven backgrounds and then proposed the smallest object that could hold
+one of those backgrounds, rather than asking which existing surface should hold
+it.
+
+**The height.** Finding 2 predicted a chip beside the figure would cost 8px per
+card, and it did. What shipped costs **0** — a 30px glyph fits inside the 36px
+figure line, so the row never grows. Cards measure 283px at 1536×639 and 301px
+at 1280, which are the heights they had before this branch. The fold concern
+raised against the chip does not apply to what merged.
+
+### What is now true of the page, measured after the merge
+
+- The three reading cards are `bg-dark` `#1a1a2e`. Text on them: figures and
+  stat values `text-white` (17.06:1), eyebrow `text-yellow` (15.22:1), prose
+  `text-white/75` (10.02:1), provenance and stat labels `text-white/55`
+  (5.96:1). The two secondary roles are named in `src/components/cardText.ts`.
+- The now-band's glyphs are 🐚 🏄 💨 at 30px, bare, on the figure's row.
+- **The week grid is unchanged**: seven `bg-mist` cells at 1.10:1 against the
+  page, 159 × 148 at 1280, `rounded-card` 24px, labels repeated fourteen times,
+  one cell wrapping where six do not.
+- So the page now has a dark band above a pale grid. ADR-0015 left that
+  deliberately — "now" and "planning" as different registers — and names itself
+  as the decision to convert against if it reads as an oversight instead. That
+  is the open question in front of finding 5.

--- a/docs/adr/0015-reading-card-glyph-vocabulary.md
+++ b/docs/adr/0015-reading-card-glyph-vocabulary.md
@@ -47,8 +47,17 @@ consider is that the row above the heading is not the only place a glyph can go.
 ## Decision
 
 **The now-band's vocabulary is 🐚 lowest tide, 🏄 waves and water, 💨 air**, and
-the same three mark the same products in the week grid and its reserved rows.
-🌊 leaves `/conditions` entirely.
+the same three mark the same products in the week's reserved rows. 🌊 leaves
+`/conditions` entirely.
+
+> Amended 2026-08-25, after this shipped. The vocabulary reached the week
+> grid's `<dt>` labels too, and it should not have: those are set at 10px, and
+> at 10px a shell is a grey smudge on a pale cell — the exact failure the card
+> was given a dark surface to escape, repeated fourteen times. **A glyph marks a
+> panel on this page. A row inside one is named in words.** The week grid's row
+> glyphs are gone; the reserved slots keep theirs, being panels at 24px and 48px.
+> The rule this ADR was reaching for is about which glyph means which product,
+> and that is unaffected.
 
 **The card is `bg-dark`, and the glyph stands on it bare at 30px, beside the
 lead figure.** The contrast objection is answered by the surface the glyph
@@ -117,10 +126,11 @@ defensible for them to look different, but if it ever reads as an oversight
 rather than a distinction, this is the decision it gets converted against.
 
 **`ReadingCard`'s "the glyph labels the heading rather than floating above it"
-paragraph is superseded and rewritten.** Its reasoning about `WeekGrid` marking
-one product two ways still stands — the week grid keeps its inline `<dt>` glyph,
-because a 30px glyph in a 148px cell on a pale surface is not the same problem
-as a 30px glyph beside a 36px figure on a dark one.
+paragraph is superseded and rewritten.** Its reasoning was that one page should
+not mark a product two ways, and it resolved that by copying the week grid's
+inline treatment onto the card. The resolution is now the other way round: the
+card's glyph is the one that works, and the week grid has none, so there is one
+treatment on the page and it is the legible one.
 
 **This reverses finding 9 of `.design/conditions-page/DESIGN_REVIEW.md`
 (2026-08-24), which shipped the 10px inline glyph.** That finding was right

--- a/src/components/DaylightWeek.test.tsx
+++ b/src/components/DaylightWeek.test.tsx
@@ -20,3 +20,20 @@ test("sunrise leads, and sunset follows it in reading order", () => {
 
   expect(container.textContent).toBe("6:48 AM to 4:47 PM");
 });
+
+/**
+ * Regression. The two clock times were set on one line, which fitted six days
+ * of the week and wrapped on the seventh, taking that column's rows out of line
+ * with its neighbours. Breaking them deliberately fixed the grid and, on the
+ * first attempt, silently joined the words: two `block` spans with no text node
+ * between them read aloud as "6:48 AMto 4:47 PM". A line break a reader can see
+ * must not become a word break a reader can hear.
+ */
+test("breaking the line does not join the words", () => {
+  const { container } = render(
+    <DaylightWeek day={{ sunriseLabel: "6:48 AM", sunsetLabel: "4:47 PM" }} />,
+  );
+
+  expect(container.textContent).toContain("6:48 AM to 4:47 PM");
+  expect(container.textContent).not.toContain("AMto");
+});

--- a/src/components/DaylightWeek.tsx
+++ b/src/components/DaylightWeek.tsx
@@ -12,6 +12,19 @@
  * arranged so that nobody can use it: the reader is choosing when to leave the
  * house, and the two clock times are what that turns on.
  *
+ * **Two lines, always, rather than one that sometimes becomes two.** Set on one
+ * line this is about nineteen characters against a 124px cell, so it fits on
+ * six days and wraps on the seventh -- and the wrap pushed that column's rows
+ * out of line with its neighbours, which is the thing a grid exists to prevent.
+ * Breaking it on purpose costs the same height on every day and buys back the
+ * alignment. The sunrise leads because it is the one a reader plans against.
+ *
+ * The space between the two spans stays. Two blocks collapse it visually, but
+ * it is still a text node, and without it the accessible text runs together as
+ * "6:48 AMto 4:47 PM" -- the same concatenation `ReadingCard` records hitting
+ * in the accessible-name algorithm. A line break a reader can see must not be
+ * a word break a reader can hear.
+ *
  * **No glyph.** This row carried 🌅, and the tide row beside it 🐚, at the 10px
  * the week grid's labels are set in. See ADR-0015: at that size a full-colour
  * emoji is not a mark, and the shell in particular rendered as a grey smudge on
@@ -36,8 +49,8 @@ export function DaylightWeek({
 }) {
   return (
     <>
-      <span className="font-extrabold">{day.sunriseLabel}</span>{" "}
-      <span className="text-fog">to {day.sunsetLabel}</span>
+      <span className="block font-extrabold">{day.sunriseLabel}</span>{" "}
+      <span className="block text-fog">to {day.sunsetLabel}</span>
     </>
   );
 }

--- a/src/components/DaylightWeek.tsx
+++ b/src/components/DaylightWeek.tsx
@@ -12,10 +12,11 @@
  * arranged so that nobody can use it: the reader is choosing when to leave the
  * house, and the two clock times are what that turns on.
  *
- * **🌅 rather than ☀️.** The glyph has to mean sunrise and sunset rather than
- * "sunny", because the air card next to it is where sky belongs and a page's
- * glyph may mean one thing. It is also not an animal, which the brief reserves
- * for sightings.
+ * **No glyph.** This row carried 🌅, and the tide row beside it 🐚, at the 10px
+ * the week grid's labels are set in. See ADR-0015: at that size a full-colour
+ * emoji is not a mark, and the shell in particular rendered as a grey smudge on
+ * the pale cell. A glyph marks a panel on this page; a row inside one is named
+ * in words.
  *
  * **A cell rather than a row**, for the reason `TideWeek` gives: the grid is
  * day-major, so a row is seven of these rather than one subtree.
@@ -23,9 +24,8 @@
 
 import type { DaylightWeekDay } from "@/lib/conditions";
 
-/** What every day of this row shares: the glyph that marks it and the words that name it. */
+/** What every day of this row shares: the words that name it. */
 export const DAYLIGHT_WEEK_ROW = {
-  emoji: "🌅",
   label: "Daylight",
 } as const;
 

--- a/src/components/TideWeek.test.tsx
+++ b/src/components/TideWeek.test.tsx
@@ -32,12 +32,12 @@ test("a day the window did not cover says so rather than rendering a blank", () 
 });
 
 /**
- * ADR-0015, and the reason the row exports its glyph rather than each caller
- * writing one: the tide is marked the same way in the now-band and in the week,
- * and a page marking one product two ways was the drift `ReadingCard` and
- * `ReservedSlot` were both extracted to stop.
+ * ADR-0015. The row carried 🐚 to match the now-band's card, and at the 10px a
+ * week label is set in it rendered as a grey smudge on the pale cell -- the
+ * exact pale-on-pale failure the card was given a dark surface to escape. The
+ * row is named in words instead, so there is no glyph here to keep in step.
  */
-test("the week's tide row is marked by the same shell as the now-band", () => {
-  expect(TIDE_WEEK_ROW.emoji).toBe("🐚");
+test("the week's tide row is named in words and carries no glyph", () => {
   expect(TIDE_WEEK_ROW.label).toBe("Lowest tide");
+  expect(TIDE_WEEK_ROW).not.toHaveProperty("emoji");
 });

--- a/src/components/TideWeek.tsx
+++ b/src/components/TideWeek.tsx
@@ -27,13 +27,8 @@
 
 import type { TideWeekDay } from "@/lib/conditions";
 
-/** What every day of this row shares: the glyph that marks it and the words that name it. */
+/** What every day of this row shares: the words that name it. */
 export const TIDE_WEEK_ROW = {
-  // 🐚 rather than 🌊, reversing what this comment used to argue. See ADR-0015:
-  // the sightings roster is ten animals and a shell is not among them, and the
-  // pale-on-pale objection is answered by backing the glyph rather than by
-  // giving it up. The now-band's tide card makes the same call.
-  emoji: "🐚",
   label: "Lowest tide",
 } as const;
 

--- a/src/components/WeekGrid.test.tsx
+++ b/src/components/WeekGrid.test.tsx
@@ -11,7 +11,6 @@ const DAYS: WeekDay[] = [
 
 /** Deliberately ragged: the 19th is missing, which is a row this product cannot fill that far out. */
 const TIDE_ROW: WeekRow = {
-  emoji: "🌊",
   label: "Lowest tide",
   cells: {
     "2026-08-17": "6:41 PM",
@@ -80,14 +79,24 @@ test("today is named in words, not carried by a colour alone", () => {
   expect(screen.getByText(/Today · Mon, Aug 17/)).toBeDefined();
 });
 
-test("the glyph is decoration and never the only label a row has", () => {
-  const { container } = renderGrid();
+/**
+ * ADR-0015. The rows carried 🐚 and 🌅 at the 10px these labels are set in,
+ * where a full-colour emoji is not a mark -- the shell rendered as a grey
+ * smudge on the pale cell, fourteen times over. A glyph marks a panel on this
+ * page now; a row inside one is named in words, which is what a screen reader
+ * was hearing all along.
+ */
+test("a row is named in words, with no glyph beside it", () => {
+  const { container } = renderGrid({ reserved: RESERVED });
 
-  const glyph = container.querySelector('[aria-hidden="true"]');
-  expect(glyph?.textContent).toBe("🌊");
-  // The text label is what a screen reader hears, per the brief's rule that
-  // emoji mark categories and never carry them.
   expect(screen.getAllByText("Lowest tide").length).toBeGreaterThan(0);
+
+  // The reserved band below still carries one, so this cannot pass by the grid
+  // having rendered nothing at all.
+  const glyphs = [...container.querySelectorAll('[aria-hidden="true"]')].map(
+    (node) => node.textContent,
+  );
+  expect(glyphs).toEqual(["🏄"]);
 });
 
 test("label and value are a description list, so the pairing is structural", () => {

--- a/src/components/WeekGrid.test.tsx
+++ b/src/components/WeekGrid.test.tsx
@@ -215,3 +215,39 @@ test("the week's heading outranks the day headings inside it", () => {
   expect(day?.className).toContain("text-2xs");
   expect(day?.className).not.toContain("text-quote");
 });
+
+/**
+ * The property the cell's own comment claims and nothing asserted: today is
+ * marked by the colour of its edge, not by a thicker one. A `border-2` on the
+ * marked day alone would make it two pixels narrower inside than the six beside
+ * it, which is the kind of misalignment nobody finds by reading the diff.
+ */
+test("today is marked by the colour of its edge, never by a wider one", () => {
+  const { container } = renderGrid();
+
+  const cells = [...container.querySelectorAll("ol > li")];
+  expect(cells.length).toBe(3);
+
+  const widths = new Set(
+    cells.map((c) => (c.className.match(/border-\[[^\]]+\]/) ?? [""])[0]),
+  );
+  expect(widths.size).toBe(1);
+
+  expect(cells[0].className).toContain("border-ocean");
+  expect(cells[1].className).toContain("border-lavender");
+  expect(cells[2].className).toContain("border-lavender");
+});
+
+/**
+ * `rounded-tile`, not the 24px `rounded-card` a 520px hero card takes. On a
+ * 159x148 cell that radius is 15% of the width and the corner stops reading as
+ * a corner — see this component's own comment, and finding 1 of the 2026-08-25
+ * review.
+ */
+test("a day cell takes the radius of a box its own size", () => {
+  const { container } = renderGrid();
+
+  const cell = container.querySelector("ol > li");
+  expect(cell?.className).toContain("rounded-tile");
+  expect(cell?.className).not.toContain("rounded-card");
+});

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -155,7 +155,29 @@ export function WeekGrid({
                 day.isToday ? "border-ocean" : "border-lavender"
               }`}
             >
-              <h3 className="text-2xs mb-2 font-extrabold tracking-widest text-ocean uppercase">
+              {/*
+                `min-h-8` holds two lines whether or not this day needs them.
+                "Today · " is eight characters of a 10px `tracking-widest`
+                label in a 124px cell, so the marked day wraps where the other
+                six do not -- and every row beneath it in that column then sits
+                a line lower than the same row beside it. Reserving the line is
+                what keeps the seven columns readable across rather than only
+                down.
+
+                It costs one line. Together with the daylight cell's deliberate
+                break, the grid goes 146px to 163px at 1280 -- no cell had both
+                a two-line header and a two-line value before, and now every
+                cell has both. That is the price of the seven columns being
+                identical, paid once and below the fold, and it is worth it:
+                a grid whose rows do not line up across is a table pretending.
+
+                Reserved rather than shortened. "Today" alone fits, and drops
+                the date from the one column a reader without the layout most
+                needs it named in; splitting the visible text from the
+                accessible one would need an `sr-only`, which this repo does
+                not use (`ReadingCard` records why).
+              */}
+              <h3 className="text-2xs mb-2 min-h-8 font-extrabold tracking-widest text-ocean uppercase">
                 {day.isToday ? `Today · ${day.dayLabel}` : day.dayLabel}
               </h3>
 

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -52,8 +52,6 @@ export type WeekDay = {
 
 /** One product across the week. */
 export type WeekRow = {
-  /** Marks the product at a glance; hidden from assistive tech, which reads the label. */
-  emoji: string;
   /**
    * Names the product inside every day.
    *
@@ -158,7 +156,7 @@ export function WeekGrid({
                   return (
                     <div key={row.label} className="mb-2 last:mb-0">
                       <dt className="text-2xs font-extrabold tracking-widest text-fog uppercase">
-                        <span aria-hidden="true">{row.emoji}</span> {row.label}
+                        {row.label}
                       </dt>
                       <dd className="text-base text-dark">{cell}</dd>
                     </div>

--- a/src/components/WeekGrid.tsx
+++ b/src/components/WeekGrid.tsx
@@ -131,17 +131,28 @@ export function WeekGrid({
         `bg-lavender` was tried and removed: fog on lavender is 4.29:1, under
         the 4.5:1 this page holds itself to, and it would have reintroduced on
         one column the exact failure `globals.css` records fog being darkened to
-        escape. A border is a boundary rather than text, and ocean on mist
-        clears 7:1 as one. Every block carries `border-2` so the marked day is
-        not two pixels wider than its neighbours.
+        escape. A border is a boundary rather than text, and ocean clears 7:1 as
+        one. Every block carries the same border width so the marked day is not
+        wider than its neighbours -- what changes is only its colour.
+
+        `rounded-tile` with a `lavender` edge on `white/60`, which is the
+        treatment `SessionSchedule` and `/art` already use for a box this size,
+        rather than `rounded-card` on `bg-mist`. Two things were wrong with
+        that. The radius is a 520px hero card's, and on a 159x148 cell it is 15%
+        of the width -- the corner stops being a corner. And `mist` sits at
+        1.10:1 against the cream page, so the fill was never visible and the
+        corner arc was most of what the eye had to go on: a large radius on an
+        invisible surface is what reads as a blob. The reading cards escaped
+        this by going dark (ADR-0015); a cell this size takes the edge instead,
+        because seven dark blocks under a dark band is a different page.
       */}
       {days.length > 0 && (
         <ol className="mb-4 grid gap-3 lg:grid-cols-7">
           {days.map((day) => (
             <li
               key={day.localDate}
-              className={`rounded-card border-2 bg-mist px-4 py-3 ${
-                day.isToday ? "border-ocean" : "border-transparent"
+              className={`rounded-tile border-[1.5px] bg-white/60 px-4 py-3 ${
+                day.isToday ? "border-ocean" : "border-lavender"
               }`}
             >
               <h3 className="text-2xs mb-2 font-extrabold tracking-widest text-ocean uppercase">


### PR DESCRIPTION
The other half of the 2026-08-25 review, plus one defect that PR #142 caused.
Four slices, each committed on its own.

## What changed, and why

**1 · Record what shipped against the review that asked for it.** Two of that
review's _Fix:_ clauses are now wrong and it sits on `main` where the next
reader would follow them — finding 1 says to cut the reading card's radius
(#142 did not, and did not need to), and finding 3 specifies an ocean chip
(built, rejected). Amended with a dated addendum rather than marked historical,
because findings 5–8 were still open and were this PR's brief. It gets
`docs/plans/README.md`'s historical note when this merges.

**2 · The week's rows are named in words, and their glyphs are gone.**
**This fixes something PR #142 broke.** The tide row carried 🐚 at the 10px a
week label is set in, where a pale-lavender shell on a pale cell is a grey
smudge — the exact pale-on-pale failure the reading card was given a dark
surface to escape, printed seven times. The wave it replaced was also failing
at that size; the shell made it undeniable.

Dropped rather than enlarged, because the row was never the thing being marked:
a glyph marks a panel on this page (the three cards, the reserved slots at 24px
and 48px), and a row inside a panel is named in words — which is what a screen
reader was hearing all along. ADR-0015 claimed the vocabulary reached the week
grid, so it is amended.

**3 · The day cells get an edge and a radius their own size.** A cell is
159 × 148 and was taking `rounded-card` — a 520px hero card's 24px, **15% of the
cell's width**. The fill made it worse: `bg-mist` is **1.10:1** against the cream
page, so there was no visible surface for the radius to belong to and the corner
arc was most of what the eye had. `rounded-tile` with a 1.5px lavender edge on
`white/60` — the treatment `SessionSchedule` and `/art` already use for a box
this size.

Not dark, though the cards above went dark for the same underlying reason: seven
dark blocks under a dark band is a different page from the one being fixed.

**4 · The seven columns line up across, not only down.** Measured before:

| | Header lines | Value lines |
| --- | --- | --- |
| Today | **2** | 1, 1 |
| Wed, Fri, Sat, Sun, Mon | 1 | 1, 1 |
| Thu | 1 | 1, **2** |

Two cells out of step with five. Every row beneath a wrap sat a line lower than
the same row in the next column, so the grid read down but not across — the one
thing a grid is for. Both wraps are now deliberate and identical in all seven
cells: two header lines, a one-line tide, a two-line daylight.

## What it costs, stated plainly

**The grid grows one line, 146px → 163px at 1280.** No cell previously had both
a two-line header and a two-line value; now every cell has both. That is the
price of seven identical columns, paid once, below the fold. An earlier version
of the comment in `WeekGrid` claimed it was free — it is not, and the comment
was corrected before commit.

**The header is reserved rather than shortened.** "Today" alone fits on one
line and would drop the date from the one column a reader without the layout
most needs it named in. Splitting visible text from accessible text would need
an `sr-only`, which this repo does not use (`ReadingCard` records why).

## A bug the tests caught

Breaking the daylight value onto two lines with two `block` spans and no text
node between them makes the accessible text read **"6:48 AMto 4:47 PM"** — the
same concatenation `ReadingCard`'s docstring records hitting in the
accessible-name algorithm. `DaylightWeek.test.tsx` failed on it immediately. The
space is restored and there is now a named regression test: a line break a
reader can see must not become a word break a reader can hear.

## Not done here

- **The week grid stays light.** ADR-0015 left this open and names itself as the
  decision to convert against; the edge treatment was chosen over going dark.
  Worth another look now that both halves are visible together.
- **🏖️ still marks the rip-current forecast** — open since finding 12 of the
  2026-08-24 review.
- **Finding 7, the week as a real matrix**, is untouched. It contradicts
  `WeekGrid`'s recorded day-major decision and ADR-0005, so it needs a decision
  before it can be worked rather than riding along in a shape PR.
- **Finding 8**, the dashed placeholders at 19% of page height, is untouched.

## Gate

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

775 tests pass. New assertions: a row is named in words with no glyph beside it
(guarded against passing by the grid rendering nothing); today is marked by the
colour of its edge and never by a wider one — a property `WeekGrid`'s own
comment has always claimed and nothing checked; a day cell takes the radius of a
box its own size; and the daylight regression above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
