### PR TITLE
Compare grid cells on availability, not on volatile forecast counts

### DIFF
--- a/scripts/probe-grid-cells.mjs
+++ b/scripts/probe-grid-cells.mjs
@@ -218,11 +218,53 @@ export function document(table, now = new Date()) {
 }
 
 /**
+ * Each cell's three series reduced to whether it publishes them at all.
+ *
+ * The counts stay in the file -- they are the record of what was seen, and
+ * `visibility_entries` is there precisely so a change upstream shows as a diff.
+ * What the counts are not is a fact about the grid: they count rows in a live
+ * forecast response, so they move whenever the forecast refreshes.
+ *
+ * @param {Record<string, object>} cells
+ * @returns {Record<string, object>}
+ */
+function availability(cells) {
+  return Object.fromEntries(
+    Object.entries(cells).map(([id, cell]) => [
+      id,
+      {
+        ...cell,
+        sky_cover_entries: cell.sky_cover_entries > 0,
+        visibility_entries: cell.visibility_entries > 0,
+        ceiling_entries: cell.ceiling_entries > 0,
+      },
+    ]),
+  );
+}
+
+/**
  * Whether the committed table disagrees with what was just measured.
  *
  * `generated` moves on every run by design, so comparing it would make every
  * check fail and mean nothing -- the same exclusion `probe-mop-lines.mjs` and
  * `probe-observation-stations.mjs` already make, and spelled the same way.
+ *
+ * The series counts are excluded for the same reason and not the same way. They
+ * are a measurement worth keeping, so they stay in the file; it is comparing
+ * them by value that is wrong. Against a file written 2026-08-26 this check
+ * failed on 2026-08-27 over `sky_cover_entries` alone, 34-37 becoming 39-41 at
+ * all 21 cells, with no id, coordinate, elevation or `delivers` value moved
+ * (#162). A check that is expected to fail is a check nobody reads, which is
+ * how a real change -- a cell that stops publishing sky, a gridpoint that moves
+ * -- would arrive inside a diff nobody opens.
+ *
+ * So the comparison is over what the counts mean: whether each cell publishes
+ * each series at all. `0` to any non-zero is still an event and still fails,
+ * which is the whole reason `visibility_entries` is recorded. `37` to `41` is
+ * not. `probe-observation-stations.mjs` reached the same conclusion by keeping
+ * its counts out of its file entirely -- "a file whose --check fails from noise
+ * stops being read"; this table keeps its provenance and moves the judgement
+ * into the comparison instead.
  *
  * This was an inline regex over the serialised text inside `main()`. It is the
  * one piece of judgement in this script, and it was the one piece no test could
@@ -235,7 +277,11 @@ export function document(table, now = new Date()) {
  */
 export function hasMoved(committed, built) {
   const comparable = (doc) =>
-    JSON.stringify({ ...doc, generated: null }, null, 2);
+    JSON.stringify(
+      { ...doc, generated: null, cells: availability(doc.cells) },
+      null,
+      2,
+    );
   return comparable(committed) !== comparable(built);
 }
 

--- a/scripts/probe-grid-cells.mjs
+++ b/scripts/probe-grid-cells.mjs
@@ -217,6 +217,28 @@ export function document(table, now = new Date()) {
   };
 }
 
+/**
+ * Whether the committed table disagrees with what was just measured.
+ *
+ * `generated` moves on every run by design, so comparing it would make every
+ * check fail and mean nothing -- the same exclusion `probe-mop-lines.mjs` and
+ * `probe-observation-stations.mjs` already make, and spelled the same way.
+ *
+ * This was an inline regex over the serialised text inside `main()`. It is the
+ * one piece of judgement in this script, and it was the one piece no test could
+ * reach; taking documents rather than text is what lets a test call it
+ * directly. See ADR-0002 for the split this follows.
+ *
+ * @param {object} committed  The table as read from disk.
+ * @param {object} built      The table as just measured.
+ * @returns {boolean}
+ */
+export function hasMoved(committed, built) {
+  const comparable = (doc) =>
+    JSON.stringify({ ...doc, generated: null }, null, 2);
+  return comparable(committed) !== comparable(built);
+}
+
 async function main() {
   const checkOnly = process.argv.includes("--check");
 
@@ -288,10 +310,9 @@ async function main() {
         "grid-cells.json is missing. Run without --check to write it.",
       );
     }
-    // The generated date moves on every run and is not a measurement, so it is
-    // excluded from the comparison the way probe-mop-lines.mjs excludes its own.
-    const strip = (text) => text.replace(/"generated": "[^"]*"/, "");
-    if (strip(committed) !== strip(serialised)) {
+    // A file that is present but not JSON raises here rather than being read as
+    // "missing", which would name the wrong repair.
+    if (hasMoved(JSON.parse(committed), built)) {
       throw new Error(
         "grid-cells.json has moved. Re-run without --check, read the diff, and say in the " +
           "commit message what changed upstream.",

--- a/scripts/probe-grid-cells.test.mjs
+++ b/scripts/probe-grid-cells.test.mjs
@@ -228,23 +228,21 @@ describe("hasMoved", () => {
     },
   };
 
+  const RESOLUTIONS = {
+    "del-mar-city-beach": {
+      upper: { cell: "SGX/55,26" },
+      lower: { cell: "SGX/55,25" },
+    },
+  };
+
   /**
    * A whole document in the shape `document()` really produces, so the
    * comparison is exercised against the thing it compares rather than a sketch.
    */
-  const doc = (cells, now = new Date("2026-08-26T12:00:00Z")) =>
-    document(
-      buildTable(
-        {
-          "del-mar-city-beach": {
-            upper: { cell: "SGX/55,26" },
-            lower: { cell: "SGX/55,25" },
-          },
-        },
-        cells,
-      ),
-      now,
-    );
+  const doc = (
+    cells,
+    { resolutions = RESOLUTIONS, now = new Date("2026-08-26T12:00:00Z") } = {},
+  ) => document(buildTable(resolutions, cells), now);
 
   /** The same document with one cell edited, so each test states one change. */
   const edited = (edit) => {
@@ -259,8 +257,85 @@ describe("hasMoved", () => {
 
   it("ignores the generated date, which moves on every run", () => {
     expect(
-      hasMoved(doc(CELLS), doc(CELLS, new Date("2026-09-14T12:00:00Z"))),
+      hasMoved(
+        doc(CELLS),
+        doc(CELLS, { now: new Date("2026-09-14T12:00:00Z") }),
+      ),
     ).toBe(false);
+  });
+
+  it("does not report a forecast refresh, which moves the counts alone", () => {
+    // The regression. Measured 2026-08-27 against a file written 2026-08-26:
+    // sky_cover_entries went 34-37 to 39-41 at all 21 cells and nothing else
+    // moved, and --check failed on it (#162).
+    expect(
+      hasMoved(
+        doc(CELLS),
+        edited((cells) => {
+          cells["SGX/55,25"].sky_cover_entries = 41;
+          cells["SGX/55,26"].sky_cover_entries = 39;
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not report a count moving in a series already publishing", () => {
+    // Visibility measured zero everywhere in August. If it starts publishing,
+    // its count becomes as volatile as sky cover's and must not fire either --
+    // what is an event is that it started, not what it reads on a given day.
+    const publishing = structuredClone(CELLS);
+    publishing["SGX/55,25"].visibility_entries = 4;
+    publishing["SGX/55,25"].ceiling_entries = 6;
+    const later = structuredClone(publishing);
+    later["SGX/55,25"].visibility_entries = 9;
+    later["SGX/55,25"].ceiling_entries = 2;
+
+    expect(hasMoved(doc(publishing), doc(later))).toBe(false);
+  });
+
+  it("reports a cell that stops publishing sky cover", () => {
+    expect(
+      hasMoved(
+        doc(CELLS),
+        edited((cells) => {
+          cells["SGX/55,25"].sky_cover_entries = 0;
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("reports a cell that starts publishing visibility", () => {
+    // The tripwire the field exists for: zero to any non-zero is the event.
+    expect(
+      hasMoved(
+        doc(CELLS),
+        edited((cells) => {
+          cells["SGX/55,25"].visibility_entries = 3;
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("reports a cell that starts publishing a ceiling", () => {
+    expect(
+      hasMoved(
+        doc(CELLS),
+        edited((cells) => {
+          cells["SGX/55,25"].ceiling_entries = 3;
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("reports a changed delivers value", () => {
+    expect(
+      hasMoved(
+        doc(CELLS),
+        edited((cells) => {
+          cells["SGX/55,25"].delivers = false;
+        }),
+      ),
+    ).toBe(true);
   });
 
   it("reports a cell whose elevation moved", () => {
@@ -274,17 +349,36 @@ describe("hasMoved", () => {
     ).toBe(true);
   });
 
-  it("today: a forecast refresh alone reads as movement -- issue #162", () => {
-    // The defect, pinned rather than described. `sky_cover_entries` counts rows
-    // in a live NWS forecast response, so it moves whenever the forecast
-    // refreshes and nothing upstream has rotted. Recorded here so that the next
-    // commit's change to this judgement is a visible diff in the test, not only
-    // in the script.
+  it("reports a cell whose grid coordinate moved", () => {
     expect(
       hasMoved(
         doc(CELLS),
         edited((cells) => {
-          cells["SGX/55,25"].sky_cover_entries = 41;
+          cells["SGX/55,25"].y = 24;
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("reports a renamed cell id", () => {
+    const renamed = structuredClone(CELLS);
+    renamed["SGX/55,24"] = renamed["SGX/55,25"];
+    delete renamed["SGX/55,25"];
+
+    expect(hasMoved(doc(CELLS), doc(renamed))).toBe(true);
+  });
+
+  it("reports a beach resolving to a different cell", () => {
+    expect(
+      hasMoved(
+        doc(CELLS),
+        doc(CELLS, {
+          resolutions: {
+            "del-mar-city-beach": {
+              upper: { cell: "SGX/55,26" },
+              lower: { cell: "SGX/55,26" },
+            },
+          },
         }),
       ),
     ).toBe(true);

--- a/scripts/probe-grid-cells.test.mjs
+++ b/scripts/probe-grid-cells.test.mjs
@@ -3,6 +3,7 @@ import {
   buildTable,
   CELL_ID,
   document,
+  hasMoved,
   parseCell,
   parsePoint,
 } from "./probe-grid-cells.mjs";
@@ -200,5 +201,92 @@ describe("the document", () => {
       cell: null,
       reason: "the grid does not cover 32.53,-117.12",
     });
+  });
+});
+
+describe("hasMoved", () => {
+  const CELLS = {
+    "SGX/55,25": {
+      office: "SGX",
+      x: 55,
+      y: 25,
+      elevation_m: 102.108,
+      sky_cover_entries: 37,
+      visibility_entries: 0,
+      ceiling_entries: 0,
+      delivers: true,
+    },
+    "SGX/55,26": {
+      office: "SGX",
+      x: 55,
+      y: 26,
+      elevation_m: 21.9456,
+      sky_cover_entries: 37,
+      visibility_entries: 0,
+      ceiling_entries: 0,
+      delivers: true,
+    },
+  };
+
+  /**
+   * A whole document in the shape `document()` really produces, so the
+   * comparison is exercised against the thing it compares rather than a sketch.
+   */
+  const doc = (cells, now = new Date("2026-08-26T12:00:00Z")) =>
+    document(
+      buildTable(
+        {
+          "del-mar-city-beach": {
+            upper: { cell: "SGX/55,26" },
+            lower: { cell: "SGX/55,25" },
+          },
+        },
+        cells,
+      ),
+      now,
+    );
+
+  /** The same document with one cell edited, so each test states one change. */
+  const edited = (edit) => {
+    const cells = structuredClone(CELLS);
+    edit(cells);
+    return doc(cells);
+  };
+
+  it("compares a document with itself as unchanged", () => {
+    expect(hasMoved(doc(CELLS), doc(CELLS))).toBe(false);
+  });
+
+  it("ignores the generated date, which moves on every run", () => {
+    expect(
+      hasMoved(doc(CELLS), doc(CELLS, new Date("2026-09-14T12:00:00Z"))),
+    ).toBe(false);
+  });
+
+  it("reports a cell whose elevation moved", () => {
+    expect(
+      hasMoved(
+        doc(CELLS),
+        edited((cells) => {
+          cells["SGX/55,25"].elevation_m = 3.048;
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("today: a forecast refresh alone reads as movement -- issue #162", () => {
+    // The defect, pinned rather than described. `sky_cover_entries` counts rows
+    // in a live NWS forecast response, so it moves whenever the forecast
+    // refreshes and nothing upstream has rotted. Recorded here so that the next
+    // commit's change to this judgement is a visible diff in the test, not only
+    // in the script.
+    expect(
+      hasMoved(
+        doc(CELLS),
+        edited((cells) => {
+          cells["SGX/55,25"].sky_cover_entries = 41;
+        }),
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #162

`node scripts/probe-grid-cells.mjs --check` exited non-zero on almost any day it
was run, from the one field in the file that cannot hold still. This makes it
compare what the counts mean rather than what they read.

## Slices

**1. `Extract probe-grid-cells' --check comparison as a pure function`** (c33e557)

The comparison was an inline `strip()` regex over the serialised text inside
`main()` — the one piece of judgement in the script, and the one piece no test
could reach. `hasMoved(committed, built)` takes two documents, matching the
`comparable` spelling `probe-mop-lines.mjs` and `probe-observation-stations.mjs`
already use.

No behaviour change: `--check` still exited 1 against the committed file, for
the same reason. The test committed with it pinned that reason, so slice 2's
change to the judgement is visible as a diff in the test and not only in the
script.

One incidental correction: `main()` now parses the committed file, and a file
that is present but unparseable raises where it is read rather than being
reported as "missing", which named the wrong repair.

**2. `Compare grid cells on availability, not on volatile counts`** (344609c)

`sky_cover_entries` counts rows in a live NWS gridpoint response, so it moves
whenever the forecast refreshes. The comparison now reduces each cell's three
series to whether it publishes them at all. `0` → any non-zero still fails —
that is the tripwire `visibility_entries` was recorded for. `37` → `41` does
not.

The counts stay in the committed file. `grid-cells.json` is **not** re-derived
here; it still carries its 2026-08-26 measurement, and `--check` now passes
against it unchanged.

## The measurement

Before the fix, on this branch's parent — the defect reproduced:

```
$ node scripts/probe-grid-cells.mjs --check
Error: grid-cells.json has moved. Re-run without --check, read the diff, and say in the commit message what changed upstream.
PROBE EXIT=1
```

The committed file holds `sky_cover_entries` of 34–37, measured 2026-08-26.
Re-measured 2026-08-27 they read 39–41, while every `elevation_m`,
`visibility_entries` (0), `ceiling_entries` (0) and `delivers` (true) value was
identical to what is committed. That difference is the entire cause of the
failure above.

After the fix, against the same unmodified `grid-cells.json`:

```
$ node scripts/probe-grid-cells.mjs --check
. SGX/57,10 sky=40 vis=0 elev=2.1336
. SGX/57,7 sky=41 vis=0 elev=4.8768
. SGX/57,8 sky=39 vis=0 elev=0.9144
. SGX/57,9 sky=39 vis=0 elev=10.0584
grid-cells.json is unchanged.
PROBE EXIT=0
```

Note the run still measures 39–41 against a file that says 34–37, and passes.
That is the change: the counts are kept as the record of what was seen, and are
no longer read as a fact that must match.

## Gate

Run at `344609c`, the head of this branch:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

`probe-grid-cells.test.mjs` goes 14 tests → 26. The eleven new `hasMoved` cases
cover each acceptance criterion directly: counts moving in a publishing series
(both the sky-cover refresh and a hypothetical publishing visibility) compare as
unchanged; availability flipping in any of the three series compares as changed;
so do a moved elevation, a moved grid coordinate, a renamed cell id, a changed
`delivers` value and a beach resolving to a different cell. All reach `hasMoved`
directly with fabricated documents — no network, no filesystem.

## Not done, and why

- **No plan file.** Per `CLAUDE.md`, one script change, its tests and no
  outliving decision do not need `docs/plans/`; the issue and this body are the
  durable record.
- **No ADR.** This does not change a decision — it makes an existing check mean
  what it already said it meant.
- **`grid-cells.json` not regenerated.** Out of scope per the issue, and the
  point is that it did not need to be.
- **No other probe touched.** `probe-mop-lines` and `probe-observation-stations`
  pass today.
- **The probes' differing exit and output conventions are untouched.** This
  script still throws where its siblings print and exit. That is #160's concern,
  since it is the thing that has to consume them.

## Noticed, not filed

`hasMoved` trusts that both documents carry a `cells` object, as its two
siblings' `comparable` does. A hand-corrupted file would raise a `TypeError`
from `Object.entries` rather than report a clear verdict. It is loud rather than
silent and the file has one writer, so it is left alone rather than guarded
against a case nobody has hit.
