### PR TITLE
Promise only sky from the gridded forecast row

### DIFF
--- a/src/components/conditions/WeekPanel.test.tsx
+++ b/src/components/conditions/WeekPanel.test.tsx
@@ -138,6 +138,36 @@ test("the forecasts that are not built yet are named, and waves are no longer am
   expect(screen.getByText(/gridded forecast/i)).toBeDefined();
 });
 
+/**
+ * A reserved slot is a promise, so what it does *not* say is as load-bearing as
+ * what it does. This row once offered "Temperature, wind and sky" from the grid
+ * cell, and two thirds of that could never ship: temperature and wind come from
+ * the air station at p50 3.7 km rather than from an airport, ADR-0012 records
+ * them as among the best-founded readings on the site, and replacing them with
+ * a forecast is the displacement ADR-0019 declined to decide. Visibility is not
+ * promised either — the gridpoint publishes no values for it at any cell
+ * covering this inventory.
+ *
+ * Asserted on the rendered text rather than on the constant, because the defect
+ * was a reader being told something untrue.
+ */
+test("the gridded row promises sky alone, not the readings that are already near", async () => {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
+  });
+
+  render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
+
+  const promise = screen.getByText(/grid cell/i).textContent ?? "";
+
+  expect(promise).toMatch(/cloud cover/i);
+  // The three the row must not offer, each for its own reason.
+  expect(promise).not.toMatch(/temperature/i);
+  expect(promise).not.toMatch(/wind/i);
+  expect(promise).not.toMatch(/visibilit/i);
+});
+
 test("a NOAA outage costs the tide row, not the whole grid", async () => {
   readWeekOfLowestLows.mockResolvedValue({
     ...BINDING,
@@ -186,11 +216,16 @@ test("a failure to resolve the beach is not swallowed into a rendered nothing", 
 
 /**
  * ADR-0015. The reserved row and the live card describe the same product from
- * different feeds, so they take the same glyph — the gridded forecast is the
- * air card's replacement, and marking it with the thermometer the air card no
- * longer uses would leave the page saying two things about one product.
+ * different feeds, so they take the same glyph — the gridded forecast lands in
+ * the air card, replacing its sky half, and marking it with the thermometer the
+ * air card no longer uses would leave the page saying two things about one
+ * product.
+ *
+ * Whether a row about cloud alone still wants the wind glyph is a question for
+ * the slice that fills it: the vocabulary is ADR-0015's and changing it is a
+ * design decision rather than a copy fix.
  */
-test("the gridded forecast is marked like the air card it will replace", async () => {
+test("the gridded forecast is marked like the air card whose sky it will replace", async () => {
   readWeekOfLowestLows.mockResolvedValue({
     beachName: "La Jolla Shores Beach",
     station: { name: "La Jolla (Scripps Institution Wharf)", distanceM: 1369 },

--- a/src/components/conditions/WeekPanel.tsx
+++ b/src/components/conditions/WeekPanel.tsx
@@ -45,8 +45,21 @@ import { WeekGrid, type ReservedRow, type WeekRow } from "./WeekGrid";
  * filled row would promise it twice.
  *
  * The gridded National Weather Service forecast is #95, which exists so that
- * sky and visibility can come from this beach's own grid cell instead of an
- * aerodrome. The surf zone forecast is zone-level and reaches about three days
+ * sky can come from this beach's own grid cell instead of an aerodrome.
+ *
+ * **It promises sky and nothing else, and both halves of that are measured.**
+ * Visibility cannot follow: the gridpoint declares `visibility` and
+ * `ceilingHeight` as keys and publishes no values for either -- measured
+ * 2026-08-26, zero entries at every one of the 21 cells covering this
+ * inventory, against 34-37 for `skyCover` -- so a row promising visibility
+ * would promise a product that does not exist. Temperature and wind must not
+ * follow: they come from the air
+ * station rather than an airport, measured at p50 3.7 km and max 7.4 km, and
+ * ADR-0012 records them as among the best-founded readings here. Moving those
+ * to a forecast is the displacement ADR-0019 declined to decide, and this row
+ * previously promised it.
+ *
+ * The surf zone forecast is zone-level and reaches about three days
  * out; it is the product the tide heights on this page were checked against.
  *
  * No issue numbers in the copy. A reader is owed what is coming, not our
@@ -57,7 +70,7 @@ const RESERVED: readonly ReservedRow[] = [
     emoji: "💨",
     headline: "A gridded forecast is coming.",
     detail:
-      "Temperature, wind and sky for this beach's own grid cell, instead of the nearest airport's reading.",
+      "Cloud cover for this beach's own grid cell, instead of the nearest airport's reading.",
   },
   {
     emoji: "🏖️",


### PR DESCRIPTION
The week grid's reserved gridded-forecast row promised readers something two
thirds of which can never ship. This corrects the promise and keeps the slot.

Small lane: page copy, no logic, no data shape, no contract, and it contradicts
nothing in `docs/adr/` or `CONTEXT.md`. **No plan file** — this is one nameable
change that finishes in one sitting and turns on no choice between approaches.

Relates to #95. Does not close it.

## What changed

The row read:

> Temperature, wind and sky for this beach's own grid cell, instead of the
> nearest airport's reading.

It now reads:

> Cloud cover for this beach's own grid cell, instead of the nearest airport's
> reading.

## Why

**Temperature and wind do not come from an airport, and must not move to a
forecast.** They come from the air station, which ADR-0010 split off precisely
so the scarcest variable would stop deciding where the temperature was measured.
Measured across the served inventory: air station min 0.7 km, p50 3.7 km, max
7.4 km, against sky's p50 7.9 km. ADR-0012 records them as among the
best-founded readings on the site. Replacing them with a forecast is the
displacement ADR-0019 named and explicitly declined to decide — *"A model
displacing a measurement the site would have published is a different decision
and is not made here."*

**Visibility cannot follow sky onto the grid at all.** Probed 2026-08-26 across
the 21 grid cells covering the 45 served beaches:

| variable | cells carrying values |
| --- | --- |
| `skyCover` | 21 of 21 (34–37 entries each) |
| `visibility` | **0 of 21** |
| `ceilingHeight` | **0 of 21** |

Both are declared keys in the gridpoint payload with empty `values` arrays. A
row promising visibility promises a product that does not exist. Full
measurement is on #95.

**The slot itself stays.** #95 is open and unresolved, and this file's own rule
is that a reserved slot comes out in the slice that fills it — removing it now
would leave the page promising less than it did, rather than promising it
accurately.

## Test

`the gridded row promises sky alone, not the readings that are already near`
asserts the rendered sentence rather than the constant, because the defect was a
reader being told something untrue. It fails on the old copy — confirmed before
the fix was restored:

```
 FAIL  src/components/conditions/WeekPanel.test.tsx > the gridded row promises sky alone, not the readings that are already near
AssertionError: expected 'A gridded forecast is coming.Temperat…' to match /cloud cover/i

- Expected:
/cloud cover/i

+ Received:
"A gridded forecast is coming.Temperature, wind and sky for this beach's own grid cell, instead of the nearest airport's reading."

 Test Files  1 failed (1)
      Tests  1 failed | 16 skipped (17)
```

## Gate

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

## Noticed, not filed

**The row's glyph is 💨.** It was chosen under ADR-0015 because the reserved row
and the air card describe the same product from different feeds, and the row was
then about wind among other things. A row about cloud alone may want a different
glyph. Changing it is a design decision in ADR-0015's vocabulary rather than a
copy fix, so it is left to the slice that fills the row, and the test's docstring
now says so.

## Not done

- The air card's own copy is untouched. It describes what actually ships today
  and ADR-0012 records it as having nothing left to disclose harder.
- Nothing about #95's decision is pre-empted. Whether a gridded forecast may take
  the observation's slot at all is still `needs-human`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
