### PR TITLE
Bind each beach to its National Weather Service forecast cell

### DIFF
--- a/docs/adr/0012-sky-and-visibility-kept-knowingly.md
+++ b/docs/adr/0012-sky-and-visibility-kept-knowingly.md
@@ -1,6 +1,6 @@
 # 0012 — Sky and visibility are kept knowingly, until a forecast can replace them
 
-Date: 2026-08-19. Status: accepted.
+Date: 2026-08-19. Status: superseded by ADR-0020, 2026-08-26.
 
 ## Context
 

--- a/docs/adr/0020-sky-leaves-the-card-for-the-week.md
+++ b/docs/adr/0020-sky-leaves-the-card-for-the-week.md
@@ -1,0 +1,214 @@
+# 0020 — Sky leaves the card for the week, and visibility leaves entirely
+
+Date: 2026-08-26. Status: accepted.
+
+Supersedes ADR-0012, which held sky and visibility on the now-card pending a
+forecast that could replace them **in that slot**. That is not what happens, so
+this is a supersession rather than an amendment: ADR-0012's reasoning no longer
+matches any decision in force, and editing it would leave a document arguing for
+a position nobody holds.
+
+## Context
+
+ADR-0012 kept an airport METAR's sky and visibility on every beach's air card,
+knowing the site's own reference forbids it. Its exit condition was #95 — a
+gridded National Weather Service forecast, published for the beach's own cell
+rather than an aerodrome's runway reference point — and it said in terms that if
+#95 stalled, "that justification expires, and the honest consequence is
+deletion."
+
+#95's measurement is now done. It changes the shape of the answer.
+
+### What the gridpoint carries
+
+Probed 2026-08-26 against `api.weather.gov` over all 45 served beaches and both
+ends of each segment: 89 of 90 ends resolved, into 21 distinct cells, all in
+office `SGX`.
+
+| variable        | cells carrying values            |
+| --------------- | -------------------------------- |
+| `skyCover`      | **21 of 21**, 34–37 entries each |
+| `visibility`    | **0 of 21**                      |
+| `ceilingHeight` | **0 of 21**                      |
+
+`visibility` and `ceilingHeight` are declared keys with empty `values` arrays at
+every cell. `skyCover` is in `wmoUnit:percent` on 3- and 6-hour steps across a
+`P7DT13H` window; the run seen was stamped `2026-08-26T18:36:01+00:00`.
+
+Fog survives, but not as a series. The `weather` product carries it as an
+occasional phenomenon: in three cells read in full, 12 entries each, 6 named a
+phenomenon — `fog` ×4, `rain_showers` ×2 — and 4 carried a visibility figure of
+1.609 km. So the beach's own cell does forecast fog, and does not measure
+visibility.
+
+**This is why the replacement ADR-0012 imagined does not exist.** It assumed one
+product would step into the slot the METAR vacated. Sky can move; visibility
+cannot follow it anywhere.
+
+### What the cell is
+
+Cells measure 2,512–2,525 m by 2,501–2,522 m. From a beach's own coordinate to
+the centre of the cell answering for it, over 89 ends: min 103 m, p50 999 m,
+p90 1,615 m, max 2,043 m. Against the sky station, re-derived over the same 45
+beaches: min 1.6 km, p50 7.9 km, p90 13.0 km, max 14.5 km, with 40 of 45 beyond
+5 km and 20 of 45 beyond 10 km.
+
+### The defect ADR-0012 did not name
+
+Distance was not the whole fault. Cell `SGX/53,19` holds four beaches, and on the
+day of measurement they were told opposite things:
+
+| beach                    | sky station     | what it said    |
+| ------------------------ | --------------- | --------------- |
+| La Jolla Community Beach | KNKX at 11.0 km | "Mostly Cloudy" |
+| WindanSea Beach          | KNKX at 13.5 km | "Mostly Cloudy" |
+| Bird Rock (NR)           | KSAN at 11.7 km | "Clear"         |
+| Tourmaline Surfing Park  | KSAN at 10.3 km | "Clear"         |
+
+Four beaches inside one 2.5 km square, given contradictory descriptions of the
+same sky, decided by which airport a join happened to bind. `SGX/57,9` splits the
+same way between KSAN and KSDM. No disclosure addresses this, because each
+sentence is individually true.
+
+## The decision
+
+**The gridded cloud-cover forecast fills a row in the week grid. The air card's
+sky group is deleted, and visibility is not published anywhere.**
+
+Three parts, and the order matters.
+
+**Sky moves to the week, not to the card.** A forecast in a forecast row is not
+standing in an observation's slot, so this needs no new provenance argument — it
+is ADR-0016's shipped shape reused. ADR-0012's closing consequence warned that
+"putting one in the other's slot without saying so would be a new provenance
+problem rather than a fix for this one." Nothing here does that. The card's
+lead figure stays a measurement; the week's rows stay forecasts.
+
+**The card's sky group is deleted rather than kept.** This is #91's Option 1,
+and it is now available because the objection that defeated it has gone. That
+objection was one sentence — "Loses the only cloud information on the site" —
+and it is false once the week row exists. The information survives, at a better
+provenance, in a slot that admits what it is.
+
+**Visibility is not replaced.** The gridpoint does not carry it, the fog
+phenomenon is a different kind of claim on a different cadence, and keeping the
+METAR figure alone would leave a single off-field aerodrome reading as the last
+survivor of the exact anti-pattern this supersession exists to end. The site
+publishes no visibility figure after this.
+
+**The row's statistic is cloud cover, and fog annotates it.** `skyCover` is
+populated for every cell and every step, so the row is never ragged; when the
+`weather` series names a phenomenon for a day, that day's cell says so. One row,
+one question — "what will the sky do" — which keeps ADR-0016's rule that a row's
+label names its own statistic. The phenomenon's 1.609 km visibility figure is
+**not** printed: it appears in about a third of entries, and a precision the rest
+of the row cannot match would read as a measurement.
+
+**The cell is bound by a join, and the end is chosen by elevation.** Every other
+binding here is a committed join with recorded provenance (ADR-0009), and a
+re-gridded forecast point is already named there as something this repo owns that
+rots. Distance cannot choose the end, because every point inside a cell is
+equally inside it. The criterion is the cell whose mean elevation is nearest sea
+level, which is derived from what a beach is rather than from the answer we
+wanted: it moves Del Mar City Beach from a 102 m cell to a 22 m one and La Jolla
+Shores Beach from 117 m to 0 m.
+
+## The bluff cells, and the limit of the evidence
+
+After end selection, three beaches still read a cell averaging far above sea
+level: Torrey Pines State Beach (102 m), Torrey Pines City Beach (117 m) and
+La Jolla Cove (106 m). Across all 89 ends the p50 is 2.1 m, so these are the
+exception rather than the rule.
+
+**They are served, and the provenance line says the cell spans the shore and the
+bluff above it.**
+
+The honest reason to serve rather than withhold is that the evidence is weaker
+than it looks. Cell elevation is the grid's **terrain** figure. It is not a
+demonstrated forecast error, and these fields are built by forecasters who know
+the terrain — a 117 m cell is not a 117 m forecast. That is a materially weaker
+proxy than ADR-0011's distances, every one of which measured a real separation
+between an instrument and a beach. Blanking three of the most-visited beaches on
+this coast, on a proxy, once the card's sky group is already gone, would cost a
+reader more than the caveat does.
+
+**The counter-argument, which is not silly:** a marine layer sitting on the sand
+while the clifftop is in sun is precisely the Torrey Pines failure mode, and a
+cell containing both is where a reader would most want the site to decline. If
+that turns out to be right, the remedy is a terrain bound sibling to
+`MODELLED_SOURCE_TOLERANCE_M`, and it is a smaller change than this one.
+
+## Alternatives considered
+
+**Replace the card's sky with the gridded value.** The literal reading of
+ADR-0012's exit condition. Rejected: the gridpoint has no observation in it — its
+earliest entry is the 3-hour block containing now — so this puts a forecast in a
+slot a reader currently reads as measured, which is the "different kind of wrong"
+#91's Option 3 named and ADR-0019 explicitly declined to decide ("a model
+displacing a measurement the site would have published is a different decision
+and is not made here"). Moving sky to the week costs nothing this would have
+bought and asks for none of the argument.
+
+**Fill the week row and leave the card's sky alone.** The smallest change that
+discharges the reserved slot. Rejected: it leaves the off-field METAR on the card
+with ADR-0012's exit condition spent and #95 closed, so the hold becomes
+permanent by attrition — the exact failure #95 was filed to prevent, one level up.
+It also leaves the site saying two things about one sky, one of them from an
+airport 14.5 km away.
+
+**Keep visibility on the card alone.** Sky moves, visibility stays. Rejected: it
+preserves a single aerodrome visibility reading as the last instance of the
+anti-pattern, in a stat group with one provenance and no company, and the
+sentence explaining it would have to say the site knows better and does it anyway.
+
+**Two rows, cloud cover and present weather.** Strictest reading of ADR-0016's
+label rule. Rejected on the measurement: most steps name no phenomenon at all, so
+the present-weather row is empty on most days, and a blank row in a seven-column
+grid reads as a fault rather than as "nothing forecast".
+
+**Cloud cover only, no fog relay.** Smallest, most uniform row. Rejected: it
+deletes the METAR visibility and puts no fog signal anywhere, on a coast where
+fog is the thing a parent is actually deciding about, while the fog forecast for
+the beach's own cell sits unread.
+
+**Read a neighbouring sea-level cell at the three bluff beaches.** Named only so
+it stays rejected: it reintroduces the off-site transfer this supersession exists
+to end, and the row's claim is the beach's _own_ cell.
+
+**Make the hold permanent and defend it.** Amend ADR-0012 to drop the exit
+condition and argue the disclosure is enough. Rejected: it is a coherent position
+and it was weighed, but it commits the site permanently to something its own
+reference lists under §12 anti-patterns, at the moment a better source has been
+measured and found to work.
+
+## Consequences
+
+- **The site publishes no current sky reading and no visibility at all.** A
+  reader gets today's cloud-cover forecast for this beach's cell, not what the
+  sky is doing this minute. That is a real loss of immediacy, accepted because
+  the thing lost was an aerodrome's sky at a median 7.9 km, and 20 of 45 beaches
+  read it from beyond 10 km.
+- **The air card keeps its name and loses two stats.** It is titled "Air" rather
+  than "Sky", so nothing has to be renamed. Temperature and wind — p50 3.7 km,
+  max 7.4 km — are untouched, which is what ADR-0010 split the provenances to
+  protect.
+- **`sky_station` leaves the inventory, and `publishes_sky` does not.** The
+  binding is a join result and goes with the join that made it; the flag is a
+  measurement of the network — 10 of 62 stations, every one an airport — and it
+  is the evidence this ADR and ADR-0012 both rest on. Deleting it would delete
+  the basis of the argument.
+- **`ConditionsNotes` keeps a sky entry and rewrites it.** A reader who wonders
+  where the sky reading went is owed the answer, and "no station near this shore
+  publishes it" is the answer.
+- **One beach has an end outside the grid.** Border Field State Park's lower end
+  returns `InvalidPoint`; its upper end resolves. The join takes the resolving
+  end and records that the other had none, rather than silently preferring one.
+- **17 of 45 beaches straddle two cells**, so `grid_cell_from_end` is not
+  decoration — it is the whole of how the binding is decided, and a re-join that
+  ignores it would move beaches between cells silently.
+- **A second NWS product enters the page,** from a host already spoken to for
+  observations, so the user-agent convention, the failure vocabulary and the
+  caching approach are all the existing ones.
+- **If the bluff-cell judgement is wrong,** the fix is a terrain tolerance beside
+  `MODELLED_SOURCE_TOLERANCE_M` and it withholds three cells. Nothing else in
+  this decision depends on it.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -16,8 +16,9 @@ Each file carries a note under its title:
 > It records what was intended then, not what the code does now, and is not
 > maintained. See [`README.md`](README.md).
 
-A plan still being worked carries no such note. Today every plan here is
-historical; nothing is in flight.
+A plan still being worked carries no such note. One plan is in flight —
+[`sky-from-the-grid.md`](sky-from-the-grid.md) — and every other file here is
+historical.
 
 ## What that means in practice
 

--- a/docs/plans/sky-from-the-grid.md
+++ b/docs/plans/sky-from-the-grid.md
@@ -1,0 +1,242 @@
+# Sky from the grid, and visibility gone
+
+Closes the question ADR-0012 held open. The decision is
+[`docs/adr/0020-sky-leaves-the-card-for-the-week.md`](../adr/0020-sky-leaves-the-card-for-the-week.md);
+this plan is how it gets built. Issues #95 and #91.
+
+## The problem, from the reader's point of view
+
+A parent opens a beach page to decide whether to take children to the coast
+tomorrow. The air card tells them the sky at that beach is "Mostly Cloudy" and
+visibility is over ten miles.
+
+Neither statement is about that beach. Both were measured at an airport — a
+median of 7.9 km away across all 45 served beaches, and beyond 10 km for 20 of
+them. `docs/reference/sensor-representativeness.md` §7 puts ceiling and
+visibility alone among the surface variables at **not transferable**, and §12
+names transferring aerodrome ceiling and visibility off-field as an
+anti-pattern to refuse.
+
+It is also inconsistent between neighbours in a way no disclosure covers.
+Measured 2026-08-26, four beaches inside one 2.5 km square were told opposite
+things:
+
+| beach                    | sky station     | what it said    |
+| ------------------------ | --------------- | --------------- |
+| La Jolla Community Beach | KNKX at 11.0 km | "Mostly Cloudy" |
+| WindanSea Beach          | KNKX at 13.5 km | "Mostly Cloudy" |
+| Bird Rock (NR)           | KSAN at 11.7 km | "Clear"         |
+| Tourmaline Surfing Park  | KSAN at 10.3 km | "Clear"         |
+
+Each sentence is individually true, which is why the existing disclosure does
+not help.
+
+Afterwards: the week grid carries a cloud-cover forecast for this beach's own
+grid cell, saying "fog" on the days fog is forecast, and the card carries
+temperature and wind and nothing else.
+
+## The upstream contract, measured rather than remembered
+
+Probed 2026-08-26 against `api.weather.gov` over all 45 served beaches and both
+ends of each segment. 89 of 90 ends resolved, into 21 distinct cells, all in
+office `SGX`.
+
+**Two requests, not one.** `/points/{lat},{lon}` resolves a coordinate to a
+cell. `/gridpoints/{office}/{x},{y}` returns the forecast and the cell's own
+polygon and mean elevation. There is no catalog to probe: unlike MOP lines or
+observation stations, a cell is derived per beach rather than drawn from a
+published table, so **this binding gets no data table of its own.**
+
+| variable        | cells carrying values            |
+| --------------- | -------------------------------- |
+| `skyCover`      | **21 of 21**, 34–37 entries each |
+| `visibility`    | **0 of 21**                      |
+| `ceilingHeight` | **0 of 21**                      |
+
+`visibility` and `ceilingHeight` are declared keys with empty `values` arrays at
+every cell. `skyCover` is `wmoUnit:percent` on 3- and 6-hour steps across a
+`P7DT13H` window.
+
+Fog is in the `weather` product as an occasional phenomenon, not a series: in
+three cells read in full, 12 entries each, 6 named a phenomenon — `fog` ×4,
+`rain_showers` ×2 — and 4 carried a visibility figure of 1.609 km.
+
+Failure vocabulary to pin:
+
+| condition                       | response                                |
+| ------------------------------- | --------------------------------------- |
+| coordinate outside the NWS grid | `404` `problems/InvalidPoint`           |
+| cell retired or re-gridded      | `404` on `/gridpoints`                  |
+| variable this site asks for     | present as a key with an empty `values` |
+
+That last row is the one to be careful about: **a declared key is not a
+populated one.** A parser checking `"skyCover" in properties` would pass while
+the feed carried nothing.
+
+## The join, measured
+
+Cells are 2,512–2,525 m by 2,501–2,522 m. Beach coordinate to the centre of its
+own cell, over 89 ends: min 103 m, p50 999 m, p90 1,615 m, max 2,043 m.
+
+**A beach is a segment and 17 of 45 straddle two cells**, so an end must be
+chosen. Distance cannot choose it — every point inside a cell is equally inside
+it — so the criterion is the cell whose mean elevation is nearest sea level.
+Over all 89 ends the p50 elevation is 2.1 m; five beaches have an end above
+50 m, and the criterion fixes two of them:
+
+| beach                    | best end                  | worst end                 |
+| ------------------------ | ------------------------- | ------------------------- |
+| Del Mar City Beach       | upper, `SGX/55,26`, 22 m  | lower, `SGX/55,25`, 102 m |
+| La Jolla Shores Beach    | lower, `SGX/54,21`, 0 m   | upper, `SGX/55,22`, 117 m |
+| Torrey Pines State Beach | upper, `SGX/55,25`, 102 m | lower, `SGX/55,22`, 117 m |
+| Torrey Pines City Beach  | both ends `SGX/55,22`,    | 117 m                     |
+| La Jolla Cove            | both ends `SGX/54,20`,    | 106 m                     |
+
+The three that remain are served with the bluff named in the provenance line.
+ADR-0020 records why, and records that the elevation proxy is weaker evidence
+than ADR-0011's instrument distances.
+
+**Border Field State Park's lower end returns `InvalidPoint`** — it is south of
+the border. Its upper end resolves to `SGX/57,7`. The join takes the resolving
+end and records that the other had none.
+
+## What is being built
+
+1. A `grid_cell` binding on each beach, with the cell id, the end it was
+   measured from, the cell's mean elevation, and a null reason when absent.
+2. A parser, a fetcher and a read for the gridded forecast, following the shape
+   `mop-forecast.ts` / `fetchMopForecast` / `readWaveWeek` already established.
+3. A cloud-cover row in the week grid, replacing the gridded `ReservedRow`.
+4. The removal of sky and visibility from the air card, and of the
+   `sky_station` binding that fed them.
+
+## The one thing not yet decided
+
+**ADR-0017 says every row leads with the extreme that falls in daylight** —
+"Lowest daylight tide", "Biggest daylight swell" — and carries the day's own
+extreme beside it.
+
+Cloud cover has no extreme in that sense. It is a field sampled every three
+hours, not an event with a peak. "Cloudiest daylight hour" would let a single
+90% step make an otherwise clear day read as overcast; "clearest" misleads the
+other way.
+
+**Recommendation: the daylight mean, labelled "Cloud by day", with no secondary
+figure.** It is the representative value rather than an extreme, which is a
+deliberate departure from ADR-0017 on the grounds that ADR-0017's argument is
+about _when a thing happens_ — a low tide at 3 AM is unreachable — and cloud
+cover does not happen at a time. The fog annotation carries the "when" instead,
+since that is the part of the sky a reader plans around.
+
+This wants settling before slice 4. If the answer is instead an extreme, the row
+label changes and nothing else does.
+
+## Test seams
+
+Agreed before starting, because they decide whether any of this can be
+verified.
+
+- **`parseGridpointForecast(payload, cell)`** — pure, offline, asserted against
+  a committed JSON fixture captured from a real response. Pins `skyCover`'s
+  `wmoUnit:percent`, the ISO-8601 interval form of `validTime`, and the
+  `weather` entry shape. **Asserts that a key present with an empty `values`
+  array is treated as absent**, which is the specific trap this feed sets.
+  Raises `NwsGridpointDriftError` for a shape or unit change and
+  `NwsGridpointNoDataError` for a cell that answered with nothing usable.
+  Existing seam shape: `parseMopForecast`, `parseNwsObservation`.
+- **`fetchGridForecast(cell)`** in `lib/upstream.ts` — names its own
+  `next.revalidate`, never throws, turns every failure above into an
+  `unavailable` carrying its reason and URL. Existing seam shape:
+  `fetchMopForecast`.
+- **`readSkyWeek(slug, nowMs)`** in `lib/conditions.ts` — `nowMs` injected, so
+  day selection and the daylight window are asserted against fixed instants and
+  no clock is read during a render. Existing seam shape: `readWaveWeek`.
+- **`bindGridCell(beach, resolvedEnds)`** in `scripts/grid-cell-join.mjs` —
+  pure, no network, called with already-resolved cells so the elevation
+  criterion and the `InvalidPoint` case are both asserted offline. Existing
+  seam shape: `bindMopLine`.
+- **`SkyWeek`** — a cell, not a row, because the grid is day-major. Existing
+  seam shape: `WaveWeek`.
+
+The join script's own HTTP calls stay outside a seam, for the reason
+`probe-observation-stations.mjs` gives about its own: it is not a gate row and
+its output is the committed binding.
+
+**A fixture-fed test only fails if it reads real data.** The parser fixture is a
+captured payload rather than a hand-written one, and the empty-`values` case is
+asserted from the real thing, because that is the assertion most likely to be
+written to pass rather than to check.
+
+## Slices
+
+Three PRs, split at the binding boundary and again at the deletion. **The
+ordering constraint is load-bearing: the deletion must not merge before the row
+exists**, or the site ships an interval with no cloud information at all. The
+reverse overlap — both the row and the card's sky live for a while — is
+acceptable and is the "beside" arrangement ADR-0016 already permits.
+
+**PR 1 — the binding.**
+
+1. **Bind each beach to its grid cell.** `scripts/grid-cell-join.mjs` resolves
+   both ends, chooses by cell elevation and records the choice;
+   `seed-beaches.mjs` wires it; `beaches.json` gains `grid_cell`,
+   `grid_cell_from_end`, `grid_cell_elevation_m` and `grid_cell_null_reason`;
+   `beaches.ts` gains the type and `gridCellFor`.
+
+**PR 2 — the reading and the row.**
+
+2. **Read a gridded forecast for a beach.** Parser and fixture, fetcher, and
+   `readSkyWeek` — a complete path from the network to a view model, verified
+   without touching the network.
+3. **Put cloud cover in the week grid.** `SkyWeek` renders a cell; `WeekPanel`
+   composes the row and drops the gridded `ReservedRow` in the same change; the
+   provenance line names the office, the cell and — at the three bluff beaches —
+   that the cell spans the shore and the bluff above it.
+
+**PR 3 — the deletion.**
+
+4. **Take sky and visibility off the air card.** `skyStats`, the sky
+   `StatGroup`, its `ProvenanceLine`, `SkyState` and `readSkyHalf` all go;
+   `ConditionsNotes`' "Sky and visibility" entry is rewritten to say why the
+   site publishes neither.
+5. **Retire the sky binding.** `sky_station`, `sky_station_distance_m`,
+   `sky_station_from_end` and `sky_station_null_reason` leave `beaches.json`;
+   `sky-join.mjs` and its test go; `skyStationFor` goes; the parser's `sky`,
+   `visibilityMi` and `visibilityAtCeiling` fields go. **`publishes_sky` stays**
+   — it is a measurement of the network, not a join result, and it is the
+   evidence ADR-0020 rests on. `CONTEXT.md` retires the "Sky station" term in
+   this slice, because this is where it stops being true.
+
+Slice 2 depends on 1. Slice 3 depends on 2. Slices 4 and 5 depend on 3, and 5
+depends on 4.
+
+## Considered and rejected
+
+Recorded in full in ADR-0020: replacing the card's sky with the gridded value;
+filling the row and leaving the card alone; keeping visibility on the card
+alone; two rows rather than one; cloud cover with no fog relay; reading a
+neighbouring sea-level cell at the bluff beaches; and making ADR-0012's hold
+permanent.
+
+One rejection belongs here rather than there, because it is about build order:
+
+**Deleting the card's sky first, then adding the row.** Smaller PRs and the
+anti-pattern goes sooner. Rejected: it leaves an interval with no cloud
+information anywhere on the site, which is the churn ADR-0012 warned costs a
+reader twice.
+
+## Out of scope
+
+- **Temperature and wind.** They come from the air station at p50 3.7 km and
+  max 7.4 km. ADR-0012 records them as among the best-founded readings here and
+  ADR-0019 declined to decide whether a model may displace a published
+  measurement. Nothing in this plan touches them.
+- **The surf zone forecast**, which is the other reserved row.
+- **The 10 km inventory bound** (ADR-0011) and the modelled-source tolerance
+  (ADR-0019). No beach enters or leaves the inventory here.
+- **A terrain tolerance for the bluff cells.** ADR-0020 records it as the remedy
+  if the judgement to serve them turns out wrong. It is not built now.
+- **The row's glyph.** The gridded `ReservedRow` carries 💨 under ADR-0015
+  because it was once about wind. Whether a cloud row wants a different glyph is
+  a design decision in that ADR's vocabulary, and it is settled in slice 3 with
+  a human looking at it rather than assumed here.

--- a/scripts/grid-cell-join.mjs
+++ b/scripts/grid-cell-join.mjs
@@ -1,0 +1,147 @@
+/**
+ * Binding a beach to its National Weather Service forecast cell.
+ *
+ * Pure, like the four joins beside it, and the same contract: a binding with
+ * the end it came from, or a null with a reason. What differs is what decides
+ * it, and the difference is forced rather than chosen.
+ *
+ * DISTANCE CANNOT CHOOSE THE END HERE. Every other join measures a beach
+ * against a point -- a station, a buoy, a model line -- and takes the nearer
+ * end. A forecast cell is an area about 2.5 km square, and every coordinate
+ * inside it is equally inside it: there is no distance to be nearer by. A beach
+ * is a segment, and 17 of the 45 served straddle a cell boundary, so an end
+ * still has to be picked.
+ *
+ * SO IT IS PICKED BY ELEVATION, WHICH IS ABOUT THE BEACH RATHER THAN ABOUT US.
+ * A beach is at sea level. Of two cells a beach's ends fall in, the one whose
+ * mean elevation is nearer sea level is the one describing this shore rather
+ * than the terrain behind it. Measured 2026-08-26 that moves Del Mar City Beach
+ * from a cell averaging 102 m to one averaging 22 m, and La Jolla Shores Beach
+ * from 117 m to 0 m. It does not rescue everything -- three beaches have no
+ * low-lying end to pick -- and ADR-0020 records why they are served anyway and
+ * how weak the proxy is.
+ *
+ * THE CRITERION IS NOT FITTED TO THE OUTCOME, and the distinction matters
+ * because ADR-0019 was explicit that a bound derived from the answer you wanted
+ * is not a bound. Sea level is where a beach is; it was not chosen because of
+ * which beaches it happened to move.
+ *
+ * IT READS A RESOLUTION RATHER THAN COMPUTING ONE. `/points` owns the mapping
+ * from a coordinate to a cell and it cannot be recomputed offline, so
+ * `probe-grid-cells.mjs` records it and this reads it. That keeps the join pure
+ * and testable, which is the same trade the other four make against their own
+ * tables.
+ */
+
+/** How far above sea level a cell may average before the page says so. */
+export const BLUFF_ELEVATION_M = 50;
+
+/**
+ * Bind one beach to a forecast cell.
+ *
+ * @param {{slug: string}} beach
+ * @param {{cells: Record<string, {elevation_m: number | null, delivers: boolean}>,
+ *   resolutions: Record<string, Record<string, {cell: string | null, reason?: string}>>}} table
+ * @returns {{cellId: string, fromEnd: string, elevationM: number | null}
+ *   | {cellId: null, reason: string}}
+ */
+export function bindGridCell(beach, table) {
+  const resolution = table.resolutions[beach.slug];
+
+  if (resolution === undefined) {
+    // Two different situations reach here and the wording has to fit both.
+    // `/points` needs a coordinate, and the only coordinates this repo holds
+    // are the served inventory's -- an excluded beach records why it was
+    // excluded and nothing else -- so the table covers the served beaches and
+    // the seed asks it about all 73. For an excluded beach this is expected and
+    // the binding is discarded; for a served one it means the inventory moved
+    // since the last probe, which `seed-beaches.mjs` raises rather than files
+    // away. Claiming staleness in both cases would cry wolf on 28 beaches
+    // every run.
+    return {
+      cellId: null,
+      reason:
+        `the forecast-cell table does not list ${beach.slug}; it covers the beaches this ` +
+        `site serves, because resolving a cell needs a coordinate and an excluded beach ` +
+        `has none recorded`,
+    };
+  }
+
+  const candidates = [];
+  const refusals = [];
+
+  for (const end of ["lower", "upper"]) {
+    const resolved = resolution[end];
+    if (resolved === undefined) continue;
+    if (resolved.cell === null) {
+      refusals.push(`${end}: ${resolved.reason}`);
+      continue;
+    }
+    const cell = table.cells[resolved.cell];
+    if (cell === undefined) {
+      refusals.push(
+        `${end}: cell ${resolved.cell} is named by the resolution and missing from the table`,
+      );
+      continue;
+    }
+    if (!cell.delivers) {
+      refusals.push(
+        `${end}: cell ${resolved.cell} answers but publishes no sky cover series`,
+      );
+      continue;
+    }
+    candidates.push({
+      cellId: resolved.cell,
+      fromEnd: end,
+      elevationM: cell.elevation_m,
+    });
+  }
+
+  if (candidates.length === 0) {
+    return {
+      cellId: null,
+      reason:
+        refusals.length > 0
+          ? `no forecast cell answers for this beach -- ${refusals.join("; ")}`
+          : "this beach's segment resolved to no forecast cell at either end",
+    };
+  }
+
+  let best = null;
+  for (const candidate of candidates) {
+    // A cell with no published elevation cannot win on elevation, but it can
+    // still be the only candidate. Sorting it last rather than dropping it is
+    // what keeps a beach bound when the figure is missing rather than high.
+    const height = candidate.elevationM ?? Number.POSITIVE_INFINITY;
+    const bestHeight =
+      best === null ? null : (best.elevationM ?? Number.POSITIVE_INFINITY);
+    // Ties break on the cell id, so two runs over the same inputs agree and the
+    // re-join's diff keeps meaning something. Both ends of 27 of 45 beaches
+    // resolve into one cell, where the tie is the common case rather than the
+    // edge one.
+    if (
+      best === null ||
+      height < bestHeight ||
+      (height === bestHeight && candidate.cellId < best.cellId)
+    ) {
+      best = candidate;
+    }
+  }
+
+  return best;
+}
+
+/**
+ * Whether a bound cell averages far enough above sea level that the page owes
+ * the reader a sentence about it.
+ *
+ * Separate from the binding because it is a fact about the cell rather than a
+ * reason to refuse one: ADR-0020 serves these beaches and discloses, rather
+ * than withholding.
+ *
+ * @param {number | null} elevationM
+ * @returns {boolean}
+ */
+export function spansBluff(elevationM) {
+  return elevationM !== null && elevationM > BLUFF_ELEVATION_M;
+}

--- a/scripts/grid-cell-join.test.mjs
+++ b/scripts/grid-cell-join.test.mjs
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import {
+  bindGridCell,
+  spansBluff,
+  BLUFF_ELEVATION_M,
+} from "./grid-cell-join.mjs";
+
+/**
+ * Five cells shaped like the ones this coast actually resolves into, measured
+ * 2026-08-26: two at sea level, two on the Torrey Pines and Point La Jolla
+ * bluffs, and one that answers without publishing sky.
+ */
+const CELLS = {
+  "SGX/54,21": { elevation_m: 0, delivers: true },
+  "SGX/55,26": { elevation_m: 21.9456, delivers: true },
+  "SGX/55,25": { elevation_m: 102.108, delivers: true },
+  "SGX/55,22": { elevation_m: 117.0432, delivers: true },
+  "SGX/57,7": { elevation_m: 4.8768, delivers: true },
+  "SGX/99,99": { elevation_m: 1, delivers: false },
+};
+
+const table = (resolutions) => ({ cells: CELLS, resolutions });
+
+describe("bindGridCell", () => {
+  it("binds a beach whose two ends fall in one cell", () => {
+    // 27 of 45 beaches do this, so the tie-break is the common path.
+    const bound = bindGridCell(
+      { slug: "la-jolla-cove" },
+      table({
+        "la-jolla-cove": {
+          upper: { cell: "SGX/55,22" },
+          lower: { cell: "SGX/55,22" },
+        },
+      }),
+    );
+    expect(bound.cellId).toBe("SGX/55,22");
+    expect(bound.elevationM).toBe(117.0432);
+  });
+
+  it("takes the end whose cell averages nearer sea level, not the first one", () => {
+    // Del Mar City Beach, measured: upper falls in a 22 m cell and lower in a
+    // 102 m one. A beach is at sea level, so the low cell is the one describing
+    // this shore rather than the terrain behind it.
+    const bound = bindGridCell(
+      { slug: "del-mar-city-beach" },
+      table({
+        "del-mar-city-beach": {
+          upper: { cell: "SGX/55,26" },
+          lower: { cell: "SGX/55,25" },
+        },
+      }),
+    );
+    expect(bound.cellId).toBe("SGX/55,26");
+    expect(bound.fromEnd).toBe("upper");
+  });
+
+  it("picks the low end even when it is the lower one", () => {
+    // La Jolla Shores Beach, the mirror case: 117 m upper, 0 m lower. If the
+    // criterion were "prefer upper" both tests would still pass, which is why
+    // both directions are asserted.
+    const bound = bindGridCell(
+      { slug: "la-jolla-shores-beach" },
+      table({
+        "la-jolla-shores-beach": {
+          upper: { cell: "SGX/55,22" },
+          lower: { cell: "SGX/54,21" },
+        },
+      }),
+    );
+    expect(bound.cellId).toBe("SGX/54,21");
+    expect(bound.fromEnd).toBe("lower");
+  });
+
+  it("binds the resolving end when the other is outside the grid", () => {
+    // Border Field State Park: its lower end is south of the border and
+    // /points answers InvalidPoint for it.
+    const bound = bindGridCell(
+      { slug: "border-field-state-park" },
+      table({
+        "border-field-state-park": {
+          upper: { cell: "SGX/57,7" },
+          lower: {
+            cell: null,
+            reason:
+              "the National Weather Service grid does not cover 32.534367,-117.124197",
+          },
+        },
+      }),
+    );
+    expect(bound.cellId).toBe("SGX/57,7");
+    expect(bound.fromEnd).toBe("upper");
+  });
+
+  it("refuses, with every end's reason, when no end resolved", () => {
+    const bound = bindGridCell(
+      { slug: "somewhere-else" },
+      table({
+        "somewhere-else": {
+          upper: { cell: null, reason: "the grid does not cover 20,20" },
+          lower: { cell: null, reason: "the grid does not cover 20,21" },
+        },
+      }),
+    );
+    expect(bound.cellId).toBeNull();
+    // Both reasons survive: a binding that failed twice for two reasons must
+    // not report one of them.
+    expect(bound.reason).toContain("20,20");
+    expect(bound.reason).toContain("20,21");
+  });
+
+  it("refuses a cell that answers but publishes no sky cover", () => {
+    // The trap this feed sets: every payload declares skyCover, visibility and
+    // ceilingHeight as keys, and a cell can carry an empty values array. The
+    // table records entries, and a cell with none is not a source.
+    const bound = bindGridCell(
+      { slug: "nowhere" },
+      table({ nowhere: { upper: { cell: "SGX/99,99" } } }),
+    );
+    expect(bound.cellId).toBeNull();
+    expect(bound.reason).toMatch(/publishes no sky cover/);
+  });
+
+  it("refuses a cell the resolution names and the table does not describe", () => {
+    // A broken pair of halves inside one file: the resolution says the end fell
+    // in a cell, and the cell block has no entry for it. Reported rather than
+    // thrown, so the seed records it against the beach the way every other
+    // refusal is recorded, and rather than crashing a build over one row.
+    const bound = bindGridCell(
+      { slug: "half-written" },
+      table({ "half-written": { upper: { cell: "SGX/12,34" } } }),
+    );
+    expect(bound.cellId).toBeNull();
+    expect(bound.reason).toMatch(/missing from the table/);
+    expect(bound.reason).toContain("SGX/12,34");
+  });
+
+  it("refuses a beach the table does not list, rather than throwing", () => {
+    const bound = bindGridCell({ slug: "brand-new-beach" }, table({}));
+    expect(bound.cellId).toBeNull();
+    expect(bound.reason).toMatch(/does not list brand-new-beach/);
+  });
+
+  it("still binds a cell whose elevation is missing", () => {
+    // A missing figure is not a high one. Sorting it last keeps it usable when
+    // it is the only candidate, which is the difference between a beach with no
+    // sky and a beach whose cell did not publish one number.
+    const bound = bindGridCell(
+      { slug: "unmeasured" },
+      table({
+        unmeasured: {
+          upper: { cell: "SGX/55,22" },
+          lower: { cell: "SGX/55,25" },
+        },
+      }),
+    );
+    expect(bound.cellId).toBe("SGX/55,25");
+
+    const only = bindGridCell(
+      { slug: "only-unmeasured" },
+      {
+        cells: { "SGX/1,1": { elevation_m: null, delivers: true } },
+        resolutions: { "only-unmeasured": { upper: { cell: "SGX/1,1" } } },
+      },
+    );
+    expect(only.cellId).toBe("SGX/1,1");
+    expect(only.elevationM).toBeNull();
+  });
+
+  it("is stable across runs when two ends tie", () => {
+    const resolutions = {
+      tied: { upper: { cell: "SGX/54,21" }, lower: { cell: "SGX/54,21" } },
+    };
+    const first = bindGridCell({ slug: "tied" }, table(resolutions));
+    const second = bindGridCell({ slug: "tied" }, table(resolutions));
+    expect(first).toEqual(second);
+  });
+});
+
+describe("spansBluff", () => {
+  it("marks the cells measured on the Torrey Pines and La Jolla bluffs", () => {
+    expect(spansBluff(117.0432)).toBe(true);
+    expect(spansBluff(102.108)).toBe(true);
+    expect(spansBluff(106.0704)).toBe(true);
+  });
+
+  it("leaves the shoreline cells alone", () => {
+    // p50 across all 89 measured segment ends was 2.1 m.
+    expect(spansBluff(0)).toBe(false);
+    expect(spansBluff(2.1336)).toBe(false);
+    expect(spansBluff(21.9456)).toBe(false);
+  });
+
+  it("says nothing about a cell with no published elevation", () => {
+    expect(spansBluff(null)).toBe(false);
+  });
+
+  it("is exclusive at the threshold", () => {
+    expect(spansBluff(BLUFF_ELEVATION_M)).toBe(false);
+    expect(spansBluff(BLUFF_ELEVATION_M + 0.0001)).toBe(true);
+  });
+});

--- a/scripts/probe-grid-cells.mjs
+++ b/scripts/probe-grid-cells.mjs
@@ -1,0 +1,316 @@
+/**
+ * Resolving this county's beaches to National Weather Service forecast cells.
+ *
+ *   node scripts/probe-grid-cells.mjs           write src/data/grid-cells.json
+ *   node scripts/probe-grid-cells.mjs --check   exit 1 if the committed file has moved
+ *
+ * WHY THIS TABLE HOLDS A RESOLUTION AND THE OTHERS DO NOT. `mop-lines.json` and
+ * `observation-stations.json` are catalogs of candidates with coordinates, and
+ * the join beside each one computes the distance itself. There is no catalog
+ * here. A forecast cell is not published as a point to measure against -- the
+ * mapping from a coordinate to a cell is `/points`, and it belongs to the
+ * National Weather Service. So the measurement recorded here IS that mapping,
+ * per segment end, and `grid-cell-join.mjs` stays pure by reading it rather
+ * than by recomputing something it cannot compute.
+ *
+ * TWO REQUESTS PER CELL, AND ONLY ONE PER END. `/points/{lat},{lon}` answers
+ * which cell a coordinate falls in; `/gridpoints/{office}/{x},{y}` carries the
+ * cell's own mean elevation and its forecast. Ends are resolved individually
+ * because a beach is a segment and 17 of 45 straddle a cell boundary, and cells
+ * are then fetched once each rather than once per end -- 21 cells served 89
+ * ends when this was first run.
+ *
+ * WHAT `delivers` MEANS HERE, AND WHY IT IS NOT ASSUMED. A cell that answers
+ * `/gridpoints` at all is not a cell that publishes sky: `skyCover`,
+ * `visibility` and `ceilingHeight` are all declared keys in every payload, and
+ * measured 2026-08-26 the last two carried an empty `values` array at every one
+ * of the 21 cells while `skyCover` carried 34 to 37 entries. A key is not a
+ * value. `delivers` counts entries.
+ *
+ * A COORDINATE CAN FALL OUTSIDE THE GRID. Border Field State Park's lower end
+ * is south of the border and `/points` answers 404 `InvalidPoint` for it. That
+ * is recorded against the end rather than dropped, because a beach with one
+ * unresolvable end is a different thing from a beach with none, and the join
+ * has to be able to tell them apart.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { generatedDate } from "./generated-date.mjs";
+
+const API = "https://api.weather.gov";
+
+export const NWS_DOCS =
+  "https://www.weather.gov/documentation/services-web-api";
+
+const USER_AGENT =
+  "wild-coast-kids/0.1 (+https://github.com/cweber12/wild-coast-kids) conditions";
+
+const TABLE_PATH = new URL("../src/data/grid-cells.json", import.meta.url);
+const BEACHES_PATH = new URL("../src/data/beaches.json", import.meta.url);
+
+/** `SGX/55,25`. The office and the two indices, which together name a cell. */
+export const CELL_ID = /^[A-Z]{3}\/\d+,\d+$/;
+
+/** What `/points` answers for a coordinate the grid does not cover. */
+const INVALID_POINT = "problems/InvalidPoint";
+
+/**
+ * The cell a `/points` payload names.
+ *
+ * @param {unknown} payload
+ * @returns {{cellId: string, office: string, x: number, y: number}}
+ */
+export function parsePoint(payload) {
+  const properties = payload?.properties;
+  if (!properties || typeof properties !== "object") {
+    throw new Error(
+      "api.weather.gov /points answered without a properties object",
+    );
+  }
+
+  const { gridId, gridX, gridY } = properties;
+  if (typeof gridId !== "string" || gridId.length === 0) {
+    throw new Error(
+      `api.weather.gov /points answered gridId ${JSON.stringify(gridId)}, which is not an office`,
+    );
+  }
+  if (!Number.isInteger(gridX) || !Number.isInteger(gridY)) {
+    throw new Error(
+      `api.weather.gov /points answered gridX ${JSON.stringify(gridX)} and gridY ` +
+        `${JSON.stringify(gridY)}; both must be integers`,
+    );
+  }
+
+  return {
+    cellId: `${gridId}/${gridX},${gridY}`,
+    office: gridId,
+    x: gridX,
+    y: gridY,
+  };
+}
+
+/**
+ * What a `/gridpoints` payload says about the cell itself.
+ *
+ * `delivers` counts `skyCover` entries rather than testing for the key, which
+ * is the whole point: every payload declares the key.
+ *
+ * @param {unknown} payload
+ * @returns {{elevationM: number | null, skyCoverEntries: number,
+ *   visibilityEntries: number, ceilingEntries: number, delivers: boolean}}
+ */
+export function parseCell(payload) {
+  const properties = payload?.properties;
+  if (!properties || typeof properties !== "object") {
+    throw new Error(
+      "api.weather.gov /gridpoints answered without a properties object",
+    );
+  }
+
+  const entries = (key) => {
+    const series = properties[key];
+    if (series === undefined) return 0;
+    const values = series?.values;
+    return Array.isArray(values) ? values.length : 0;
+  };
+
+  const elevation = properties.elevation;
+  if (elevation !== undefined && elevation !== null) {
+    if (elevation.unitCode !== "wmoUnit:m") {
+      throw new Error(
+        `api.weather.gov /gridpoints declared elevation in ${JSON.stringify(elevation.unitCode)}; ` +
+          `this table records metres and will not convert silently`,
+      );
+    }
+  }
+
+  const skyCoverEntries = entries("skyCover");
+
+  return {
+    elevationM: typeof elevation?.value === "number" ? elevation.value : null,
+    skyCoverEntries,
+    visibilityEntries: entries("visibility"),
+    ceilingEntries: entries("ceilingHeight"),
+    delivers: skyCoverEntries > 0,
+  };
+}
+
+async function getJson(url) {
+  const response = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT, Accept: "application/geo+json" },
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    return { ok: false, status: response.status, body };
+  }
+  return { ok: true, body: await response.json() };
+}
+
+/**
+ * Build the table from resolved ends and fetched cells.
+ *
+ * Pure, so the document's shape is asserted without a network.
+ *
+ * @param {Record<string, Record<string, {cellId: string | null, reason?: string}>>} resolutions
+ * @param {Record<string, object>} cells
+ */
+export function buildTable(resolutions, cells) {
+  const sortedCells = Object.fromEntries(
+    Object.keys(cells)
+      .sort()
+      .map((id) => [id, cells[id]]),
+  );
+  const sortedResolutions = Object.fromEntries(
+    Object.keys(resolutions)
+      .sort()
+      .map((slug) => [slug, resolutions[slug]]),
+  );
+  return { cells: sortedCells, resolutions: sortedResolutions };
+}
+
+export function document(table, now = new Date()) {
+  const cells = Object.values(table.cells);
+  const delivering = cells.filter((cell) => cell.delivers).length;
+  const withVisibility = cells.filter(
+    (cell) => cell.visibility_entries > 0,
+  ).length;
+
+  return {
+    version: "0.1.0",
+    generated: generatedDate(now),
+    _provenance:
+      `Measured by scripts/probe-grid-cells.mjs against ${API}; re-runnable and diffable ` +
+      `with --check. Each beach segment end is resolved by /points, which is the National ` +
+      `Weather Service's own mapping from a coordinate to a forecast cell and cannot be ` +
+      `recomputed offline; each distinct cell is then read once from /gridpoints for its ` +
+      `mean elevation and its published series. See ${NWS_DOCS}.`,
+    _what_was_measured:
+      `${cells.length} distinct cells serve this inventory, of which ${delivering} publish a ` +
+      `sky cover series. ${withVisibility} publish a visibility series -- a key present with ` +
+      `an empty values array is not a published variable, and every cell declares visibility ` +
+      `and ceilingHeight whether or not it fills them. That is why delivers counts entries.`,
+    _schema: {
+      "cells.<id>.office: ": "The forecast office, from /points gridId.",
+      "cells.<id>.x": "Grid column, from /points gridX.",
+      "cells.<id>.y": "Grid row, from /points gridY.",
+      "cells.<id>.elevation_m":
+        "The cell's own mean elevation in metres, as /gridpoints publishes it. This is the " +
+        "cell's terrain rather than a statement about the forecast, and the join uses it to " +
+        "choose between a beach's two ends. See docs/adr/0020-sky-leaves-the-card-for-the-week.md.",
+      "cells.<id>.sky_cover_entries":
+        "How many skyCover values the cell published when measured. Zero means the cell " +
+        "answers and does not forecast sky.",
+      "cells.<id>.visibility_entries":
+        "How many visibility values the cell published. Measured zero everywhere; recorded " +
+        "rather than assumed, so a change upstream shows up as a diff.",
+      "cells.<id>.ceiling_entries": "The same count for ceilingHeight.",
+      "cells.<id>.delivers":
+        "Whether the cell publishes sky cover. Derived from sky_cover_entries, never from " +
+        "the presence of the key.",
+      "resolutions.<slug>.<end>.cell":
+        "The cell that segment end falls in, or null when the grid does not cover it.",
+      "resolutions.<slug>.<end>.reason":
+        "Present only when cell is null. What /points said.",
+    },
+    ...table,
+  };
+}
+
+async function main() {
+  const checkOnly = process.argv.includes("--check");
+
+  const beaches = JSON.parse(readFileSync(BEACHES_PATH, "utf8")).beaches;
+
+  const resolutions = {};
+  const cellIds = new Set();
+
+  for (const beach of beaches) {
+    resolutions[beach.slug] = {};
+    for (const end of ["upper", "lower"]) {
+      const { lat, lon } = beach.segment[end];
+      const result = await getJson(`${API}/points/${lat},${lon}`);
+      if (!result.ok) {
+        const outside = result.body.includes(INVALID_POINT);
+        resolutions[beach.slug][end] = {
+          cell: null,
+          reason: outside
+            ? `the National Weather Service grid does not cover ${lat},${lon}`
+            : `/points answered HTTP ${result.status} for ${lat},${lon}`,
+        };
+        process.stderr.write(`x ${beach.slug}/${end} HTTP ${result.status}\n`);
+        continue;
+      }
+      const { cellId } = parsePoint(result.body);
+      resolutions[beach.slug][end] = { cell: cellId };
+      cellIds.add(cellId);
+      process.stderr.write(`. ${beach.slug}/${end} -> ${cellId}\n`);
+    }
+  }
+
+  const cells = {};
+  for (const cellId of [...cellIds].sort()) {
+    const result = await getJson(`${API}/gridpoints/${cellId}`);
+    if (!result.ok) {
+      throw new Error(
+        `/gridpoints answered HTTP ${result.status} for ${cellId}, which /points had just ` +
+          `named. The grid has moved under this table; re-run and read the diff.`,
+      );
+    }
+    const parsed = parseCell(result.body);
+    const [office, indices] = cellId.split("/");
+    const [x, y] = indices.split(",").map(Number);
+    cells[cellId] = {
+      office,
+      x,
+      y,
+      elevation_m: parsed.elevationM,
+      sky_cover_entries: parsed.skyCoverEntries,
+      visibility_entries: parsed.visibilityEntries,
+      ceiling_entries: parsed.ceilingEntries,
+      delivers: parsed.delivers,
+    };
+    process.stderr.write(
+      `. ${cellId} sky=${parsed.skyCoverEntries} vis=${parsed.visibilityEntries} ` +
+        `elev=${parsed.elevationM}\n`,
+    );
+  }
+
+  const built = document(buildTable(resolutions, cells));
+  const serialised = `${JSON.stringify(built, null, 2)}\n`;
+
+  if (checkOnly) {
+    let committed;
+    try {
+      committed = readFileSync(TABLE_PATH, "utf8");
+    } catch {
+      throw new Error(
+        "grid-cells.json is missing. Run without --check to write it.",
+      );
+    }
+    // The generated date moves on every run and is not a measurement, so it is
+    // excluded from the comparison the way probe-mop-lines.mjs excludes its own.
+    const strip = (text) => text.replace(/"generated": "[^"]*"/, "");
+    if (strip(committed) !== strip(serialised)) {
+      throw new Error(
+        "grid-cells.json has moved. Re-run without --check, read the diff, and say in the " +
+          "commit message what changed upstream.",
+      );
+    }
+    process.stderr.write("grid-cells.json is unchanged.\n");
+    return;
+  }
+
+  writeFileSync(TABLE_PATH, serialised, "utf8");
+  process.stderr.write(
+    `wrote grid-cells.json: ${Object.keys(cells).length} cells, ` +
+      `${Object.keys(resolutions).length} beaches\n`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/scripts/probe-grid-cells.test.mjs
+++ b/scripts/probe-grid-cells.test.mjs
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTable,
+  CELL_ID,
+  document,
+  parseCell,
+  parsePoint,
+} from "./probe-grid-cells.mjs";
+
+/**
+ * Trimmed from a real `/points` response for Del Mar City Beach's lower end,
+ * 2026-08-26. Kept in the shape the API serves rather than the shape this
+ * script wants, so a field moving is a failure here.
+ */
+const POINT = {
+  properties: {
+    gridId: "SGX",
+    gridX: 55,
+    gridY: 25,
+    forecastGridData: "https://api.weather.gov/gridpoints/SGX/55,25",
+  },
+};
+
+describe("parsePoint", () => {
+  it("names the cell from the office and the two indices", () => {
+    const parsed = parsePoint(POINT);
+    expect(parsed.cellId).toBe("SGX/55,25");
+    expect(parsed.cellId).toMatch(CELL_ID);
+    expect(parsed).toMatchObject({ office: "SGX", x: 55, y: 25 });
+  });
+
+  it("refuses a payload with no properties rather than yielding undefined/NaN", () => {
+    expect(() => parsePoint({})).toThrow(/properties/);
+    expect(() => parsePoint(null)).toThrow(/properties/);
+  });
+
+  it("refuses a non-integer index instead of building SGX/undefined,NaN", () => {
+    expect(() =>
+      parsePoint({ properties: { gridId: "SGX", gridX: "55", gridY: 25 } }),
+    ).toThrow(/integers/);
+    expect(() =>
+      parsePoint({ properties: { gridId: "SGX", gridX: 55 } }),
+    ).toThrow(/integers/);
+  });
+
+  it("refuses a missing office", () => {
+    expect(() => parsePoint({ properties: { gridX: 55, gridY: 25 } })).toThrow(
+      /office/,
+    );
+  });
+});
+
+/**
+ * The shape `/gridpoints` actually serves, and the reason this script exists:
+ * `visibility` and `ceilingHeight` are present as keys with empty `values`
+ * arrays at every cell measured, while `skyCover` carries real entries.
+ */
+const CELL = {
+  properties: {
+    elevation: { unitCode: "wmoUnit:m", value: 102.108 },
+    skyCover: {
+      uom: "wmoUnit:percent",
+      values: [
+        { validTime: "2026-08-26T12:00:00+00:00/PT3H", value: 59 },
+        { validTime: "2026-08-26T15:00:00+00:00/PT3H", value: 23 },
+      ],
+    },
+    visibility: { values: [] },
+    ceilingHeight: { values: [] },
+    weather: {
+      values: [
+        {
+          validTime: "2026-08-26T12:00:00+00:00/PT3H",
+          value: [
+            {
+              coverage: "patchy",
+              weather: "fog",
+              visibility: { unitCode: "wmoUnit:km", value: 1.609344 },
+            },
+          ],
+        },
+      ],
+    },
+  },
+};
+
+describe("parseCell", () => {
+  it("reads the cell's own mean elevation in metres", () => {
+    expect(parseCell(CELL).elevationM).toBe(102.108);
+  });
+
+  it("counts entries rather than testing for the key", () => {
+    // THE POINT OF THIS SCRIPT. Every payload declares visibility and
+    // ceilingHeight. A probe asking `"visibility" in properties` would record
+    // this cell as publishing a variable it publishes nothing for.
+    const parsed = parseCell(CELL);
+    expect(parsed.skyCoverEntries).toBe(2);
+    expect(parsed.visibilityEntries).toBe(0);
+    expect(parsed.ceilingEntries).toBe(0);
+    expect(parsed.delivers).toBe(true);
+  });
+
+  it("does not deliver when skyCover is declared and empty", () => {
+    const empty = {
+      properties: { ...CELL.properties, skyCover: { values: [] } },
+    };
+    expect(parseCell(empty).delivers).toBe(false);
+    expect(parseCell(empty).skyCoverEntries).toBe(0);
+  });
+
+  it("treats an absent key as zero rather than throwing", () => {
+    const properties = { ...CELL.properties };
+    delete properties.visibility;
+    expect(parseCell({ properties }).visibilityEntries).toBe(0);
+  });
+
+  it("refuses an elevation in units this table does not record", () => {
+    // A silent foot-to-metre confusion here would put every beach on a bluff.
+    expect(() =>
+      parseCell({
+        properties: {
+          ...CELL.properties,
+          elevation: { unitCode: "wmoUnit:ft", value: 335 },
+        },
+      }),
+    ).toThrow(/metres/);
+  });
+
+  it("records a missing elevation as null rather than as zero", () => {
+    const properties = { ...CELL.properties };
+    delete properties.elevation;
+    expect(parseCell({ properties }).elevationM).toBeNull();
+  });
+
+  it("refuses a payload with no properties", () => {
+    expect(() => parseCell({})).toThrow(/properties/);
+  });
+});
+
+describe("the document", () => {
+  const TABLE = buildTable(
+    {
+      "del-mar-city-beach": {
+        upper: { cell: "SGX/55,26" },
+        lower: { cell: "SGX/55,25" },
+      },
+      "border-field-state-park": {
+        upper: { cell: "SGX/57,7" },
+        lower: { cell: null, reason: "the grid does not cover 32.53,-117.12" },
+      },
+    },
+    {
+      "SGX/55,25": {
+        elevation_m: 102.108,
+        sky_cover_entries: 37,
+        visibility_entries: 0,
+        ceiling_entries: 0,
+        delivers: true,
+      },
+      "SGX/55,26": {
+        elevation_m: 21.9456,
+        sky_cover_entries: 37,
+        visibility_entries: 0,
+        ceiling_entries: 0,
+        delivers: true,
+      },
+      "SGX/57,7": {
+        elevation_m: 4.8768,
+        sky_cover_entries: 37,
+        visibility_entries: 0,
+        ceiling_entries: 0,
+        delivers: true,
+      },
+    },
+  );
+
+  it("sorts both halves, so two runs over the same data produce one file", () => {
+    expect(Object.keys(TABLE.cells)).toEqual([
+      "SGX/55,25",
+      "SGX/55,26",
+      "SGX/57,7",
+    ]);
+    expect(Object.keys(TABLE.resolutions)).toEqual([
+      "border-field-state-park",
+      "del-mar-city-beach",
+    ]);
+  });
+
+  it("states what was measured, including the count that is zero", () => {
+    const built = document(TABLE, new Date("2026-08-26T12:00:00Z"));
+    expect(built._what_was_measured).toContain("3 distinct cells");
+    expect(built._what_was_measured).toContain("0 publish a visibility series");
+    // The reason the zero is stated rather than omitted: it is the finding.
+    expect(built._what_was_measured).toMatch(/empty values array/);
+  });
+
+  it("keeps the resolution that failed, with its reason", () => {
+    const built = document(TABLE, new Date("2026-08-26T12:00:00Z"));
+    expect(built.resolutions["border-field-state-park"].lower).toEqual({
+      cell: null,
+      reason: "the grid does not cover 32.53,-117.12",
+    });
+  });
+});

--- a/scripts/seed-beaches.mjs
+++ b/scripts/seed-beaches.mjs
@@ -41,6 +41,7 @@ import { pathToFileURL } from "node:url";
 import { distanceMetres } from "./geo.mjs";
 import { generatedDate } from "./generated-date.mjs";
 import { bindAirStation } from "./air-join.mjs";
+import { bindGridCell } from "./grid-cell-join.mjs";
 import { bindMopLine } from "./mop-join.mjs";
 import { bindTideStation } from "./tide-join.mjs";
 import { bindWaveBuoy } from "./wave-join.mjs";
@@ -55,6 +56,7 @@ const MIRROR_RESOURCE = "fcbc9250-06e3-437d-b0c6-3cc5ddde93fc";
 const BEACHES_PATH = new URL("../src/data/beaches.json", import.meta.url);
 const BUOYS_PATH = new URL("../src/data/wave-buoys.json", import.meta.url);
 const MOP_LINES_PATH = new URL("../src/data/mop-lines.json", import.meta.url);
+const GRID_CELLS_PATH = new URL("../src/data/grid-cells.json", import.meta.url);
 const STATIONS_PATH = new URL(
   "../src/data/tide-stations.json",
   import.meta.url,
@@ -214,7 +216,14 @@ export function regionOf(waterClass, meanLat) {
   return "South County coast";
 }
 
-export function build(rows, stations, buoys, observationStations, mopLines) {
+export function build(
+  rows,
+  stations,
+  buoys,
+  observationStations,
+  mopLines,
+  gridCells,
+) {
   const seen = new Map();
 
   const joined = rows.map((row) => {
@@ -271,6 +280,14 @@ export function build(rows, stations, buoys, observationStations, mopLines) {
     const sky = fault
       ? { stationId: null, reason: fault }
       : bindSkyStation({ segment }, observationStations);
+    // Neither a distance nor a water class decides this one. A forecast cell is
+    // an area, so there is nothing to be nearer by; the end is chosen by which
+    // cell averages nearer sea level, which is where a beach is. It reads a
+    // resolution rather than computing one because /points owns the mapping
+    // from a coordinate to a cell -- see grid-cell-join.mjs and ADR-0020.
+    const grid = fault
+      ? { cellId: null, reason: fault }
+      : bindGridCell({ slug }, gridCells);
     const air = fault
       ? { stationId: null, reason: fault }
       : bindAirStation(
@@ -313,6 +330,10 @@ export function build(rows, stations, buoys, observationStations, mopLines) {
       sky_station_distance_m: sky.stationId ? Math.round(sky.distanceM) : null,
       sky_station_from_end: sky.stationId ? sky.fromEnd : null,
       sky_station_null_reason: sky.stationId ? undefined : sky.reason,
+      grid_cell: grid.cellId,
+      grid_cell_from_end: grid.cellId ? grid.fromEnd : null,
+      grid_cell_elevation_m: grid.cellId ? grid.elevationM : null,
+      grid_cell_null_reason: grid.cellId ? undefined : grid.reason,
       air_station: air.stationId,
       air_station_distance_m: air.stationId ? Math.round(air.distanceM) : null,
       air_station_from_end: air.stationId ? air.fromEnd : null,
@@ -691,6 +712,25 @@ export function document(built, now = new Date()) {
         "and buoy distances by nature: the ten stations that publish sky are all airports.",
       sky_station_from_end:
         "Which end of the segment supplied the distance, upper or lower.",
+      grid_cell:
+        "Joined, never typed: the National Weather Service forecast cell this beach falls in, " +
+        "as office/x,y. NOT a nearest-anything -- a cell is an area about 2.5 km square and " +
+        "every coordinate inside it is equally inside it, so there is no distance to be " +
+        "nearer by and this field has none beside it. The mapping from a coordinate to a cell " +
+        "belongs to the National Weather Service and cannot be recomputed offline, so it is " +
+        "measured into grid-cells.json and read from there. null means no cell answers, and " +
+        "grid_cell_null_reason says why -- which for an excluded beach is simply that the " +
+        "table records coordinates only for the beaches this site serves.",
+      grid_cell_from_end:
+        "Which end of the segment fell in the bound cell. Load-bearing rather than " +
+        "decoration: a beach is a segment and 17 of 45 straddle a cell boundary, so an end " +
+        "had to be chosen and this records which. The criterion is elevation, not distance.",
+      grid_cell_elevation_m:
+        "The bound cell's own mean elevation in metres. This is the cell's TERRAIN and not a " +
+        "statement about the forecast: it is what chose between the beach's two ends, on the " +
+        "grounds that a beach is at sea level and the lower cell is the one describing this " +
+        "shore. Three beaches have no low-lying end and read a cell averaging over 100 m; the " +
+        "page says so where it shows one. See docs/adr/0020-sky-leaves-the-card-for-the-week.md.",
       air_station:
         "Joined, never typed: the nearest station that answers, publishes air temperature AND " +
         "wind, and suits the beach's water class -- an open-coast beach binds a shore station, " +
@@ -792,6 +832,7 @@ async function main() {
   const stations = JSON.parse(readFileSync(STATIONS_PATH, "utf8")).stations;
   const buoys = JSON.parse(readFileSync(BUOYS_PATH, "utf8")).buoys;
   const mopLines = JSON.parse(readFileSync(MOP_LINES_PATH, "utf8")).lines;
+  const gridCells = JSON.parse(readFileSync(GRID_CELLS_PATH, "utf8"));
   const observationStations = JSON.parse(
     readFileSync(OBSERVATION_STATIONS_PATH, "utf8"),
   ).stations;
@@ -804,7 +845,7 @@ async function main() {
 
   const rows = await fetchRows();
   const built = document(
-    build(rows, stations, buoys, observationStations, mopLines),
+    build(rows, stations, buoys, observationStations, mopLines, gridCells),
   );
 
   // `generated` is the one field that moves on every run by design, so comparing

--- a/scripts/seed-beaches.test.mjs
+++ b/scripts/seed-beaches.test.mjs
@@ -41,6 +41,42 @@ const MOP_LINES = {
   D0085: { lat: 32.60799, lon: -117.13976, delivers: true },
 };
 
+/**
+ * Forecast cells for the slugs these rows produce. Both ends land in one cell
+ * for every fixture beach except `somewhere-beach`, which straddles two so the
+ * elevation criterion is exercised by the seed rather than only by the join's
+ * own test.
+ */
+const GRID_CELLS = {
+  cells: {
+    "SGX/54,21": { elevation_m: 0, delivers: true },
+    "SGX/55,22": { elevation_m: 117.0432, delivers: true },
+    "SGX/57,8": { elevation_m: 0.9144, delivers: true },
+  },
+  resolutions: {
+    "somewhere-beach": {
+      upper: { cell: "SGX/55,22" },
+      lower: { cell: "SGX/54,21" },
+    },
+    "far-from-any-station": {
+      upper: { cell: "SGX/54,21" },
+      lower: { cell: "SGX/54,21" },
+    },
+    "no-buoy-reaches-here": {
+      upper: { cell: "SGX/57,8" },
+      lower: { cell: "SGX/57,8" },
+    },
+    "quiet-bay": {
+      upper: { cell: "SGX/54,21" },
+      lower: { cell: "SGX/54,21" },
+    },
+    "imperial-beach-pier-area": {
+      upper: { cell: "SGX/57,8" },
+      lower: { cell: "SGX/57,8" },
+    },
+  },
+};
+
 const STATIONS = {
   9410230: {
     lat: 32.8669,
@@ -233,6 +269,7 @@ describe("build", () => {
       BUOYS,
       OBSERVATION_STATIONS,
       MOP_LINES,
+      GRID_CELLS,
     );
 
     expect(beach.slug).toBe("somewhere-beach");
@@ -265,6 +302,60 @@ describe("build", () => {
     expect(["upper", "lower"]).toContain(beach.sky_station_from_end);
   });
 
+  it("binds a forecast cell, and carries no distance beside it", () => {
+    // The one binding on a beach with no *_distance_m, and the absence is the
+    // assertion: a cell is an area about 2.5 km square, so there is nothing to
+    // be nearer by and a distance here would be an invented precision.
+    const [beach] = build(
+      [row()],
+      STATIONS,
+      BUOYS,
+      OBSERVATION_STATIONS,
+      MOP_LINES,
+      GRID_CELLS,
+    );
+
+    expect(beach.grid_cell).toBe("SGX/54,21");
+    expect(beach).not.toHaveProperty("grid_cell_distance_m");
+    expect(beach.grid_cell_null_reason).toBeUndefined();
+  });
+
+  it("chooses the end whose cell averages nearer sea level", () => {
+    // somewhere-beach straddles two cells: its upper end falls on a 117 m
+    // bluff cell and its lower end at sea level. Every other binding on this
+    // row takes the *nearer* end; this one takes the *lower* one, and the two
+    // criteria disagree here on purpose.
+    const [beach] = build(
+      [row()],
+      STATIONS,
+      BUOYS,
+      OBSERVATION_STATIONS,
+      MOP_LINES,
+      GRID_CELLS,
+    );
+
+    expect(beach.grid_cell_from_end).toBe("lower");
+    expect(beach.grid_cell_elevation_m).toBe(0);
+  });
+
+  it("says why, when the table does not list the beach", () => {
+    // What every excluded beach hits, because resolving a cell needs a
+    // coordinate and an excluded beach records none. A null with no reason
+    // would be the silent failure this repo does not ship.
+    const [beach] = build(
+      [row({ Beach_Name: "Unprobed Cove" })],
+      STATIONS,
+      BUOYS,
+      OBSERVATION_STATIONS,
+      MOP_LINES,
+      GRID_CELLS,
+    );
+
+    expect(beach.grid_cell).toBeNull();
+    expect(beach.grid_cell_elevation_m).toBeNull();
+    expect(beach.grid_cell_null_reason).toMatch(/does not list unprobed-cove/);
+  });
+
   it("binds the air separately from the sky, and nearer", () => {
     // The two provenances, produced by two joins over one table. The sky
     // station is the nearest airport; the air station is the nearest station
@@ -276,6 +367,7 @@ describe("build", () => {
       BUOYS,
       OBSERVATION_STATIONS,
       MOP_LINES,
+      GRID_CELLS,
     );
 
     expect(beach.air_station).toBe("LJAC1");
@@ -295,6 +387,7 @@ describe("build", () => {
       BUOYS,
       OBSERVATION_STATIONS,
       MOP_LINES,
+      GRID_CELLS,
     );
 
     expect(beach.air_station).not.toBe("D3101");
@@ -307,6 +400,7 @@ describe("build", () => {
       BUOYS,
       OBSERVATION_STATIONS,
       MOP_LINES,
+      GRID_CELLS,
     );
 
     // Swell does not reach into a bay, and the tide certainly does.
@@ -347,6 +441,7 @@ describe("build", () => {
       BUOYS,
       OBSERVATION_STATIONS,
       MOP_LINES,
+      GRID_CELLS,
     );
 
     expect(beach.air_station).toBe("D3101");
@@ -369,6 +464,7 @@ describe("build", () => {
       BUOYS,
       OBSERVATION_STATIONS,
       MOP_LINES,
+      GRID_CELLS,
     );
 
     expect(beach.air_station).toBe("LJAC1");
@@ -389,6 +485,7 @@ describe("build", () => {
       BUOYS,
       OBSERVATION_STATIONS,
       MOP_LINES,
+      GRID_CELLS,
     );
 
     expect(beach.tide_station).toBeNull();
@@ -405,7 +502,14 @@ describe("build", () => {
     // A slug is a primary key. Making one unique automatically would make it
     // unstable, and data accumulates against it.
     expect(() =>
-      build([row(), row()], STATIONS, BUOYS, OBSERVATION_STATIONS, MOP_LINES),
+      build(
+        [row(), row()],
+        STATIONS,
+        BUOYS,
+        OBSERVATION_STATIONS,
+        MOP_LINES,
+        GRID_CELLS,
+      ),
     ).toThrow(/is claimed by both/);
   });
 
@@ -413,7 +517,14 @@ describe("build", () => {
     const missing = row();
     delete missing["Beach_ UpperLon"];
     expect(() =>
-      build([missing], STATIONS, BUOYS, OBSERVATION_STATIONS, MOP_LINES),
+      build(
+        [missing],
+        STATIONS,
+        BUOYS,
+        OBSERVATION_STATIONS,
+        MOP_LINES,
+        GRID_CELLS,
+      ),
     ).toThrow(/has drifted/);
   });
 
@@ -425,6 +536,7 @@ describe("build", () => {
         BUOYS,
         OBSERVATION_STATIONS,
         MOP_LINES,
+        GRID_CELLS,
       ),
     ).toThrow(/did not parse as numbers/);
   });
@@ -447,6 +559,7 @@ describe("build", () => {
       BUOYS,
       OBSERVATION_STATIONS,
       MOP_LINES,
+      GRID_CELLS,
     );
     expect(built.map((b) => b.slug)).toEqual(["north-one", "south-one"]);
   });
@@ -718,7 +831,14 @@ describe("dropReplacedBuoy", () => {
 describe("document", () => {
   it("lists only the beaches whose stations reach them", () => {
     const doc = document(
-      build([row(), FAR_ROW], STATIONS, BUOYS, OBSERVATION_STATIONS, MOP_LINES),
+      build(
+        [row(), FAR_ROW],
+        STATIONS,
+        BUOYS,
+        OBSERVATION_STATIONS,
+        MOP_LINES,
+        GRID_CELLS,
+      ),
     );
 
     expect(doc.beaches.map((b) => b.slug)).toEqual(["somewhere-beach"]);
@@ -726,7 +846,14 @@ describe("document", () => {
 
   it("records every beach it does not list, with the distance that cut it", () => {
     const doc = document(
-      build([row(), FAR_ROW], STATIONS, BUOYS, OBSERVATION_STATIONS, MOP_LINES),
+      build(
+        [row(), FAR_ROW],
+        STATIONS,
+        BUOYS,
+        OBSERVATION_STATIONS,
+        MOP_LINES,
+        GRID_CELLS,
+      ),
     );
 
     expect(doc._excluded).toEqual([
@@ -747,6 +874,7 @@ describe("document", () => {
       BUOYS,
       OBSERVATION_STATIONS,
       MOP_LINES,
+      GRID_CELLS,
     );
     const doc = document(built);
 
@@ -769,6 +897,7 @@ describe("document", () => {
         BUOYS,
         OBSERVATION_STATIONS,
         MOP_LINES,
+        GRID_CELLS,
       ),
     );
     const caveat = doc.unresolved.find((entry) =>
@@ -795,6 +924,7 @@ describe("document", () => {
         BUOYS,
         OBSERVATION_STATIONS,
         MOP_LINES,
+        GRID_CELLS,
       ),
     );
 
@@ -809,14 +939,28 @@ describe("document", () => {
     // would replace the whole inventory with a silence.
     expect(() =>
       document(
-        build([FAR_ROW], STATIONS, BUOYS, OBSERVATION_STATIONS, MOP_LINES),
+        build(
+          [FAR_ROW],
+          STATIONS,
+          BUOYS,
+          OBSERVATION_STATIONS,
+          MOP_LINES,
+          GRID_CELLS,
+        ),
       ),
     ).toThrow(/excluded all 1/);
   });
 
   it("tells a reader that a beach out of range is not listed at all", () => {
     const doc = document(
-      build([row()], STATIONS, BUOYS, OBSERVATION_STATIONS, MOP_LINES),
+      build(
+        [row()],
+        STATIONS,
+        BUOYS,
+        OBSERVATION_STATIONS,
+        MOP_LINES,
+        GRID_CELLS,
+      ),
     );
     const bound = doc.unresolved.find((entry) =>
       entry.includes("nearest station of matching water class"),
@@ -832,7 +976,14 @@ describe("document", () => {
 
   it("tells a reader the sky figures are read at an airport", () => {
     const built = document(
-      build([row()], STATIONS, BUOYS, OBSERVATION_STATIONS, MOP_LINES),
+      build(
+        [row()],
+        STATIONS,
+        BUOYS,
+        OBSERVATION_STATIONS,
+        MOP_LINES,
+        GRID_CELLS,
+      ),
     );
     const airport = built.unresolved.find((entry) =>
       entry.includes("read at an airport"),
@@ -868,7 +1019,14 @@ describe("document", () => {
     });
 
     const built = document(
-      build([near, far], STATIONS, BUOYS, OBSERVATION_STATIONS, MOP_LINES),
+      build(
+        [near, far],
+        STATIONS,
+        BUOYS,
+        OBSERVATION_STATIONS,
+        MOP_LINES,
+        GRID_CELLS,
+      ),
     );
     const airport = built.unresolved.find((entry) =>
       entry.includes("read at an airport"),
@@ -888,6 +1046,7 @@ describe("document", () => {
       BUOYS,
       OBSERVATION_STATIONS,
       MOP_LINES,
+      GRID_CELLS,
     );
     const first = document(built).unresolved;
     const second = document(built).unresolved;
@@ -908,6 +1067,7 @@ describe("document", () => {
       BUOYS,
       OBSERVATION_STATIONS,
       MOP_LINES,
+      GRID_CELLS,
     );
 
     expect(document(built, new Date("2026-08-19T01:59:22Z")).generated).toBe(

--- a/src/data/beaches.json
+++ b/src/data/beaches.json
@@ -28,6 +28,9 @@
     "sky_station": "Joined, never typed: the nearest station that both answers and publishes sky. Supplies the panel's sky and visibility ONLY -- temperature and wind come from air_station. Unlike the wave buoy, every beach binds one -- air reaches a lagoon. null means the join could not bind one, and sky_station_null_reason says why.",
     "sky_station_distance_m": "Great-circle metres from the nearer segment end to the station. Larger than the tide and buoy distances by nature: the ten stations that publish sky are all airports.",
     "sky_station_from_end": "Which end of the segment supplied the distance, upper or lower.",
+    "grid_cell": "Joined, never typed: the National Weather Service forecast cell this beach falls in, as office/x,y. NOT a nearest-anything -- a cell is an area about 2.5 km square and every coordinate inside it is equally inside it, so there is no distance to be nearer by and this field has none beside it. The mapping from a coordinate to a cell belongs to the National Weather Service and cannot be recomputed offline, so it is measured into grid-cells.json and read from there. null means no cell answers, and grid_cell_null_reason says why -- which for an excluded beach is simply that the table records coordinates only for the beaches this site serves.",
+    "grid_cell_from_end": "Which end of the segment fell in the bound cell. Load-bearing rather than decoration: a beach is a segment and 17 of 45 straddle a cell boundary, so an end had to be chosen and this records which. The criterion is elevation, not distance.",
+    "grid_cell_elevation_m": "The bound cell's own mean elevation in metres. This is the cell's TERRAIN and not a statement about the forecast: it is what chose between the beach's two ends, on the grounds that a beach is at sea level and the lower cell is the one describing this shore. Three beaches have no low-lying end and read a cell averaging over 100 m; the page says so where it shows one. See docs/adr/0020-sky-leaves-the-card-for-the-week.md.",
     "air_station": "Joined, never typed: the nearest station that answers, publishes air temperature AND wind, and suits the beach's water class -- an open-coast beach binds a shore station, a bay or lagoon binds the nearest of any kind. Usually not the same station as sky_station, and may be on either network; see the `network` field in observation-stations.json. null means the join could not bind one, and air_station_null_reason says why.",
     "air_station_distance_m": "Great-circle metres from the nearer segment end to the station. Much smaller than sky_station_distance_m, which is the point of the second binding.",
     "air_station_from_end": "Which end of the segment supplied the distance, upper or lower."
@@ -69,6 +72,9 @@
       "sky_station": "KNKX",
       "sky_station_distance_m": 14548,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/55,26",
+      "grid_cell_from_end": "upper",
+      "grid_cell_elevation_m": 21.9456,
       "air_station": "SOBSD",
       "air_station_distance_m": 3026,
       "air_station_from_end": "upper"
@@ -109,6 +115,9 @@
       "sky_station": "KNKX",
       "sky_station_distance_m": 10797,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/55,25",
+      "grid_cell_from_end": "upper",
+      "grid_cell_elevation_m": 102.108,
       "air_station": "LJAC1",
       "air_station_distance_m": 3217,
       "air_station_from_end": "lower"
@@ -149,6 +158,9 @@
       "sky_station": "KNKX",
       "sky_station_distance_m": 10429,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/55,22",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 117.0432,
       "air_station": "LJAC1",
       "air_station_distance_m": 1894,
       "air_station_from_end": "lower"
@@ -189,6 +201,9 @@
       "sky_station": "KNKX",
       "sky_station_distance_m": 10429,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/54,21",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0,
       "air_station": "LJAC1",
       "air_station_distance_m": 1381,
       "air_station_from_end": "lower"
@@ -229,6 +244,9 @@
       "sky_station": "KNKX",
       "sky_station_distance_m": 12294,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/54,20",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 106.0704,
       "air_station": "LJAC1",
       "air_station_distance_m": 2340,
       "air_station_from_end": "lower"
@@ -269,6 +287,9 @@
       "sky_station": "KNKX",
       "sky_station_distance_m": 12524,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/53,20",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0,
       "air_station": "LJAC1",
       "air_station_distance_m": 2514,
       "air_station_from_end": "upper"
@@ -311,6 +332,9 @@
       "sky_station": "KNKX",
       "sky_station_distance_m": 12887,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/53,20",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0,
       "air_station": "LJAC1",
       "air_station_distance_m": 2944,
       "air_station_from_end": "upper"
@@ -351,6 +375,9 @@
       "sky_station": "KNKX",
       "sky_station_distance_m": 12952,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/53,20",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0,
       "air_station": "LJAC1",
       "air_station_distance_m": 2996,
       "air_station_from_end": "upper"
@@ -391,6 +418,9 @@
       "sky_station": "KNKX",
       "sky_station_distance_m": 12991,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/53,20",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0,
       "air_station": "LJAC1",
       "air_station_distance_m": 3120,
       "air_station_from_end": "upper"
@@ -431,6 +461,9 @@
       "sky_station": "KNKX",
       "sky_station_distance_m": 13449,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/53,20",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0,
       "air_station": "LJAC1",
       "air_station_distance_m": 3866,
       "air_station_from_end": "upper"
@@ -471,6 +504,9 @@
       "sky_station": "KNKX",
       "sky_station_distance_m": 11003,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/53,19",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0,
       "air_station": "LJAC1",
       "air_station_distance_m": 1381,
       "air_station_from_end": "upper"
@@ -511,6 +547,9 @@
       "sky_station": "KNKX",
       "sky_station_distance_m": 13458,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/53,19",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0,
       "air_station": "LJAC1",
       "air_station_distance_m": 4076,
       "air_station_from_end": "upper"
@@ -551,6 +590,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 11702,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/53,19",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0,
       "air_station": "LJAC1",
       "air_station_distance_m": 5944,
       "air_station_from_end": "upper"
@@ -591,6 +633,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 10333,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/53,19",
+      "grid_cell_from_end": "upper",
+      "grid_cell_elevation_m": 0,
       "air_station": "LJAC1",
       "air_station_distance_m": 6628,
       "air_station_from_end": "upper"
@@ -631,6 +676,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 9523,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,18",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 25.908,
       "air_station": "LJAC1",
       "air_station_distance_m": 7365,
       "air_station_from_end": "upper"
@@ -673,6 +721,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 7748,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/55,18",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 35.9664,
       "air_station": "MSDSD",
       "air_station_distance_m": 2731,
       "air_station_from_end": "upper"
@@ -715,6 +766,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 7097,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/55,18",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 35.9664,
       "air_station": "MSDSD",
       "air_station_distance_m": 3539,
       "air_station_from_end": "upper"
@@ -757,6 +811,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 6588,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/55,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 3.9624,
       "air_station": "MSDSD",
       "air_station_distance_m": 3746,
       "air_station_from_end": "upper"
@@ -799,6 +856,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 7918,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0.9144,
       "air_station": "MSDSD",
       "air_station_distance_m": 2654,
       "air_station_from_end": "upper"
@@ -841,6 +901,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 6193,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/55,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 3.9624,
       "air_station": "MSDSD",
       "air_station_distance_m": 4267,
       "air_station_from_end": "upper"
@@ -883,6 +946,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 7112,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0.9144,
       "air_station": "MSDSD",
       "air_station_distance_m": 2977,
       "air_station_from_end": "upper"
@@ -925,6 +991,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 7125,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0.9144,
       "air_station": "MSDSD",
       "air_station_distance_m": 3138,
       "air_station_from_end": "upper"
@@ -967,6 +1036,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 5536,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/55,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 3.9624,
       "air_station": "MSDSD",
       "air_station_distance_m": 4351,
       "air_station_from_end": "upper"
@@ -1009,6 +1081,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 7993,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0.9144,
       "air_station": "MSDSD",
       "air_station_distance_m": 3730,
       "air_station_from_end": "upper"
@@ -1051,6 +1126,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 7740,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0.9144,
       "air_station": "MSDSD",
       "air_station_distance_m": 3874,
       "air_station_from_end": "upper"
@@ -1093,6 +1171,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 7595,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0.9144,
       "air_station": "MSDSD",
       "air_station_distance_m": 4115,
       "air_station_from_end": "upper"
@@ -1133,6 +1214,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 7225,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,16",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 3.048,
       "air_station": "E9951",
       "air_station_distance_m": 5594,
       "air_station_from_end": "lower"
@@ -1175,6 +1259,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 4871,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/55,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 3.9624,
       "air_station": "KSAN",
       "air_station_distance_m": 4871,
       "air_station_from_end": "lower"
@@ -1217,6 +1304,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 7259,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0.9144,
       "air_station": "MSDSD",
       "air_station_distance_m": 4291,
       "air_station_from_end": "upper"
@@ -1259,6 +1349,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 6959,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/54,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0.9144,
       "air_station": "MSDSD",
       "air_station_distance_m": 4502,
       "air_station_from_end": "upper"
@@ -1301,6 +1394,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 6990,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0.9144,
       "air_station": "MSDSD",
       "air_station_distance_m": 4514,
       "air_station_from_end": "upper"
@@ -1343,6 +1439,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 4718,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/55,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 3.9624,
       "air_station": "KSAN",
       "air_station_distance_m": 4718,
       "air_station_from_end": "lower"
@@ -1385,6 +1484,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 5099,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,17",
+      "grid_cell_from_end": "upper",
+      "grid_cell_elevation_m": 0.9144,
       "air_station": "MSDSD",
       "air_station_distance_m": 5012,
       "air_station_from_end": "upper"
@@ -1427,6 +1529,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 6682,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/54,17",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0.9144,
       "air_station": "E9951",
       "air_station_distance_m": 5573,
       "air_station_from_end": "upper"
@@ -1469,6 +1574,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 6295,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,16",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 3.048,
       "air_station": "E9951",
       "air_station_distance_m": 5425,
       "air_station_from_end": "lower"
@@ -1511,6 +1619,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 6287,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,16",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 3.048,
       "air_station": "E9951",
       "air_station_distance_m": 5403,
       "air_station_from_end": "lower"
@@ -1553,6 +1664,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 1615,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/55,15",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 2.1336,
       "air_station": "KSAN",
       "air_station_distance_m": 1615,
       "air_station_from_end": "lower"
@@ -1595,6 +1709,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 3803,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,14",
+      "grid_cell_from_end": "upper",
+      "grid_cell_elevation_m": 0,
       "air_station": "E9951",
       "air_station_distance_m": 732,
       "air_station_from_end": "lower"
@@ -1637,6 +1754,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 3400,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/54,14",
+      "grid_cell_from_end": "upper",
+      "grid_cell_elevation_m": 0,
       "air_station": "E9951",
       "air_station_distance_m": 1329,
       "air_station_from_end": "upper"
@@ -1679,6 +1799,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 11444,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/57,10",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 2.1336,
       "air_station": "TIXC1",
       "air_station_distance_m": 6282,
       "air_station_from_end": "lower"
@@ -1720,6 +1843,9 @@
       "sky_station": "KSAN",
       "sky_station_distance_m": 11356,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/57,10",
+      "grid_cell_from_end": "upper",
+      "grid_cell_elevation_m": 2.1336,
       "air_station": "TIXC1",
       "air_station_distance_m": 3843,
       "air_station_from_end": "lower"
@@ -1761,6 +1887,9 @@
       "sky_station": "KSDM",
       "sky_station_distance_m": 13144,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/57,8",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 0.9144,
       "air_station": "TIXC1",
       "air_station_distance_m": 1396,
       "air_station_from_end": "lower"
@@ -1802,6 +1931,9 @@
       "sky_station": "KSDM",
       "sky_station_distance_m": 13145,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/57,8",
+      "grid_cell_from_end": "upper",
+      "grid_cell_elevation_m": 0.9144,
       "air_station": "TIXC1",
       "air_station_distance_m": 1127,
       "air_station_from_end": "lower"
@@ -1844,6 +1976,9 @@
       "sky_station": "KSDM",
       "sky_station_distance_m": 12852,
       "sky_station_from_end": "lower",
+      "grid_cell": "SGX/57,7",
+      "grid_cell_from_end": "lower",
+      "grid_cell_elevation_m": 4.8768,
       "air_station": "TIXC1",
       "air_station_distance_m": 1129,
       "air_station_from_end": "upper"
@@ -1885,6 +2020,9 @@
       "sky_station": "KSDM",
       "sky_station_distance_m": 12863,
       "sky_station_from_end": "upper",
+      "grid_cell": "SGX/57,7",
+      "grid_cell_from_end": "upper",
+      "grid_cell_elevation_m": 4.8768,
       "air_station": "TIXC1",
       "air_station_distance_m": 2467,
       "air_station_from_end": "upper"

--- a/src/data/grid-cells.json
+++ b/src/data/grid-cells.json
@@ -1,0 +1,593 @@
+{
+  "version": "0.1.0",
+  "generated": "2026-08-26",
+  "_provenance": "Measured by scripts/probe-grid-cells.mjs against https://api.weather.gov; re-runnable and diffable with --check. Each beach segment end is resolved by /points, which is the National Weather Service's own mapping from a coordinate to a forecast cell and cannot be recomputed offline; each distinct cell is then read once from /gridpoints for its mean elevation and its published series. See https://www.weather.gov/documentation/services-web-api.",
+  "_what_was_measured": "21 distinct cells serve this inventory, of which 21 publish a sky cover series. 0 publish a visibility series -- a key present with an empty values array is not a published variable, and every cell declares visibility and ceilingHeight whether or not it fills them. That is why delivers counts entries.",
+  "_schema": {
+    "cells.<id>.office: ": "The forecast office, from /points gridId.",
+    "cells.<id>.x": "Grid column, from /points gridX.",
+    "cells.<id>.y": "Grid row, from /points gridY.",
+    "cells.<id>.elevation_m": "The cell's own mean elevation in metres, as /gridpoints publishes it. This is the cell's terrain rather than a statement about the forecast, and the join uses it to choose between a beach's two ends. See docs/adr/0020-sky-leaves-the-card-for-the-week.md.",
+    "cells.<id>.sky_cover_entries": "How many skyCover values the cell published when measured. Zero means the cell answers and does not forecast sky.",
+    "cells.<id>.visibility_entries": "How many visibility values the cell published. Measured zero everywhere; recorded rather than assumed, so a change upstream shows up as a diff.",
+    "cells.<id>.ceiling_entries": "The same count for ceilingHeight.",
+    "cells.<id>.delivers": "Whether the cell publishes sky cover. Derived from sky_cover_entries, never from the presence of the key.",
+    "resolutions.<slug>.<end>.cell": "The cell that segment end falls in, or null when the grid does not cover it.",
+    "resolutions.<slug>.<end>.reason": "Present only when cell is null. What /points said."
+  },
+  "cells": {
+    "SGX/53,19": {
+      "office": "SGX",
+      "x": 53,
+      "y": 19,
+      "elevation_m": 0,
+      "sky_cover_entries": 37,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/53,20": {
+      "office": "SGX",
+      "x": 53,
+      "y": 20,
+      "elevation_m": 0,
+      "sky_cover_entries": 37,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/54,14": {
+      "office": "SGX",
+      "x": 54,
+      "y": 14,
+      "elevation_m": 0,
+      "sky_cover_entries": 36,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/54,16": {
+      "office": "SGX",
+      "x": 54,
+      "y": 16,
+      "elevation_m": 3.048,
+      "sky_cover_entries": 35,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/54,17": {
+      "office": "SGX",
+      "x": 54,
+      "y": 17,
+      "elevation_m": 0.9144,
+      "sky_cover_entries": 35,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/54,18": {
+      "office": "SGX",
+      "x": 54,
+      "y": 18,
+      "elevation_m": 25.908,
+      "sky_cover_entries": 36,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/54,20": {
+      "office": "SGX",
+      "x": 54,
+      "y": 20,
+      "elevation_m": 106.0704,
+      "sky_cover_entries": 36,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/54,21": {
+      "office": "SGX",
+      "x": 54,
+      "y": 21,
+      "elevation_m": 0,
+      "sky_cover_entries": 37,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/55,14": {
+      "office": "SGX",
+      "x": 55,
+      "y": 14,
+      "elevation_m": 0.9144,
+      "sky_cover_entries": 36,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/55,15": {
+      "office": "SGX",
+      "x": 55,
+      "y": 15,
+      "elevation_m": 2.1336,
+      "sky_cover_entries": 37,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/55,16": {
+      "office": "SGX",
+      "x": 55,
+      "y": 16,
+      "elevation_m": 7.9248,
+      "sky_cover_entries": 34,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/55,17": {
+      "office": "SGX",
+      "x": 55,
+      "y": 17,
+      "elevation_m": 3.9624,
+      "sky_cover_entries": 37,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/55,18": {
+      "office": "SGX",
+      "x": 55,
+      "y": 18,
+      "elevation_m": 35.9664,
+      "sky_cover_entries": 35,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/55,22": {
+      "office": "SGX",
+      "x": 55,
+      "y": 22,
+      "elevation_m": 117.0432,
+      "sky_cover_entries": 36,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/55,25": {
+      "office": "SGX",
+      "x": 55,
+      "y": 25,
+      "elevation_m": 102.108,
+      "sky_cover_entries": 37,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/55,26": {
+      "office": "SGX",
+      "x": 55,
+      "y": 26,
+      "elevation_m": 21.9456,
+      "sky_cover_entries": 37,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/56,13": {
+      "office": "SGX",
+      "x": 56,
+      "y": 13,
+      "elevation_m": 0.9144,
+      "sky_cover_entries": 36,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/57,10": {
+      "office": "SGX",
+      "x": 57,
+      "y": 10,
+      "elevation_m": 2.1336,
+      "sky_cover_entries": 36,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/57,7": {
+      "office": "SGX",
+      "x": 57,
+      "y": 7,
+      "elevation_m": 4.8768,
+      "sky_cover_entries": 37,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/57,8": {
+      "office": "SGX",
+      "x": 57,
+      "y": 8,
+      "elevation_m": 0.9144,
+      "sky_cover_entries": 37,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    },
+    "SGX/57,9": {
+      "office": "SGX",
+      "x": 57,
+      "y": 9,
+      "elevation_m": 10.0584,
+      "sky_cover_entries": 37,
+      "visibility_entries": 0,
+      "ceiling_entries": 0,
+      "delivers": true
+    }
+  },
+  "resolutions": {
+    "bird-rock-nr": {
+      "upper": {
+        "cell": "SGX/53,19"
+      },
+      "lower": {
+        "cell": "SGX/53,19"
+      }
+    },
+    "border-field-state-park": {
+      "upper": {
+        "cell": "SGX/57,7"
+      },
+      "lower": {
+        "cell": null,
+        "reason": "the National Weather Service grid does not cover 32.534367,-117.124197"
+      }
+    },
+    "childrens-pool": {
+      "upper": {
+        "cell": "SGX/53,20"
+      },
+      "lower": {
+        "cell": "SGX/53,20"
+      }
+    },
+    "coronado-cays-nr": {
+      "upper": {
+        "cell": "SGX/57,10"
+      },
+      "lower": {
+        "cell": "SGX/57,10"
+      }
+    },
+    "del-mar-city-beach": {
+      "upper": {
+        "cell": "SGX/55,26"
+      },
+      "lower": {
+        "cell": "SGX/55,25"
+      }
+    },
+    "fiesta-island": {
+      "upper": {
+        "cell": "SGX/55,17"
+      },
+      "lower": {
+        "cell": "SGX/55,17"
+      }
+    },
+    "imperial-beach-municipal-beach-other": {
+      "upper": {
+        "cell": "SGX/57,8"
+      },
+      "lower": {
+        "cell": "SGX/57,7"
+      }
+    },
+    "la-jolla-community-beach": {
+      "upper": {
+        "cell": "SGX/54,21"
+      },
+      "lower": {
+        "cell": "SGX/53,19"
+      }
+    },
+    "la-jolla-cove": {
+      "upper": {
+        "cell": "SGX/54,20"
+      },
+      "lower": {
+        "cell": "SGX/54,20"
+      }
+    },
+    "la-jolla-shores-beach": {
+      "upper": {
+        "cell": "SGX/55,22"
+      },
+      "lower": {
+        "cell": "SGX/54,21"
+      }
+    },
+    "marine-street-beach": {
+      "upper": {
+        "cell": "SGX/53,20"
+      },
+      "lower": {
+        "cell": "SGX/53,20"
+      }
+    },
+    "mission-bay": {
+      "upper": {
+        "cell": "SGX/54,16"
+      },
+      "lower": {
+        "cell": "SGX/54,16"
+      }
+    },
+    "mission-bay-bahia-point": {
+      "upper": {
+        "cell": "SGX/54,17"
+      },
+      "lower": {
+        "cell": "SGX/54,17"
+      }
+    },
+    "mission-bay-campland-on-the-bay": {
+      "upper": {
+        "cell": "SGX/55,18"
+      },
+      "lower": {
+        "cell": "SGX/55,18"
+      }
+    },
+    "mission-bay-crown-point-shores": {
+      "upper": {
+        "cell": "SGX/55,18"
+      },
+      "lower": {
+        "cell": "SGX/54,17"
+      }
+    },
+    "mission-bay-de-anza-cove": {
+      "upper": {
+        "cell": "SGX/55,18"
+      },
+      "lower": {
+        "cell": "SGX/55,18"
+      }
+    },
+    "mission-bay-fanuel-park": {
+      "upper": {
+        "cell": "SGX/54,18"
+      },
+      "lower": {
+        "cell": "SGX/54,17"
+      }
+    },
+    "mission-bay-leisure-lagoon": {
+      "upper": {
+        "cell": "SGX/55,17"
+      },
+      "lower": {
+        "cell": "SGX/55,17"
+      }
+    },
+    "mission-bay-mariners-basin": {
+      "upper": {
+        "cell": "SGX/54,16"
+      },
+      "lower": {
+        "cell": "SGX/54,17"
+      }
+    },
+    "mission-bay-north-pacific-passage": {
+      "upper": {
+        "cell": "SGX/55,17"
+      },
+      "lower": {
+        "cell": "SGX/55,17"
+      }
+    },
+    "mission-bay-quivera-basin": {
+      "upper": {
+        "cell": "SGX/54,16"
+      },
+      "lower": {
+        "cell": "SGX/54,16"
+      }
+    },
+    "mission-bay-riviera-shores": {
+      "upper": {
+        "cell": "SGX/54,17"
+      },
+      "lower": {
+        "cell": "SGX/54,17"
+      }
+    },
+    "mission-bay-sail-bay": {
+      "upper": {
+        "cell": "SGX/54,17"
+      },
+      "lower": {
+        "cell": "SGX/54,17"
+      }
+    },
+    "mission-bay-san-juan-cove": {
+      "upper": {
+        "cell": "SGX/54,17"
+      },
+      "lower": {
+        "cell": "SGX/54,17"
+      }
+    },
+    "mission-bay-santa-barbara-cove": {
+      "upper": {
+        "cell": "SGX/54,17"
+      },
+      "lower": {
+        "cell": "SGX/54,17"
+      }
+    },
+    "mission-bay-sea-world": {
+      "upper": {
+        "cell": "SGX/54,17"
+      },
+      "lower": {
+        "cell": "SGX/55,16"
+      }
+    },
+    "mission-bay-vacation-isle": {
+      "upper": {
+        "cell": "SGX/54,17"
+      },
+      "lower": {
+        "cell": "SGX/54,17"
+      }
+    },
+    "mission-bay-ventura-cove": {
+      "upper": {
+        "cell": "SGX/54,17"
+      },
+      "lower": {
+        "cell": "SGX/54,17"
+      }
+    },
+    "mission-bay-visitor-s-center": {
+      "upper": {
+        "cell": "SGX/55,18"
+      },
+      "lower": {
+        "cell": "SGX/55,17"
+      }
+    },
+    "mission-beach": {
+      "upper": {
+        "cell": "SGX/54,18"
+      },
+      "lower": {
+        "cell": "SGX/54,16"
+      }
+    },
+    "north-imperial-beach": {
+      "upper": {
+        "cell": "SGX/57,9"
+      },
+      "lower": {
+        "cell": "SGX/57,8"
+      }
+    },
+    "pacific-beach": {
+      "upper": {
+        "cell": "SGX/54,18"
+      },
+      "lower": {
+        "cell": "SGX/54,18"
+      }
+    },
+    "san-diego-bay": {
+      "upper": {
+        "cell": "SGX/54,14"
+      },
+      "lower": {
+        "cell": "SGX/56,13"
+      }
+    },
+    "shell-beach": {
+      "upper": {
+        "cell": "SGX/53,20"
+      },
+      "lower": {
+        "cell": "SGX/53,20"
+      }
+    },
+    "shoreline-park": {
+      "upper": {
+        "cell": "SGX/54,14"
+      },
+      "lower": {
+        "cell": "SGX/55,14"
+      }
+    },
+    "silver-strand-state-beach": {
+      "upper": {
+        "cell": "SGX/57,10"
+      },
+      "lower": {
+        "cell": "SGX/57,9"
+      }
+    },
+    "south-casa-beach-s-d": {
+      "upper": {
+        "cell": "SGX/53,20"
+      },
+      "lower": {
+        "cell": "SGX/53,20"
+      }
+    },
+    "spanish-landing-park": {
+      "upper": {
+        "cell": "SGX/55,15"
+      },
+      "lower": {
+        "cell": "SGX/55,15"
+      }
+    },
+    "tecolote-shores": {
+      "upper": {
+        "cell": "SGX/55,17"
+      },
+      "lower": {
+        "cell": "SGX/55,17"
+      }
+    },
+    "tijuana-slough-national-wildlife-refuge": {
+      "upper": {
+        "cell": "SGX/57,7"
+      },
+      "lower": {
+        "cell": "SGX/57,7"
+      }
+    },
+    "torrey-pines-city-beach": {
+      "upper": {
+        "cell": "SGX/55,22"
+      },
+      "lower": {
+        "cell": "SGX/55,22"
+      }
+    },
+    "torrey-pines-state-beach": {
+      "upper": {
+        "cell": "SGX/55,25"
+      },
+      "lower": {
+        "cell": "SGX/55,22"
+      }
+    },
+    "tourmaline-surfing-park": {
+      "upper": {
+        "cell": "SGX/53,19"
+      },
+      "lower": {
+        "cell": "SGX/54,18"
+      }
+    },
+    "whispering-sands-nicholson-pt": {
+      "upper": {
+        "cell": "SGX/53,20"
+      },
+      "lower": {
+        "cell": "SGX/53,20"
+      }
+    },
+    "windansea-beach": {
+      "upper": {
+        "cell": "SGX/53,20"
+      },
+      "lower": {
+        "cell": "SGX/53,19"
+      }
+    }
+  }
+}

--- a/src/lib/beaches.ts
+++ b/src/lib/beaches.ts
@@ -83,6 +83,26 @@ export interface Beach {
   /** Present exactly when sky_station is null, and required then. */
   sky_station_null_reason?: string;
   /**
+   * Joined, never typed: the National Weather Service forecast cell this beach
+   * falls in, as `office/x,y`. It carries no distance, and that absence is the
+   * point -- a cell is an area about 2.5 km square and every coordinate inside
+   * it is equally inside it, so there is nothing to be nearer by.
+   */
+  grid_cell: string | null;
+  /**
+   * Which end of the segment fell in the bound cell. 17 of 45 beaches straddle
+   * a boundary, so an end had to be chosen; the criterion is elevation.
+   */
+  grid_cell_from_end: string | null;
+  /**
+   * The bound cell's own mean elevation in metres -- its TERRAIN, not a claim
+   * about the forecast. It is what chose between the two ends, and at three
+   * beaches it is above 100 m, which the page says rather than hides.
+   */
+  grid_cell_elevation_m: number | null;
+  /** Present exactly when grid_cell is null, and required then. */
+  grid_cell_null_reason?: string;
+  /**
    * Joined, never typed. Supplies air temperature and wind: the nearest station
    * that publishes both and suits this beach's water class. Usually a different
    * station from `sky_station`, and much nearer.

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -51,11 +51,21 @@ export default defineConfig({
       // run-vitest.mjs, check-built-css.mjs, check-db.mjs and
       // check-adr-numbers.mjs sit at 0% on purpose, and all five drag these
       // figures down in plain sight rather than quietly.
+      //
+      // LOWERED 2026-08-26 under reason 1, when probe-grid-cells.mjs arrived.
+      // Its pure half -- parsePoint, parseCell, buildTable, document -- is
+      // fully tested; its main() is 85 lines of fetch-and-write plumbing that
+      // resolves 90 coordinates against api.weather.gov, and testing it would
+      // mean either mocking the network at a seam this repo deliberately does
+      // not put one at, or making a gate row that needs the internet.
+      // probe-mop-lines.mjs (60.6%) and probe-observation-stations.mjs (82.8%)
+      // sit here for the same reason. The join beside it, grid-cell-join.mjs,
+      // is at 100% statements -- that is the half that decides anything.
       thresholds: {
-        statements: 90.72,
-        branches: 90.71,
-        functions: 95.26,
-        lines: 90.45,
+        statements: 88.83,
+        branches: 90.49,
+        functions: 94.72,
+        lines: 88.41,
       },
     },
   },


### PR DESCRIPTION
PR 1 of 3 from [`docs/plans/sky-from-the-grid.md`](docs/plans/sky-from-the-grid.md).
The decision behind it is [ADR-0020](docs/adr/0020-sky-leaves-the-card-for-the-week.md),
which supersedes ADR-0012.

**Nothing reads this binding yet.** The week-grid row that will is PR 2; the
deletion of the card's sky group is PR 3, and it must not land before PR 2 or
the site ships an interval with no cloud information at all.

Relates to #95 and #91. Closes neither — they close when the row ships and the
card's sky group goes.

## Three commits

1. **ADR-0020**, and ADR-0012 marked superseded.
2. **The plan**, five slices across three PRs, with one design question left
   open rather than decided quietly.
3. **The binding** — the only code in this PR.

## What the binding is, and what it deliberately lacks

Every beach now carries `grid_cell`, `grid_cell_from_end` and
`grid_cell_elevation_m`. **There is no `grid_cell_distance_m`, and the absence
is the design.** A forecast cell is an area about 2.5 km square and every
coordinate inside it is equally inside it, so there is nothing to be nearer by
— a distance here would be an invented precision.

An end still has to be chosen, because a beach is a segment and **17 of 45
straddle a cell boundary**. The criterion is the cell averaging nearer sea
level, which is where a beach is. Measured over the inventory:

| beach | before | after |
| --- | --- | --- |
| Del Mar City Beach | 102 m cell | **22 m**, upper end |
| La Jolla Shores Beach | 117 m cell | **0 m**, lower end |

Three beaches have no low-lying end and keep a bluff cell — Torrey Pines State
(102 m), Torrey Pines City (117 m), La Jolla Cove (106 m). ADR-0020 records why
they are served anyway, and is explicit that terrain is a weaker proxy than
ADR-0011's instrument distances.

## The measurement the probe exists to make

`delivers` counts entries rather than testing for a key, and that is the whole
point. Every `/gridpoints` payload declares all three of these:

| variable | cells carrying values |
| --- | --- |
| `skyCover` | **21 of 21**, 34–37 entries each |
| `visibility` | **0 of 21** |
| `ceilingHeight` | **0 of 21** |

A probe asking `"visibility" in properties` would have recorded a variable this
feed publishes nothing for — and PR 2's parser would have been built to read it.
The zeroes are committed rather than omitted, so a change upstream shows up as a
diff.

## Edge case found and handled

**Border Field State Park's lower end is south of the border.** `/points`
answers `404 problems/InvalidPoint`. The resolution keeps that end with its
reason and the join binds the upper one:

```json
"border-field-state-park": {
  "upper": { "cell": "SGX/57,7" },
  "lower": {
    "cell": null,
    "reason": "the National Weather Service grid does not cover 32.534367,-117.124197"
  }
}
```

## Coverage floor lowered — reason 1, named

`vitest.config.mts` allows this for two reasons and requires the commit to name
the uncovered statements. This is reason 1, the denominator growing with
untested entry plumbing:

- `probe-grid-cells.mjs` sits at **48.9%**. Its `main()` is 85 lines resolving
  90 coordinates over the network. Its pure half — `parsePoint`, `parseCell`,
  `buildTable`, `document` — is fully tested.
- `probe-mop-lines.mjs` (60.6%) and `probe-observation-stations.mjs` (82.8%)
  already sit here for the same reason.
- **`grid-cell-join.mjs`, the half that decides anything, is at 100%
  statements.**

No test was lost and no tested code became uncovered. Statements 90.72 → 88.83,
branches 90.71 → 90.49, functions 95.26 → 94.72, lines 90.45 → 88.41.

## Gate

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

Verified beyond "it ran": re-seeding bound **45 of 45** served beaches, the two
rescued beaches moved as predicted, exactly the three predicted bluff beaches
remain, and Border Field took its resolving end.

## Still open, and it is yours

ADR-0017 has every row lead with the **daylight extreme** — "Lowest daylight
tide", "Biggest daylight swell". Cloud cover has no extreme: it is a field
sampled every three hours, not an event with a peak. "Cloudiest daylight hour"
would let one 90% step make an otherwise clear day read as overcast.

The plan recommends the **daylight mean, labelled "Cloud by day"**, and says why
that departs from ADR-0017. It only affects the row's label, so it can wait
until PR 2 — but it is a judgement about what a reader sees, not an
implementation detail.

## Noticed, not filed

The gridded `ReservedRow` carries 💨 under ADR-0015, chosen when the row was
about wind. A row about cloud alone may want a different glyph. That is a design
decision in ADR-0015's vocabulary and is settled in PR 2 with a human looking at
it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
