### PR TITLE
Admit a modelled wave source to the inventory (ADR-0019)

### DIFF
--- a/docs/adr/0019-a-modelled-source-may-qualify-a-beach.md
+++ b/docs/adr/0019-a-modelled-source-may-qualify-a-beach.md
@@ -1,9 +1,16 @@
 # 0019 — A modelled wave source may qualify a beach
 
-Date: 2026-08-26. Status: **proposed.** This one is not settled by measurement
-and is not mine to accept; see _The decision_ and _The case against_ below.
+Date: 2026-08-26. Status: accepted, 2026-08-26, on the argument below rather
+than on the measurements — those were never the part in question.
 
 Amends ADR-0011's service predicate. Does not replace it.
+
+_The case against_ is kept in full below. It was not answered, it was outweighed,
+and the distinction matters to whoever revisits this: the objection that this
+makes "we do not publish a reading taken more than 10 km away" mean something
+weaker is **correct**, and the disclosure in `WavesToday` is the whole of what
+this decision offers in exchange. If that disclosure is ever removed or
+weakened, this decision goes with it.
 
 ## Context
 
@@ -170,9 +177,10 @@ choice to know less than the site can.
 
 **Keep them out.** No new category, no amendment, one rule that still means what
 it says, and the exclusion is already recorded with its distance so nothing is
-silent. This is the live alternative, and it is why the status above is
-_proposed_: it costs four beaches on a coast this site covers, and it is
-defensible.
+silent. This was the real alternative rather than a foil — it is defensible, and
+it was rejected for what it costs rather than for being wrong: four beaches on a
+coast this site covers, removed by one station's uptime, invisible to the reader
+it affects.
 
 ## Consequences
 

--- a/docs/adr/0019-a-modelled-source-may-qualify-a-beach.md
+++ b/docs/adr/0019-a-modelled-source-may-qualify-a-beach.md
@@ -1,0 +1,211 @@
+# 0019 — A modelled wave source may qualify a beach
+
+Date: 2026-08-26. Status: **proposed.** This one is not settled by measurement
+and is not mine to accept; see _The decision_ and _The case against_ below.
+
+Amends ADR-0011's service predicate. Does not replace it.
+
+## Context
+
+ADR-0011 bounds the inventory by distance to a **station**: a beach is served
+only if its tide station is within 10 km and, if a wave buoy is bound at all,
+that buoy is within 10 km. The bound's own defence is that its inputs are
+measurements — "every distance came out of a join" — and that a beach it refuses
+is refused with the distance that refused it.
+
+NDBC 46235 Imperial Beach Nearshore answered 404 in May 2026. `wave-buoys.json`
+records it as the only buoy south of Point Loma, and records the consequence in
+its own `unresolved` block: "every south-county beach reads a buoy well to its
+north-west across water of different exposure." Four beaches read one 28 km away
+and left the inventory for it. Their tide stations are 948 m to 3,407 m away and
+were never in question.
+
+Since #126, the site also reads CDIP's MOP model — a wave estimate at 10 m depth
+about every 100 m along this coast, seven days ahead, driven by real buoy
+directional spectra and accounting for the island sheltering and refraction that
+dominate the Southern California Bight. Fifteen beaches already carry one, at
+117 m to 910 m, and it fills the week grid's wave row and a subordinate block on
+the now-card.
+
+The four excluded beaches bind lines at 466 m, 478 m, 485 m and 644 m. Measured
+2026-08-26, every one of those lines returned 48 forecast rows, all flagged
+`good`, indistinguishable in shape from `D0606`, which serves Del Mar today.
+
+**So nothing about the distances is in doubt, and that is precisely why this is
+a decision rather than a re-seed.** ADR-0011 bounds a beach by its distance to
+an instrument. No instrument sits on a MOP line. `mop-lines.json` says so
+without being asked:
+
+> A MOP estimate is model output, not a measurement. It is driven by real buoy
+> directional spectra and accounts for island sheltering and refraction, which
+> is why it can stand this close to the shore at all — but no instrument sits on
+> a MOP line, and nothing in this table says otherwise.
+
+And ADR-0016 admits the model only **beside** a measurement — "it never replaces
+the measured reading and never becomes the card's lead figure." At these four
+there is no measured reading for it to sit beside. Today the answer is
+implicitly no: 26 of the 41 served beaches carry `mop_line: null`, so MOP is a
+supplement and has never been a qualifier. Changing that is a change of category,
+not of number.
+
+## The decision
+
+**A beach may be served when a modelled wave source is its only wave source,
+provided the measurement it replaces is dropped rather than published, and
+provided the page says the figure is modelled.**
+
+Concretely, added to the service predicate in `seed-beaches.mjs`:
+
+> When a beach's tide station is within `SERVICE_TOLERANCE_M`, its bound wave
+> buoy is **not**, and it binds a MOP line within `MODELLED_SOURCE_TOLERANCE_M`,
+> the **buoy binding is dropped** — null, with a reason naming the distance that
+> refused it and the line that answers instead. The predicate then sees no buoy
+> binding, and the beach is served on its tide alone.
+
+Three things carry the argument.
+
+**The measurement is dropped, not kept.** This is the whole of why the change is
+defensible rather than a loophole. Serving the four while they still name a buoy
+28 km offshore would put that reading on the page, which is the exact failure
+ADR-0011 exists to prevent, and it would be worse than the exclusion because the
+number would look like every other number on the site. A beach admitted this way
+publishes no measured wave height at all.
+
+**It fires only where the buoy is the sole fault.** A looser form — drop any
+out-of-bound buoy wherever a line replaces it — was written first and measured
+second. It also fires on seven beaches that stay excluded on tide, rewriting each
+one's exclusion reason to drop its wave clause and telling a reader less than
+before, for beaches nobody can visit on this site either way. Measured, the
+tightened form moves four beaches and changes **no** surviving `_excluded`
+entry.
+
+**The modelled bound is derived from the model, not fitted to the outcome.** Of
+the county's 73 beaches, 45 bind a line: forty-three between 117 m and 930 m,
+then `tide-beach-park` at 2,594 m and `tijana-river` at 6,395 m. Those two are
+exactly the beaches ADR-0011 already records as published where their names are
+not — one "recorded 34 km from the city it names", the other 6–7 km inland up a
+river. At ~100 m alongshore spacing, a line kilometres away does not mean the
+model is coarse there; it means the nearest open coast is kilometres away and
+the segment is not on it. `MODELLED_SOURCE_TOLERANCE_M = 1_000` tests whether
+the beach is on this shoreline at all, which is the only question a distance to
+a model can honestly answer. It is a second constant rather than a reuse of
+`SERVICE_TOLERANCE_M` because the two ask different questions, and at 10 km the
+river reach would qualify.
+
+**The disclosure is part of the decision, not a follow-up.** `WavesToday`'s
+`no-buoy` state currently reads "We cannot give a wave height here, and that is
+what we expect rather than a fault. Every wave buoy sits out on the open coast."
+That sentence was written for a bay. On an open-coast beach admitted under this
+ADR it is **false**, and it would be the page's explanation for the absence of
+the only measurement. A beach may not be admitted under this decision until the
+card says instead that no buoy reaches this stretch of coast and that the height
+shown is modelled. That is a condition of the decision, and it is the half no
+gate can assert.
+
+## The case against, stated as strongly as it deserves
+
+**"We do not publish a reading taken more than 10 km away" becomes weaker than
+it sounds.** A model is not taken anywhere. After this, a reader who understands
+the sentence exactly still cannot infer that some beaches are answered by
+something that was never measured at all. The bound stops being one rule and
+becomes two with a joint in the middle.
+
+**It is per-variable suppression, which ADR-0011 examined and refused.** That
+refusal was explicit and it was not about mechanism: "the machinery to hide one
+panel already exists... What was rejected was not the mechanism but the outcome —
+a beach page with two panels and a hole answers 'should we go here' worse than no
+page at all." This decision reopens it. The answer offered here is that there is
+no hole — MOP fills the suppressed variable, so the page has three panels and
+three answers, one of which is modelled and says so. Whether that distinction
+holds is the judgement, and it is genuinely arguable: ADR-0011 might reply that a
+page whose wave figure is modelled _is_ the hole, wearing a number.
+
+**ADR-0016's shape is not this shape.** Its whole argument is a modelled forecast
+sitting beside a measured height, distinguishable because "the two answer
+different questions and the page says which". Remove the measurement and the
+distinction has nothing to be a distinction from. The precedent it set was
+explicitly said not to generalise for free.
+
+**The reader most likely to be misled is the one this site is for.** A parent
+reading "1.5 ft" before taking children into the water is not weighing model
+against instrument. If the modelled figure is wrong at the shore — and ADR-0016
+records the two disagreeing by 2.0 ft against 0.8 ft at La Jolla Shores on
+2026-08-26 — the disclosure is what stands between them and a confident wrong
+number.
+
+**And the case for, in one sentence:** the alternative is that one instrument's
+failure silently deletes a stretch of public coastline from a site whose reach
+is meant to be a measurement of the networks rather than an artifact of one
+station's uptime, and the deletion is invisible to the reader it affects.
+
+## Alternatives considered
+
+**Raise `SERVICE_TOLERANCE_M`.** The change #146's body implies. Rejected: the
+four are 28 km from a buoy, so any tolerance admitting them admits a reading
+taken most of the way to the next county, and it would readmit beaches excluded
+on tide that nothing here argues for. The problem is not that the threshold is
+in the wrong place.
+
+**Put the ceiling in `wave-join.mjs`,** so the join declines a buoy beyond 10 km
+and the predicate never sees one. Smaller diff, same four beaches. Rejected: it
+erases the distinction ADR-0011 turns on — a beach fails on a binding it _has_,
+never on one a join correctly declined — and it makes the readmission invisible,
+because `_excluded` would simply stop mentioning a buoy with no record that one
+was refused. A join that silently withholds a candidate for a reason belonging to
+the publisher is the shape that lost both Scripps Pier stations before #80.
+
+**Retire the wave clause entirely,** dropping any out-of-bound buoy everywhere.
+More uniform and more literally faithful to the sentence about 10 km. Rejected:
+it is per-variable suppression across the whole inventory rather than at four
+beaches with a replacement, and it readmits `tijana-river` as a beach with no
+wave source at all — deciding by side effect a question that deserves its own
+argument.
+
+**Serve the four with the wave panel suppressed and no forecast** — the honest
+minimum, admitting the beach on its tide and saying plainly that no wave source
+reaches it. Rejected because it is strictly worse than what is proposed and
+better than nothing: a MOP line at 466 m exists, delivers, and is already trusted
+for the week grid at fifteen other beaches. Declining to read it would be a
+choice to know less than the site can.
+
+**Keep them out.** No new category, no amendment, one rule that still means what
+it says, and the exclusion is already recorded with its distance so nothing is
+silent. This is the live alternative, and it is why the status above is
+_proposed_: it costs four beaches on a coast this site covers, and it is
+defensible.
+
+## Consequences
+
+- **The site answers for 45 beaches instead of 41**, and `_excluded` falls from
+  32 to 28 with no surviving entry reworded. The chooser grows a fourth region
+  group, "South County coast", and ADR-0014's region headings apply to it
+  unchanged.
+- **Four beaches publish no measured wave height.** Their `wave_buoy` is null
+  and carries the distance that refused it, so the exclusion of the
+  _measurement_ is recorded on the beach the way the exclusion of a _beach_ is
+  recorded in `_excluded`.
+- **An invariant is broken deliberately.** `beaches.test.ts` currently pins that
+  a served beach has a buoy exactly when it has a line. Four will have a line and
+  no buoy. What replaces it is the asymmetric half — no served beach has a buoy
+  without a line — plus each binding against its own tolerance. A test that
+  merely relaxed to accept both nulls and both non-nulls would assert nothing.
+- **`SERVICE_TOLERANCE_M` acquires a sibling**, and the two must not be confused:
+  one bounds how far a reading may travel, the other whether a beach is on the
+  coast a model describes. They are separate constants for that reason and each
+  is defended where it is declared.
+- **A future modelled product inherits a precedent, and it does not generalise
+  for free** — the same caution ADR-0016 attached to its own. What makes this
+  acceptable is that the model replaces a measurement the site would not have
+  published anyway, and that the page says so. A model displacing a measurement
+  the site _would_ have published is a different decision and is not made here.
+- **Tijana River is not admitted by this**, and not by name: its line is 6,395 m
+  and fails the modelled bound like any other. Whether it should be served with
+  no wave source at all — the treatment
+  `tijuana-slough-national-wildlife-refuge` already has — is left open
+  deliberately. Note for anyone who follows: the slug `tijana-river` and the name
+  "Tijana River" are upstream's own spelling, not a typo introduced here, and
+  correcting them silently breaks the join.
+- **If this is not accepted**, `docs/plans/mop-qualified-inventory.md` is marked
+  historical, the four beaches stay out, and #146 closes with the measurement
+  recorded — which is worth something on its own, because the next person to ask
+  will otherwise re-measure it.

--- a/docs/plans/mop-qualified-inventory.md
+++ b/docs/plans/mop-qualified-inventory.md
@@ -1,8 +1,9 @@
 # A modelled wave source may qualify a beach
 
-Planned 2026-08-26 for #146. Blocked at slice 2 on the decision in
+Planned 2026-08-26 for #146. Slice 2's decision,
 [`docs/adr/0019-a-modelled-source-may-qualify-a-beach.md`](../adr/0019-a-modelled-source-may-qualify-a-beach.md),
-which is proposed rather than accepted.
+was accepted on 2026-08-26, so slices 3–5 are unblocked. In flight; not
+historical yet.
 
 ## The problem, from a reader's point of view
 

--- a/docs/plans/mop-qualified-inventory.md
+++ b/docs/plans/mop-qualified-inventory.md
@@ -1,0 +1,241 @@
+# A modelled wave source may qualify a beach
+
+Planned 2026-08-26 for #146. Blocked at slice 2 on the decision in
+[`docs/adr/0019-a-modelled-source-may-qualify-a-beach.md`](../adr/0019-a-modelled-source-may-qualify-a-beach.md),
+which is proposed rather than accepted.
+
+## The problem, from a reader's point of view
+
+A parent in Imperial Beach opens the conditions page and cannot find their
+beach. Nothing on the page tells them why in terms they would recognise: the
+disclosure says the site answers for 41 of the county's 73, and the entry for
+their beach says a wave buoy is 28 km away. The beach is not closed, not
+unlisted, not a bay. It is missing because NDBC's only buoy south of Point Loma
+answered 404 in May 2026, so the wave join reached past it to the next one and
+the inventory bound refused the result.
+
+Four beaches are in that state and no other: Border Field State Park, Silver
+Strand State Beach, north Imperial Beach, and Imperial Beach municipal beach,
+other. Each has a tide station within 3.5 km. Each has a CDIP MOP line under
+650 m. The site already reads MOP at fifteen beaches for the week grid's wave
+row and the now-card's forecast block (ADR-0016). What it has never done is let
+that source decide whether a beach exists at all.
+
+So the question is not whether 466 m is close enough. It is whether a beach may
+be served when its only wave source is a model. ADR-0011 bounds a beach by its
+distance to an _instrument_, and no instrument sits on a MOP line —
+`mop-lines.json` says so in its own provenance.
+
+## What was measured
+
+Against `main` at `9af8197`, on 2026-08-26. `seed-beaches.mjs --check` reported
+the committed inventory current — 41 beaches, join unchanged — so these figures
+are the shipped join's, re-derived rather than recalled. Distances are the
+repo's own `segmentDistance`; no new arithmetic was written.
+
+### The four, and what they bind
+
+| Beach                                 | MOP line | MOP   | Buoy  | Buoy    | Tide      | Tide    |
+| ------------------------------------- | -------- | ----- | ----- | ------- | --------- | ------- |
+| Border Field State Park               | `D0001`  | 466 m | 46232 | 28.2 km | `9410120` | 2,914 m |
+| Silver Strand State Beach             | `D0085`  | 478 m | 46254 | 28.1 km | `9410120` | 3,407 m |
+| north Imperial Beach                  | `D0085`  | 485 m | 46232 | 28.5 km | `9410120` | 948 m   |
+| Imperial Beach municipal beach, other | `D0061`  | 644 m | 46232 | 27.9 km | `9410120` | 1,050 m |
+
+All four sit inside the spread of the fifteen served beaches that already bind a
+line — 117 m to 910 m, median 519 m — and two beat that median. Tide was never
+the blocker for any of them, which is confirmed by measurement rather than
+trusted: the `why` string in `beaches.json` names only the buoy.
+
+The triage brief listed Silver Strand's tide station as `9410135` at 3.4 km.
+That is South San Diego Bay, a bay station 3,378 m away. Silver Strand is open
+coast, so the tide join matches water class and binds `9410120` Imperial Beach
+at 3,407 m. The distance in the brief is right to one decimal; the station is
+not, and the two are different water.
+
+### The lines carry rows today
+
+`mop-lines.json` records that CDIP _publishes_ a forecast for a line and says
+plainly that this is not the same fact as today's run carrying usable rows —
+"which is a per-request fact". So the lines were fetched, over a
+2026-08-27 → 2026-09-03 window, with `D0606` (Del Mar, already live) as a
+control:
+
+```
+line  | HTTP | bytes | rows | flag=1 | Hs range m
+D0001 |  200 |  3721 |   48 |     48 | 0.40-0.99
+D0061 |  200 |  3741 |   48 |     48 | 0.34-0.90
+D0085 |  200 |  3761 |   48 |     48 | 0.43-0.96
+D0008 |  200 |  3742 |   48 |     48 | 0.39-0.96
+D0606 |  200 |  3760 |   48 |     48 | 0.44-0.88
+```
+
+Every row flagged `waveFlagPrimary=1`, which this feed's own metadata declares
+as `good`. Identical in shape to the line already serving the live site.
+
+### The model's spacing gives the bound, and it was not chosen to fit
+
+Of the county's 73 beaches, 45 bind a MOP line at all. Their distances:
+
+```
+117 m … 930 m     43 beaches    la-jolla-cove 117 -> coronado-central 930
+      2,594 m      tide-beach-park
+      6,395 m      tijana-river
+```
+
+Forty-three inside a kilometre, then an order of magnitude of empty space, then
+two. The two are exactly the beaches ADR-0011 already records as having
+coordinates that do not put them where their name says: `tide-beach-park`,
+"recorded 34 km from the city it names", and `tijana-river`, published 6–7 km
+inland up the river rather than on the shoreline.
+
+That is what makes a one-kilometre bound on a modelled source a measurement
+rather than a tuned constant. MOP publishes about every 100 m alongshore. A line
+kilometres from a beach does not mean the model is imprecise there; it means the
+nearest open coast is kilometres away, and the segment is not on it. The bound
+tests whether the beach is on this shoreline at all, which is the only thing
+distance to a model can honestly test.
+
+## The design
+
+**One rule, added to the service predicate, and it fires only where the buoy is
+the sole fault.**
+
+A beach whose tide station is in bound, whose bound wave buoy is out of bound,
+and which binds a MOP line within `MODELLED_SOURCE_TOLERANCE_M`, has its **buoy
+binding dropped** — set null, with a reason naming the distance that refused it
+and the line that answers instead. The service predicate then sees no buoy
+binding at all, and the beach passes on its tide alone, the way every bay
+already does.
+
+Dropping the binding is not tidiness. Without it the four would be served while
+still naming a buoy 28 km offshore, and the page would publish that reading —
+which is worse than the exclusion it replaces, and is the exact thing ADR-0011
+exists to prevent.
+
+**Why "sole fault" and not "wherever a line replaces it."** The looser form was
+written first and measured second. It also fires on seven beaches that stay
+excluded on tide — Carlsbad Municipal, Ocean Beach, Dog Beach O.B., Sunset
+Cliffs, and the three Coronado entries — rewriting each one's `_excluded` reason
+to drop its wave clause. Those beaches are not served either way, so the whole
+effect is that their exclusion record tells a reader less than it did. The
+tightened form touches four beaches and nothing else; measured, `_excluded` goes
+32 → 28 with **zero** `why` strings changed on a beach that stays out.
+
+**What it does to the file**, measured by simulating the predicate over a live
+upstream fetch:
+
+- served 41 → 45; the four arrive, nothing departs
+- `_excluded` 32 → 28, no surviving entry reworded
+- `tijana-river` untouched, still excluded on its 34.2 km buoy — its line is
+  6,395 m and does not qualify
+- `tide-beach-park` untouched, still naming both distances — its line is 2,594 m
+- the chooser grows a fourth region group, "South County coast", after "Bays,
+  lagoons and inlets"
+
+**What it does to an invariant.** Today every served beach with a buoy has a
+line and every beach with a line has a buoy, and `beaches.test.ts` pins that.
+The change breaks it deliberately: four beaches will carry a line and no buoy.
+What survives, and is worth pinning in its place, is the asymmetric half —
+**no served beach has a buoy without a line** — plus the two bounds, each
+against its own tolerance.
+
+## Test seams
+
+Agreed before starting, and all three already exist:
+
+- **`serviceFault` / the replacement rule**, pure functions over a built beach
+  in `seed-beaches.mjs`, tested in `seed-beaches.test.mjs` against fixtures. The
+  new rule goes beside `serviceFault` at the same altitude, not inside a join —
+  a join binds the nearest candidate and has no opinion about whether the site
+  will publish it, which is the split `wave-join.mjs` and `serviceFault` already
+  keep.
+- **`allBeaches()` and `inventoryReach()`**, over the shipped `beaches.json`, in
+  `src/lib/beaches.test.ts`. This is where the count and the bindings are
+  asserted against the file that ships rather than against a fixture, which is
+  what makes them evidence.
+- **`WavesToday`**, rendered directly in `WavesToday.test.tsx` with a
+  hand-built view. The `no-buoy` state and the forecast block are already
+  covered there; the new case is the two together.
+
+No new seam is needed and none is proposed.
+
+**A committed probe is deliberately not part of this.** The brief suggested one,
+on the pattern of `probe-mop-lines.mjs`. Every join figure above is already
+re-derivable by `seed-beaches.mjs --check`, and the one figure that is not — the
+distance distribution justifying the modelled bound — belongs as an assertion
+over the shipped file in `beaches.test.ts`, where it runs on every gate rather
+than when someone remembers to run a script. A third probe would be a fourth
+copy of a fetch that two scripts already make.
+
+## Slices
+
+1. **This plan file.** Its own commit.
+2. **ADR-0019.** The decision, both designs, both sides. Written before any code
+   because 3–5 are only defensible if it lands. **The work stops here for a
+   human.**
+3. **The predicate admits a qualifying line, and the inventory is re-seeded.**
+   One slice, not two: a predicate with no re-seed is a layer nothing
+   demonstrates. Carries the rule, its unit tests, the regenerated
+   `beaches.json`, the `_served` and `_schema` prose that describes it, and the
+   four assertions in `beaches.test.ts` and `page.test.tsx` that the new count
+   and the broken invariant fail.
+4. **The card stops claiming no buoy reaches here, and says the figure is
+   modelled.** `needs-human`: no gate can assert how a page reads.
+5. **Tijana River.** Served with waves null and the reason stated, or left
+   excluded. Its own decision, and small either way.
+
+3 depends on 2 landing. 4 depends on 3. 5 depends on 3 and is otherwise
+independent of 4.
+
+## Considered and rejected
+
+**Relax the 10 km tolerance.** The simplest change, and it answers the wrong
+question. The four are 28 km from a buoy; a tolerance that admitted them would
+admit a reading taken most of the way to the next county, and would also readmit
+beaches excluded on tide, which nothing here argues for. #146's own body frames
+the problem as a threshold; it is not one.
+
+**Put the ceiling in `wave-join.mjs`,** so the join declines to bind a buoy
+beyond 10 km and the predicate never sees one. It readmits the same four with a
+smaller diff. Rejected because it erases the distinction ADR-0011 turns on — "a
+beach fails when a binding it _has_ is too far, never when a join correctly
+declined to make one" — and it makes the readmission invisible: `_excluded`
+would simply stop mentioning a buoy, with no record that one had been refused. A
+join that silently withholds a candidate for a reason belonging to the publisher
+is the shape that lost both Scripps Pier stations before #80.
+
+**Retire the wave clause entirely** and drop any out-of-bound buoy binding
+everywhere. More uniform, and more literally faithful to "we do not publish a
+reading taken more than 10 km away". Rejected: it is per-variable suppression
+across the whole inventory, which ADR-0011 considered at length and refused —
+"a beach page with two panels and a hole answers 'should we go here' worse than
+no page at all" — and it would readmit `tijana-river` as a beach with no wave
+source at all, pre-empting slice 5's decision by accident rather than by
+argument.
+
+**Reuse `SERVICE_TOLERANCE_M` for the modelled source.** One number instead of
+two, and no new constant to defend. Rejected on measurement: at 10 km
+`tijana-river` qualifies on a line 6,395 m away and 6–7 km up a river, which is
+the one outcome the brief and this plan both refuse. The two numbers answer
+different questions — how far a _reading_ may travel, against whether the beach
+is on the coast the _model_ describes — and collapsing them makes the second
+unanswerable.
+
+**Hand-write an exclusion for Tijana River,** the way `sheltered.mjs` hand-writes
+Children's Pool. Rejected: ADR-0011 already flags that this repo is at three
+hand-written join inputs and that a fourth is the point to name the pattern
+instead. The measured bound handles Tijana River as a consequence of the rule,
+which is strictly better than handling it by name.
+
+## Out of scope
+
+- The eight beaches excluded for wave _and_ tide distance. MOP answers only the
+  wave half; nothing here admits them, and their exclusion records are
+  deliberately left byte-identical.
+- Reviving 46235 or finding a replacement buoy. It is a gap in what NDBC
+  publishes.
+- The 10.0 km figure itself.
+- Whether the now-card should ever lead with a modelled figure. ADR-0016 says it
+  must not; slice 4 works within that and does not reopen it.
+- Runup and total water level, still out under ADR-0009 and ADR-0016.

--- a/docs/plans/mop-qualified-inventory.md
+++ b/docs/plans/mop-qualified-inventory.md
@@ -240,3 +240,32 @@ which is strictly better than handling it by name.
 - Whether the now-card should ever lead with a modelled figure. ADR-0016 says it
   must not; slice 4 works within that and does not reopen it.
 - Runup and total water level, still out under ADR-0009 and ADR-0016.
+
+## Addendum — 2026-08-26, during slice 5
+
+**Slice 5 turned out to be neither of the two options it was written as.** It
+was posed as a choice between serving Tijana River with waves null and leaving
+it excluded. Serving it was already dead by the time the slice was reached:
+ADR-0019 admits a beach only where a modelled source _replaces_ the measurement,
+and Tijana River has no qualifying line, so serving it would mean a beach with
+no wave source at all — the per-variable suppression with a hole that ADR-0011
+refused and ADR-0019 explicitly declined to extend. Leaving it excluded is the
+decision.
+
+**But leaving it excluded is not the same as leaving it alone, and slice 3 is
+why.** Border Field State Park and Tijana River sit at the same river mouth.
+Before slice 3 both were absent for the same published reason — a wave buoy tens
+of kilometres away. After it, one is listed and the other is not, with that same
+sentence still explaining the second. A reader who knows the coastline would
+read it as arbitrary, and they would be right to: the sentence no longer
+contains the thing that separates them.
+
+So slice 5 is a clause in `serviceFault`, derived rather than written against a
+slug: where the buoy is what refused the beach and a line was near enough to
+have stood in but is not, the reason says so and gives both distances. Measured,
+it changes two entries — Tijana River and Tide Beach Park, which are the two
+beaches where a model could have helped and could not. Every other exclusion
+reason is untouched.
+
+This is a consequence of the earlier slice rather than a new idea, which is why
+it is recorded here rather than argued in the ADR.

--- a/scripts/seed-beaches.mjs
+++ b/scripts/seed-beaches.mjs
@@ -25,6 +25,15 @@
  * `servesBeach` below -- is judgement and says so, because it decides how far a
  * measurement may be taken from the place it is shown for. Every beach the
  * second refuses is written to `_excluded` with the distance that refused it.
+ *
+ * AND ONE TRANSFORM SITS BETWEEN THEM. `dropReplacedBuoy` removes a wave buoy
+ * this site would not publish where a MOP line stands near enough to answer for
+ * the beach instead, so four beaches are served with a modelled wave figure and
+ * no measured one. That is the one place in this file where something other
+ * than a measurement decides whether a beach exists, it is an amendment to
+ * ADR-0011 rather than a tweak to it, and the page carries a disclosure that is
+ * part of the same decision. See
+ * docs/adr/0019-a-modelled-source-may-qualify-a-beach.md.
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
@@ -208,7 +217,7 @@ export function regionOf(waterClass, meanLat) {
 export function build(rows, stations, buoys, observationStations, mopLines) {
   const seen = new Map();
 
-  const beaches = rows.map((row) => {
+  const joined = rows.map((row) => {
     for (const column of COLUMNS) {
       if (!(column in row)) {
         throw new Error(
@@ -311,6 +320,12 @@ export function build(rows, stations, buoys, observationStations, mopLines) {
     };
   });
 
+  // After every join and before the predicate reads them: a buoy this site
+  // would not publish is dropped where a MOP line stands near enough to answer
+  // instead. Wrapped rather than passed by reference, because `map` would hand
+  // the index in as the tolerance. See `dropReplacedBuoy` and ADR-0019.
+  const beaches = joined.map((beach) => dropReplacedBuoy(beach));
+
   // North to south, then by slug, so the file's order is a property of the data
   // rather than of the order the portal happened to return rows in.
   beaches.sort((a, b) => {
@@ -336,7 +351,92 @@ export function build(rows, stations, buoys, observationStations, mopLines) {
  */
 export const SERVICE_TOLERANCE_M = 10_000;
 
+/**
+ * How near a MOP line must sit before the model may answer for a beach alone.
+ *
+ * A SECOND CONSTANT RATHER THAN A REUSE OF THE ONE ABOVE, because the two ask
+ * different questions and collapsing them makes the second unanswerable. That
+ * one bounds how far a *reading* may travel from the place it is shown for.
+ * This one asks whether the beach is on the coast the *model* describes at all
+ * -- which is the only thing a distance to a model can honestly test, since
+ * nothing was taken anywhere for it to have travelled from.
+ *
+ * Measured 2026-08-26 over all 73 upstream beaches: 45 bind a line, and 43 of
+ * them sit between 117 m and 930 m. The other two are `tide-beach-park` at
+ * 2,594 m and `tijana-river` at 6,395 m -- exactly the two ADR-0011 already
+ * records as published where their names are not, one 34 km from the city it
+ * names and one 6-7 km inland up a river. So this is not a threshold tuned to
+ * an outcome: at ~100 m alongshore spacing, a line kilometres away does not
+ * mean the model is coarse there, it means the nearest open coast is kilometres
+ * away and the segment is not on it.
+ *
+ * See docs/adr/0019-a-modelled-source-may-qualify-a-beach.md.
+ */
+export const MODELLED_SOURCE_TOLERANCE_M = 1_000;
+
 const kilometres = (metres) => `${(metres / 1000).toFixed(1)} km`;
+
+/**
+ * Drop a wave buoy this site would not publish, where the model replaces it.
+ *
+ * ADR-0019, and the whole of what makes it defensible rather than a loophole.
+ * A beach 28 km from the nearest delivering buoy is not served by publishing
+ * that buoy: the reading would look like every other number on the site and
+ * describe water most of the way to the next county. So the binding is dropped
+ * -- null, with the distance that refused it and the line that answers instead
+ * -- and the service predicate then passes the beach on its tide alone, exactly
+ * the way it already passes every bay.
+ *
+ * IT FIRES ONLY WHERE THE BUOY IS THE SOLE FAULT, and that guard is load-bearing
+ * rather than tidy. Without it the rule also fires on seven beaches excluded on
+ * tide -- Carlsbad Municipal, Ocean Beach, Dog Beach O.B., Sunset Cliffs and the
+ * three Coronado entries -- stripping the wave clause out of each one's
+ * `_excluded` reason. They stay excluded either way, so the entire effect would
+ * be that their exclusion record tells a reader less than it did. Measured, the
+ * guarded form moves four beaches and reworks no surviving entry.
+ *
+ * A TRANSFORM AND NOT A JOIN. `wave-join.mjs` binds the nearest delivering buoy
+ * and has no opinion about whether this site will publish it; that split is what
+ * lets `_excluded` say a buoy was refused rather than silently omitting one, and
+ * it is the shape that lost both Scripps Pier stations before #80 when it was
+ * not kept. So this runs after the joins, at the altitude of the predicate it
+ * feeds.
+ *
+ * @param {object} beach A built beach, with its bindings and their distances.
+ * @param {number} [toleranceM] How far a reading may travel.
+ * @param {number} [modelledM] How near the line must be to answer alone.
+ * @returns {object} The beach, or a copy of it with the buoy binding dropped.
+ */
+export function dropReplacedBuoy(
+  beach,
+  toleranceM = SERVICE_TOLERANCE_M,
+  modelledM = MODELLED_SOURCE_TOLERANCE_M,
+) {
+  // Sole fault: the tide reaches, the buoy does not, and a line stands near
+  // enough to answer in its place. Any other shape is left exactly as joined.
+  if (beach.tide_station === null || beach.tide_station_distance_m > toleranceM)
+    return beach;
+  if (beach.wave_buoy === null || beach.wave_buoy_distance_m <= toleranceM)
+    return beach;
+  if (beach.mop_line === null || beach.mop_line_distance_m > modelledM)
+    return beach;
+
+  return {
+    ...beach,
+    wave_buoy: null,
+    wave_buoy_distance_m: null,
+    wave_buoy_from_end: null,
+    // Both halves, because either alone misleads: the distance without the
+    // replacement reads as a beach with no waves at all, and the replacement
+    // without the distance hides that a measurement was refused.
+    wave_buoy_null_reason:
+      `the nearest delivering buoy ${beach.wave_buoy} is ` +
+      `${kilometres(beach.wave_buoy_distance_m)} away, further than this site publishes a ` +
+      `reading from, so it is not read here; MOP line ${beach.mop_line} answers for the ` +
+      `waves at ${kilometres(beach.mop_line_distance_m)}, and it is a model rather than a ` +
+      `measurement`,
+  };
+}
 
 /**
  * Why the station networks cannot serve this beach, or null when they can.
@@ -359,10 +459,15 @@ const kilometres = (metres) => `${(metres / 1000).toFixed(1)} km`;
  * Air is deliberately not a clause, and neither is the MOP line. Every bound
  * beach already reads air within 7.4 km and a MOP line within 1 km, so adding
  * either would exclude nobody while implying a filter doing work it is not
- * doing. The MOP omission is the load-bearing one: a wave source this close
- * WOULD readmit beaches the buoy clause excluded, which is a re-seed of the
- * inventory and an amendment to ADR-0011 rather than a side effect of filling a
- * row. It is #146. See docs/adr/0011-inventory-bounded-by-station-networks.md.
+ * doing.
+ *
+ * THE MOP LINE REACHES THIS PREDICATE ANYWAY, but through `dropReplacedBuoy`
+ * above rather than as a clause here. That is deliberate: a line near enough to
+ * answer alone does not *pass* a beach, it removes the buoy binding that was
+ * failing it, so the rule below still reads the way it always did and there is
+ * still exactly one thing that can refuse a beach on waves -- a binding it has
+ * that is too far. See docs/adr/0011-inventory-bounded-by-station-networks.md
+ * and docs/adr/0019-a-modelled-source-may-qualify-a-beach.md.
  *
  * @param {object} beach A built beach, with its bindings and their distances.
  * @param {number} [toleranceM]
@@ -484,8 +589,15 @@ export function document(built, now = new Date()) {
       `small-scale and local applications; no standard reporting radius exists, so the figure ` +
       `is defended rather than cited. What keeps it honest is that its inputs are measured: ` +
       `every distance came out of a join. Every beach it refuses is in _excluded below, with ` +
-      `the binding distance that refused it, so nothing leaves this inventory silently. See ` +
-      `docs/adr/0011-inventory-bounded-by-station-networks.md.`,
+      `the binding distance that refused it, so nothing leaves this inventory silently. ` +
+      `ONE THING IS NOT A MEASUREMENT, and it is the newer half: where the tide reaches a ` +
+      `beach but no buoy does, a CDIP MOP line within ` +
+      `${kilometres(MODELLED_SOURCE_TOLERANCE_M)} may answer for the waves instead, and the ` +
+      `buoy binding is dropped rather than published -- so those beaches carry wave_buoy null ` +
+      `with the distance that refused it, and their only wave figure is model output. The ` +
+      `page says so where it shows one. See ` +
+      `docs/adr/0011-inventory-bounded-by-station-networks.md and ` +
+      `docs/adr/0019-a-modelled-source-may-qualify-a-beach.md.`,
     _pinned: {
       field_name_with_a_space:
         "Upstream names one field 'Beach_ UpperLon', with an embedded space. That is the " +
@@ -514,16 +626,37 @@ export function document(built, now = new Date()) {
         "Great-circle metres from the nearer segment end to the station.",
       tide_station_from_end:
         "Which end of the segment supplied the distance, upper or lower.",
+      wave_buoy:
+        "Joined, never typed: the nearest delivering NDBC buoy that publishes waves, and the " +
+        "only measurement of the sea itself on this page. null carries TWO meanings and " +
+        "wave_buoy_null_reason always distinguishes them: the join declined to bind one -- " +
+        "every bay and lagoon, and the cove closed off by a breakwater -- or the join bound " +
+        "one and this site declined to publish it, because it sits further away than _served " +
+        "allows and a MOP line answers in its place. The second is the newer case, it names " +
+        "both the refused distance and the line that replaced it, and it means the beach's " +
+        "only wave figure is modelled. See docs/adr/0019-a-modelled-source-may-qualify-a-beach.md.",
+      wave_buoy_distance_m:
+        "Great-circle metres from the nearer segment end to the buoy. Always within _served's " +
+        "tolerance when it is present at all: a buoy further than that is dropped rather than " +
+        "recorded, so this field never carries a distance the site would not publish.",
+      wave_buoy_from_end:
+        "Which end of the segment supplied the distance, upper or lower.",
       mop_line:
         "Joined, never typed: the nearest delivering CDIP MOP line, subject to the same " +
         "water-class refusal as wave_buoy -- every line sits at 10 m depth on the open coast. " +
-        "A SECOND wave binding rather than a replacement: wave_buoy answers for now and this " +
-        "answers for the week ahead. null means the join could not bind one, and " +
-        "mop_line_null_reason says why. See mop-lines.json.",
+        "USUALLY a second wave binding rather than a replacement: wave_buoy answers for now " +
+        "and this answers for the week ahead. At the four beaches no buoy reaches it is the " +
+        "only wave source, which is a decision rather than a join result and is why _served " +
+        "names it. null means the join could not bind one, and mop_line_null_reason says why. " +
+        "See mop-lines.json.",
       mop_line_distance_m:
         "Great-circle metres from the nearer segment end to the line. Much smaller than " +
-        "wave_buoy_distance_m -- the lines are about 100 m apart -- which is why the refusal " +
-        "above is a rule about the water and not a distance.",
+        "wave_buoy_distance_m wherever both are present -- the lines are about 100 m apart -- " +
+        "which is why the water-class refusal above is a rule about the water and not a " +
+        "distance. A distance rule exists all the same, and answers a different question: a " +
+        "line beyond _served's modelled tolerance cannot answer for a beach ALONE, because at " +
+        "this spacing a line kilometres away means the nearest open coast is kilometres away " +
+        "rather than that the model is coarse there. It still binds, and still fills the week.",
       mop_line_from_end:
         "Which end of the segment supplied the distance, upper or lower.",
       sky_station:
@@ -569,22 +702,33 @@ export function document(built, now = new Date()) {
         `${farthest.name}'s, at ${kilometres(farthest.tide_station_distance_m)}. See ` +
         `tide-stations.json, whose own unresolved list records that the one open-coast station ` +
         `between La Jolla and Imperial Beach does not deliver predictions.`,
-      `${beaches.filter((b) => b.wave_buoy === null).length} of these beaches get no wave height at all. ` +
-        `Every NDBC wave buoy sits on the open coast, and ocean swell does not reach into a bay or ` +
-        `lagoon, so binding one to the nearest buoy would put an open-ocean number on enclosed water. ` +
-        `Their water temperature is missing for the same reason and is not yet filled from another source.`,
-      `The same ${beaches.filter((b) => b.mop_line === null).length} beaches get no wave forecast, ` +
-        `and the refusal costs more here than it does for the buoy: MOP lines sit about 100 m ` +
+      `${beaches.filter((b) => b.wave_buoy === null).length} of these beaches get no MEASURED wave ` +
+        `height, for two different reasons that their wave_buoy_null_reason tells apart. At ` +
+        `${beaches.filter((b) => b.wave_buoy === null && b.mop_line === null).length} of them the ` +
+        `join bound no buoy: every NDBC wave buoy sits on the open coast, and ocean swell does not ` +
+        `reach into a bay or lagoon, so binding one to the nearest buoy would put an open-ocean ` +
+        `number on enclosed water. Their water temperature is missing for the same reason and is ` +
+        `not yet filled from another source. At the other ` +
+        `${beaches.filter((b) => b.wave_buoy === null && b.mop_line !== null).length} the join DID ` +
+        `bind a buoy and this site declined to publish it, because the only one left is far past ` +
+        `${kilometres(SERVICE_TOLERANCE_M)} -- 46235 Imperial Beach Nearshore died in May 2026 and ` +
+        `was the only buoy south of Point Loma. Those beaches are open coast and do get a wave ` +
+        `figure, from a model rather than an instrument, and the page says which it is. See ` +
+        `docs/adr/0019-a-modelled-source-may-qualify-a-beach.md.`,
+      `${beaches.filter((b) => b.mop_line === null).length} beaches get no wave forecast, and ` +
+        `the refusal costs more here than it does for the buoy: MOP lines sit about 100 m ` +
         `apart, so the nearest one to an enclosed beach is close enough to look right. It would ` +
         `still be describing the open coast outside.` +
         (mopReach === null
           ? ""
           : ` The median bound beach reads a line ${mopReach.medianM} m away and the farthest ` +
             `reads one ${mopReach.farthest.mop_line_distance_m} m away, at ` +
-            `${mopReach.farthest.name}. Every one is inside a kilometre, which is why this ` +
-            `binding is NOT a clause of the service predicate above: admitting it would readmit ` +
-            `beaches the buoy clause excluded, and that is a re-seed of the inventory rather ` +
-            `than a consequence of adding a forecast.`),
+            `${mopReach.farthest.name}. Every one is inside a kilometre, and that closeness is ` +
+            `now load-bearing rather than merely reassuring: where no buoy is in range, a line ` +
+            `within ${kilometres(MODELLED_SOURCE_TOLERANCE_M)} answers for the beach on its own ` +
+            `and the beach is listed on the strength of it. A model deciding what this site ` +
+            `covers is a change of kind, and it is argued in ` +
+            `docs/adr/0019-a-modelled-source-may-qualify-a-beach.md rather than assumed here.`),
       "A tide prediction is for the station, not for the beach. It is the best published figure " +
         "for that stretch of shore and it is not a measurement taken there.",
       `Sky and visibility are read at an airport, because the ten stations in this county that ` +

--- a/scripts/seed-beaches.mjs
+++ b/scripts/seed-beaches.mjs
@@ -473,7 +473,11 @@ export function dropReplacedBuoy(
  * @param {number} [toleranceM]
  * @returns {string | null}
  */
-export function serviceFault(beach, toleranceM = SERVICE_TOLERANCE_M) {
+export function serviceFault(
+  beach,
+  toleranceM = SERVICE_TOLERANCE_M,
+  modelledM = MODELLED_SOURCE_TOLERANCE_M,
+) {
   if (beach.tide_station === null) {
     return `no tide station was bound to it at all: ${beach.tide_station_null_reason}`;
   }
@@ -485,7 +489,9 @@ export function serviceFault(beach, toleranceM = SERVICE_TOLERANCE_M) {
         `${kilometres(beach.tide_station_distance_m)} away`,
     );
   }
-  if (beach.wave_buoy !== null && beach.wave_buoy_distance_m > toleranceM) {
+  const buoyTooFar =
+    beach.wave_buoy !== null && beach.wave_buoy_distance_m > toleranceM;
+  if (buoyTooFar) {
     tooFar.push(
       `its wave buoy ${beach.wave_buoy} is ` +
         `${kilometres(beach.wave_buoy_distance_m)} away`,
@@ -493,9 +499,25 @@ export function serviceFault(beach, toleranceM = SERVICE_TOLERANCE_M) {
   }
   if (tooFar.length === 0) return null;
 
+  // ADR-0019 made this sentence incomplete on its own. A reader who finds
+  // Border Field State Park listed and Tijana River not, both refused for a
+  // buoy tens of kilometres away, has been told the same reason for two
+  // different outcomes. So where the buoy is what refused the beach and a line
+  // was near enough to have stood in but is not, say that too -- derived from
+  // the binding rather than written against a slug, so it explains any beach in
+  // that state and stops explaining one that leaves it.
+  const modelCouldNotStandIn =
+    buoyTooFar &&
+    beach.mop_line !== null &&
+    beach.mop_line_distance_m > modelledM
+      ? `. A model can answer for the waves where no buoy is in range, but not here: the ` +
+        `nearest MOP line is ${kilometres(beach.mop_line_distance_m)} away, and every beach ` +
+        `on this coast binds one inside ${kilometres(modelledM)}`
+      : "";
+
   return (
     `${tooFar.join(" and ")}, and this site does not publish a reading taken more than ` +
-    `${kilometres(toleranceM)} from the beach it is shown for`
+    `${kilometres(toleranceM)} from the beach it is shown for${modelCouldNotStandIn}`
   );
 }
 

--- a/scripts/seed-beaches.test.mjs
+++ b/scripts/seed-beaches.test.mjs
@@ -555,6 +555,57 @@ describe("serviceFault", () => {
     expect(why).toContain("14.8 km");
   });
 
+  it("says when a model could have stood in for the buoy and could not", () => {
+    // The asymmetry ADR-0019 created. Border Field is listed and Tijana River
+    // is not, and before this clause both carried the same reason -- a buoy
+    // tens of kilometres away -- which told a reader the same thing about two
+    // opposite outcomes.
+    const why = serviceFault(
+      bound({
+        wave_buoy: "46232",
+        wave_buoy_distance_m: 34_159,
+        mop_line: "D0008",
+        mop_line_distance_m: 6_395,
+      }),
+    );
+
+    expect(why).toContain("34.2 km");
+    expect(why).toContain("6.4 km");
+    expect(why).toContain("1.0 km");
+  });
+
+  it("stays quiet about the model where a line was near enough", () => {
+    // Ocean Beach: the buoy is too far AND a line is 776 m away, so MOP is not
+    // what kept it out -- its tide station is. A clause here would name an
+    // innocent binding.
+    const why = serviceFault(
+      bound({
+        tide_station_distance_m: 12_300,
+        wave_buoy: "46254",
+        wave_buoy_distance_m: 12_500,
+        mop_line: "D0333",
+        mop_line_distance_m: 776,
+      }),
+    );
+
+    expect(why).not.toContain("MOP line");
+  });
+
+  it("stays quiet about the model where the buoy was not the problem", () => {
+    // San Onofre: out on tide alone, with a line 689 m away. Mentioning MOP
+    // would imply the waves were ever in question.
+    const why = serviceFault(
+      bound({
+        tide_station_distance_m: 56_557,
+        wave_buoy_distance_m: 1_000,
+        mop_line: "D1210",
+        mop_line_distance_m: 689,
+      }),
+    );
+
+    expect(why).not.toContain("MOP line");
+  });
+
   it("repeats the join's own reason when nothing was bound", () => {
     const why = serviceFault(
       bound({

--- a/scripts/seed-beaches.test.mjs
+++ b/scripts/seed-beaches.test.mjs
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   build,
   document,
+  dropReplacedBuoy,
+  MODELLED_SOURCE_TOLERANCE_M,
   regionOf,
   segmentFault,
   SERVICE_TOLERANCE_M,
@@ -34,6 +36,9 @@ const MOP_LINES = {
   D0001: { lat: 32.875, lon: -117.256, delivers: true },
   D0002: { lat: 32.88, lon: -117.25, delivers: false },
   D0003: { lat: 32.877, lon: -117.254, delivers: true },
+  // Thirty kilometres south of the rest, for NO_BUOY_ROW. Far enough from the
+  // La Jolla cluster that it changes no other beach's binding.
+  D0085: { lat: 32.60799, lon: -117.13976, delivers: true },
 };
 
 const STATIONS = {
@@ -44,6 +49,9 @@ const STATIONS = {
     delivers: true,
   },
   9410170: { lat: 32.7156, lon: -117.1767, water: "bay", delivers: true },
+  // Open coast, thirty kilometres south, and the reason NO_BUOY_ROW can have a
+  // tide station in range while its nearest buoy is not.
+  9410120: { lat: 32.5783, lon: -117.135, water: "open-coast", delivers: true },
 };
 
 /**
@@ -128,6 +136,32 @@ const FAR_ROW = row({
   "Beach_ UpperLon": "-117.40",
   Beach_LowerLat: "33.20",
   Beach_LowerLon: "-117.40",
+});
+
+/**
+ * The shape ADR-0019 admits, laid out the way the real south county is: a tide
+ * station and a MOP line close by, and the nearest delivering buoy thirty
+ * kilometres north. `9410120` and `D0085` above exist for this row alone --
+ * every other fixture beach sits in the La Jolla cluster, where the tide
+ * station and the buoy are 900 m apart and this case cannot be built.
+ */
+const NO_BUOY_ROW = row({
+  Beach_Name: "No Buoy Reaches Here",
+  Beach_UpperLat: "32.612",
+  "Beach_ UpperLon": "-117.135",
+  Beach_LowerLat: "32.604",
+  Beach_LowerLon: "-117.135",
+});
+
+/** Enclosed water: the joins decline a buoy AND a line, which is the other
+ * reason a served beach carries no measured wave height. */
+const BAY_ROW = row({
+  Beach_Name: "Quiet Bay",
+  WaterBodyType: "Sound, Bay, or Inlet",
+  Beach_UpperLat: "32.72",
+  "Beach_ UpperLon": "-117.18",
+  Beach_LowerLat: "32.71",
+  Beach_LowerLon: "-117.18",
 });
 
 describe("segmentFault", () => {
@@ -536,6 +570,100 @@ describe("serviceFault", () => {
   });
 });
 
+describe("dropReplacedBuoy", () => {
+  /** The shape ADR-0019 is about: tide reaches, buoy does not, line does. */
+  const replaceable = (overrides = {}) =>
+    bound({
+      tide_station_distance_m: 2_914,
+      wave_buoy: "46232",
+      wave_buoy_distance_m: 28_153,
+      wave_buoy_from_end: "lower",
+      mop_line: "D0001",
+      mop_line_distance_m: 466,
+      ...overrides,
+    });
+
+  it("is a one-kilometre rule by default, and says so in one place", () => {
+    // A second judgement, and a different question from SERVICE_TOLERANCE_M --
+    // not how far a reading may travel, but whether the beach is on the coast
+    // the model describes. Changing it must be a one-line edit like the other.
+    expect(MODELLED_SOURCE_TOLERANCE_M).toBe(1_000);
+  });
+
+  it("drops a buoy too far to publish when a line can answer instead", () => {
+    const beach = dropReplacedBuoy(replaceable());
+
+    expect(beach.wave_buoy).toBeNull();
+    expect(beach.wave_buoy_distance_m).toBeNull();
+    expect(beach.wave_buoy_from_end).toBeNull();
+    expect(beach.mop_line).toBe("D0001");
+  });
+
+  it("records the refused distance and the line that replaced it", () => {
+    // Either half alone misleads: the distance without the replacement reads as
+    // a beach with no waves, and the replacement without the distance hides
+    // that a measurement was refused.
+    const { wave_buoy_null_reason: why } = dropReplacedBuoy(replaceable());
+
+    expect(why).toContain("46232");
+    expect(why).toContain("28.2 km");
+    expect(why).toContain("D0001");
+    expect(why).toContain("0.5 km");
+    expect(why).toContain("model rather than a measurement");
+  });
+
+  it("leaves a beach whose buoy is inside the tolerance alone", () => {
+    const beach = replaceable({ wave_buoy_distance_m: 1_565 });
+    expect(dropReplacedBuoy(beach)).toBe(beach);
+  });
+
+  it("leaves a beach whose line is too far to answer alone", () => {
+    // Tijana River: published 6-7 km up the river, so its nearest line is
+    // 6,395 m. It fails on the rule rather than by name, and stays excluded.
+    const beach = replaceable({
+      mop_line: "D0008",
+      mop_line_distance_m: 6_395,
+    });
+    expect(dropReplacedBuoy(beach)).toBe(beach);
+  });
+
+  it("leaves a beach the tide also fails, so its reason keeps naming both", () => {
+    // The guard that makes this four beaches instead of eleven. Ocean Beach is
+    // out on tide either way; dropping its buoy would only make `_excluded`
+    // tell a reader less than it did.
+    const beach = replaceable({
+      tide_station_distance_m: 12_300,
+      wave_buoy: "46254",
+      wave_buoy_distance_m: 12_500,
+      mop_line_distance_m: 776,
+    });
+
+    expect(dropReplacedBuoy(beach)).toBe(beach);
+    expect(serviceFault(dropReplacedBuoy(beach))).toContain("46254");
+  });
+
+  it("leaves a beach the join bound no line to", () => {
+    // A bay: swell does not reach it, so nothing replaces anything. It has no
+    // buoy either, and this must not invent a reason for that.
+    const beach = replaceable({
+      wave_buoy: null,
+      wave_buoy_distance_m: null,
+      mop_line: null,
+      mop_line_distance_m: null,
+    });
+    expect(dropReplacedBuoy(beach)).toBe(beach);
+  });
+
+  it("turns the fault it clears into no fault at all", () => {
+    // The whole point, asserted end to end rather than through the fields: the
+    // beach was refused on its buoy, and after the transform it is served.
+    const beach = replaceable();
+
+    expect(serviceFault(beach)).toContain("46232");
+    expect(serviceFault(dropReplacedBuoy(beach))).toBeNull();
+  });
+});
+
 describe("document", () => {
   it("lists only the beaches whose stations reach them", () => {
     const doc = document(
@@ -576,6 +704,30 @@ describe("document", () => {
       ...doc._excluded.map((b) => b.slug),
     ];
     expect(listed.sort()).toEqual(built.map((b) => b.slug).sort());
+  });
+
+  it("tells the two reasons for a missing wave height apart, and counts each", () => {
+    // Both beaches carry `wave_buoy: null` and they do not mean the same thing:
+    // at the bay no buoy was ever bound, and at the other one was bound and
+    // refused. A caveat that merged them would tell a reader in Imperial Beach
+    // that swell does not reach their beach, which is the opposite of true.
+    const doc = document(
+      build(
+        [row(), NO_BUOY_ROW, BAY_ROW],
+        STATIONS,
+        BUOYS,
+        OBSERVATION_STATIONS,
+        MOP_LINES,
+      ),
+    );
+    const caveat = doc.unresolved.find((entry) =>
+      entry.includes("no MEASURED wave height"),
+    );
+
+    expect(caveat).toContain("2 of these beaches");
+    expect(caveat).toContain("At 1 of them the join bound no buoy");
+    expect(caveat).toContain("At the other 1 the join DID bind a buoy");
+    expect(caveat).toContain("46235");
   });
 
   it("records a beach nothing could be bound to, and repeats the join's reason", () => {

--- a/src/app/conditions/page.test.tsx
+++ b/src/app/conditions/page.test.tsx
@@ -36,10 +36,10 @@ test("a reader can choose another beach from here", () => {
 
   const select = screen.getByLabelText("Choose a beach") as HTMLSelectElement;
   expect(select.value).toBe(DEFAULT_BEACH_SLUG);
-  // Every beach in the inventory is offered, not a curated subset. It is 41
+  // Every beach in the inventory is offered, not a curated subset. It is 45
   // rather than the county's 73 because the inventory itself is bounded by the
   // stations that reach it, not because the chooser hides any of it.
-  expect(select.querySelectorAll("option").length).toBe(41);
+  expect(select.querySelectorAll("option").length).toBe(45);
 });
 
 test("the page revalidates often enough that 'today' does not go stale", () => {

--- a/src/components/conditions/WavesToday.test.tsx
+++ b/src/components/conditions/WavesToday.test.tsx
@@ -138,6 +138,7 @@ test("a bay beach is told this is expected, not a fault", () => {
         kind: "no-buoy",
         reason:
           "every wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so no buoy describes the water here",
+        modelAnswersInstead: false,
       }}
     />,
   );
@@ -149,6 +150,93 @@ test("a bay beach is told this is expected, not a fault", () => {
   expect(screen.queryByText(/Try again shortly/)).toBeNull();
   expect(screen.queryByText(/Measured at NDBC buoy/)).toBeNull();
   expect(screen.getByText(/does not reach into a bay or lagoon/)).toBeDefined();
+});
+
+/**
+ * The disclosure ADR-0019 was accepted on, and the reason slice 4 of
+ * `docs/plans/mop-qualified-inventory.md` is not optional. Four beaches now
+ * carry a wave figure that was never measured anywhere, and the card is the
+ * only place a reader meets it before the number.
+ */
+const NO_BUOY_MODELLED = {
+  kind: "no-buoy",
+  reason:
+    "the nearest delivering buoy 46232 is 28.2 km away, further than this site publishes a reading from, so it is not read here; MOP line D0001 answers for the waves at 0.5 km, and it is a model rather than a measurement",
+  modelAnswersInstead: true,
+} as const;
+
+test("a beach no buoy reaches is told its wave heights are modelled", () => {
+  render(
+    <WavesToday
+      beachName="Border Field State Park"
+      buoy={null}
+      state={NO_BUOY_MODELLED}
+      peak={PEAK}
+    />,
+  );
+
+  expect(screen.getByText(/nothing here is measured/)).toBeDefined();
+  expect(screen.getByText(/come from a model of the swell/)).toBeDefined();
+  // The figures are still shown. Withholding them was never the alternative --
+  // the alternative was not listing the beach.
+  expect(screen.getByText("0.8 ft")).toBeDefined();
+});
+
+test("it does not tell an open-coast beach that swell does not reach it", () => {
+  // The sentence the bay branch shows was written for enclosed water. On these
+  // four it states the reason their beach is fine as the reason it is not, and
+  // it is the specific falsehood this slice exists to remove.
+  render(
+    <WavesToday
+      beachName="Border Field State Park"
+      buoy={null}
+      state={NO_BUOY_MODELLED}
+      peak={PEAK}
+    />,
+  );
+
+  expect(
+    screen.queryByText(/Every wave buoy sits out on the open coast/),
+  ).toBeNull();
+  expect(screen.queryByText(/what we expect rather than a fault/)).toBeNull();
+});
+
+test("it still says nothing was measured when the model cannot be reached", () => {
+  // CDIP having a bad day must not make the card fall back to the bay
+  // sentence, which is why `modelAnswersInstead` is a fact from the join
+  // rather than a reading of whether a forecast arrived.
+  render(
+    <WavesToday
+      beachName="Border Field State Park"
+      buoy={null}
+      state={NO_BUOY_MODELLED}
+      peak={null}
+    />,
+  );
+
+  expect(screen.getByText(/nothing here is measured/)).toBeDefined();
+  expect(screen.getByText(/could not be reached just now/)).toBeDefined();
+  expect(
+    screen.queryByText(/Every wave buoy sits out on the open coast/),
+  ).toBeNull();
+});
+
+test("the refused buoy and the line that replaced it both reach the reader", () => {
+  // Either half alone misleads, and this is the last place the pair can be
+  // dropped between `beaches.json` and a person.
+  render(
+    <WavesToday
+      beachName="Border Field State Park"
+      buoy={null}
+      state={NO_BUOY_MODELLED}
+      peak={PEAK}
+    />,
+  );
+
+  const why = screen.getByText(/nearest delivering buoy 46232/);
+  expect(why.textContent).toContain("28.2 km");
+  expect(why.textContent).toContain("D0001");
+  expect(why.textContent).toContain("model rather than a measurement");
 });
 
 test("an unavailable buoy is a sentence with the reason behind a disclosure", () => {
@@ -208,6 +296,7 @@ test("every disclosure this card can render composes the touch-target floor", ()
         state={{
           kind: "no-buoy",
           reason: "every wave buoy sits on the open coast",
+          modelAnswersInstead: false,
         }}
       />,
     ),

--- a/src/components/conditions/WavesToday.tsx
+++ b/src/components/conditions/WavesToday.tsx
@@ -145,9 +145,34 @@ export function WavesToday({
 
       {state.kind === "no-buoy" && (
         <>
+          {/*
+            Two beaches reach this branch for opposite reasons, and one sentence
+            cannot serve both. At a bay there is no wave figure and there never
+            will be. At the four beaches ADR-0019 admits, the coast is open, the
+            swell is real, and what is missing is the instrument -- so telling
+            that reader "every wave buoy sits out on the open coast" would state
+            the reason their beach is fine as the reason it is not.
+
+            The second sentence is the disclosure ADR-0019 was accepted on. It
+            leads rather than sitting in the attribution below, because the card
+            has no measured figure at all here and a reader who stops at the
+            plain-words line must still learn that nothing on it was measured.
+          */}
           <p className={`leading-relaxed mb-4 text-base ${CARD_PROSE}`}>
-            We cannot give a wave height here, and that is what we expect rather
-            than a fault. Every wave buoy sits out on the open coast.
+            {state.modelAnswersInstead ? (
+              <>
+                No wave buoy reaches this stretch of coast, so nothing here is
+                measured.{" "}
+                {peak !== null
+                  ? "The wave heights below come from a model of the swell, not from an instrument in the water."
+                  : "The model that answers here instead could not be reached just now."}
+              </>
+            ) : (
+              <>
+                We cannot give a wave height here, and that is what we expect
+                rather than a fault. Every wave buoy sits out on the open coast.
+              </>
+            )}
           </p>
           <details className={`mb-4 text-sm ${CARD_PROSE}`}>
             <summary className={DISCLOSURE_TARGET}>Why not</summary>

--- a/src/data/beaches.json
+++ b/src/data/beaches.json
@@ -2004,7 +2004,7 @@
     {
       "slug": "tide-beach-park",
       "name": "Tide Beach Park",
-      "why": "its tide station 9410120 is 12.5 km away and its wave buoy 46254 is 21.8 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+      "why": "its tide station 9410120 is 12.5 km away and its wave buoy 46254 is 21.8 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for. A model can answer for the waves where no buoy is in range, but not here: the nearest MOP line is 2.6 km away, and every beach on this coast binds one inside 1.0 km"
     },
     {
       "slug": "coronado-north-beach",
@@ -2024,7 +2024,7 @@
     {
       "slug": "tijana-river",
       "name": "Tijana River",
-      "why": "its wave buoy 46232 is 34.2 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+      "why": "its wave buoy 46232 is 34.2 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for. A model can answer for the waves where no buoy is in range, but not here: the nearest MOP line is 6.4 km away, and every beach on this coast binds one inside 1.0 km"
     },
     {
       "slug": "imperial-beach-pier-area",

--- a/src/data/beaches.json
+++ b/src/data/beaches.json
@@ -4,7 +4,7 @@
   "time_zone": "America/Los_Angeles",
   "_provenance": "Seeded from the Beach Detail Information resource of \"Beach Advisories (Postings and Closures) and Beach Water Quality Monitoring\", published by the California State Water Resources Control Board: https://data.cnra.ca.gov/dataset/beach-advisories-postings-and-closures-and-beach-water-quality-monitoring, resource cc674e59-036c-45c3-bec2-5d3d294e0e3d. The data.ca.gov copy (resource fcbc9250-06e3-437d-b0c6-3cc5ddde93fc) serves identical content and is the mirror. Rebuilt by scripts/seed-beaches.mjs; re-runnable and diffable with --check. Field values are reproduced as the resource serves them, including BeachType \"UNKNOWN\".",
   "_inclusion": "County San Diego, Status Active, BeachAccess PUBLIC, CountAsBeach 1. A predicate over published fields rather than a judgement about which beaches are worth listing.",
-  "_served": "And then, of those: a tide station within 10.0 km, and if a wave buoy is bound at all, that buoy within 10.0 km. Unlike _inclusion this one IS a judgement -- it decides how far a measurement may be taken from the place it is shown for -- and it is stated here rather than left implicit in how far a join happened to reach. Ten kilometres is WMO-No. 8 §1.1.2's scale for small-scale and local applications; no standard reporting radius exists, so the figure is defended rather than cited. What keeps it honest is that its inputs are measured: every distance came out of a join. Every beach it refuses is in _excluded below, with the binding distance that refused it, so nothing leaves this inventory silently. See docs/adr/0011-inventory-bounded-by-station-networks.md.",
+  "_served": "And then, of those: a tide station within 10.0 km, and if a wave buoy is bound at all, that buoy within 10.0 km. Unlike _inclusion this one IS a judgement -- it decides how far a measurement may be taken from the place it is shown for -- and it is stated here rather than left implicit in how far a join happened to reach. Ten kilometres is WMO-No. 8 §1.1.2's scale for small-scale and local applications; no standard reporting radius exists, so the figure is defended rather than cited. What keeps it honest is that its inputs are measured: every distance came out of a join. Every beach it refuses is in _excluded below, with the binding distance that refused it, so nothing leaves this inventory silently. ONE THING IS NOT A MEASUREMENT, and it is the newer half: where the tide reaches a beach but no buoy does, a CDIP MOP line within 1.0 km may answer for the waves instead, and the buoy binding is dropped rather than published -- so those beaches carry wave_buoy null with the distance that refused it, and their only wave figure is model output. The page says so where it shows one. See docs/adr/0011-inventory-bounded-by-station-networks.md and docs/adr/0019-a-modelled-source-may-qualify-a-beach.md.",
   "_pinned": {
     "field_name_with_a_space": "Upstream names one field 'Beach_ UpperLon', with an embedded space. That is the resource's own spelling, and the seeding script asserts it rather than tolerating its absence.",
     "numerics_are_strings": "The datastore serialises numeric columns as JSON strings. They are converted once, at seed time, and anything that does not parse stops the seed.",
@@ -19,8 +19,11 @@
     "tide_station": "Joined, never typed: the nearest delivering station of the beach's own water class. Re-runnable with scripts/seed-beaches.mjs --check. null means the join could not bind one, and tide_station_null_reason says why.",
     "tide_station_distance_m": "Great-circle metres from the nearer segment end to the station.",
     "tide_station_from_end": "Which end of the segment supplied the distance, upper or lower.",
-    "mop_line": "Joined, never typed: the nearest delivering CDIP MOP line, subject to the same water-class refusal as wave_buoy -- every line sits at 10 m depth on the open coast. A SECOND wave binding rather than a replacement: wave_buoy answers for now and this answers for the week ahead. null means the join could not bind one, and mop_line_null_reason says why. See mop-lines.json.",
-    "mop_line_distance_m": "Great-circle metres from the nearer segment end to the line. Much smaller than wave_buoy_distance_m -- the lines are about 100 m apart -- which is why the refusal above is a rule about the water and not a distance.",
+    "wave_buoy": "Joined, never typed: the nearest delivering NDBC buoy that publishes waves, and the only measurement of the sea itself on this page. null carries TWO meanings and wave_buoy_null_reason always distinguishes them: the join declined to bind one -- every bay and lagoon, and the cove closed off by a breakwater -- or the join bound one and this site declined to publish it, because it sits further away than _served allows and a MOP line answers in its place. The second is the newer case, it names both the refused distance and the line that replaced it, and it means the beach's only wave figure is modelled. See docs/adr/0019-a-modelled-source-may-qualify-a-beach.md.",
+    "wave_buoy_distance_m": "Great-circle metres from the nearer segment end to the buoy. Always within _served's tolerance when it is present at all: a buoy further than that is dropped rather than recorded, so this field never carries a distance the site would not publish.",
+    "wave_buoy_from_end": "Which end of the segment supplied the distance, upper or lower.",
+    "mop_line": "Joined, never typed: the nearest delivering CDIP MOP line, subject to the same water-class refusal as wave_buoy -- every line sits at 10 m depth on the open coast. USUALLY a second wave binding rather than a replacement: wave_buoy answers for now and this answers for the week ahead. At the four beaches no buoy reaches it is the only wave source, which is a decision rather than a join result and is why _served names it. null means the join could not bind one, and mop_line_null_reason says why. See mop-lines.json.",
+    "mop_line_distance_m": "Great-circle metres from the nearer segment end to the line. Much smaller than wave_buoy_distance_m wherever both are present -- the lines are about 100 m apart -- which is why the water-class refusal above is a rule about the water and not a distance. A distance rule exists all the same, and answers a different question: a line beyond _served's modelled tolerance cannot answer for a beach ALONE, because at this spacing a line kilometres away means the nearest open coast is kilometres away rather than that the model is coarse there. It still binds, and still fills the week.",
     "mop_line_from_end": "Which end of the segment supplied the distance, upper or lower.",
     "sky_station": "Joined, never typed: the nearest station that both answers and publishes sky. Supplies the panel's sky and visibility ONLY -- temperature and wind come from air_station. Unlike the wave buoy, every beach binds one -- air reaches a lagoon. null means the join could not bind one, and sky_station_null_reason says why.",
     "sky_station_distance_m": "Great-circle metres from the nearer segment end to the station. Larger than the tide and buoy distances by nature: the ten stations that publish sky are all airports.",
@@ -1681,6 +1684,129 @@
       "air_station_from_end": "lower"
     },
     {
+      "slug": "silver-strand-state-beach",
+      "name": "Silver Strand State Beach",
+      "region": "South County coast",
+      "segment": {
+        "upper": {
+          "lat": 32.636836,
+          "lon": -117.144303
+        },
+        "lower": {
+          "lat": 32.608936,
+          "lon": -117.134783
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA801475",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410120",
+      "tide_station_distance_m": 3407,
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "the nearest delivering buoy 46254 is 28.1 km away, further than this site publishes a reading from, so it is not read here; MOP line D0085 answers for the waves at 0.5 km, and it is a model rather than a measurement",
+      "mop_line": "D0085",
+      "mop_line_distance_m": 478,
+      "mop_line_from_end": "lower",
+      "sky_station": "KSAN",
+      "sky_station_distance_m": 11356,
+      "sky_station_from_end": "upper",
+      "air_station": "TIXC1",
+      "air_station_distance_m": 3843,
+      "air_station_from_end": "lower"
+    },
+    {
+      "slug": "north-imperial-beach",
+      "name": "north Imperial Beach",
+      "region": "South County coast",
+      "segment": {
+        "upper": {
+          "lat": 32.6089,
+          "lon": -117.1347
+        },
+        "lower": {
+          "lat": 32.5866,
+          "lon": -117.1327
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA134387",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Imperial Beach"
+      },
+      "tide_station": "9410120",
+      "tide_station_distance_m": 948,
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "the nearest delivering buoy 46232 is 28.5 km away, further than this site publishes a reading from, so it is not read here; MOP line D0085 answers for the waves at 0.5 km, and it is a model rather than a measurement",
+      "mop_line": "D0085",
+      "mop_line_distance_m": 485,
+      "mop_line_from_end": "upper",
+      "sky_station": "KSDM",
+      "sky_station_distance_m": 13144,
+      "sky_station_from_end": "lower",
+      "air_station": "TIXC1",
+      "air_station_distance_m": 1396,
+      "air_station_from_end": "lower"
+    },
+    {
+      "slug": "imperial-beach-municipal-beach-other",
+      "name": "Imperial Beach municipal beach, other",
+      "region": "South County coast",
+      "segment": {
+        "upper": {
+          "lat": 32.587527,
+          "lon": -117.132598
+        },
+        "lower": {
+          "lat": 32.566219,
+          "lon": -117.133006
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA068221",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Imperial Beach"
+      },
+      "tide_station": "9410120",
+      "tide_station_distance_m": 1050,
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "the nearest delivering buoy 46232 is 27.9 km away, further than this site publishes a reading from, so it is not read here; MOP line D0061 answers for the waves at 0.6 km, and it is a model rather than a measurement",
+      "mop_line": "D0061",
+      "mop_line_distance_m": 644,
+      "mop_line_from_end": "upper",
+      "sky_station": "KSDM",
+      "sky_station_distance_m": 13145,
+      "sky_station_from_end": "upper",
+      "air_station": "TIXC1",
+      "air_station_distance_m": 1127,
+      "air_station_from_end": "lower"
+    },
+    {
       "slug": "tijuana-slough-national-wildlife-refuge",
       "name": "Tijuana Slough National Wildlife Refuge",
       "region": "Bays, lagoons and inlets",
@@ -1720,6 +1846,47 @@
       "sky_station_from_end": "lower",
       "air_station": "TIXC1",
       "air_station_distance_m": 1129,
+      "air_station_from_end": "upper"
+    },
+    {
+      "slug": "border-field-state-park",
+      "name": "Border Field State Park",
+      "region": "South County coast",
+      "segment": {
+        "upper": {
+          "lat": 32.55282,
+          "lon": -117.127708
+        },
+        "lower": {
+          "lat": 32.534367,
+          "lon": -117.124197
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA809706",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "9410120",
+      "tide_station_distance_m": 2914,
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "the nearest delivering buoy 46232 is 28.2 km away, further than this site publishes a reading from, so it is not read here; MOP line D0001 answers for the waves at 0.5 km, and it is a model rather than a measurement",
+      "mop_line": "D0001",
+      "mop_line_distance_m": 466,
+      "mop_line_from_end": "lower",
+      "sky_station": "KSDM",
+      "sky_station_distance_m": 12863,
+      "sky_station_from_end": "upper",
+      "air_station": "TIXC1",
+      "air_station_distance_m": 2467,
       "air_station_from_end": "upper"
     }
   ],
@@ -1855,29 +2022,9 @@
       "why": "its tide station 9410120 is 11.2 km away and its wave buoy 46254 is 21.2 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
     },
     {
-      "slug": "silver-strand-state-beach",
-      "name": "Silver Strand State Beach",
-      "why": "its wave buoy 46254 is 28.1 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
-    },
-    {
-      "slug": "north-imperial-beach",
-      "name": "north Imperial Beach",
-      "why": "its wave buoy 46232 is 28.5 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
-    },
-    {
-      "slug": "imperial-beach-municipal-beach-other",
-      "name": "Imperial Beach municipal beach, other",
-      "why": "its wave buoy 46232 is 27.9 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
-    },
-    {
       "slug": "tijana-river",
       "name": "Tijana River",
       "why": "its wave buoy 46232 is 34.2 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
-    },
-    {
-      "slug": "border-field-state-park",
-      "name": "Border Field State Park",
-      "why": "its wave buoy 46232 is 28.2 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
     },
     {
       "slug": "imperial-beach-pier-area",
@@ -1888,11 +2035,11 @@
   "unresolved": [
     "beach_type is UNKNOWN upstream for most of these beaches. That is a gap in the resource, not a shorthand for sand, and nothing may render it as a description of what the shore is made of.",
     "The join binds by nearest station of matching water class, and a beach whose nearest is further than 10.0 km away is not listed here at all rather than listed with a reading from out of range. The farthest any listed beach reads is Del Mar City Beach's, at 9.2 km. See tide-stations.json, whose own unresolved list records that the one open-coast station between La Jolla and Imperial Beach does not deliver predictions.",
-    "26 of these beaches get no wave height at all. Every NDBC wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so binding one to the nearest buoy would put an open-ocean number on enclosed water. Their water temperature is missing for the same reason and is not yet filled from another source.",
-    "The same 26 beaches get no wave forecast, and the refusal costs more here than it does for the buoy: MOP lines sit about 100 m apart, so the nearest one to an enclosed beach is close enough to look right. It would still be describing the open coast outside. The median bound beach reads a line 519 m away and the farthest reads one 910 m away, at Tourmaline Surfing Park. Every one is inside a kilometre, which is why this binding is NOT a clause of the service predicate above: admitting it would readmit beaches the buoy clause excluded, and that is a re-seed of the inventory rather than a consequence of adding a forecast.",
+    "30 of these beaches get no MEASURED wave height, for two different reasons that their wave_buoy_null_reason tells apart. At 26 of them the join bound no buoy: every NDBC wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so binding one to the nearest buoy would put an open-ocean number on enclosed water. Their water temperature is missing for the same reason and is not yet filled from another source. At the other 4 the join DID bind a buoy and this site declined to publish it, because the only one left is far past 10.0 km -- 46235 Imperial Beach Nearshore died in May 2026 and was the only buoy south of Point Loma. Those beaches are open coast and do get a wave figure, from a model rather than an instrument, and the page says which it is. See docs/adr/0019-a-modelled-source-may-qualify-a-beach.md.",
+    "26 beaches get no wave forecast, and the refusal costs more here than it does for the buoy: MOP lines sit about 100 m apart, so the nearest one to an enclosed beach is close enough to look right. It would still be describing the open coast outside. The median bound beach reads a line 503 m away and the farthest reads one 910 m away, at Tourmaline Surfing Park. Every one is inside a kilometre, and that closeness is now load-bearing rather than merely reassuring: where no buoy is in range, a line within 1.0 km answers for the beach on its own and the beach is listed on the strength of it. A model deciding what this site covers is a change of kind, and it is argued in docs/adr/0019-a-modelled-source-may-qualify-a-beach.md rather than assumed here.",
     "A tide prediction is for the station, not for the beach. It is the best published figure for that stretch of shore and it is not a measurement taken there.",
-    "Sky and visibility are read at an airport, because the ten stations in this county that publish them are all airport METARs, and airports sit inland. The median beach reads its sky station 7.7 km away and the farthest reads one 14.5 km away, at Del Mar City Beach. Coastal fog is precisely what changes over that distance, so those two figures describe the airport and not the shoreline.",
-    "Air temperature and wind come from a different station than sky and visibility, and the page names both. The median beach reads its air station 3.7 km away against 7.7 km for its sky station. Two provenances behind one panel is a deliberate trade: requiring one station to supply all four values meant the scarcest of them, sky, decided where the temperature was measured, which put an inland reading on a coastal beach. See docs/adr/0010-two-provenances-in-the-air-panel.md.",
+    "Sky and visibility are read at an airport, because the ten stations in this county that publish them are all airport METARs, and airports sit inland. The median beach reads its sky station 7.9 km away and the farthest reads one 14.5 km away, at Del Mar City Beach. Coastal fog is precisely what changes over that distance, so those two figures describe the airport and not the shoreline.",
+    "Air temperature and wind come from a different station than sky and visibility, and the page names both. The median beach reads its air station 3.7 km away against 7.9 km for its sky station. Two provenances behind one panel is a deliberate trade: requiring one station to supply all four values meant the scarcest of them, sky, decided where the temperature was measured, which put an inland reading on a coastal beach. See docs/adr/0010-two-provenances-in-the-air-panel.md.",
     "An air station is still not the beach. It is the nearest measurement of the air the beach is in, chosen for exposure as well as distance -- an open-coast beach binds a station standing in the marine layer at the shoreline, a bay or lagoon binds the nearest of any kind. The shore classification is an author judgement; observation-stations.json records it and says so.",
     "The network module carries no build-time guard against being imported by a browser bundle. The `server-only` package is the intended enforcement and is not installed: importing it breaks the tests under jsdom until vitest is configured with the `react-server` resolve condition. Today the guarantee rests on the module having no client-side importer, which nothing checks."
   ]

--- a/src/data/wave-buoys.json
+++ b/src/data/wave-buoys.json
@@ -124,7 +124,7 @@
     }
   },
   "unresolved": [
-    "46235 Imperial Beach Nearshore is the only buoy south of Point Loma and it does not deliver, so every south-county beach reads a buoy well to its north-west across water of different exposure. The join records the distance rather than hiding it. This is a gap in what NDBC publishes, not one this site can close.",
+    "46235 Imperial Beach Nearshore is the only buoy south of Point Loma and it does not deliver, so no south-county beach reads a measured wave height at all. The join still binds the nearest delivering buoy and still records the distance rather than hiding it -- 28 km, across water of different exposure -- and the seed then drops that binding rather than publishing it, listing those beaches on a CDIP MOP line instead. Their wave figure is model output, and the page says so. This is a gap in what NDBC publishes, not one this site can close; what changed is what the site does about it. See docs/adr/0019-a-modelled-source-may-qualify-a-beach.md.",
     "A buoy's significant wave height is not the height of the wave breaking at the shore. No shoaling or refraction transform is applied, and none is planned: the number shown is what the buoy reported, which is the only thing actually measured.",
     "46086 San Clemente Basin sits twenty-seven nautical miles offshore, outside the county, and no beach is bound to it. It publishes wind, water temperature, and wave height on 27 of the 48 newest rows -- its wave cycle is slower than its reporting cycle, so a third of its rows carry none. It is recorded here because it fell inside the box this table was filtered from and it delivers, and it is left out of the wave join by that distance rather than by what it measures."
   ]

--- a/src/lib/beaches.test.ts
+++ b/src/lib/beaches.test.ts
@@ -14,10 +14,39 @@ import {
 
 describe("the inventory", () => {
   test("holds only the beaches the station networks reach", () => {
-    // The county lists 73. The other 32 are in beaches.json's `_excluded`
+    // The county lists 73. The other 28 are in beaches.json's `_excluded`
     // block, each with the binding distance that removed it; see
     // docs/adr/0011-inventory-bounded-by-station-networks.md.
-    expect(allBeaches()).toHaveLength(41);
+    expect(allBeaches()).toHaveLength(45);
+  });
+
+  test("holds the four beaches no buoy reaches, which a model answers for", () => {
+    // 41 before ADR-0019. These four left when 46235 died in May 2026 and the
+    // wave join reached 28 km past it; each binds a MOP line under 650 m, and
+    // is served on that with no measured wave height at all. Named rather than
+    // counted, because the count alone would go green if four different
+    // beaches arrived.
+    for (const slug of [
+      "silver-strand-state-beach",
+      "north-imperial-beach",
+      "imperial-beach-municipal-beach-other",
+      "border-field-state-park",
+    ]) {
+      const beach = beachBySlug(slug);
+      expect(beach).not.toBeNull();
+      expect(beach!.wave_buoy).toBeNull();
+      expect(beach!.mop_line).not.toBeNull();
+    }
+  });
+
+  test("does not hold the river reach published six kilometres inland", () => {
+    // Tijana River fails on the same rule rather than by name: its nearest line
+    // is 6,395 m, against 117-930 m for every beach actually on this coast. The
+    // spelling is upstream's own and is not a typo to fix here.
+    expect(beachBySlug("tijana-river")).toBeNull();
+    expect(
+      inventoryReach().excluded.find((b) => b.slug === "tijana-river")?.why,
+    ).toContain("wave buoy 46232");
   });
 
   test("a beach the county lists but no station reaches is not in it", () => {
@@ -239,13 +268,47 @@ describe("caveats", () => {
 });
 
 describe("the MOP line binding", () => {
-  test("every beach with a buoy also has a line, and the reverse", () => {
-    // Two separate joins over two tables, and they must agree about which
-    // water ocean swell reaches. If they ever disagree, one of the two wave
-    // numbers on the page is describing somewhere else.
+  test("every beach with a buoy also has a line, but not the reverse", () => {
+    // This used to be an equivalence: two joins over two tables, agreeing about
+    // which water ocean swell reaches. ADR-0019 broke the second direction on
+    // purpose -- four beaches carry a line and no buoy, because the buoy the
+    // join bound is further away than this site will publish. The first
+    // direction still holds and is the half that catches the two joins
+    // disagreeing about the water, which is what the equivalence was for: a
+    // buoy without a line would mean one of them let swell into a bay.
     for (const beach of allBeaches()) {
-      expect(beach.mop_line === null).toBe(beach.wave_buoy === null);
+      if (beach.wave_buoy !== null) expect(beach.mop_line).not.toBeNull();
     }
+  });
+
+  test("a beach a model answers for alone has a line inside the modelled bound", () => {
+    // The predicate ADR-0019 actually states, asserted over the file that
+    // ships. NOT "every bound line is within a kilometre" -- that is true today
+    // and the rule does not require it, so pinning it would fail a beach whose
+    // buoy is fine and whose line happens to sit further out.
+    const modelledOnly = allBeaches().filter(
+      (beach) => beach.wave_buoy === null && beach.mop_line !== null,
+    );
+    expect(modelledOnly).toHaveLength(4);
+
+    for (const beach of modelledOnly) {
+      expect(beach.mop_line_distance_m).toBeLessThanOrEqual(1_000);
+    }
+  });
+
+  test("a dropped buoy says both that it was refused and what replaced it", () => {
+    // Either half alone misleads. The distance without the replacement reads as
+    // a beach with no waves; the replacement without the distance hides that a
+    // measurement was refused. This is the reason the card and the caveats both
+    // relay, so it is the reason a reader ends up holding.
+    const beach = beachBySlug("border-field-state-park")!;
+
+    expect(beach.wave_buoy_null_reason).toContain("46232");
+    expect(beach.wave_buoy_null_reason).toContain("28.2 km");
+    expect(beach.wave_buoy_null_reason).toContain("D0001");
+    expect(beach.wave_buoy_null_reason).toContain(
+      "model rather than a measurement",
+    );
   });
 
   test("bound lines deliver, and the beach is open coast", () => {
@@ -274,8 +337,16 @@ describe("the MOP line binding", () => {
     // Not a claim that the forecast is a better reading of now -- it is model
     // output and the buoy is a measurement. It is why a forecast this close to
     // the shore is worth relaying at all.
-    for (const beach of allBeaches()) {
-      if (beach.mop_line === null) continue;
+    //
+    // Both bindings, not just the line: since ADR-0019 four beaches have a line
+    // and no buoy, and comparing against a null distance would compare against
+    // zero and pass by accident on a file where the line had moved anywhere.
+    const both = allBeaches().filter(
+      (beach) => beach.mop_line !== null && beach.wave_buoy !== null,
+    );
+    expect(both.length).toBeGreaterThan(0);
+
+    for (const beach of both) {
       expect(beach.mop_line_distance_m!).toBeLessThan(
         beach.wave_buoy_distance_m!,
       );

--- a/src/lib/beaches.test.ts
+++ b/src/lib/beaches.test.ts
@@ -44,9 +44,18 @@ describe("the inventory", () => {
     // is 6,395 m, against 117-930 m for every beach actually on this coast. The
     // spelling is upstream's own and is not a typo to fix here.
     expect(beachBySlug("tijana-river")).toBeNull();
-    expect(
-      inventoryReach().excluded.find((b) => b.slug === "tijana-river")?.why,
-    ).toContain("wave buoy 46232");
+
+    // And its reason has to survive standing next to Border Field State Park,
+    // its neighbour at the same river mouth, which IS listed. Both were refused
+    // for a buoy tens of kilometres away; a reader owed the difference gets it
+    // from the second sentence rather than from knowing the coastline.
+    const why = inventoryReach().excluded.find(
+      (b) => b.slug === "tijana-river",
+    )?.why;
+
+    expect(why).toContain("wave buoy 46232");
+    expect(why).toContain("6.4 km");
+    expect(beachBySlug("border-field-state-park")).not.toBeNull();
   });
 
   test("a beach the county lists but no station reaches is not in it", () => {

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -548,6 +548,29 @@ test("a bay beach is never asked about, because there is nothing to ask", async 
   expect(fetchLatestWave).not.toHaveBeenCalled();
   if (view.state.kind === "no-buoy") {
     expect(view.state.reason).toMatch(/does not reach into a bay/);
+    // Nothing answers for the waves here, so the card must not promise a
+    // modelled figure below a sentence saying none is coming.
+    expect(view.state.modelAnswersInstead).toBe(false);
+  }
+});
+
+test("a beach whose buoy was refused says a model answers instead", async () => {
+  // The other half of `no-buoy`, since ADR-0019. Read against the shipped
+  // inventory rather than a fixture: the guarantee this asserts is that the
+  // seed only ever drops a buoy where a line replaced it, and a fixture would
+  // assert that about itself.
+  const view = await readLatestWaves(
+    "border-field-state-park",
+    NOON_PACIFIC_20260817,
+  );
+
+  expect(view.state.kind).toBe("no-buoy");
+  expect(view.buoy).toBeNull();
+  // Still no request: the buoy is not read here, it is declined.
+  expect(fetchLatestWave).not.toHaveBeenCalled();
+  if (view.state.kind === "no-buoy") {
+    expect(view.state.modelAnswersInstead).toBe(true);
+    expect(view.state.reason).toMatch(/further than this site publishes/);
   }
 });
 

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -554,7 +554,22 @@ export type WavesState =
       directionDegT: number | null;
       waterTempF: number | null;
     }
-  | { kind: "no-buoy"; reason: string }
+  | {
+      kind: "no-buoy";
+      reason: string;
+      /**
+       * Whether a model answers for the waves here instead of a buoy.
+       *
+       * `no-buoy` used to mean one thing -- enclosed water, where swell does
+       * not reach and nothing describes the waves at all. Since ADR-0019 it
+       * means two, and they need opposite sentences: at a bay the card says no
+       * wave figure is coming, and at these four it says the figure below is
+       * modelled. Carried as a fact from the join rather than inferred from
+       * whether a forecast happened to arrive, because CDIP having a bad day
+       * must not make the card claim swell does not reach an open coast.
+       */
+      modelAnswersInstead: boolean;
+    }
   | { kind: "unavailable"; detail: string; drift: boolean };
 
 export interface WavesView {
@@ -592,6 +607,11 @@ export async function readLatestWaves(
         reason:
           beach.wave_buoy_null_reason ??
           "the join bound no wave buoy to this beach, and recorded no reason",
+        // A line bound to a beach with no buoy is the ADR-0019 case, and the
+        // seed guarantees the pairing: a buoy is only ever dropped where a
+        // qualifying line replaced it. Read from the binding rather than from
+        // the reason string, which is prose meant for a reader.
+        modelAnswersInstead: beach.mop_line !== null,
       },
     };
   }


### PR DESCRIPTION
Closes #146.

ADR-0019 was proposed in this PR and accepted mid-flight, so all five slices are
here rather than the two the PR opened with.

## What changed

| # | Slice | Commit |
| --- | --- | --- |
| 1 | Plan file | `1c722bd` |
| 2 | ADR-0019 proposed — both designs, both sides | `a60c939` |
| — | ADR-0019 accepted | `99cac6e` |
| 3 | Predicate admits a qualifying line; re-seed 41 → 45 | `7d71424` |
| 4 | The card says the wave figure is modelled — **needs-human** | `25570eb` |
| 5 | Say why a model could not stand in, where one could have | `cd235c2` |

**The decision.** ADR-0011 bounds a beach by its distance to an *instrument*, and
no instrument sits on a MOP line. 46235 died on 2026-05-03 and was the only buoy
south of Point Loma, so four beaches left the inventory for a buoy 28 km away.
ADR-0019 admits them on a modelled source, on three conditions: the 28 km
measurement is **dropped rather than published**, the line must be within a
separately-defended 1 km bound, and the page must say the figure is modelled.

The case against is kept in full in the ADR. It was outweighed, not answered:
"we do not publish a reading taken more than 10 km away" really does mean
something weaker now, and the disclosure is the whole of what is offered in
exchange — which is why the ADR ties the two together explicitly.

**Measured effect:** served 41 → 45, `_excluded` 32 → 28, nothing departs.
Two exclusion reasons change (slice 5, below); the other 26 are byte-identical.

## Three corrections to the triage brief, all verified

1. **Silver Strand's tide station is `9410120`, not `9410135`.** The latter is
   South San Diego Bay, a *bay* station at 3,378 m. Silver Strand is open coast,
   so the join matches water class and binds Imperial Beach at 3,407 m.
2. **The predicted test breakage does not happen.** `Caveats.test.tsx` (43/77/99)
   and `ConditionsNotes.test.tsx:119` render from hand-written `REACH` literals
   and pass unchanged at 45. What actually failed: `beaches.test.ts:20`,
   `page.test.tsx:42`, and two invariants at `beaches.test.ts:245`/`:271` that
   this change breaks **on purpose**.
3. **The modelled bound is measurable, so Tijana River needs no special case.**
   Of the 45 beaches countywide binding a line, 43 sit between 117 m and 930 m;
   then `tide-beach-park` at 2,594 m and `tijana-river` at 6,395 m — the two
   ADR-0011 already records as published where their names are not.

## Two things measurement caught that the plan had wrong

**My own spec was too loose.** I first wrote "drop the buoy wherever a qualifying
line replaces it" and claimed it left the tide-failing beaches untouched.
Simulating it showed it firing on **seven** still-excluded beaches, stripping the
wave clause from each `_excluded` reason for no benefit. Tightened to fire only
where the buoy is the **sole** fault.

**Slice 5 was neither of the two options it was written as.** Serving Tijana
River with waves null was already dead — ADR-0019 admits a beach only where a
model *replaces* the measurement, so serving it would mean a hole ADR-0011
refused. But leaving it excluded was not leaving it alone: Border Field and
Tijana River sit at the same river mouth, and after slice 3 one is listed and the
other is not, with the same sentence still explaining the second. So slice 5 is a
derived clause in `serviceFault` that names the line that could have stood in and
did not. It reaches exactly two entries — the two where a model could have helped
and could not — and stays quiet where the buoy was never the problem.

The plan carries a dated addendum for this rather than a rewrite.

## Two invariants moved rather than relaxed

- *"A beach has a buoy exactly when it has a line"* was an equivalence. The
  reverse half is now false by design; what is pinned instead is the half that
  still catches the two joins disagreeing about the water.
- *"Every bound line is nearer than the buoy"* now requires **both** bindings —
  comparing against a null distance compares against zero and passes by accident.

## Caveats that had gone false

Three, all of which reach a reader through `inventoryCaveats()`:

- the generated one saying a missing wave height means swell does not reach that
  water — the opposite of true at these four;
- the generated one saying the MOP binding is not a clause of the predicate;
- `wave-buoys.json`'s, saying every south-county beach reads a distant buoy. None
  does now.

## Coverage

The floor caught two uncovered branches in the new code (branches 90.69% against
a 90.71% floor). Fixed by covering them with assertions that were worth making —
the caveat must tell the two reasons for a missing wave height apart — plus two
new seed fixtures, since every existing fixture beach sits in the La Jolla
cluster where the tide station and the buoy are 900 m apart and this case cannot
be built.

## Gates

Run at `cd235c2`, the tip of this branch, after `rm -rf .next`:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

937 tests passing, up from 916. Green at every commit on the branch.

## Slice 4 needs a person

No gate can assert how a page reads. Rendered at 1536×639 against live NOAA and
CDIP data, the three states of the wave card now read:

- **Border Field State Park** (new) — no lead figure; *"No wave buoy reaches this
  stretch of coast, so nothing here is measured. The wave heights below come from
  a model of the swell, not from an instrument in the water."* Then the forecast
  block, attributed to MOP line D0001.
- **La Jolla Shores** (unchanged) — 2.6 ft measured, then the forecast block.
- **Mission Bay** (unchanged) — the bay sentence, no figures.

Screenshots were sent to @cweber12 in the working session.

## What I did not do

- **No committed probe script**, as agreed: `seed-beaches.mjs --check` re-derives
  every join figure, and the distance distribution behind the 1 km bound is now a
  test assertion that runs on every gate.
- **No issues filed per slice** — one dependency chain on one branch, so two
  people could not have taken two of them without colliding.
- **The eight beaches failing tide are untouched**, deliberately, and their
  exclusion records are byte-identical apart from Tide Beach Park's, which gains
  the slice-5 clause because a model could have helped it and could not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
