### PR TITLE
Put cloud cover in the week grid, from the beach's own forecast cell

### DIFF
--- a/docs/plans/sky-from-the-grid.md
+++ b/docs/plans/sky-from-the-grid.md
@@ -240,3 +240,44 @@ reader twice.
   because it was once about wind. Whether a cloud row wants a different glyph is
   a design decision in that ADR's vocabulary, and it is settled in slice 3 with
   a human looking at it rather than assumed here.
+
+## Addendum, 2026-08-27: the day's figure is the daylight mean
+
+**The open question was mis-scheduled above, and the schedule mattered.** The
+section headed "the one thing not yet decided" says it wants settling before
+slice 4, and that "if the answer is instead an extreme, the row label changes
+and nothing else does". Both are wrong. The daily figure is computed in
+`readSkyWeek`, which is slice 2, so the question blocked the next slice rather
+than a later one — and a mean is not a relabelled extreme, it is a different
+computation over a different number of steps.
+
+**Decided: the daylight mean, labelled "Cloud by day", with no secondary
+figure.**
+
+Measured at `SGX/54,21` on 2026-08-27, over the daylight steps of each of the
+seven days the forecast reaches:
+
+| day        | mean | min | max | spread |
+| ---------- | ---- | --- | --- | ------ |
+| 2026-08-26 | 44%  | 33% | 66% | 33     |
+| 2026-08-27 | 67%  | 53% | 73% | 20     |
+| 2026-08-28 | 55%  | 44% | 64% | 20     |
+| 2026-08-29 | 38%  | 20% | 47% | 27     |
+| 2026-08-30 | 39%  | 21% | 62% | 41     |
+| 2026-08-31 | 49%  | 35% | 70% | 35     |
+| 2026-09-01 | 62%  | 48% | 76% | 28     |
+
+So the choice moves the published figure by 20 to 41 points, which is the
+difference between a day reading as grey and reading as bright.
+
+**Why this departs from ADR-0017 rather than conforming to it.** That ADR's
+argument is reachability: a lowest low at 3:14 AM is a number nobody planning a
+trip with children can use, so the row leads with the extreme that falls between
+sunrise and sunset. Cloud cover has no unreachable hours — the daylight window
+_is_ the trip — so there is no unreachable extreme to route around, and taking
+one anyway would import ADR-0017's pessimism without its reason. On 2026-08-30
+the cloudiest daylight step is 62% against a mean of 39%, and the row would have
+told a reader the day was grey when most of it is not.
+
+The fog annotation carries the "when" that ADR-0017's times carry for the tide
+and swell rows, which is the part of the sky a reader plans around.

--- a/src/components/conditions/ConditionsNotes.test.tsx
+++ b/src/components/conditions/ConditionsNotes.test.tsx
@@ -90,6 +90,10 @@ test("the safety framing is not repeated here, it is above the readings", () => 
   // figure -- which is what the heading above them promises.
   expect(screen.getByText("Tide heights")).toBeDefined();
   expect(screen.getByText("Wave heights")).toBeDefined();
+  // Four now, not three. The cloud row's entry joins the airport one rather
+  // than replacing it: ADR-0020 removes the card's sky in a later slice, and
+  // until it does BOTH are on the page and both are owed an explanation.
+  expect(screen.getByText("Cloud by day")).toBeDefined();
   expect(screen.getByText("Sky and visibility")).toBeDefined();
 });
 
@@ -103,6 +107,25 @@ test("it explains the page rather than claiming this beach has these readings", 
   render(<ConditionsNotes entries={ENTRIES} reach={REACH} />);
 
   expect(screen.getByText(/Where they are shown/)).toBeDefined();
+});
+
+/**
+ * The week's forecast is a different kind of figure from the readings on the
+ * cards, and the block a reader goes to for "what does this number mean" has to
+ * say which. It must NOT yet claim the page carries no current sky reading: the
+ * air card still shows one until ADR-0020's deletion slice lands, and a note
+ * saying otherwise would be false while both are on screen.
+ */
+test("the cloud row is explained as a forecast for a square of the map", () => {
+  render(<ConditionsNotes entries={ENTRIES} reach={REACH} />);
+
+  expect(screen.getByText(/this beach's own square/)).toBeDefined();
+  expect(
+    screen.getByText(/rather than the cloudiest hour of it/),
+  ).toBeDefined();
+  expect(
+    screen.queryByText(/no reading of what the sky is doing right now/),
+  ).toBeNull();
 });
 
 /**
@@ -132,12 +155,15 @@ test("each note is a term and its explanation, not a run of prose", () => {
   const details = container.querySelectorAll("dd");
 
   expect(terms.length).toBe(details.length);
-  // Five: three since the safety framing became a standing notice above the
+  // Six: three since the safety framing became a standing notice above the
   // readings, a fourth when the week gained a modelled wave height beside the
-  // measured one, and a fifth when the rows began leading with what daylight
-  // reaches. The named-term assertions elsewhere in this file are what stop a
-  // note being dropped silently; this number only tracks them.
-  expect(terms.length).toBe(5);
+  // measured one, a fifth when the rows began leading with what daylight
+  // reaches, and a sixth when the week gained the gridded cloud row. That last
+  // one is temporary at six -- ADR-0020 removes the airport entry beside it in
+  // the slice that takes sky off the card, and this returns to five. The
+  // named-term assertions elsewhere in this file are what stop a note being
+  // dropped silently; this number only tracks them.
+  expect(terms.length).toBe(6);
 });
 
 test("it is a labelled region, so the notes are reachable as a landmark", () => {

--- a/src/components/conditions/ConditionsNotes.tsx
+++ b/src/components/conditions/ConditionsNotes.tsx
@@ -87,6 +87,14 @@ const NOTES = [
       "the sand. The lines naming each source say which is which.",
   },
   {
+    term: "Cloud by day",
+    detail:
+      "A forecast for this beach's own square of the National Weather Service's map, about " +
+      "2.5 km across, rather than a reading taken anywhere. It averages the forecast hours " +
+      "between sunrise and sunset, so it describes the day you would be there rather than " +
+      "the cloudiest hour of it, and it names fog on the days fog is expected.",
+  },
+  {
     term: "Sky and visibility",
     detail:
       "Where they are shown, they come from an airport. Cloud and visibility are only " +

--- a/src/components/conditions/SkyWeek.test.tsx
+++ b/src/components/conditions/SkyWeek.test.tsx
@@ -1,0 +1,104 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SkyWeek, SKY_WEEK_ROW } from "./SkyWeek";
+import { gridCellCaveat, phenomenonWords } from "./gridCell";
+
+test("the day's figure is a percentage, and it leads", () => {
+  const { container } = render(
+    <SkyWeek day={{ cloudPercent: 44, phenomenon: null }} />,
+  );
+
+  expect(screen.getByText("44%")).toBeDefined();
+  // The lead figure is the bold one, the way every other cell in this grid
+  // leads with its own first fact.
+  expect(container.querySelector(".font-extrabold")?.textContent).toBe("44%");
+});
+
+test("the label names an average, not a superlative", () => {
+  // `TideWeek` and `WaveWeek` say "Lowest" and "Biggest" because they show one
+  // of a day's estimates. This shows all of them, averaged, and a reader who
+  // read the label as a superlative would be wrong about the number.
+  expect(SKY_WEEK_ROW.label).toBe("Cloud by day");
+  expect(SKY_WEEK_ROW.label).not.toMatch(/cloudiest|clearest|most|least/i);
+});
+
+test("a day with fog forecast says so, under the figure", () => {
+  render(
+    <SkyWeek
+      day={{
+        cloudPercent: 67,
+        phenomenon: { weather: "fog", coverage: "patchy" },
+      }}
+    />,
+  );
+
+  expect(screen.getByText("Patchy fog")).toBeDefined();
+});
+
+test("a day with no phenomenon renders the figure alone, not an empty line", () => {
+  const { container } = render(
+    <SkyWeek day={{ cloudPercent: 30, phenomenon: null }} />,
+  );
+
+  // Most days name nothing. A blank second line would read as a reading that
+  // failed rather than as an ordinary day.
+  expect(container.textContent?.trim()).toBe("30%");
+});
+
+test("the accessible text does not run the two facts together", () => {
+  // The space between the spans is a real text node; two blocks collapse it
+  // visually but a screen reader still needs it, or this reads "67%Patchy fog".
+  const { container } = render(
+    <SkyWeek
+      day={{
+        cloudPercent: 67,
+        phenomenon: { weather: "fog", coverage: "patchy" },
+      }}
+    />,
+  );
+
+  expect(container.textContent).toContain("67% Patchy fog");
+});
+
+test("no glyph and no attribution inside the cell", () => {
+  const { container } = render(
+    <SkyWeek day={{ cloudPercent: 44, phenomenon: null }} />,
+  );
+
+  expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  expect(container.textContent).not.toMatch(/National Weather Service/);
+});
+
+/* =========================================================================
+ * gridCell.ts
+ * ========================================================================= */
+
+test("a phenomenon is relayed in the service's own words", () => {
+  // ADR-0009: this site relays a forecaster's judgement rather than forming
+  // one. The underscore and the capital are the only changes made.
+  expect(phenomenonWords({ weather: "fog", coverage: "patchy" })).toBe(
+    "Patchy fog",
+  );
+  expect(phenomenonWords({ weather: "rain_showers", coverage: "chance" })).toBe(
+    "Chance rain showers",
+  );
+});
+
+test("a phenomenon with no coverage still reads as a sentence fragment", () => {
+  expect(phenomenonWords({ weather: "fog", coverage: null })).toBe("Fog");
+});
+
+test("only a cell that covers the bluff carries the caveat", () => {
+  // Three beaches read one: Torrey Pines State at 102 m, Torrey Pines City at
+  // 117 m and La Jolla Cove at 106 m, against a median of 2.1 m across the
+  // inventory. ADR-0020 serves them and discloses rather than withholding, and
+  // this sentence is the half of that decision no gate can assert.
+  expect(gridCellCaveat(117.0432)).toMatch(/covers the bluff/);
+  expect(gridCellCaveat(117.0432)).toMatch(/117 m/);
+  expect(gridCellCaveat(2.1336)).toBeNull();
+  expect(gridCellCaveat(0)).toBeNull();
+});
+
+test("a cell with no published elevation makes no claim either way", () => {
+  expect(gridCellCaveat(null)).toBeNull();
+});

--- a/src/components/conditions/SkyWeek.tsx
+++ b/src/components/conditions/SkyWeek.tsx
@@ -1,0 +1,74 @@
+/**
+ * One day's cloud cover, as the week grid prints it.
+ *
+ * **The label names the selection, like every row above it, and names a
+ * different kind of selection.** `TideWeek` and `WaveWeek` say "Lowest daylight
+ * tide" and "Biggest daylight swell" because they show one of a day's estimates
+ * and which one is a judgement. This shows all of them, averaged, and "Cloud by
+ * day" says that — a reader who reads it as a superlative would be wrong about
+ * the number in a way the tide and swell labels are built to prevent.
+ *
+ * **Why an average where the rows above take an extreme.** ADR-0017 selects for
+ * reachability: a lowest low at 3:14 AM is a number nobody planning a trip with
+ * children can use, so the row leads with the extreme that falls between
+ * sunrise and sunset. Cloud cover has no unreachable hours — the daylight
+ * window *is* the trip — so there is no extreme to route around, and taking one
+ * anyway would import that ADR's pessimism without its reason. Measured at
+ * `SGX/54,21`, the cloudiest daylight step on 2026-08-30 was 62% against a
+ * daylight mean of 39%. The plan's 2026-08-27 addendum records the decision.
+ *
+ * **The phenomenon carries the "when" the percentage cannot.** Every other row
+ * in this grid leads with a time. This one has none to lead with, because a
+ * mean is about a window rather than an instant — and a parent does not plan
+ * around 44% cloud, they plan around fog. So the second line is the phenomenon
+ * when one is forecast for a daylight hour, and absent when none is, which is
+ * most days. An absent line is an ordinary day rather than a missing reading:
+ * the percentage above it still answers.
+ *
+ * **No visibility figure, and that is the point rather than an omission.** The
+ * gridpoint declares `visibility` and publishes nothing for it at any cell
+ * covering this inventory, and the fog entry's own 1.6 km figure appears in
+ * about a third of entries — a precision the rest of the row cannot match would
+ * read as a measurement. ADR-0020.
+ *
+ * **No cell where the forecast does not reach**, which is the caller's doing:
+ * `readSkyWeek` returns only the days it has and `WeekGrid` draws no pair for a
+ * day a row has nothing for. A label over a gap would read as an instrument
+ * that failed.
+ *
+ * **No glyph and no attribution here**, for the reasons `WaveWeek` records:
+ * ADR-0015 on a full-colour emoji at 10px, and `WeekGrid`'s single provenance
+ * line beneath the grid. Which cell this came from is one fact about a feed.
+ *
+ * **A cell rather than a row**, because the grid is day-major.
+ */
+
+import type { SkyWeekDay } from "@/lib/conditions";
+import { phenomenonWords } from "./gridCell";
+
+/** What every day of this row shares: the words that name it. */
+export const SKY_WEEK_ROW = {
+  label: "Cloud by day",
+} as const;
+
+export function SkyWeek({
+  day,
+}: {
+  day: Pick<SkyWeekDay, "cloudPercent" | "phenomenon">;
+}) {
+  return (
+    <>
+      {/*
+        The space between the spans stays, for the reason `DaylightWeek`
+        records: two blocks collapse it visually and it is still a text node,
+        and without it the accessible text runs together as "44%Patchy fog".
+      */}
+      <span className="font-extrabold lg:block">{day.cloudPercent}%</span>{" "}
+      {day.phenomenon !== null && (
+        <span className="text-fog lg:block">
+          {phenomenonWords(day.phenomenon)}
+        </span>
+      )}
+    </>
+  );
+}

--- a/src/components/conditions/WeekPanel.test.tsx
+++ b/src/components/conditions/WeekPanel.test.tsx
@@ -4,10 +4,12 @@ import { render, screen } from "@testing-library/react";
 const readWeekOfLowestLows = vi.fn();
 const readDaylightWeek = vi.fn();
 const readWaveWeek = vi.fn();
+const readSkyWeek = vi.fn();
 vi.mock("@/lib/conditions", () => ({
   readWeekOfLowestLows,
   readDaylightWeek,
   readWaveWeek,
+  readSkyWeek,
 }));
 
 const { WeekPanel } = await import("./WeekPanel");
@@ -51,6 +53,31 @@ function cellLabels(container: HTMLElement): string[] {
 const countOf = (labels: string[], label: string) =>
   labels.filter((each) => each === label).length;
 
+/** The cell binding, carried through a failure the way the tide's station is. */
+const CELL = { id: "SGX/54,21", elevationM: 0 };
+
+function skyWeek(
+  days: {
+    index: number;
+    cloudPercent: number;
+    phenomenon?: { weather: string; coverage: string | null };
+  }[],
+  cell = CELL,
+) {
+  return {
+    beachName: BINDING.beachName,
+    cell,
+    state: {
+      kind: "week",
+      days: days.map(({ index, cloudPercent, phenomenon = null }) => ({
+        ...DATES[index],
+        cloudPercent,
+        phenomenon,
+      })),
+    },
+  };
+}
+
 /** The MOP binding, carried through a failure the way the tide's station is. */
 const LINE = { id: "D0498", distanceM: 325 };
 
@@ -91,6 +118,17 @@ beforeEach(() => {
   readWeekOfLowestLows.mockReset();
   readDaylightWeek.mockReset();
   readWaveWeek.mockReset();
+  readSkyWeek.mockReset();
+  readSkyWeek.mockResolvedValue(
+    skyWeek([
+      { index: 0, cloudPercent: 44 },
+      {
+        index: 1,
+        cloudPercent: 67,
+        phenomenon: { weather: "fog", coverage: "patchy" },
+      },
+    ]),
+  );
   readDaylightWeek.mockReturnValue(daylightWeek());
   readWaveWeek.mockResolvedValue(
     waveWeek([
@@ -134,24 +172,19 @@ test("the forecasts that are not built yet are named, and waves are no longer am
   // The wave slot came out in the same change that filled its row: a slot left
   // in beside a live row promises the same product twice.
   expect(screen.queryByText(/A wave forecast is coming/i)).toBeNull();
+  // The gridded slot went the same way in the change that filled its row.
+  expect(screen.queryByText(/A gridded forecast is coming/i)).toBeNull();
   expect(screen.getByText(/surf zone forecast/i)).toBeDefined();
-  expect(screen.getByText(/gridded forecast/i)).toBeDefined();
 });
 
 /**
- * A reserved slot is a promise, so what it does *not* say is as load-bearing as
- * what it does. This row once offered "Temperature, wind and sky" from the grid
- * cell, and two thirds of that could never ship: temperature and wind come from
- * the air station at p50 3.7 km rather than from an airport, ADR-0012 records
- * them as among the best-founded readings on the site, and replacing them with
- * a forecast is the displacement ADR-0019 declined to decide. Visibility is not
- * promised either — the gridpoint publishes no values for it at any cell
- * covering this inventory.
- *
- * Asserted on the rendered text rather than on the constant, because the defect
- * was a reader being told something untrue.
+ * The row that replaced the promise. Until 2026-08-27 this slot said a gridded
+ * forecast was coming and, briefly, over-promised temperature and wind with it.
+ * A slot and the row it stood in for must never both be on the page: that is
+ * the same rule the wave slot came out under, and it is why the removal is in
+ * the change that fills the row rather than a tidy-up after it.
  */
-test("the gridded row promises sky alone, not the readings that are already near", async () => {
+test("the gridded row is live, and the slot that promised it is gone", async () => {
   readWeekOfLowestLows.mockResolvedValue({
     ...BINDING,
     state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
@@ -159,13 +192,122 @@ test("the gridded row promises sky alone, not the readings that are already near
 
   render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
 
-  const promise = screen.getByText(/grid cell/i).textContent ?? "";
+  expect(readSkyWeek).toHaveBeenCalledWith("la-jolla-shores-beach");
+  expect(screen.getAllByText("Cloud by day").length).toBeGreaterThan(0);
+  expect(screen.getByText("44%")).toBeDefined();
+  expect(screen.queryByText(/A gridded forecast is coming/i)).toBeNull();
+  expect(
+    screen.queryByText(/grid cell, instead of the nearest airport/i),
+  ).toBeNull();
+});
 
-  expect(promise).toMatch(/cloud cover/i);
-  // The three the row must not offer, each for its own reason.
-  expect(promise).not.toMatch(/temperature/i);
-  expect(promise).not.toMatch(/wind/i);
-  expect(promise).not.toMatch(/visibilit/i);
+/**
+ * These two notes carry more weight than the wave row's equivalents. After
+ * ADR-0020 this row is the only sky anywhere on the site, so a reader who came
+ * to find out whether it will be foggy is told nothing at all -- and a row that
+ * simply vanished would read as a clear week rather than as a missing forecast.
+ */
+test("a beach with no forecast cell says so, rather than dropping the row silently", async () => {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
+  });
+  readSkyWeek.mockResolvedValue({
+    beachName: BINDING.beachName,
+    cell: null,
+    state: { kind: "no-cell", reason: "the grid does not cover this beach" },
+  });
+
+  render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
+
+  expect(screen.getByText(/no cloud forecast for this beach/i)).toBeDefined();
+  expect(screen.queryByText("Cloud by day")).toBeNull();
+});
+
+test("an outage at the National Weather Service says so, and names the reason", async () => {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
+  });
+  readSkyWeek.mockResolvedValue({
+    beachName: BINDING.beachName,
+    cell: CELL,
+    state: {
+      kind: "unavailable",
+      detail:
+        "The National Weather Service returned HTTP 503 for forecast cell SGX/54,21.",
+      drift: false,
+    },
+  });
+
+  render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
+
+  expect(
+    screen.getByText(/could not get this week's cloud forecast/i),
+  ).toBeDefined();
+  expect(screen.getByText(/HTTP 503/)).toBeDefined();
+  // Not drift, so the sentence blaming this repo must not appear.
+  expect(screen.queryByText(/bug here rather than a problem/)).toBeNull();
+});
+
+test("drift says the bug is here, not at the National Weather Service", async () => {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
+  });
+  readSkyWeek.mockResolvedValue({
+    beachName: BINDING.beachName,
+    cell: CELL,
+    state: {
+      kind: "unavailable",
+      detail: 'SGX/54,21: skyCover is declared in "wmoUnit:one".',
+      drift: true,
+    },
+  });
+
+  render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
+
+  expect(
+    screen.getByText(
+      /bug here rather than a problem at the National Weather Service/,
+    ),
+  ).toBeDefined();
+});
+
+test("a bluff cell says the square covers the cliff as well as the shore", async () => {
+  // Torrey Pines City Beach reads a cell averaging 117 m. ADR-0020 serves it
+  // and discloses rather than withholding, and this sentence is the half of
+  // that decision no gate can assert -- so a gate asserts it reaches the page.
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
+  });
+  readSkyWeek.mockResolvedValue(
+    skyWeek([{ index: 0, cloudPercent: 44 }], {
+      id: "SGX/55,22",
+      elevationM: 117.0432,
+    }),
+  );
+
+  render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
+
+  expect(screen.getByText(/covers the bluff above this beach/)).toBeDefined();
+});
+
+test("a shoreline cell adds no bluff sentence", async () => {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
+  });
+
+  render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
+
+  expect(screen.queryByText(/covers the bluff/)).toBeNull();
+  // The clause that always stands, which is what separates this row from the
+  // readings on the cards above.
+  expect(
+    screen.getByText(/a forecast, not a reading taken at the beach/),
+  ).toBeDefined();
 });
 
 test("a NOAA outage costs the tide row, not the whole grid", async () => {
@@ -215,17 +357,13 @@ test("a failure to resolve the beach is not swallowed into a rendered nothing", 
 });
 
 /**
- * ADR-0015. The reserved row and the live card describe the same product from
- * different feeds, so they take the same glyph — the gridded forecast lands in
- * the air card, replacing its sky half, and marking it with the thermometer the
- * air card no longer uses would leave the page saying two things about one
- * product.
- *
- * Whether a row about cloud alone still wants the wind glyph is a question for
- * the slice that fills it: the vocabulary is ADR-0015's and changing it is a
- * design decision rather than a copy fix.
+ * ADR-0015 marked the gridded slot with the air card's glyph while it was a
+ * promise about that card. The slot is gone, so the glyph question goes with
+ * it: rows in this grid carry no glyph at all -- a full-colour emoji at 10px is
+ * a smudge rather than a mark -- and the only glyph left in this band belongs
+ * to the one slot still reserved.
  */
-test("the gridded forecast is marked like the air card whose sky it will replace", async () => {
+test("the filled row brings no glyph, and only the reserved slot still has one", async () => {
   readWeekOfLowestLows.mockResolvedValue({
     beachName: "La Jolla Shores Beach",
     station: { name: "La Jolla (Scripps Institution Wharf)", distanceM: 1369 },
@@ -239,8 +377,7 @@ test("the gridded forecast is marked like the air card whose sky it will replace
   const glyphs = [...container.querySelectorAll('[aria-hidden="true"]')].map(
     (node) => node.textContent,
   );
-  expect(glyphs).toContain("💨");
-  expect(glyphs).not.toContain("🌡️");
+  expect(glyphs).toEqual(["🏖️"]);
 });
 
 /* =========================================================================
@@ -435,10 +572,14 @@ test("the wave row sits under daylight, not between it and the tide", async () =
   const labels = [...container.querySelectorAll("li:first-child dt")].map(
     (node) => node.textContent,
   );
+  // Cloud last, and last for a reason: it is the only row with no time in it,
+  // so a reader scanning a column reads three "when"s and then the one figure
+  // about the whole day.
   expect(labels).toEqual([
     "Lowest daylight tide",
     "Daylight",
     "Biggest daylight swell",
+    "Cloud by day",
   ]);
 });
 

--- a/src/components/conditions/WeekPanel.tsx
+++ b/src/components/conditions/WeekPanel.tsx
@@ -7,21 +7,26 @@
  * rather than in `lib/conditions.ts` because which glyph marks a row and what a
  * row is called are presentation.
  *
- * **Three reads, and only one of them cannot fail.** The tide comes from NOAA
- * and the wave forecast from CDIP; daylight is computed in this repo from the
- * beach's own coordinates. So the columns are taken from the daylight read: an
+ * **Four reads, and only one of them cannot fail.** The tide comes from NOAA,
+ * the wave forecast from CDIP and the cloud forecast from the National Weather
+ * Service; daylight is computed in this repo from the beach's own coordinates. So the columns are taken from the daylight read: an
  * outage then costs a row rather than the whole grid, and the week still
  * answers a question a parent came with. All three build their days from one
  * helper in `lib/conditions.ts`, which is what stops the rows disagreeing about
  * which day is Tuesday.
  *
- * **The two upstream reads are made concurrently and fail apart.** They share
+ * **The three upstream reads are made concurrently and fail apart.** They share
  * no publisher and no failure, and NOAA going quiet must not cost the week its
  * wave row -- the same argument `readLatestAir` makes for its two stations.
+ * The cloud read joins them under ADR-0020, which moved sky off the air card
+ * and into this grid: after that change this row is the only sky on the site,
+ * so an outage here is a whole variable missing rather than one row thinner,
+ * and it says so in the notes below the grid.
  */
 
 import {
   readDaylightWeek,
+  readSkyWeek,
   readWaveWeek,
   readWeekOfLowestLows,
 } from "@/lib/conditions";
@@ -32,6 +37,13 @@ import {
   mopLineDistanceKm,
   mopLineSource,
 } from "./mopLine";
+import {
+  GRID_MODEL_NOTE,
+  GRID_NETWORK,
+  GRID_SOURCE,
+  gridCellCaveat,
+} from "./gridCell";
+import { SkyWeek, SKY_WEEK_ROW } from "./SkyWeek";
 import { TideWeek, TIDE_WEEK_ROW } from "./TideWeek";
 import { WaveWeek, WAVE_WEEK_ROW } from "./WaveWeek";
 import { WeekGrid, type ReservedRow, type WeekRow } from "./WeekGrid";
@@ -44,8 +56,10 @@ import { WeekGrid, type ReservedRow, type WeekRow } from "./WeekGrid";
  * would leave the page promising less than it did, and a slot left in beside a
  * filled row would promise it twice.
  *
- * The gridded National Weather Service forecast is #95, which exists so that
- * sky can come from this beach's own grid cell instead of an aerodrome.
+ * **The gridded slot is gone**, because the row it stood in for exists. Same
+ * rule the wave slot came out under: a slot removed before its replacement
+ * would leave the page promising less than it did, and a slot left in beside a
+ * filled row would promise it twice.
  *
  * **It promises sky and nothing else, and both halves of that are measured.**
  * Visibility cannot follow: the gridpoint declares `visibility` and
@@ -67,12 +81,6 @@ import { WeekGrid, type ReservedRow, type WeekRow } from "./WeekGrid";
  */
 const RESERVED: readonly ReservedRow[] = [
   {
-    emoji: "💨",
-    headline: "A gridded forecast is coming.",
-    detail:
-      "Cloud cover for this beach's own grid cell, instead of the nearest airport's reading.",
-  },
-  {
     emoji: "🏖️",
     headline: "The surf zone forecast is coming.",
     detail:
@@ -83,9 +91,10 @@ const RESERVED: readonly ReservedRow[] = [
 export async function WeekPanel({ slug }: { slug: string }) {
   // Concurrently, and failing apart: NOAA and CDIP share no publisher and no
   // outage, so neither may hold up or take down the other's row.
-  const [view, waves] = await Promise.all([
+  const [view, waves, sky] = await Promise.all([
     readWeekOfLowestLows(slug),
     readWaveWeek(slug),
+    readSkyWeek(slug),
   ]);
   const daylight = readDaylightWeek(slug);
 
@@ -157,6 +166,41 @@ export async function WeekPanel({ slug }: { slug: string }) {
   }
 
   /*
+    Last of the four, under the wave row. The order down a day block is tide,
+    daylight, swell, cloud -- what the sea does, when the sun is up, what the
+    swell does, what the sky does. Cloud goes last because it is the only row
+    with no time in it: a reader scanning a column reads three "when"s and then
+    the one figure that is about the whole day, and putting it between two
+    timed rows would break that reading.
+
+    Ragged like the wave row, and for the same reason: the product reaches about
+    seven and a half days and the far column may have none.
+  */
+  if (sky.state.kind === "week" && sky.cell !== null) {
+    const cell = sky.cell;
+    rows.push({
+      ...SKY_WEEK_ROW,
+      cells: Object.fromEntries(
+        sky.state.days.map((day) => [
+          day.localDate,
+          <SkyWeek key={day.localDate} day={day} />,
+        ]),
+      ),
+      // Every word from `gridCell.ts`, for the reason `mopLine.ts` exists: two
+      // call sites wording one fact is how `ProvenanceLine` came to print the
+      // same station two ways on one card. The caveat is null at all but three
+      // beaches, where the cell averages over 100 m and covers the bluff.
+      provenance: {
+        source: GRID_SOURCE,
+        network: GRID_NETWORK,
+        note: [GRID_MODEL_NOTE, gridCellCaveat(cell.elevationM)]
+          .filter((part) => part !== null)
+          .join("; "),
+      },
+    });
+  }
+
+  /*
     One sentence, not seven. The upstream detail stays behind the disclosure on
     the tide card above, which shares this exact request and therefore fails at
     the same moment — repeating it here would be the same failure twice.
@@ -190,6 +234,31 @@ export async function WeekPanel({ slug }: { slug: string }) {
         "depth out on the open coast.",
     );
   }
+  /*
+    The cloud row's failures get their own sentences, and they carry more weight
+    than the wave row's. After ADR-0020 this row is the only sky on the site, so
+    a reader who came to find out whether it will be foggy is told nothing at
+    all rather than told it elsewhere -- and a silent gap would read as a clear
+    week.
+  */
+  if (sky.state.kind === "no-cell") {
+    notes.push(
+      "We have no cloud forecast for this beach. The National Weather Service " +
+        "publishes its forecasts for squares of the map, and this beach does not " +
+        "sit in one we can read.",
+    );
+  }
+  if (sky.state.kind === "unavailable") {
+    notes.push(
+      `We could not get this week's cloud forecast from the National Weather Service just ` +
+        `now. ${sky.state.detail}` +
+        (sky.state.drift
+          ? " The forecast's payload was not the shape this site pins, which is a bug here " +
+            "rather than a problem at the National Weather Service."
+          : ""),
+    );
+  }
+
   if (waves.state.kind === "unavailable") {
     notes.push(
       `We could not get this week's wave forecast from CDIP just now. ${waves.state.detail}` +

--- a/src/components/conditions/gridCell.ts
+++ b/src/components/conditions/gridCell.ts
@@ -1,0 +1,88 @@
+/**
+ * How a forecast cell is named, credited and qualified for a reader.
+ *
+ * The same job `mopLine.ts` does for a MOP line, and here for the same reason:
+ * more than one place is about to state these facts, and `ProvenanceLine`'s
+ * docstring records what happens when two call sites each word one — the page
+ * printed "San Diego Airport · 4.7 km from this beach" and "San Diego Airport ·
+ * 4.7 km away" eighty pixels apart.
+ *
+ * Presentation, so it sits here rather than in `lib/`: what a reader is told a
+ * cell is, not what the join knows about it.
+ */
+
+/** How far above sea level a cell may average before the page says so. */
+const BLUFF_ELEVATION_M = 50;
+
+/**
+ * Who publishes the forecast.
+ *
+ * The office rather than the agency alone. "National Weather Service" is the
+ * publisher a reader knows, and San Diego is which of its offices issued this
+ * grid — the same reason `MOP_NETWORK` carries Scripps as well as CDIP.
+ */
+export const GRID_NETWORK = "National Weather Service, San Diego";
+
+/**
+ * What the figure is, said on the line rather than left to be inferred.
+ *
+ * The page has no measured sky on it at all after ADR-0020, so unlike the wave
+ * card there is no measurement beside this for a reader to confuse it with. The
+ * clause is here anyway, because the row sits under a tide row of astronomical
+ * predictions and beside a wave row of model output, and "forecast" is the word
+ * that separates all three from the readings on the cards above.
+ */
+export const GRID_MODEL_NOTE = "a forecast, not a reading taken at the beach";
+
+/**
+ * What the page calls a cell.
+ *
+ * "this beach's own grid cell" rather than `SGX/54,21`. The identifier is how
+ * the National Weather Service addresses a square of the map and means nothing
+ * to a reader — and the whole point of this row is *whose* sky it is, which the
+ * identifier states worse than the words do. #87 is the record of what happens
+ * when a callsign is printed as prose.
+ */
+export const GRID_SOURCE = "this beach's own grid cell";
+
+/**
+ * The sentence a cell that spans the shoreline and the bluff above it owes.
+ *
+ * Three beaches read one: Torrey Pines State, Torrey Pines City and La Jolla
+ * Cove, whose cells average 102 m, 117 m and 106 m against a median of 2.1 m
+ * across the inventory. ADR-0020 serves them rather than withholding, on the
+ * grounds that terrain is a weaker proxy than an instrument distance and that
+ * blanking three of this coast's most-visited beaches costs a reader more than
+ * the caveat does. This is the caveat, and the decision is conditional on it.
+ *
+ * Returns null for a cell at the shore, so the ordinary case says nothing extra.
+ */
+export function gridCellCaveat(elevationM: number | null): string | null {
+  if (elevationM === null || elevationM <= BLUFF_ELEVATION_M) return null;
+  return (
+    `this cell averages ${Math.round(elevationM)} m of elevation, so it covers the bluff ` +
+    `above this beach as well as the shore`
+  );
+}
+
+/**
+ * A forecast phenomenon in the register the page already writes in.
+ *
+ * The service publishes `fog` with coverage `patchy`, and its own plain-language
+ * product renders that "Patchy Fog". So the words are upstream's and the only
+ * thing done here is the underscore and the capital — nothing is added, which
+ * is ADR-0009's rule that this site relays a forecaster's judgement rather than
+ * forming one. "Chance rain showers" reads oddly and is what the National
+ * Weather Service itself says; inventing "a chance of rain showers" would be
+ * this site wording someone else's forecast.
+ */
+export function phenomenonWords(phenomenon: {
+  weather: string;
+  coverage: string | null;
+}): string {
+  const words = [phenomenon.coverage, phenomenon.weather]
+    .filter((part): part is string => part !== null && part !== "")
+    .join(" ")
+    .replaceAll("_", " ");
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}

--- a/src/lib/__fixtures__/nws-gridpoint-sgx-54-21-20260827.json
+++ b/src/lib/__fixtures__/nws-gridpoint-sgx-54-21-20260827.json
@@ -1,0 +1,386 @@
+{
+  "type": "Feature",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -117.2477,
+          32.8545
+        ],
+        [
+          -117.2521,
+          32.8768
+        ],
+        [
+          -117.2787,
+          32.8731
+        ],
+        [
+          -117.2743,
+          32.8508
+        ],
+        [
+          -117.2477,
+          32.8545
+        ]
+      ]
+    ]
+  },
+  "properties": {
+    "@id": "https://api.weather.gov/gridpoints/SGX/54,21",
+    "@type": "wx:Gridpoint",
+    "updateTime": "2026-08-26T18:36:01+00:00",
+    "validTimes": "2026-08-26T12:00:00+00:00/P7DT13H",
+    "elevation": {
+      "unitCode": "wmoUnit:m",
+      "value": 0
+    },
+    "gridId": "SGX",
+    "gridX": 54,
+    "gridY": 21,
+    "skyCover": {
+      "uom": "wmoUnit:percent",
+      "values": [
+        {
+          "validTime": "2026-08-26T12:00:00+00:00/PT3H",
+          "value": 66
+        },
+        {
+          "validTime": "2026-08-26T15:00:00+00:00/PT3H",
+          "value": 39
+        },
+        {
+          "validTime": "2026-08-26T18:00:00+00:00/PT3H",
+          "value": 50
+        },
+        {
+          "validTime": "2026-08-26T21:00:00+00:00/PT3H",
+          "value": 41
+        },
+        {
+          "validTime": "2026-08-27T00:00:00+00:00/PT3H",
+          "value": 33
+        },
+        {
+          "validTime": "2026-08-27T03:00:00+00:00/PT3H",
+          "value": 48
+        },
+        {
+          "validTime": "2026-08-27T06:00:00+00:00/PT3H",
+          "value": 60
+        },
+        {
+          "validTime": "2026-08-27T09:00:00+00:00/PT3H",
+          "value": 74
+        },
+        {
+          "validTime": "2026-08-27T12:00:00+00:00/PT3H",
+          "value": 71
+        },
+        {
+          "validTime": "2026-08-27T15:00:00+00:00/PT3H",
+          "value": 73
+        },
+        {
+          "validTime": "2026-08-27T18:00:00+00:00/PT3H",
+          "value": 66
+        },
+        {
+          "validTime": "2026-08-27T21:00:00+00:00/PT3H",
+          "value": 53
+        },
+        {
+          "validTime": "2026-08-28T00:00:00+00:00/PT6H",
+          "value": 72
+        },
+        {
+          "validTime": "2026-08-28T06:00:00+00:00/PT6H",
+          "value": 73
+        },
+        {
+          "validTime": "2026-08-28T12:00:00+00:00/PT6H",
+          "value": 64
+        },
+        {
+          "validTime": "2026-08-28T18:00:00+00:00/PT6H",
+          "value": 54
+        },
+        {
+          "validTime": "2026-08-29T00:00:00+00:00/PT6H",
+          "value": 44
+        },
+        {
+          "validTime": "2026-08-29T06:00:00+00:00/PT6H",
+          "value": 35
+        },
+        {
+          "validTime": "2026-08-29T12:00:00+00:00/PT6H",
+          "value": 47
+        },
+        {
+          "validTime": "2026-08-29T18:00:00+00:00/PT6H",
+          "value": 40
+        },
+        {
+          "validTime": "2026-08-30T00:00:00+00:00/PT6H",
+          "value": 20
+        },
+        {
+          "validTime": "2026-08-30T06:00:00+00:00/PT6H",
+          "value": 32
+        },
+        {
+          "validTime": "2026-08-30T12:00:00+00:00/PT6H",
+          "value": 62
+        },
+        {
+          "validTime": "2026-08-30T18:00:00+00:00/PT6H",
+          "value": 28
+        },
+        {
+          "validTime": "2026-08-31T00:00:00+00:00/PT6H",
+          "value": 21
+        },
+        {
+          "validTime": "2026-08-31T06:00:00+00:00/PT6H",
+          "value": 35
+        },
+        {
+          "validTime": "2026-08-31T12:00:00+00:00/PT6H",
+          "value": 70
+        },
+        {
+          "validTime": "2026-08-31T18:00:00+00:00/PT6H",
+          "value": 39
+        },
+        {
+          "validTime": "2026-09-01T00:00:00+00:00/PT6H",
+          "value": 35
+        },
+        {
+          "validTime": "2026-09-01T06:00:00+00:00/PT6H",
+          "value": 51
+        },
+        {
+          "validTime": "2026-09-01T12:00:00+00:00/PT6H",
+          "value": 76
+        },
+        {
+          "validTime": "2026-09-01T18:00:00+00:00/PT6H",
+          "value": 57
+        },
+        {
+          "validTime": "2026-09-02T00:00:00+00:00/PT6H",
+          "value": 48
+        },
+        {
+          "validTime": "2026-09-02T06:00:00+00:00/PT6H",
+          "value": 71
+        },
+        {
+          "validTime": "2026-09-02T12:00:00+00:00/PT6H",
+          "value": 85
+        },
+        {
+          "validTime": "2026-09-02T18:00:00+00:00/PT6H",
+          "value": 64
+        },
+        {
+          "validTime": "2026-09-03T00:00:00+00:00/PT6H",
+          "value": 55
+        }
+      ]
+    },
+    "weather": {
+      "values": [
+        {
+          "validTime": "2026-08-26T12:00:00+00:00/PT3H",
+          "value": [
+            {
+              "coverage": "patchy",
+              "weather": "fog",
+              "intensity": null,
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": 4.828032
+              },
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "validTime": "2026-08-26T15:00:00+00:00/PT15H",
+          "value": [
+            {
+              "coverage": null,
+              "weather": null,
+              "intensity": null,
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": null
+              },
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "validTime": "2026-08-27T06:00:00+00:00/PT12H",
+          "value": [
+            {
+              "coverage": "patchy",
+              "weather": "fog",
+              "intensity": null,
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": 4.828032
+              },
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "validTime": "2026-08-27T18:00:00+00:00/PT12H",
+          "value": [
+            {
+              "coverage": null,
+              "weather": null,
+              "intensity": null,
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": null
+              },
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "validTime": "2026-08-28T06:00:00+00:00/PT12H",
+          "value": [
+            {
+              "coverage": "patchy",
+              "weather": "fog",
+              "intensity": null,
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": 4.828032
+              },
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "validTime": "2026-08-28T18:00:00+00:00/PT18H",
+          "value": [
+            {
+              "coverage": null,
+              "weather": null,
+              "intensity": null,
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": null
+              },
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "validTime": "2026-08-29T12:00:00+00:00/PT6H",
+          "value": [
+            {
+              "coverage": "patchy",
+              "weather": "fog",
+              "intensity": null,
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": 4.828032
+              },
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "validTime": "2026-08-29T18:00:00+00:00/P2D",
+          "value": [
+            {
+              "coverage": null,
+              "weather": null,
+              "intensity": null,
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": null
+              },
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "validTime": "2026-08-31T18:00:00+00:00/PT6H",
+          "value": [
+            {
+              "coverage": "slight_chance",
+              "weather": "rain_showers",
+              "intensity": "light",
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": null
+              },
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "validTime": "2026-09-01T00:00:00+00:00/PT6H",
+          "value": [
+            {
+              "coverage": null,
+              "weather": null,
+              "intensity": null,
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": null
+              },
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "validTime": "2026-09-01T06:00:00+00:00/PT18H",
+          "value": [
+            {
+              "coverage": "slight_chance",
+              "weather": "rain_showers",
+              "intensity": "light",
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": null
+              },
+              "attributes": []
+            }
+          ]
+        },
+        {
+          "validTime": "2026-09-02T00:00:00+00:00/P1DT6H",
+          "value": [
+            {
+              "coverage": null,
+              "weather": null,
+              "intensity": null,
+              "visibility": {
+                "unitCode": "wmoUnit:km",
+                "value": null
+              },
+              "attributes": []
+            }
+          ]
+        }
+      ]
+    },
+    "visibility": {
+      "values": []
+    },
+    "ceilingHeight": {
+      "values": []
+    }
+  }
+}

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -6,7 +6,9 @@ const fetchLatestWave = vi.fn();
 const fetchLatestObservation = vi.fn();
 const fetchLatestNdbcAir = vi.fn();
 const fetchMopForecast = vi.fn();
+const fetchGridForecast = vi.fn();
 vi.mock("./upstream", () => ({
+  fetchGridForecast,
   fetchTideExtremes,
   fetchLatestWave,
   fetchLatestObservation,
@@ -57,6 +59,10 @@ vi.mock("./beaches", async (importOriginal) => {
     sky_station_distance_m: null,
     sky_station_from_end: null,
     sky_station_null_reason: reason,
+    grid_cell: null,
+    grid_cell_from_end: null,
+    grid_cell_elevation_m: null,
+    grid_cell_null_reason: reason,
     air_station: null,
     air_station_distance_m: null,
     air_station_from_end: null,
@@ -76,6 +82,7 @@ const {
   readLatestWaves,
   readLatestAir,
   readWaveWeek,
+  readSkyWeek,
 } = await import("./conditions");
 
 /**
@@ -93,6 +100,7 @@ beforeEach(() => {
   fetchLatestObservation.mockReset();
   fetchLatestNdbcAir.mockReset();
   fetchMopForecast.mockReset();
+  fetchGridForecast.mockReset();
 });
 
 function ok(extremes: { atMs: number; feet: number; kind: "low" | "high" }[]) {
@@ -1053,5 +1061,201 @@ test("an unavailable forecast carries its reason and its drift flag through", as
 test("a slug that is not in the inventory is a coding error, not a quiet feed", async () => {
   await expect(
     readWaveWeek("no-such-beach", NOON_PACIFIC_20260817),
+  ).rejects.toThrow(/no beach in the inventory/);
+});
+
+/* =========================================================================
+ * readSkyWeek
+ * ========================================================================= */
+
+/**
+ * Sunrise and sunset at La Jolla Shores on 2026-08-17 are about 6:14 AM and
+ * 7:32 PM Pacific, so an hour stamped 14:00 UTC (7 AM Pacific) is in daylight
+ * and one stamped 09:00 UTC (2 AM Pacific) is not.
+ */
+const hourUtc = (day: number, utcHour: number) =>
+  Date.UTC(2026, 7, day, utcHour);
+
+function gridOk(
+  skyCover: { atMs: number; percent: number }[],
+  weather: { atMs: number; weather: string; coverage: string | null }[] = [],
+) {
+  fetchGridForecast.mockResolvedValue({
+    kind: "ok",
+    forecast: { cellId: "SGX/54,21", skyCover, weather },
+    url: "https://example.invalid",
+  });
+}
+
+test("a day's figure is the mean of its daylight hours, not of the whole day", async () => {
+  // THE DECISION THIS ROW TURNS ON. The night hours here are 0% and 100%; if
+  // either reached the mean the answer would not be 50. Daylight is 20 and 80.
+  gridOk([
+    { atMs: hourUtc(17, 9), percent: 0 },
+    { atMs: hourUtc(17, 15), percent: 20 },
+    { atMs: hourUtc(17, 23), percent: 80 },
+    { atMs: hourUtc(18, 8), percent: 100 },
+  ]);
+
+  const view = await readSkyWeek(BEACH, NOON_PACIFIC_20260817);
+
+  expect(view.state.kind).toBe("week");
+  if (view.state.kind !== "week") throw new Error("expected a week");
+  expect(view.state.days[0].cloudPercent).toBe(50);
+});
+
+test("the mean is not the cloudiest step, which is what ADR-0017 would have taken", async () => {
+  // Measured at SGX/54,21 for 2026-08-30: daylight steps spanning 21 to 62,
+  // mean 39. An extreme-selecting row would publish 62 for this day.
+  gridOk([
+    { atMs: hourUtc(17, 14), percent: 21 },
+    { atMs: hourUtc(17, 17), percent: 34 },
+    { atMs: hourUtc(17, 20), percent: 39 },
+    { atMs: hourUtc(17, 23), percent: 62 },
+  ]);
+
+  const view = await readSkyWeek(BEACH, NOON_PACIFIC_20260817);
+  if (view.state.kind !== "week") throw new Error("expected a week");
+
+  expect(view.state.days[0].cloudPercent).toBe(39);
+  expect(view.state.days[0].cloudPercent).not.toBe(62);
+});
+
+test("a day with fog in its daylight carries the phenomenon", async () => {
+  gridOk(
+    [{ atMs: hourUtc(17, 15), percent: 60 }],
+    [{ atMs: hourUtc(17, 15), weather: "fog", coverage: "patchy" }],
+  );
+
+  const view = await readSkyWeek(BEACH, NOON_PACIFIC_20260817);
+  if (view.state.kind !== "week") throw new Error("expected a week");
+
+  expect(view.state.days[0].phenomenon).toEqual({
+    weather: "fog",
+    coverage: "patchy",
+  });
+});
+
+test("fog outside daylight does not annotate the day", async () => {
+  // 09:00 UTC is 2 AM Pacific. Fog nobody will be at the beach for is not what
+  // the row is telling a parent about.
+  gridOk(
+    [{ atMs: hourUtc(17, 15), percent: 60 }],
+    [{ atMs: hourUtc(17, 9), weather: "fog", coverage: "patchy" }],
+  );
+
+  const view = await readSkyWeek(BEACH, NOON_PACIFIC_20260817);
+  if (view.state.kind !== "week") throw new Error("expected a week");
+
+  expect(view.state.days[0].phenomenon).toBeNull();
+});
+
+test("a day the forecast does not reach is dropped, not rendered as zero", async () => {
+  // A zero here would read as a cloudless day. The far column runs out as the
+  // product's reach does, and the grid draws no cell where a row has none.
+  gridOk([{ atMs: hourUtc(17, 15), percent: 60 }]);
+
+  const view = await readSkyWeek(BEACH, NOON_PACIFIC_20260817);
+  if (view.state.kind !== "week") throw new Error("expected a week");
+
+  expect(view.state.days).toHaveLength(1);
+  expect(view.state.days[0].localDate).toBe("2026-08-17");
+});
+
+test("the days it does reach agree with the other rows about which day is which", async () => {
+  gridOk([
+    { atMs: hourUtc(17, 15), percent: 10 },
+    { atMs: hourUtc(18, 15), percent: 20 },
+  ]);
+
+  const view = await readSkyWeek(BEACH, NOON_PACIFIC_20260817);
+  if (view.state.kind !== "week") throw new Error("expected a week");
+
+  expect(view.state.days.map((day) => day.localDate)).toEqual([
+    "2026-08-17",
+    "2026-08-18",
+  ]);
+  expect(view.state.days[0].isToday).toBe(true);
+  expect(view.state.days[1].isToday).toBe(false);
+});
+
+test("two phenomena on one day are grouped, not overwritten", async () => {
+  // Exercises the second-hour path of the by-date grouping. A day with fog in
+  // the morning and showers later must keep both hours behind one date, or the
+  // day's annotation would depend on which arrived last.
+  gridOk(
+    [
+      { atMs: hourUtc(17, 15), percent: 40 },
+      { atMs: hourUtc(17, 18), percent: 60 },
+    ],
+    [
+      { atMs: hourUtc(17, 15), weather: "fog", coverage: "patchy" },
+      { atMs: hourUtc(17, 18), weather: "rain_showers", coverage: "chance" },
+    ],
+  );
+
+  const view = await readSkyWeek(BEACH, NOON_PACIFIC_20260817);
+  if (view.state.kind !== "week") throw new Error("expected a week");
+
+  expect(view.state.days[0].cloudPercent).toBe(50);
+  // The first of the daylight window, which is the one a parent plans around.
+  expect(view.state.days[0].phenomenon?.weather).toBe("fog");
+});
+
+test("a beach with no forecast cell says so, and does not read as an outage", async () => {
+  const view = await readSkyWeek(UNBOUND_BEACH, NOON_PACIFIC_20260817);
+
+  expect(view.cell).toBeNull();
+  expect(view.state.kind).toBe("no-cell");
+  if (view.state.kind !== "no-cell") throw new Error("expected no-cell");
+  expect(view.state.reason).toMatch(/outside San Diego County/);
+  // A permanent fact about the place must not reach the network.
+  expect(fetchGridForecast).not.toHaveBeenCalled();
+});
+
+test("an upstream failure keeps the binding and carries the reason", async () => {
+  fetchGridForecast.mockResolvedValue({
+    kind: "unavailable",
+    reason:
+      "The National Weather Service returned HTTP 503 for forecast cell SGX/54,21.",
+    drift: false,
+    url: "https://example.invalid",
+  });
+
+  const view = await readSkyWeek(BEACH, NOON_PACIFIC_20260817);
+
+  expect(view.cell?.id).toBe("SGX/54,21");
+  if (view.state.kind !== "unavailable")
+    throw new Error("expected unavailable");
+  expect(view.state.detail).toMatch(/503/);
+  expect(view.state.drift).toBe(false);
+});
+
+test("drift is carried separately, because it is a bug here rather than a bad day", async () => {
+  fetchGridForecast.mockResolvedValue({
+    kind: "unavailable",
+    reason: 'SGX/54,21: skyCover is declared in "wmoUnit:one".',
+    drift: true,
+    url: "https://example.invalid",
+  });
+
+  const view = await readSkyWeek(BEACH, NOON_PACIFIC_20260817);
+  if (view.state.kind !== "unavailable")
+    throw new Error("expected unavailable");
+  expect(view.state.drift).toBe(true);
+});
+
+test("the bound cell's elevation reaches the view, for the bluff sentence", async () => {
+  gridOk([{ atMs: hourUtc(17, 15), percent: 60 }]);
+
+  const view = await readSkyWeek(BEACH, NOON_PACIFIC_20260817);
+
+  expect(view.cell?.id).toBe("SGX/54,21");
+  expect(view.cell?.elevationM).toBe(0);
+});
+
+test("a slug that is not in the inventory throws rather than rendering nothing", async () => {
+  await expect(
+    readSkyWeek("no-such-beach", NOON_PACIFIC_20260817),
   ).rejects.toThrow(/no beach in the inventory/);
 });

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -31,7 +31,9 @@ import {
 } from "./pacific-time";
 import { lowestLowBetween, lowestLowOn } from "./tide-day";
 import type { MopWaveRow } from "./mop-forecast";
+import type { SkyCoverHour, WeatherHour } from "./nws-gridpoint";
 import {
+  fetchGridForecast,
   fetchLatestNdbcAir,
   fetchLatestObservation,
   fetchLatestWave,
@@ -1059,6 +1061,163 @@ export async function readWaveWeek(
       daylight.get(frame.localDate)!,
     );
     return readings === null ? [] : [{ ...frame, ...readings }];
+  });
+
+  return { ...binding, state: { kind: "week", days } };
+}
+
+/* =========================================================================
+ * The week's cloud cover, from the beach's own forecast cell
+ * ========================================================================= */
+
+/** One day of the cloud row. */
+export interface SkyWeekDay extends WeekDayFrame {
+  /**
+   * Mean cloud cover across the day's daylight hours, 0 to 100, rounded.
+   *
+   * A mean rather than an extreme, which is a deliberate departure from
+   * ADR-0017 and the one place this row differs from the tide and swell rows
+   * above it. Those take the daylight extreme because a lowest low at 3:14 AM
+   * is a number nobody planning a trip with children can use -- the extreme is
+   * selected for *reachability*. Cloud cover has no unreachable hours: the
+   * daylight window is the trip. Measured over seven days at one cell, the
+   * daylight spread runs 20 to 41 points, and taking the cloudiest step would
+   * have reported 2026-08-30 at 62% against a daylight mean of 39%.
+   */
+  cloudPercent: number;
+  /**
+   * The phenomenon forecast for any daylight hour of this day, or null.
+   *
+   * This is what carries the "when" that ADR-0017's times carry for the rows
+   * above: a parent plans around fog rather than around a percentage. Null on
+   * most days, which is an ordinary day rather than a missing reading.
+   */
+  phenomenon: { weather: string; coverage: string | null } | null;
+}
+
+export interface SkyWeekView {
+  beachName: string;
+  /** null exactly when the state is `no-cell`. */
+  cell: { id: string; elevationM: number | null } | null;
+  state:
+    | { kind: "week"; days: SkyWeekDay[] }
+    | { kind: "no-cell"; reason: string }
+    | { kind: "unavailable"; detail: string; drift: boolean };
+}
+
+/**
+ * The daylight mean for one day, and the phenomenon if one was forecast.
+ *
+ * Returns null when no forecast hour falls in this day's daylight, which is
+ * what the far end of the week does as the product's reach runs out. A day with
+ * no hours is dropped rather than rendered as zero -- a zero here would read as
+ * a cloudless day.
+ */
+function skyReadingOn(
+  hours: readonly SkyCoverHour[],
+  weather: readonly WeatherHour[],
+  daylight: Daylight,
+): { cloudPercent: number; phenomenon: SkyWeekDay["phenomenon"] } | null {
+  const inDaylight = hours.filter(
+    (hour) => hour.atMs >= daylight.sunriseMs && hour.atMs <= daylight.sunsetMs,
+  );
+  if (inDaylight.length === 0) return null;
+
+  const total = inDaylight.reduce((sum, hour) => sum + hour.percent, 0);
+
+  // The first phenomenon of the daylight window rather than the most common
+  // one: "patchy fog" at 7 AM is the fact a parent is deciding on, and a day
+  // with fog in the morning and sun after lunch is a foggy morning rather than
+  // an average of the two.
+  const named = weather.find(
+    (hour) => hour.atMs >= daylight.sunriseMs && hour.atMs <= daylight.sunsetMs,
+  );
+
+  return {
+    cloudPercent: Math.round(total / inDaylight.length),
+    phenomenon:
+      named === undefined
+        ? null
+        : { weather: named.weather, coverage: named.coverage },
+  };
+}
+
+/**
+ * The week's cloud cover for one beach.
+ *
+ * `nowMs` is injected for the reason every read here injects it: day selection
+ * is asserted against fixed instants and no clock is read during a render.
+ */
+export async function readSkyWeek(
+  slug: string,
+  nowMs: number = Date.now(),
+): Promise<SkyWeekView> {
+  const beach = beachBySlug(slug);
+  if (!beach) {
+    throw new Error(
+      `readSkyWeek: no beach in the inventory with slug "${slug}".`,
+    );
+  }
+
+  if (beach.grid_cell === null) {
+    return {
+      beachName: beach.name,
+      cell: null,
+      state: {
+        kind: "no-cell",
+        reason:
+          beach.grid_cell_null_reason ??
+          "the join bound no forecast cell to this beach, and recorded no reason",
+      },
+    };
+  }
+
+  const binding = {
+    beachName: beach.name,
+    cell: { id: beach.grid_cell, elevationM: beach.grid_cell_elevation_m },
+  };
+
+  const result = await fetchGridForecast(beach.grid_cell);
+  if (result.kind === "unavailable") {
+    return {
+      ...binding,
+      state: {
+        kind: "unavailable",
+        detail: result.reason,
+        drift: result.drift,
+      },
+    };
+  }
+
+  const skyByDate = new Map<string, SkyCoverHour[]>();
+  for (const hour of result.forecast.skyCover) {
+    const localDate = localDateOf(hour.atMs);
+    const standing = skyByDate.get(localDate);
+    if (standing === undefined) skyByDate.set(localDate, [hour]);
+    else standing.push(hour);
+  }
+
+  const weatherByDate = new Map<string, WeatherHour[]>();
+  for (const hour of result.forecast.weather) {
+    const localDate = localDateOf(hour.atMs);
+    const standing = weatherByDate.get(localDate);
+    if (standing === undefined) weatherByDate.set(localDate, [hour]);
+    else standing.push(hour);
+  }
+
+  const daylight = daylightByDate(beach, nowMs);
+
+  // Built from `weekOfDays` rather than from the forecast's own hours, so this
+  // row cannot disagree with the tide, daylight and wave rows about which day
+  // is Tuesday. Ragged by construction: the product reaches about seven and a
+  // half days and the far column may have none.
+  const days = weekOfDays(nowMs).flatMap((frame) => {
+    const reading = skyReadingOn(
+      skyByDate.get(frame.localDate) ?? [],
+      weatherByDate.get(frame.localDate) ?? [],
+      daylight.get(frame.localDate)!,
+    );
+    return reading === null ? [] : [{ ...frame, ...reading }];
   });
 
   return { ...binding, state: { kind: "week", days } };

--- a/src/lib/nws-gridpoint.test.ts
+++ b/src/lib/nws-gridpoint.test.ts
@@ -1,0 +1,266 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  gridpointUrl,
+  NwsGridpointDriftError,
+  NwsGridpointNoDataError,
+  parseGridpointForecast,
+} from "./nws-gridpoint";
+
+/**
+ * A real response, captured from `api.weather.gov` on 2026-08-27 for the cell
+ * La Jolla Shores Beach binds. Captured rather than written, because the
+ * assertion this parser most needs -- that a declared key can carry nothing --
+ * is exactly the kind a hand-written fixture would be built to satisfy.
+ *
+ * The path is resolved from the working directory rather than `import.meta.url`,
+ * which is not a `file:` URL under this test environment.
+ */
+const PAYLOAD = JSON.parse(
+  readFileSync(
+    join(
+      process.cwd(),
+      "src",
+      "lib",
+      "__fixtures__",
+      "nws-gridpoint-sgx-54-21-20260827.json",
+    ),
+    "utf8",
+  ),
+);
+
+const CELL = "SGX/54,21";
+
+describe("parseGridpointForecast", () => {
+  it("reads the cell's sky cover as whole percentages", () => {
+    const forecast = parseGridpointForecast(PAYLOAD, CELL);
+    expect(forecast.cellId).toBe(CELL);
+    expect(forecast.skyCover.length).toBeGreaterThan(0);
+    for (const hour of forecast.skyCover) {
+      expect(hour.percent).toBeGreaterThanOrEqual(0);
+      expect(hour.percent).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("expands each interval into the hours it covers", () => {
+    // The payload's first entry is a PT3H block. A caller selecting the
+    // daylight hours of a day cannot do that against three-hour blocks without
+    // inventing a rule for one that straddles sunrise.
+    const forecast = parseGridpointForecast(PAYLOAD, CELL);
+    const entries = PAYLOAD.properties.skyCover.values.length;
+
+    expect(forecast.skyCover.length).toBeGreaterThan(entries);
+
+    const first = PAYLOAD.properties.skyCover.values[0];
+    const [instant, duration] = first.validTime.split("/");
+    const hours = /PT(\d+)H/.exec(duration);
+    if (hours === null) {
+      throw new Error("the fixture's first entry is not an hourly block");
+    }
+    const span = Number(hours[1]);
+    const startMs = Date.parse(instant);
+
+    const expanded = forecast.skyCover.filter(
+      (hour) => hour.atMs >= startMs && hour.atMs < startMs + span * 3_600_000,
+    );
+    expect(expanded).toHaveLength(span);
+    for (const hour of expanded) expect(hour.percent).toBe(first.value);
+  });
+
+  it("returns hours in order, one per hour, with no gaps inside a block", () => {
+    const forecast = parseGridpointForecast(PAYLOAD, CELL);
+    for (let i = 1; i < forecast.skyCover.length; i += 1) {
+      expect(forecast.skyCover[i].atMs).toBeGreaterThan(
+        forecast.skyCover[i - 1].atMs,
+      );
+    }
+  });
+
+  it("carries the fog the week grid annotates days with", () => {
+    const forecast = parseGridpointForecast(PAYLOAD, CELL);
+    // The captured week forecasts fog. If a future capture does not, this
+    // asserts the shape rather than the weather.
+    for (const hour of forecast.weather) {
+      expect(typeof hour.weather).toBe("string");
+      expect(hour.weather.length).toBeGreaterThan(0);
+    }
+    expect(forecast.weather.some((hour) => hour.weather === "fog")).toBe(true);
+  });
+
+  it("keeps only the entries that name a phenomenon", () => {
+    // Most weather entries name nothing, and an empty one is an ordinary hour
+    // rather than missing data. Counting them as phenomena would put a blank
+    // annotation on most days of the week.
+    const forecast = parseGridpointForecast(PAYLOAD, CELL);
+    const named = PAYLOAD.properties.weather.values.filter(
+      (entry: { value: { weather: string | null }[] }) =>
+        entry.value.some((item) => item.weather),
+    );
+    expect(named.length).toBeLessThan(PAYLOAD.properties.weather.values.length);
+    expect(forecast.weather.length).toBeGreaterThan(0);
+  });
+});
+
+describe("the variables this feed declares and does not publish", () => {
+  it("proves the fixture really carries empty visibility and ceiling", () => {
+    // Not a test of the parser. It pins the fact the whole design rests on, in
+    // the captured payload, so a future capture that starts publishing either
+    // one fails here and gets read rather than absorbed.
+    expect(PAYLOAD.properties.visibility.values).toHaveLength(0);
+    expect(PAYLOAD.properties.ceilingHeight.values).toHaveLength(0);
+  });
+
+  it("refuses a series that is declared and empty, as no-data rather than drift", () => {
+    // What visibility does at every cell, and what a real skyCover does when
+    // the office has not run the product. A quiet cell is not a bug to chase.
+    const empty = {
+      properties: {
+        ...PAYLOAD.properties,
+        skyCover: { uom: "wmoUnit:percent", values: [] },
+      },
+    };
+    expect(() => parseGridpointForecast(empty, CELL)).toThrow(
+      NwsGridpointNoDataError,
+    );
+    expect(() => parseGridpointForecast(empty, CELL)).toThrow(
+      /published no values/,
+    );
+  });
+
+  it("refuses a payload that stops declaring skyCover at all, as drift", () => {
+    const properties = { ...PAYLOAD.properties };
+    delete properties.skyCover;
+    expect(() => parseGridpointForecast({ properties }, CELL)).toThrow(
+      NwsGridpointDriftError,
+    );
+  });
+});
+
+describe("what the parser refuses", () => {
+  const withSkyCover = (values: unknown[], uom = "wmoUnit:percent") => ({
+    properties: { ...PAYLOAD.properties, skyCover: { uom, values } },
+  });
+
+  it("refuses a unit change rather than putting a fraction on the page", () => {
+    expect(() =>
+      parseGridpointForecast(
+        withSkyCover(
+          [{ validTime: "2026-08-26T12:00:00+00:00/PT3H", value: 0.66 }],
+          "wmoUnit:one",
+        ),
+        CELL,
+      ),
+    ).toThrow(/pins wmoUnit:percent/);
+  });
+
+  it("refuses an instant with no offset, which ADR-0009 names as the hazard", () => {
+    // Read as local and tagged UTC, an offset-less instant ages every reading
+    // by seven or eight hours on this coast.
+    expect(() =>
+      parseGridpointForecast(
+        withSkyCover([{ validTime: "2026-08-26T12:00:00/PT3H", value: 66 }]),
+        CELL,
+      ),
+    ).toThrow(/offset stated/);
+  });
+
+  it("refuses a value outside the range its declared unit allows", () => {
+    expect(() =>
+      parseGridpointForecast(
+        withSkyCover([
+          { validTime: "2026-08-26T12:00:00+00:00/PT3H", value: 140 },
+        ]),
+        CELL,
+      ),
+    ).toThrow(/outside the 0 to 100/);
+    expect(() =>
+      parseGridpointForecast(
+        withSkyCover([
+          { validTime: "2026-08-26T12:00:00+00:00/PT3H", value: "66" },
+        ]),
+        CELL,
+      ),
+    ).toThrow(/not a number/);
+  });
+
+  it("refuses an interval covering no time", () => {
+    expect(() =>
+      parseGridpointForecast(
+        withSkyCover([
+          { validTime: "2026-08-26T12:00:00+00:00/PT0H", value: 66 },
+        ]),
+        CELL,
+      ),
+    ).toThrow(/covers no time/);
+  });
+
+  it("skips a null step without failing the whole read", () => {
+    // The service leaves a gap where it has not forecast a step. One gap is not
+    // a dead cell, and refusing the read over it would blank a whole week.
+    const forecast = parseGridpointForecast(
+      withSkyCover([
+        { validTime: "2026-08-26T12:00:00+00:00/PT1H", value: null },
+        { validTime: "2026-08-26T13:00:00+00:00/PT1H", value: 40 },
+      ]),
+      CELL,
+    );
+    expect(forecast.skyCover).toHaveLength(1);
+    expect(forecast.skyCover[0].percent).toBe(40);
+  });
+
+  it("refuses when every step is null, as no-data", () => {
+    expect(() =>
+      parseGridpointForecast(
+        withSkyCover([
+          { validTime: "2026-08-26T12:00:00+00:00/PT1H", value: null },
+        ]),
+        CELL,
+      ),
+    ).toThrow(NwsGridpointNoDataError);
+  });
+
+  it("refuses a validTime that is not a string at all", () => {
+    expect(() =>
+      parseGridpointForecast(withSkyCover([{ validTime: 3, value: 66 }]), CELL),
+    ).toThrow(/not a string/);
+  });
+
+  it("refuses a series whose values are not an array", () => {
+    expect(() =>
+      parseGridpointForecast(
+        {
+          properties: {
+            ...PAYLOAD.properties,
+            skyCover: { uom: "wmoUnit:percent", values: {} },
+          },
+        },
+        CELL,
+      ),
+    ).toThrow(/an array of values was expected/);
+  });
+
+  it("refuses a response with no properties", () => {
+    expect(() => parseGridpointForecast({}, CELL)).toThrow(
+      /no properties object/,
+    );
+  });
+
+  it("reads a multi-day duration, which the far end of the week uses", () => {
+    const forecast = parseGridpointForecast(
+      withSkyCover([
+        { validTime: "2026-08-26T12:00:00+00:00/P1DT2H", value: 50 },
+      ]),
+      CELL,
+    );
+    expect(forecast.skyCover).toHaveLength(26);
+  });
+});
+
+describe("gridpointUrl", () => {
+  it("addresses the cell the binding names, without re-deriving it", () => {
+    expect(gridpointUrl("SGX/54,21")).toBe(
+      "https://api.weather.gov/gridpoints/SGX/54,21",
+    );
+  });
+});

--- a/src/lib/nws-gridpoint.ts
+++ b/src/lib/nws-gridpoint.ts
@@ -1,0 +1,276 @@
+/**
+ * Reading a National Weather Service gridpoint forecast.
+ *
+ * Pure and offline, like the four parsers beside it, so a pinned unit or an
+ * interval shape is asserted against a committed payload without a network.
+ *
+ * WHAT THIS FEED PUBLISHES, AND WHAT IT ONLY DECLARES. Every `/gridpoints`
+ * payload carries `skyCover`, `visibility` and `ceilingHeight` as keys. Measured
+ * 2026-08-26 across the 21 cells covering this inventory, `skyCover` held 34 to
+ * 37 entries at every one and the other two held an empty `values` array at
+ * every one. **A declared key is not a published variable**, which is why this
+ * module reads sky cover and offers no visibility at all, and why
+ * `assertPublished` counts entries rather than testing for a key. See
+ * `docs/adr/0020-sky-leaves-the-card-for-the-week.md`.
+ *
+ * TIME ARRIVES AS AN INTERVAL, NOT AN INSTANT. Each entry's `validTime` is
+ * `<ISO-8601 instant>/<ISO-8601 duration>` -- `2026-08-26T12:00:00+00:00/PT3H`
+ * -- and one entry therefore covers three or six hours. The instants carry an
+ * offset, which is what keeps this clear of the hazard ADR-0009 records: a feed
+ * whose timestamps have no zone, read as local and tagged UTC, ages every
+ * reading by seven or eight hours. This parser refuses an offset-less instant
+ * rather than assuming one.
+ *
+ * ENTRIES ARE EXPANDED TO HOURLY STEPS. A caller selecting the daylight hours
+ * of a day cannot do it against three-hour blocks without deciding what a block
+ * straddling sunrise means. Expanding here, once, means every caller asks the
+ * same question of the same shape -- and it is the parser's job because the
+ * duration is part of the payload's contract rather than of anybody's view.
+ *
+ * FOG IS NOT A SERIES. `weather` carries phenomena as occasional entries, most
+ * of them naming nothing: measured across three cells read in full, 12 entries
+ * each, six named a phenomenon and the rest were empty. So a day usually has no
+ * phenomenon and that is normal rather than missing.
+ */
+
+/** What the payload must declare for the one number this module reads. */
+const SKY_COVER_UNIT = "wmoUnit:percent";
+
+/** `2026-08-26T12:00:00+00:00/PT3H`. Offset-less would be ADR-0009's hazard. */
+const INTERVAL =
+  /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2}))\/P(?:(\d+)D)?(?:T(?:(\d+)H)?)?$/;
+
+export class NwsGridpointDriftError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NwsGridpointDriftError";
+  }
+}
+
+export class NwsGridpointNoDataError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NwsGridpointNoDataError";
+  }
+}
+
+/** One hour of the forecast, expanded from the interval that covered it. */
+export interface SkyCoverHour {
+  /** Start of the hour, epoch milliseconds UTC. */
+  atMs: number;
+  /** Cloud cover as a percentage, 0 to 100, as the service publishes it. */
+  percent: number;
+}
+
+/** One hour a phenomenon was forecast for. */
+export interface WeatherHour {
+  atMs: number;
+  /** The phenomenon itself, as published: `fog`, `rain_showers`. */
+  weather: string;
+  /** `patchy`, `areas`, `chance` -- null when the service names none. */
+  coverage: string | null;
+}
+
+export interface GridpointForecast {
+  /** The cell this was read for, as `office/x,y`. */
+  cellId: string;
+  /** Every forecast hour, oldest first. */
+  skyCover: SkyCoverHour[];
+  /** Only the hours a phenomenon was named for, which is most days none. */
+  weather: WeatherHour[];
+}
+
+/** Hours covered by an ISO-8601 duration of the shape this feed uses. */
+function hoursOf(days: string | undefined, hours: string | undefined): number {
+  return (
+    (days === undefined ? 0 : Number(days) * 24) +
+    (hours === undefined ? 0 : Number(hours))
+  );
+}
+
+/**
+ * The start instant and length of one entry's interval.
+ *
+ * Throws rather than skipping: an interval this parser cannot read is a change
+ * in the payload's contract, and silently dropping it would shorten the week by
+ * a day nobody noticed.
+ */
+function intervalOf(
+  validTime: unknown,
+  cellId: string,
+  key: string,
+): { startMs: number; hours: number } {
+  if (typeof validTime !== "string") {
+    throw new NwsGridpointDriftError(
+      `${cellId}: a ${key} entry carried validTime ${JSON.stringify(validTime)}, which is ` +
+        `not a string.`,
+    );
+  }
+
+  const match = INTERVAL.exec(validTime);
+  if (match === null) {
+    throw new NwsGridpointDriftError(
+      `${cellId}: a ${key} entry carried validTime ${JSON.stringify(validTime)}. This parser ` +
+        `pins <instant>/<duration> with the instant's offset stated; an instant without one ` +
+        `would be read as local and tagged UTC, which ages every reading by hours.`,
+    );
+  }
+
+  const [, instant, days, hours] = match;
+  const startMs = Date.parse(instant);
+  if (Number.isNaN(startMs)) {
+    throw new NwsGridpointDriftError(
+      `${cellId}: a ${key} entry's validTime ${JSON.stringify(validTime)} matched the shape ` +
+        `and did not parse as an instant.`,
+    );
+  }
+
+  const span = hoursOf(days, hours);
+  if (span <= 0) {
+    throw new NwsGridpointDriftError(
+      `${cellId}: a ${key} entry's validTime ${JSON.stringify(validTime)} covers no time.`,
+    );
+  }
+
+  return { startMs, hours: span };
+}
+
+/**
+ * The `values` array of a series that must actually carry values.
+ *
+ * The whole reason this function exists rather than a property access: the key
+ * is always there. `visibility` and `ceilingHeight` prove it on every request.
+ */
+function assertPublished(
+  properties: Record<string, unknown>,
+  key: string,
+  cellId: string,
+): unknown[] {
+  const series = properties[key] as { values?: unknown } | undefined;
+  if (series === undefined || series === null) {
+    throw new NwsGridpointDriftError(
+      `${cellId}: the payload declares no ${key} at all. Every gridpoint response has ` +
+        `carried one, so its absence is a change in the product rather than a quiet cell.`,
+    );
+  }
+
+  const values = series.values;
+  if (!Array.isArray(values)) {
+    throw new NwsGridpointDriftError(
+      `${cellId}: ${key} carried ${JSON.stringify(values)} where an array of values was ` +
+        `expected.`,
+    );
+  }
+
+  if (values.length === 0) {
+    // Not drift. This is exactly what visibility and ceilingHeight do at every
+    // cell, and what a real cell does when the office has not run the product.
+    throw new NwsGridpointNoDataError(
+      `${cellId}: the National Weather Service declares ${key} and published no values for ` +
+        `it. The cell answers and does not forecast this.`,
+    );
+  }
+
+  return values;
+}
+
+/**
+ * Read one cell's sky cover and present weather.
+ *
+ * @throws {NwsGridpointDriftError} the payload's shape or unit moved
+ * @throws {NwsGridpointNoDataError} the cell published no sky cover
+ */
+export function parseGridpointForecast(
+  payload: unknown,
+  cellId: string,
+): GridpointForecast {
+  const properties = (payload as { properties?: Record<string, unknown> })
+    ?.properties;
+  if (!properties || typeof properties !== "object") {
+    throw new NwsGridpointDriftError(
+      `${cellId}: the response carried no properties object.`,
+    );
+  }
+
+  const skyCoverSeries = properties.skyCover as { uom?: unknown };
+  const values = assertPublished(properties, "skyCover", cellId);
+
+  if (skyCoverSeries.uom !== SKY_COVER_UNIT) {
+    throw new NwsGridpointDriftError(
+      `${cellId}: skyCover is declared in ${JSON.stringify(skyCoverSeries.uom)} where this ` +
+        `site pins ${SKY_COVER_UNIT}. A silent unit change would put a fraction on the page ` +
+        `as a percentage.`,
+    );
+  }
+
+  const skyCover: SkyCoverHour[] = [];
+  for (const entry of values as { validTime?: unknown; value?: unknown }[]) {
+    const { startMs, hours } = intervalOf(entry.validTime, cellId, "skyCover");
+    // A null value inside a populated series is one gap rather than a dead
+    // cell: the service leaves them where it has not forecast that step, and
+    // dropping the step is right where refusing the whole read would not be.
+    if (entry.value === null || entry.value === undefined) continue;
+    if (typeof entry.value !== "number" || !Number.isFinite(entry.value)) {
+      throw new NwsGridpointDriftError(
+        `${cellId}: a skyCover entry carried value ${JSON.stringify(entry.value)}, which is ` +
+          `not a number.`,
+      );
+    }
+    if (entry.value < 0 || entry.value > 100) {
+      throw new NwsGridpointDriftError(
+        `${cellId}: a skyCover entry carried ${entry.value}, outside the 0 to 100 its ` +
+          `declared unit allows.`,
+      );
+    }
+    for (let hour = 0; hour < hours; hour += 1) {
+      skyCover.push({
+        atMs: startMs + hour * 3_600_000,
+        percent: entry.value,
+      });
+    }
+  }
+
+  if (skyCover.length === 0) {
+    throw new NwsGridpointNoDataError(
+      `${cellId}: every skyCover entry the National Weather Service published was empty, so ` +
+        `there is no cloud cover to show.`,
+    );
+  }
+
+  // Present weather is optional in a way sky cover is not: a week with no fog
+  // and no showers forecast is an ordinary week, not a failure.
+  const weather: WeatherHour[] = [];
+  const weatherSeries = properties.weather as { values?: unknown } | undefined;
+  if (weatherSeries && Array.isArray(weatherSeries.values)) {
+    for (const entry of weatherSeries.values as {
+      validTime?: unknown;
+      value?: unknown;
+    }[]) {
+      if (!Array.isArray(entry.value)) continue;
+      const named = (
+        entry.value as { weather?: unknown; coverage?: unknown }[]
+      ).find(
+        (item) => typeof item?.weather === "string" && item.weather !== "",
+      );
+      if (named === undefined) continue;
+      const { startMs, hours } = intervalOf(entry.validTime, cellId, "weather");
+      for (let hour = 0; hour < hours; hour += 1) {
+        weather.push({
+          atMs: startMs + hour * 3_600_000,
+          weather: named.weather as string,
+          coverage: typeof named.coverage === "string" ? named.coverage : null,
+        });
+      }
+    }
+  }
+
+  skyCover.sort((a, b) => a.atMs - b.atMs);
+  weather.sort((a, b) => a.atMs - b.atMs);
+
+  return { cellId, skyCover, weather };
+}
+
+/** The URL one cell's forecast is read from. */
+export function gridpointUrl(cellId: string): string {
+  return `https://api.weather.gov/gridpoints/${cellId}`;
+}

--- a/src/lib/upstream.test.ts
+++ b/src/lib/upstream.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
+  fetchGridForecast,
+  GRID_FORECAST_REVALIDATE_SECONDS,
   fetchLatestNdbcAir,
   fetchLatestObservation,
   fetchLatestWave,
@@ -719,5 +721,133 @@ describe("fetchMopForecast", () => {
     expect(result.kind).toBe("unavailable");
     if (result.kind !== "unavailable") return;
     expect(result.reason).toContain("HTTP 503");
+  });
+});
+
+describe("fetchGridForecast", () => {
+  const CELL = "SGX/54,21";
+
+  const GRIDPOINT = JSON.parse(
+    readFileSync(
+      join(
+        process.cwd(),
+        "src/lib/__fixtures__/nws-gridpoint-sgx-54-21-20260827.json",
+      ),
+      "utf8",
+    ),
+  );
+
+  test("opts the request into caching, at the step the product moves on", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(GRIDPOINT));
+
+    await fetchGridForecast(CELL);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.weather.gov/gridpoints/SGX/54,21");
+    expect(init.next.revalidate).toBe(GRID_FORECAST_REVALIDATE_SECONDS);
+    expect(init.headers["User-Agent"]).toMatch(/wild-coast-kids/);
+  });
+
+  test("reads a real payload into hours", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(GRIDPOINT));
+
+    const result = await fetchGridForecast(CELL);
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") throw new Error("expected ok");
+    expect(result.forecast.cellId).toBe(CELL);
+    expect(result.forecast.skyCover.length).toBeGreaterThan(0);
+  });
+
+  test("a 404 means the binding is stale, not that the sky is unknown", async () => {
+    // The National Weather Service re-grids without notice, which ADR-0009
+    // names as one of the things this repo owns that rots. Telling a reader to
+    // come back later would be the wrong sentence and would hide a dead join.
+    fetchMock.mockResolvedValue(jsonResponse({}, 404));
+
+    const result = await fetchGridForecast(CELL);
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") throw new Error("expected unavailable");
+    expect(result.reason).toMatch(/needs re-probing/);
+    expect(result.drift).toBe(true);
+  });
+
+  test("another HTTP status is a bad day rather than drift", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, 503));
+
+    const result = await fetchGridForecast(CELL);
+    if (result.kind !== "unavailable") throw new Error("expected unavailable");
+    expect(result.reason).toMatch(/HTTP 503/);
+    expect(result.drift).toBe(false);
+  });
+
+  test("never throws when the request itself fails", async () => {
+    fetchMock.mockRejectedValue(new Error("getaddrinfo ENOTFOUND"));
+
+    const result = await fetchGridForecast(CELL);
+    if (result.kind !== "unavailable") throw new Error("expected unavailable");
+    expect(result.reason).toMatch(/did not complete/);
+    expect(result.reason).toMatch(/ENOTFOUND/);
+  });
+
+  test("a body that is not JSON is reported rather than thrown", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("Unexpected token < in JSON");
+      },
+    });
+
+    const result = await fetchGridForecast(CELL);
+    if (result.kind !== "unavailable") throw new Error("expected unavailable");
+    expect(result.reason).toMatch(/was not JSON/);
+  });
+
+  test("a declared-and-empty series is a quiet cell, not drift", async () => {
+    // Exactly what visibility and ceilingHeight do at every cell. A reader is
+    // told the cell does not forecast this; nobody is sent to chase a bug.
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        properties: {
+          ...GRIDPOINT.properties,
+          skyCover: { uom: "wmoUnit:percent", values: [] },
+        },
+      }),
+    );
+
+    const result = await fetchGridForecast(CELL);
+    if (result.kind !== "unavailable") throw new Error("expected unavailable");
+    expect(result.reason).toMatch(/published no values/);
+    expect(result.drift).toBe(false);
+  });
+
+  test("a unit change is drift, which is a bug here rather than at the office", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        properties: {
+          ...GRIDPOINT.properties,
+          skyCover: {
+            uom: "wmoUnit:one",
+            values: [
+              { validTime: "2026-08-26T12:00:00+00:00/PT3H", value: 0.66 },
+            ],
+          },
+        },
+      }),
+    );
+
+    const result = await fetchGridForecast(CELL);
+    if (result.kind !== "unavailable") throw new Error("expected unavailable");
+    expect(result.reason).toMatch(/pins wmoUnit:percent/);
+    expect(result.drift).toBe(true);
+  });
+
+  test("carries the URL, so a failure can be reproduced by hand", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({}, 503));
+
+    const result = await fetchGridForecast(CELL);
+    expect(result.url).toBe("https://api.weather.gov/gridpoints/SGX/54,21");
   });
 });

--- a/src/lib/upstream.ts
+++ b/src/lib/upstream.ts
@@ -70,6 +70,13 @@ import {
   parseMopForecast,
 } from "./mop-forecast";
 import {
+  type GridpointForecast,
+  gridpointUrl,
+  NwsGridpointDriftError,
+  NwsGridpointNoDataError,
+  parseGridpointForecast,
+} from "./nws-gridpoint";
+import {
   NwsObservationDriftError,
   NwsObservationNoDataError,
   parseNwsObservation,
@@ -594,6 +601,101 @@ export async function fetchMopForecast(
   } catch (cause) {
     if (cause instanceof MopDriftError) return unavailable(cause.message, true);
     if (cause instanceof MopNoDataError) return unavailable(cause.message);
+    return unavailable(cause instanceof Error ? cause.message : String(cause));
+  }
+}
+
+/* =========================================================================
+ * NWS gridpoints: the cloud cover the week grid reads
+ * ========================================================================= */
+
+/**
+ * One hour, which is the finest step this product moves on.
+ *
+ * The forecast itself sits on three- and six-hour blocks and the office reruns
+ * it a few times a day, so an hour never serves a block that has been
+ * superseded for long, and asking more often cannot return a different value.
+ * Shorter than MOP's three hours because this feed's blocks are shorter and its
+ * near end is the day a reader is standing in; longer than the observations
+ * above because a forecast for a three-hour block does not change on the
+ * quarter hour the way a special observation does.
+ */
+export const GRID_FORECAST_REVALIDATE_SECONDS = 3600;
+
+export type GridForecastResult =
+  | { kind: "ok"; forecast: GridpointForecast; url: string }
+  | { kind: "unavailable"; reason: string; drift: boolean; url: string };
+
+/**
+ * Fetch one forecast cell's sky cover and present weather.
+ *
+ * Never throws.
+ *
+ * THE 404 HERE MEANS THE BINDING HAS GONE STALE, not that the sky is unknown.
+ * `/gridpoints` answers for a cell that exists, and the National Weather
+ * Service re-grids without notice -- ADR-0009 names a re-gridded forecast point
+ * as one of the things this repo owns that rots. So the reason says to re-probe
+ * rather than telling a reader to come back later.
+ */
+export async function fetchGridForecast(
+  cellId: string,
+): Promise<GridForecastResult> {
+  const url = gridpointUrl(cellId);
+
+  const unavailable = (reason: string, drift = false): GridForecastResult => ({
+    kind: "unavailable",
+    reason,
+    drift,
+    url,
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { "User-Agent": USER_AGENT },
+      next: { revalidate: GRID_FORECAST_REVALIDATE_SECONDS },
+    });
+  } catch (cause) {
+    return unavailable(
+      `The request to the National Weather Service for forecast cell ${cellId} did not ` +
+        `complete: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+
+  if (response.status === 404) {
+    return unavailable(
+      `The National Weather Service publishes no forecast for cell ${cellId}. The grid has ` +
+        `moved and the cell binding needs re-probing.`,
+      true,
+    );
+  }
+  if (!response.ok) {
+    return unavailable(
+      `The National Weather Service returned HTTP ${response.status} for forecast cell ${cellId}.`,
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (cause) {
+    return unavailable(
+      `The National Weather Service's response for forecast cell ${cellId} was not JSON: ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+
+  try {
+    return {
+      kind: "ok",
+      forecast: parseGridpointForecast(payload, cellId),
+      url,
+    };
+  } catch (cause) {
+    if (cause instanceof NwsGridpointDriftError)
+      return unavailable(cause.message, true);
+    if (cause instanceof NwsGridpointNoDataError)
+      return unavailable(cause.message);
     return unavailable(cause instanceof Error ? cause.message : String(cause));
   }
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -61,11 +61,21 @@ export default defineConfig({
       // probe-mop-lines.mjs (60.6%) and probe-observation-stations.mjs (82.8%)
       // sit here for the same reason. The join beside it, grid-cell-join.mjs,
       // is at 100% statements -- that is the half that decides anything.
+      //
+      // 2026-08-27, the gridded sky read. Three rose and one fell, and the one
+      // that fell is named rather than absorbed: fetchGridForecast ends with
+      // the same defensive `cause instanceof Error ? cause.message : String(cause)`
+      // fallthrough fetchMopForecast has, and its non-Error arm is unreachable
+      // through parseGridpointForecast's contract -- that parser throws only
+      // NwsGridpointDriftError and NwsGridpointNoDataError, both handled above
+      // it. Deleting the arm would be the alternative, and it would let a
+      // non-Error throw escape a function whose whole contract is that it never
+      // throws. So two branches were added that cannot be reached on purpose.
       thresholds: {
-        statements: 88.83,
-        branches: 90.49,
-        functions: 94.72,
-        lines: 88.41,
+        statements: 89.39,
+        branches: 90.35,
+        functions: 94.95,
+        lines: 89.03,
       },
     },
   },


### PR DESCRIPTION
PR 2 of 3 from [`docs/plans/sky-from-the-grid.md`](docs/plans/sky-from-the-grid.md),
under [ADR-0020](docs/adr/0020-sky-leaves-the-card-for-the-week.md).
**This is the first change a visitor sees.**

PR 3 removes sky and visibility from the air card. It must not land before this
one, or the site ships an interval with no cloud information at all.

Relates to #95 and #91.

## What a reader gets

A cloud row in the week grid, for the beach's own 2.5 km forecast cell instead
of an airport 7.9 km away:

```
Cloud by day │ Wed │ Thu        │ Fri │ Sat
             │ 43% │ Patchy fog │ 66% │ …
└ this beach's own grid cell · National Weather Service, San Diego
  · a forecast, not a reading taken at the beach
```

## Three commits

1. **The daylight mean settled**, as a dated plan addendum.
2. **The read** — parser, fixture, fetcher, `readSkyWeek`.
3. **The row** — `SkyWeek`, `WeekPanel`, `ConditionsNotes`, and the reserved
   slot retired.

## The decision this row turns on

**Every other row here leads with the daylight *extreme* under ADR-0017. This
one takes the daylight mean, deliberately.**

ADR-0017 selects for *reachability*: a lowest low at 3:14 AM is a number nobody
planning a trip with children can use. Cloud cover has no unreachable hours —
the daylight window **is** the trip — so there is no extreme to route around,
and taking one anyway would import that ADR's pessimism without its reason.

Measured at `SGX/54,21`, the daylight spread runs 20–41 points:

| day | mean | min | max |
| --- | --- | --- | --- |
| 2026-08-30 | **39%** | 21% | 62% |

An extreme-selecting row would have published 62% for a day most of which sits
near 39%.

**The rule is pinned by a mutation test.** Removing the daylight filter from
`skyReadingOn` turns 50 into 33, and the test fails. I made that change and
watched it fail before restoring it:

```
AssertionError: expected 33 to be 50 // Object.is equality
      Tests  1 failed | 68 passed (69)
```

## A bug I caught before committing

My first draft of `ConditionsNotes` rewrote the airport entry to say the page
carries no current sky reading. **That is only true after PR 3.** The air card
still shows an airport sky until then, so the note would have been false while
both were on screen. Both entries now stand during the overlap — the "beside"
arrangement ADR-0016 permits — and the note-count test says six is temporary.

## The plan was wrong about scheduling, and it's amended

The plan said the open ADR-0017 question wanted settling "before slice 4" and
would change "the row label and nothing else". Both were false: the figure is
computed in `readSkyWeek`, which is slice 2, and a mean is not a relabelled
extreme. Recorded as a dated addendum rather than an edit, per
`docs/plans/README.md`.

## A declared key is not a published variable

The parser enforces the finding PR 1's probe made. An empty `values` array
raises `NwsGridpointNoDataError` — a quiet cell, what `visibility` and
`ceilingHeight` do at every one of the 21 cells — while a missing key or changed
unit raises `NwsGridpointDriftError`, a bug to chase.

The fixture is a **captured** payload, and one test asserts against the fixture
itself that `visibility` and `ceilingHeight` really are empty, so a future
capture that starts publishing either one fails and gets read rather than
absorbed.

The parser also refuses an offset-less instant rather than assuming one — the
hazard ADR-0009 records, which would age every reading by seven or eight hours.

## Verified in the running app, not only in jsdom

```
la-jolla-shores-beach   → 43%, 66%, "Patchy fog"
torrey-pines-city-beach → "averages 117 m of elevation, so it covers the
                           bluff above this beach as well as the shore"
```

That bluff sentence is the half of ADR-0020 no gate can assert, so a gate now
asserts it reaches the page.

## The glyph question answered itself

The plan flagged the reserved slot's 💨 as a design decision needing a human.
The slot is deleted in this PR and rows in this grid carry no glyph at all
(ADR-0015 — a full-colour emoji at 10px is a smudge), so the question went with
the slot. Nothing to decide.

## Coverage

Three thresholds rose, one fell, all four named in `vitest.config.mts`.
Statements 88.83 → 89.39, functions 94.72 → 94.95, lines 88.41 → 89.03.
Branches 90.49 → 90.35, because `fetchGridForecast` carries the same defensive
`cause instanceof Error` fallthrough `fetchMopForecast` has, and its non-Error
arm cannot be reached through `parseGridpointForecast`'s contract. Deleting the
arm would let a non-Error throw escape a function whose contract is that it
never throws.

## Gate

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

## Not done

- **The air card still shows airport sky and visibility.** That is PR 3, and the
  ordering is deliberate.
- No beach enters or leaves the inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
