### PR TITLE
Name both stations in the air panel's loading line

### DIFF
--- a/src/components/ConditionsSection.test.tsx
+++ b/src/components/ConditionsSection.test.tsx
@@ -2,13 +2,32 @@ import { expect, test, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 vi.mock("@/components/TidePanel", () => ({
-  TidePanel: ({ slug }: { slug: string }) => <p>panel for {slug}</p>,
+  TidePanel: ({ slug }: { slug: string }) => {
+    if (slug === "suspend-the-panels") throw new Promise(() => {});
+    return <p>panel for {slug}</p>;
+  },
 }));
 vi.mock("@/components/WavePanel", () => ({
-  WavePanel: ({ slug }: { slug: string }) => <p>waves for {slug}</p>,
+  WavePanel: ({ slug }: { slug: string }) => {
+    if (slug === "suspend-the-panels") throw new Promise(() => {});
+    return <p>waves for {slug}</p>;
+  },
 }));
+// A loading line only exists while its panel is unresolved, and these mocks
+// resolve at once -- so rendering the fallbacks needs a way to hold the three
+// Suspense boundaries open. Each panel mock throws a never-settling promise
+// for one reserved slug and behaves normally for every other, which is what
+// lets the tests below read what a waiting reader sees.
+//
+// Spelled literally inside each factory rather than referencing the constant:
+// `vi.mock` is hoisted above every other statement in the file, so a `const`
+// declared beside them is not initialised when the factory is defined.
+const SUSPEND = "suspend-the-panels";
 vi.mock("@/components/WindPanel", () => ({
-  WindPanel: ({ slug }: { slug: string }) => <p>wind for {slug}</p>,
+  WindPanel: ({ slug }: { slug: string }) => {
+    if (slug === "suspend-the-panels") throw new Promise(() => {});
+    return <p>wind for {slug}</p>;
+  },
 }));
 vi.mock("@/components/WeekPanel", () => ({
   WeekPanel: ({ slug }: { slug: string }) => <p>week for {slug}</p>,
@@ -138,4 +157,46 @@ test("the safety framing is stated once, above the readings", () => {
 
   expect(screen.queryByText(/None of it is a safety assessment/)).toBeNull();
   expect(screen.getAllByText(/not a safety assessment/)).toHaveLength(1);
+});
+
+/**
+ * Issue #94. The air panel's loading line said "Reading the weather station…",
+ * which was wrong twice over. It is singular where the panel reads two — air
+ * for temperature and wind, sky for cloud and visibility, usually a different
+ * station and much further away, which is the whole of ADR-0010. And "weather"
+ * is on the `Conditions` glossary's avoid list in `CONTEXT.md`, so it was
+ * rendered copy using a word the domain model had already rejected.
+ *
+ * Asserted through the rendered fallback rather than against a string constant,
+ * because what matters is that a reader waiting on the panel sees it.
+ */
+test("the air panel's loading line names both stations it is reading", () => {
+  render(<ConditionsSection slug={SUSPEND} />);
+
+  const loading = screen.getByText(/^Reading the .*stations…$/);
+  expect(loading.textContent).toContain("air");
+  expect(loading.textContent).toContain("sky");
+});
+
+/**
+ * The rule the line above broke, checked across all three panels rather than
+ * only the one that broke it. `CONTEXT.md`'s `Conditions` entry ends
+ * `_Avoid_: weather, forecast, surf report`, and a loading line is the easiest
+ * place on the page for one of those to reappear.
+ */
+test("no panel's loading line uses a word the glossary rejects", () => {
+  const { container } = render(<ConditionsSection slug={SUSPEND} />);
+
+  const loading = [...container.querySelectorAll("p")]
+    .map((node) => node.textContent ?? "")
+    .filter((text) => text.startsWith("Reading "));
+
+  // All three panels are suspended, so all three loading lines are on the
+  // page. Asserted so this cannot pass by finding none of them.
+  expect(loading.length).toBe(3);
+  for (const line of loading) {
+    expect(line.toLowerCase()).not.toContain("weather");
+    expect(line.toLowerCase()).not.toContain("forecast");
+    expect(line.toLowerCase()).not.toContain("surf report");
+  }
 });

--- a/src/components/ConditionsSection.tsx
+++ b/src/components/ConditionsSection.tsx
@@ -118,12 +118,21 @@ export function ConditionsSection({ slug }: { slug: string }) {
         </Suspense>
 
         {/*
-          The fallback names one station where the panel reads two, which is
-          issue #94 and not this slice's to fix.
+          Two stations, named, because the panel reads two: air for temperature
+          and wind, sky for cloud and visibility -- usually a different station
+          and much further away, which is what ADR-0010 turns on. A singular
+          line here promised a simpler answer than the card delivers.
+
+          "Stations" rather than "weather station" also keeps the loading copy
+          inside the glossary: CONTEXT.md's `Conditions` entry ends
+          `_Avoid_: weather, forecast, surf report`, and this was the last
+          rendered text on the page still using one of them.
         */}
         <Suspense
           fallback={
-            <p className="text-base text-fog">Reading the weather station…</p>
+            <p className="text-base text-fog">
+              Reading the air and sky stations…
+            </p>
           }
         >
           <WindPanel slug={slug} />


### PR DESCRIPTION
Closes #94.

Small lane: page copy, contradicting nothing in `docs/adr/` or `CONTEXT.md`, so
no plan file and no slice table. It still ships with a test.

## What was wrong

`ConditionsSection`'s air fallback said **"Reading the weather station…"**.

1. **Singular where the panel reads two.** Air supplies temperature and wind,
   sky supplies cloud and visibility — usually a different station and much
   further away. That difference is the whole of ADR-0010, and the card renders
   both stations with both distances once it loads. The loading line promised a
   simpler answer than the card delivers.
2. **"weather" is on the glossary's avoid list.** `CONTEXT.md`'s `Conditions`
   entry ends `_Avoid_: weather, forecast, surf report`. This was the last
   rendered text on the page still using one of them — the remaining occurrences
   are in code comments.

Now **"Reading the air and sky stations…"**, which names its source the way its
two siblings in the same file already do: "Reading today's tide from NOAA…" and
"Reading the buoy…".

> The issue cites `ConditionsSection.tsx:76`; the line is now 126. Direction
> unchanged, location re-derived.

## The test seam

Asserted through the **rendered fallback**, not a string constant — what matters
is what a reader waiting on the panel actually sees. The file had no way to see
one: its panel mocks resolve immediately, so no Suspense boundary ever stays
open. Each mock now throws a never-settling promise for one reserved slug and
behaves normally for every other.

With all three boundaries open, the second test checks the glossary rule across
**every** loading line on the page rather than only the one that broke it, and
asserts it found three so it cannot pass by finding none. Both tests were
confirmed failing before the fix — the second on
`expected 'reading the weather station…' not to contain 'weather'`.

## Gate

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

777 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
