### PR TITLE
Mark the MOP inventory plan historical

### DIFF
--- a/docs/plans/mop-qualified-inventory.md
+++ b/docs/plans/mop-qualified-inventory.md
@@ -1,9 +1,13 @@
 # A modelled wave source may qualify a beach
 
-Planned 2026-08-26 for #146. Slice 2's decision,
+> **Historical.** Planned 2026-08-26, shipped in PR #153 on 2026-08-26.
+> It records what was intended then, not what the code does now, and is not
+> maintained. See [`README.md`](README.md).
+
+Planned for #146. Slice 2's decision,
 [`docs/adr/0019-a-modelled-source-may-qualify-a-beach.md`](../adr/0019-a-modelled-source-may-qualify-a-beach.md),
-was accepted on 2026-08-26, so slices 3–5 are unblocked. In flight; not
-historical yet.
+was accepted on 2026-08-26 and is the part still kept current — ADRs are, and
+this file is not.
 
 ## The problem, from a reader's point of view
 


### PR DESCRIPTION
Follow-up to #153, which shipped without this.

CLAUDE.md says a plan is marked historical **in the PR that ships it**. #153 did
not, so `docs/plans/mop-qualified-inventory.md` has been describing itself as
"In flight; not historical yet" since the merge — the one thing
`docs/plans/README.md` says a reader must be able to tell at a glance, and it
also made that README's "nothing is in flight" false.

One line changed to the standard note, plus a pointer that ADR-0019 is the half
still kept current. No logic, no data, no contract — small lane.

**Noticed, not filed:** no gate row reads `docs/plans/`, which is why this
survived a green gate and a merge. Filing it would grow the tracker a row for a
rule followed by hand everywhere else; it is recorded in the commit message
instead.

## Gates

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)