### PR TITLE
Measure tide-station delivery against the committed flags

### DIFF
--- a/docs/adr/0021-a-station-table-with-prose-gets-a-checker.md
+++ b/docs/adr/0021-a-station-table-with-prose-gets-a-checker.md
@@ -1,0 +1,115 @@
+# 0021 — A station table carrying hand-written prose gets a checker, not a generator
+
+Date: 2026-08-27. Status: accepted.
+
+## Context
+
+Four of the five station/line bindings this site reads now have a re-runnable
+probe. Three of them — `probe-grid-cells.mjs`, `probe-mop-lines.mjs`,
+`probe-observation-stations.mjs` — are **generators**: each re-derives its whole
+table from upstream, writes it, and under `--check` re-derives it again and
+fails if the committed file differs. That shape is why the committed file can be
+trusted: it is not a record of what someone typed, it is the output of a rule
+anyone can re-run.
+
+`tide-stations.json` is the fourth, and it is not that kind of file.
+
+Its nine stations carry four fields a probe can never re-derive:
+
+- `water`, an open-coast/bay judgement the file itself records as "an author
+  judgement, written by hand because no upstream authority publishes one";
+- `dead_note`, a paragraph of prose per dead station explaining what it answered
+  and why it was kept rather than deleted;
+- `_provenance`, which records a coordinate filter applied by hand on a date;
+- two `unresolved` entries, one of which `beaches.ts` spreads into the caveats
+  shown to readers.
+
+Only `delivers` is measurable. `probe-observation-stations.mjs` met the
+equivalent problem and solved it by hoisting its hand-written `shore` judgement
+into the script as a literal; doing the same here would move several paragraphs
+of prose out of the data file and into a `.mjs`, for no gain in what can be
+checked.
+
+There is a second reason, and it is mechanical rather than editorial. The
+stations are committed **north to south** — 9410230 La Jolla first, TWC0405 last
+— and seven of the nine ids are integer-like strings. JavaScript objects iterate
+integer-like keys in ascending numeric order regardless of insertion order, so
+`JSON.parse` followed by `JSON.stringify` does not round-trip this file:
+
+```
+committed order:   9410230 9410196 TWC0413 9410170 9410166 9410152 9410135 9410120 TWC0405
+after a round-trip: 9410120 9410135 9410152 9410166 9410170 9410196 9410230 TWC0413 TWC0405
+```
+
+A generator would rewrite the whole file on its first run, destroying the
+geographic ordering, and every diff afterwards would carry that noise. This is
+easy to miss: reading the file with `JSON.parse` and printing `Object.keys`
+shows the _reordered_ order, so the committed order is only visible in the bytes.
+
+The measurement that prompted this: `TWC0405` Point Loma is committed as not
+delivering, measured 2026-08-18. Asked the same question under the same contract
+on 2026-08-27 it answers with real predictions. Nine days, and nothing in the
+repo noticed, because nothing was watching.
+
+## Decision
+
+**`scripts/probe-tide-stations.mjs` reads and reports. It never writes.**
+
+There is no flag for a mode that does — not `--write`, not a default-write with
+`--check` — because a mode that regenerates this file cannot reproduce it.
+
+Three things follow from that, and they are the decision as much as the first
+sentence is:
+
+**The verdict is a pure function over two arguments.** `verdict(stations,
+measured)` takes a committed table and a set of measurements and returns the
+rows to print and the exit code. It is the part that can be wrong, so it is the
+part a test calls directly with a fabricated table — the same split ADR-0002
+made for the gate runner.
+
+**A fourth outcome sits beside the parser's three.** `src/lib/coops-predictions.ts`
+already distinguishes a usable payload, a CO-OPS error object arriving under
+HTTP 200, and a payload whose shape has drifted. A request that never completes
+— a refused connection, a timeout, a non-200 — is none of those. It is reported
+as `unreachable` and is never folded into `not-delivering`. A station this site
+could not reach today has not been measured to have stopped delivering, and
+reporting it as though it had would manufacture the false alarm the probe exists
+to prevent.
+
+**The request contract is mirrored, and the mirror is pinned by test.** The
+probe runs under node unbuilt and cannot import TypeScript, so the datum, units,
+time zone, application identifier and URL builder are spelled twice —
+`generated-date.mjs` already says the same thing about `pacific-time.ts` and
+spells its zone twice on purpose. What is new here is that the duplication is
+not left on trust: `probe-tide-stations.test.mjs` imports both sides and asserts
+that they build the same URL for the same station and range, and that they
+classify the same payload the same way. A probe measuring a contract the site
+does not read measures nothing.
+
+## Consequences
+
+**A human edits `tide-stations.json`, and the probe is what tells them to.**
+This is more work than the generator shape, and it is work the generator shape
+could not have done correctly. The exchange is that the file keeps its prose and
+its geography, and gains a check on the one field that rots.
+
+**A `delivers` flag is now a claim with an expiry.** Before this, the flag was a
+measurement that had quietly become a typed value; the gap between 2026-08-18
+and 2026-08-27 is what that costs. Running the probe is now the difference
+between a measured flag and a remembered one.
+
+**Nothing runs it yet.** Like its three siblings it reaches the network, so it is
+not a row in the gate table — the gate stays offline so it passes on a fresh
+clone with no credentials. Running it on a schedule is issue #160, and this probe
+is designed to be a row in that table rather than a special case in it.
+
+**The two copies of the request contract can still drift, and will fail loudly
+when they do.** The pinning test is the whole guard. If a future change adds a
+parameter to `coopsPredictionsUrl` in `src/` and not here, the URLs stop matching
+and the test says so. That is a deliberately brittle test: it is asserting an
+agreement, and an agreement that can be broken silently is not one.
+
+**This does not decide what the flag should say.** The probe measures; a person
+decides what the inventory records and writes the prose that goes with it.
+`TWC0405`'s revival is issue #161, which is blocked on this one precisely so the
+flag is flipped from a measurement rather than from a memory.

--- a/scripts/probe-tide-stations.mjs
+++ b/scripts/probe-tide-stations.mjs
@@ -1,0 +1,400 @@
+/**
+ * Whether every tide station still delivers what the table records it as
+ * delivering.
+ *
+ *   node scripts/probe-tide-stations.mjs   report every station; exit 1 on any
+ *                                          disagreement, in either direction
+ *
+ * WHY THIS ONE ONLY CHECKS, WHERE ITS THREE SIBLINGS REGENERATE. `delivers` is
+ * the only field in `tide-stations.json` a probe can measure. `water`,
+ * `dead_note` and both `unresolved` entries are hand-written prose, and
+ * `_provenance` records a filter applied by hand on a date. A generator would
+ * have to carry all of that as string literals to reproduce the file it
+ * replaced. It would also reorder it: the stations are committed north to south
+ * -- 9410230 La Jolla first, TWC0405 last -- and seven of the nine ids are
+ * integer-like strings, which JavaScript objects iterate in ascending numeric
+ * order whatever order they were inserted in. `JSON.parse` then `JSON.stringify`
+ * yields 9410120 first and the geography gone, so a generator would rewrite the
+ * whole file on its first run and every diff after it would carry that noise.
+ * So this reads and reports, and a human edits the table. See
+ * docs/adr/0021-a-station-table-with-prose-gets-a-checker.md.
+ *
+ * FOUR OUTCOMES, NOT THREE, AND THE FOURTH IS THE POINT. A station can answer
+ * usefully, answer with a CO-OPS error object under HTTP 200, or answer with a
+ * payload whose shape is not what the parser pins. Those three are what a
+ * reader's request would hit, and `src/lib/coops-predictions.ts` already names
+ * them. A request that never completes -- a refused connection, a timeout, a
+ * non-200 -- is none of them. It is not a measurement that a station stopped
+ * delivering, and reporting it as one would manufacture exactly the false alarm
+ * this probe exists to prevent. It is reported as `unreachable` and never
+ * folded into `not-delivering`.
+ *
+ * THE CONTRACT IS MIRRORED FROM `src/lib/coops-predictions.ts`, NOT IMPORTED.
+ * These scripts run under node unbuilt, so they cannot read TypeScript --
+ * `generated-date.mjs` says the same thing about `pacific-time.ts` and spells
+ * its zone twice on purpose. A probe that measured a *different* contract would
+ * measure nothing, so the duplication is not left on trust: the test imports
+ * both sides and pins this file's URL against the site's for the same station
+ * and range, and pins this file's classification against the site's parser
+ * payload for payload.
+ *
+ * IT REACHES THE NETWORK, so it is not a gate row -- the same reason its three
+ * siblings are not, and the gate stays runnable on a fresh clone with no
+ * credentials. Running it on a schedule is issue #160.
+ *
+ * IT NEVER WRITES. There is no flag for a mode that does, which is the whole
+ * decision above.
+ */
+
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { generatedDate } from "./generated-date.mjs";
+
+const TABLE_PATH = new URL("../src/data/tide-stations.json", import.meta.url);
+
+const USER_AGENT =
+  "wild-coast-kids/0.1 (+https://github.com/cweber12/wild-coast-kids) conditions";
+
+/**
+ * The request contract, mirrored from `src/lib/coops-predictions.ts`.
+ *
+ * Every one of these is pinned against its counterpart by test. Changing one
+ * here without changing it there fails that test rather than quietly making
+ * this probe answer a question the site never asks.
+ */
+const COOPS_ENDPOINT =
+  "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter";
+export const COOPS_DATUM = "MLLW";
+export const COOPS_UNITS = "english";
+export const COOPS_TIME_ZONE = "gmt";
+export const COOPS_APPLICATION = "wild-coast-kids";
+
+/**
+ * Build the high/low predictions URL for a station and date range.
+ *
+ * @param {{stationId: string, beginDate: string, endDate: string}} contract
+ * @returns {string}
+ */
+export function coopsPredictionsUrl(contract) {
+  const query = new URLSearchParams({
+    product: "predictions",
+    application: COOPS_APPLICATION,
+    station: contract.stationId,
+    begin_date: contract.beginDate,
+    end_date: contract.endDate,
+    datum: COOPS_DATUM,
+    time_zone: COOPS_TIME_ZONE,
+    units: COOPS_UNITS,
+    interval: "hilo",
+    format: "json",
+  });
+  return `${COOPS_ENDPOINT}?${query.toString()}`;
+}
+
+/** The station answered with predictions this stack can read. */
+export const DELIVERING = "delivering";
+
+/** CO-OPS said it has nothing for this station, under HTTP 200. */
+export const NOT_DELIVERING = "not-delivering";
+
+/** Something answered, and it is not the shape the parser pins. */
+export const DRIFT = "drift";
+
+/** No measurement was taken. Never read as "stopped delivering". */
+export const UNREACHABLE = "unreachable";
+
+/**
+ * The window to ask each station for, as CO-OPS `YYYYMMDD` compact dates.
+ *
+ * Two days from the Pacific date the run falls on. The site asks for a wider
+ * window and that difference is deliberate: this asks whether a station answers
+ * at all, and one that serves today's turning points serves the week's. What
+ * has to match is the contract those dates are requested under, which is what
+ * the test pins.
+ *
+ * The second date is stepped as a calendar date rather than by adding
+ * milliseconds, so the two days either side of a daylight-saving change are not
+ * the two days this quietly asks for the wrong range on.
+ *
+ * @param {Date} now
+ * @returns {{beginDate: string, endDate: string}}
+ */
+export function predictionsWindow(now) {
+  const begin = generatedDate(now);
+  const [year, month, day] = begin.split("-").map(Number);
+  const end = new Date(Date.UTC(year, month - 1, day + 1))
+    .toISOString()
+    .slice(0, 10);
+  return {
+    beginDate: begin.replaceAll("-", ""),
+    endDate: end.replaceAll("-", ""),
+  };
+}
+
+/** The `t` shape `parseGmtTimestamp` pins. An offsetless string, and nothing more. */
+const TIMESTAMP = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/;
+
+/**
+ * Whether one row is the `{t, v, type}` shape the parser accepts.
+ *
+ * The three checks are `parseGmtTimestamp`, `parseFeet` and `parseKind` in
+ * `coops-predictions.ts`, in that order. A row this rejects is a row a reader's
+ * request raises `CoopsDriftError` on, which is what makes reporting it as
+ * drift rather than as delivery the honest answer.
+ *
+ * @param {unknown} row
+ * @returns {boolean}
+ */
+function isPrediction(row) {
+  if (typeof row !== "object" || row === null) return false;
+  if (typeof row.t !== "string" || !TIMESTAMP.test(row.t)) return false;
+  if (typeof row.v !== "string" || !Number.isFinite(Number(row.v)))
+    return false;
+  return row.type === "H" || row.type === "L";
+}
+
+/**
+ * Which of the three payload outcomes a body falls into.
+ *
+ * Pure, and deliberately the same decisions in the same order as
+ * `parseCoopsHiLo`: an `error` key is CO-OPS reporting under a success code, a
+ * missing or empty `predictions` array is drift, and so is a row that is not
+ * the pinned shape. An empty array is drift rather than "no tide today" for the
+ * parser's own reason -- this product is astronomical, so a station asked for
+ * two days of turning points and answering with none has not told us the tide
+ * is flat.
+ *
+ * @param {unknown} payload
+ * @returns {{outcome: string, detail: string}}
+ */
+export function classifyPayload(payload) {
+  if (typeof payload !== "object" || payload === null) {
+    return { outcome: DRIFT, detail: "the payload was not an object" };
+  }
+
+  if ("error" in payload) {
+    const message = payload.error?.message;
+    return {
+      outcome: NOT_DELIVERING,
+      detail:
+        `CO-OPS reported: ` +
+        `${typeof message === "string" ? message : "no message given"} ` +
+        `(arriving under HTTP 200, so the status code did not say so)`,
+    };
+  }
+
+  const rows = payload.predictions;
+  if (!Array.isArray(rows)) {
+    return {
+      outcome: DRIFT,
+      detail: `expected a "predictions" array and found ${typeof rows}`,
+    };
+  }
+  if (rows.length === 0) {
+    return {
+      outcome: DRIFT,
+      detail:
+        `"predictions" was empty for the range asked. Predictions are ` +
+        `astronomical, so an empty range is a broken request, not a flat tide`,
+    };
+  }
+
+  const bad = rows.findIndex((row) => !isPrediction(row));
+  if (bad !== -1) {
+    return {
+      outcome: DRIFT,
+      detail: `prediction row ${bad} is not the pinned {t, v, type} shape`,
+    };
+  }
+
+  return { outcome: DELIVERING, detail: `${rows.length} turning points` };
+}
+
+/**
+ * Whether an outcome is a delivery measurement at all.
+ *
+ * Drift and unreachable are not. Neither says a station stopped delivering, and
+ * neither may be compared against the committed flag as though it did.
+ *
+ * @param {string} outcome
+ * @returns {boolean}
+ */
+function measuresDelivery(outcome) {
+  return outcome === DELIVERING || outcome === NOT_DELIVERING;
+}
+
+/**
+ * Compare what was measured against what is committed, for every station.
+ *
+ * This is the part that can be wrong, so it is pure and takes both halves as
+ * arguments: a fabricated table and fabricated measurements reach it directly.
+ * Following ADR-0002, the same split `gates.mjs` makes.
+ *
+ * A row is `ok` only when the station was actually measured and the measurement
+ * agrees. A station that could not be measured is not a passing station -- the
+ * committed flag is unconfirmed, and saying nothing about it would be the
+ * silent failure `CLAUDE.md` forbids -- but it is reported as unmeasured rather
+ * than as a station that changed.
+ *
+ * @param {Record<string, {delivers: boolean}>} stations  The committed table.
+ * @param {Record<string, {outcome: string, detail: string}>} measured
+ * @returns {{exitCode: number, rows: Array<{id: string, committed: boolean,
+ *   outcome: string, label: string, ok: boolean, detail: string}>}}
+ */
+export function verdict(stations, measured) {
+  const rows = Object.entries(stations).map(([id, station]) => {
+    const measurement = measured[id] ?? {
+      outcome: UNREACHABLE,
+      detail: "no measurement was taken for this station",
+    };
+    const { outcome, detail } = measurement;
+
+    if (!measuresDelivery(outcome)) {
+      return {
+        id,
+        committed: station.delivers,
+        outcome,
+        label: "NOT MEASURED",
+        ok: false,
+        detail,
+      };
+    }
+
+    const agrees = (outcome === DELIVERING) === station.delivers;
+    return {
+      id,
+      committed: station.delivers,
+      outcome,
+      label: agrees ? "agrees" : "DISAGREES",
+      ok: agrees,
+      detail,
+    };
+  });
+
+  return { exitCode: rows.every((row) => row.ok) ? 0 : 1, rows };
+}
+
+/**
+ * One line per station, agreeing or not. Nothing is filtered out: a probe that
+ * printed only its complaints would leave a reader unable to tell a clean run
+ * from a run that never reached half the table.
+ *
+ * @param {ReturnType<typeof verdict>["rows"]} rows
+ * @returns {string}
+ */
+export function formatRows(rows) {
+  const idWidth = Math.max(...rows.map((row) => row.id.length));
+  const outcomeWidth = Math.max(...rows.map((row) => row.outcome.length));
+  return rows
+    .map(
+      (row) =>
+        `${row.id.padEnd(idWidth)}  committed=${String(row.committed).padEnd(5)}  ` +
+        `${row.outcome.padEnd(outcomeWidth)}  ${row.label}\n` +
+        `${" ".repeat(idWidth + 2)}${row.detail}`,
+    )
+    .join("\n");
+}
+
+/**
+ * Ask one station the question the site asks.
+ *
+ * The three failure modes are separated here rather than in the classifier
+ * because only this half can tell them apart: a thrown fetch and a 503 never
+ * produce a payload to classify.
+ *
+ * @param {string} stationId
+ * @param {{beginDate: string, endDate: string}} window
+ * @returns {Promise<{outcome: string, detail: string}>}
+ */
+export async function measureStation(stationId, window) {
+  const url = coopsPredictionsUrl({ stationId, ...window });
+
+  let response;
+  try {
+    response = await fetch(url, { headers: { "User-Agent": USER_AGENT } });
+  } catch (cause) {
+    return {
+      outcome: UNREACHABLE,
+      detail: `the request did not complete: ${cause instanceof Error ? cause.message : String(cause)}`,
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      outcome: UNREACHABLE,
+      detail: `NOAA answered HTTP ${response.status}, so no payload was measured`,
+    };
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (cause) {
+    return {
+      outcome: DRIFT,
+      detail: `the body under HTTP 200 was not JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
+    };
+  }
+
+  return classifyPayload(payload);
+}
+
+/**
+ * Measure every station in the table, in order.
+ *
+ * Serially, because nine requests to one publisher is not worth a burst.
+ *
+ * @param {Record<string, object>} stations
+ * @param {{beginDate: string, endDate: string}} window
+ * @returns {Promise<Record<string, {outcome: string, detail: string}>>}
+ */
+export async function measureAll(stations, window) {
+  const measured = {};
+  for (const id of Object.keys(stations)) {
+    measured[id] = await measureStation(id, window);
+  }
+  return measured;
+}
+
+/**
+ * The command-line half, kept behind a guard so everything with a rule in it
+ * can be imported and asserted without reaching the network.
+ */
+async function main() {
+  const { stations } = JSON.parse(readFileSync(TABLE_PATH, "utf8"));
+  const window = predictionsWindow(new Date());
+
+  console.error(
+    `Asking ${Object.keys(stations).length} stations for ${window.beginDate}-${window.endDate} ` +
+      `predictions, datum=${COOPS_DATUM} units=${COOPS_UNITS} time_zone=${COOPS_TIME_ZONE} interval=hilo...`,
+  );
+
+  const measured = await measureAll(stations, window);
+  const { exitCode, rows } = verdict(stations, measured);
+
+  console.log(formatRows(rows));
+
+  const disagreeing = rows.filter((row) => row.label === "DISAGREES");
+  const unmeasured = rows.filter((row) => row.label === "NOT MEASURED");
+
+  if (exitCode === 0) {
+    console.log(
+      `\nAll ${rows.length} stations deliver what tide-stations.json says they deliver.`,
+    );
+  } else {
+    console.error(
+      `\n${disagreeing.length} station(s) disagree with the committed delivers flag and ` +
+        `${unmeasured.length} could not be measured. tide-stations.json is edited by hand: ` +
+        `read the rows above, and say in the commit message what changed upstream.`,
+    );
+  }
+
+  process.exit(exitCode);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/scripts/probe-tide-stations.test.mjs
+++ b/scripts/probe-tide-stations.test.mjs
@@ -1,0 +1,457 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CoopsDriftError,
+  CoopsUpstreamError,
+  COOPS_APPLICATION as SITE_APPLICATION,
+  COOPS_DATUM as SITE_DATUM,
+  COOPS_TIME_ZONE as SITE_TIME_ZONE,
+  COOPS_UNITS as SITE_UNITS,
+  coopsPredictionsUrl as siteUrl,
+  parseCoopsHiLo,
+} from "../src/lib/coops-predictions.ts";
+import FIXTURE from "../src/lib/__fixtures__/coops-9410230-hilo-20260817.json" with { type: "json" };
+import {
+  classifyPayload,
+  coopsPredictionsUrl,
+  COOPS_APPLICATION,
+  COOPS_DATUM,
+  COOPS_TIME_ZONE,
+  COOPS_UNITS,
+  DELIVERING,
+  DRIFT,
+  formatRows,
+  measureAll,
+  measureStation,
+  NOT_DELIVERING,
+  predictionsWindow,
+  UNREACHABLE,
+  verdict,
+} from "./probe-tide-stations.mjs";
+
+const CONTRACT = {
+  stationId: "9410230",
+  beginDate: "20260817",
+  endDate: "20260818",
+};
+
+/**
+ * THE REASON THIS FILE EXISTS TWICE OVER.
+ *
+ * The probe cannot import `coops-predictions.ts` -- it runs under node unbuilt
+ * -- so the request contract is spelled in both places. A probe measuring a
+ * contract the site does not read measures nothing, and nothing about the two
+ * copies makes them agree except this.
+ */
+describe("the request contract, against the one the site reads", () => {
+  it("builds the same URL for the same station and range", () => {
+    expect(coopsPredictionsUrl(CONTRACT)).toBe(siteUrl(CONTRACT));
+  });
+
+  it("builds the same URL for a different station and range", () => {
+    const other = {
+      stationId: "TWC0405",
+      beginDate: "20261215",
+      endDate: "20261216",
+    };
+    expect(coopsPredictionsUrl(other)).toBe(siteUrl(other));
+  });
+
+  it("spells each pinned constant the way the site spells it", () => {
+    // Named individually rather than compared as a bag, so a failure says which
+    // one moved. Getting any of them wrong produces a confident wrong number
+    // rather than an error, which is why the site pins them at all.
+    expect(COOPS_DATUM).toBe(SITE_DATUM);
+    expect(COOPS_UNITS).toBe(SITE_UNITS);
+    expect(COOPS_TIME_ZONE).toBe(SITE_TIME_ZONE);
+    expect(COOPS_APPLICATION).toBe(SITE_APPLICATION);
+  });
+
+  it("asks for the turning points, not the six-minute series", () => {
+    expect(coopsPredictionsUrl(CONTRACT)).toContain("interval=hilo");
+  });
+});
+
+/**
+ * The payloads a station can answer with, and what each one means.
+ *
+ * `TWC0405`'s entry is the body `tide-stations.json` records it answering on
+ * 2026-08-18, quoted from the file's own `dead_note`.
+ */
+const PAYLOADS = [
+  ["the committed fixture", FIXTURE, DELIVERING],
+  [
+    "a CO-OPS error object under HTTP 200",
+    {
+      error: {
+        message:
+          "No Predictions data was found. Please make sure the Datum input is valid.",
+      },
+    },
+    NOT_DELIVERING,
+  ],
+  ["an empty predictions array", { predictions: [] }, DRIFT],
+  ["predictions that are not an array", { predictions: "none" }, DRIFT],
+  ["a body with neither key", {}, DRIFT],
+  ["a payload that is not an object", "predictions", DRIFT],
+  [
+    "a row whose timestamp carries an offset",
+    { predictions: [{ t: "2026-08-17T01:41+00:00", v: "1.366", type: "L" }] },
+    DRIFT,
+  ],
+  [
+    "a row whose type is neither H nor L",
+    { predictions: [{ t: "2026-08-17 01:41", v: "1.366", type: "X" }] },
+    DRIFT,
+  ],
+  [
+    "a row whose height is not a number",
+    { predictions: [{ t: "2026-08-17 01:41", v: "high", type: "L" }] },
+    DRIFT,
+  ],
+];
+
+/** What the site's own parser makes of a payload, as one of this probe's outcomes. */
+function asSiteOutcome(payload) {
+  try {
+    parseCoopsHiLo(payload, CONTRACT);
+    return DELIVERING;
+  } catch (error) {
+    if (error instanceof CoopsUpstreamError) return NOT_DELIVERING;
+    if (error instanceof CoopsDriftError) return DRIFT;
+    throw error;
+  }
+}
+
+describe("classifying a payload", () => {
+  it.each(PAYLOADS)(
+    "reads %s as its own outcome",
+    (_name, payload, expected) => {
+      expect(classifyPayload(payload).outcome).toBe(expected);
+    },
+  );
+
+  it.each(PAYLOADS)(
+    "agrees with the site's parser about %s",
+    (_name, payload) => {
+      // The classification the probe reports has to be the classification a
+      // reader's request would hit. This is the only thing holding the two
+      // implementations together.
+      expect(classifyPayload(payload).outcome).toBe(asSiteOutcome(payload));
+    },
+  );
+
+  it("carries CO-OPS's own message, and says the status code did not say so", () => {
+    const { detail } = classifyPayload({
+      error: { message: "No Predictions data was found." },
+    });
+    expect(detail).toContain("No Predictions data was found.");
+    expect(detail).toContain("HTTP 200");
+  });
+
+  it("says an empty range is a broken request rather than a flat tide", () => {
+    expect(classifyPayload({ predictions: [] }).detail).toMatch(/astronomical/);
+  });
+});
+
+describe("the verdict", () => {
+  const TABLE = {
+    9410230: { delivers: true },
+    TWC0405: { delivers: false },
+  };
+  const measurement = (outcome) => ({ outcome, detail: "measured" });
+
+  it("exits 0 when every flag agrees with what was measured", () => {
+    const { exitCode, rows } = verdict(TABLE, {
+      9410230: measurement(DELIVERING),
+      TWC0405: measurement(NOT_DELIVERING),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(rows.every((row) => row.label === "agrees")).toBe(true);
+  });
+
+  it("exits non-zero and names a station that stopped delivering", () => {
+    const { exitCode, rows } = verdict(TABLE, {
+      9410230: measurement(NOT_DELIVERING),
+      TWC0405: measurement(NOT_DELIVERING),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(rows.find((row) => row.id === "9410230").label).toBe("DISAGREES");
+  });
+
+  it("exits non-zero and names a station that started delivering", () => {
+    // The direction that is easy to forget. A station coming back is as much a
+    // change as one going quiet, and it is the one that actually happened.
+    const { exitCode, rows } = verdict(TABLE, {
+      9410230: measurement(DELIVERING),
+      TWC0405: measurement(DELIVERING),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(rows.find((row) => row.id === "TWC0405").label).toBe("DISAGREES");
+  });
+
+  it("reports every station, agreeing or not", () => {
+    const { rows } = verdict(TABLE, {
+      9410230: measurement(DELIVERING),
+      TWC0405: measurement(DELIVERING),
+    });
+
+    expect(rows.map((row) => row.id)).toEqual(["9410230", "TWC0405"]);
+  });
+
+  it("reports drift as drift, not as a station that stopped delivering", () => {
+    const { exitCode, rows } = verdict(TABLE, {
+      9410230: measurement(DRIFT),
+      TWC0405: measurement(NOT_DELIVERING),
+    });
+
+    const drifted = rows.find((row) => row.id === "9410230");
+    expect(drifted.outcome).toBe(DRIFT);
+    expect(drifted.label).toBe("NOT MEASURED");
+    expect(exitCode).toBe(1);
+  });
+
+  it("reports unreachable as unreachable, never as stopped delivering", () => {
+    // The false alarm this probe exists to prevent. A refused connection to a
+    // station committed as delivering must not read as that station going
+    // quiet, which is what comparing it against the flag would say.
+    const { rows } = verdict(TABLE, {
+      9410230: measurement(UNREACHABLE),
+      TWC0405: measurement(NOT_DELIVERING),
+    });
+
+    const unreached = rows.find((row) => row.id === "9410230");
+    expect(unreached.outcome).toBe(UNREACHABLE);
+    expect(unreached.label).toBe("NOT MEASURED");
+    expect(unreached.label).not.toBe("DISAGREES");
+  });
+
+  it("does not let an unmeasured station pass as agreeing", () => {
+    const { exitCode, rows } = verdict(TABLE, {
+      TWC0405: measurement(NOT_DELIVERING),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(rows.find((row) => row.id === "9410230").outcome).toBe(UNREACHABLE);
+  });
+});
+
+describe("measuring a station", () => {
+  const WINDOW = { beginDate: "20260817", endDate: "20260818" };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("asks the URL the contract builds", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => FIXTURE,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await measureStation("9410230", WINDOW);
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      siteUrl({ stationId: "9410230", ...WINDOW }),
+    );
+  });
+
+  it("reads a served payload as delivering", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, status: 200, json: async () => FIXTURE })),
+    );
+
+    expect((await measureStation("9410230", WINDOW)).outcome).toBe(DELIVERING);
+  });
+
+  it("reads a CO-OPS error under HTTP 200 as not delivering", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ error: { message: "No Predictions data" } }),
+      })),
+    );
+
+    expect((await measureStation("TWC0405", WINDOW)).outcome).toBe(
+      NOT_DELIVERING,
+    );
+  });
+
+  it("reads a refused connection as unreachable, not as not delivering", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("fetch failed");
+      }),
+    );
+
+    const measured = await measureStation("9410230", WINDOW);
+    expect(measured.outcome).toBe(UNREACHABLE);
+    expect(measured.detail).toContain("fetch failed");
+  });
+
+  it("reads a non-200 as unreachable, since no payload was measured", async () => {
+    // CO-OPS retired `product=datums` and answers HTTP 400 with a plain-text
+    // body. A status code is not a station telling us anything about delivery.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, status: 400 })),
+    );
+
+    const measured = await measureStation("9410230", WINDOW);
+    expect(measured.outcome).toBe(UNREACHABLE);
+    expect(measured.detail).toContain("400");
+  });
+
+  it("reads a non-JSON body under HTTP 200 as drift", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError("Unexpected token < in JSON at position 0");
+        },
+      })),
+    );
+
+    expect((await measureStation("9410230", WINDOW)).outcome).toBe(DRIFT);
+  });
+});
+
+describe("the window asked for", () => {
+  it("asks for two consecutive calendar days, compacted", () => {
+    expect(predictionsWindow(new Date("2026-08-27T18:00:00Z"))).toEqual({
+      beginDate: "20260827",
+      endDate: "20260828",
+    });
+  });
+
+  it("steps across a month end rather than producing day 32", () => {
+    expect(predictionsWindow(new Date("2026-08-31T18:00:00Z"))).toEqual({
+      beginDate: "20260831",
+      endDate: "20260901",
+    });
+  });
+
+  it("uses the Pacific date, not the UTC one", () => {
+    // 2026-08-28T02:00Z is still the 27th where the beaches are. A UTC date
+    // here would ask for a window that has not started in the county.
+    expect(predictionsWindow(new Date("2026-08-28T02:00:00Z")).beginDate).toBe(
+      "20260827",
+    );
+  });
+});
+
+describe("what the run prints", () => {
+  const { rows } = verdict(
+    {
+      9410230: { delivers: true },
+      TWC0413: { delivers: true },
+      TWC0405: { delivers: false },
+    },
+    {
+      9410230: { outcome: DELIVERING, detail: "8 turning points" },
+      TWC0413: { outcome: UNREACHABLE, detail: "NOAA answered HTTP 503" },
+      TWC0405: { outcome: DELIVERING, detail: "8 turning points" },
+    },
+  );
+  const printed = formatRows(rows);
+
+  it("prints a line for every station, agreeing or not", () => {
+    // A probe that printed only its complaints would leave a reader unable to
+    // tell a clean run from one that never reached half the table.
+    for (const id of ["9410230", "TWC0413", "TWC0405"]) {
+      expect(printed).toContain(id);
+    }
+  });
+
+  it("marks the station that disagrees, and only that one", () => {
+    const disagreeing = printed
+      .split("\n")
+      .filter((line) => line.includes("DISAGREES"));
+    expect(disagreeing).toHaveLength(1);
+    expect(disagreeing[0]).toContain("TWC0405");
+  });
+
+  it("carries each measurement's detail, so a reader sees why", () => {
+    expect(printed).toContain("8 turning points");
+    expect(printed).toContain("NOAA answered HTTP 503");
+  });
+
+  it("shows what was committed beside what was measured", () => {
+    expect(printed).toMatch(
+      /TWC0405\s+committed=false\s+delivering\s+DISAGREES/,
+    );
+  });
+});
+
+describe("measuring the whole table", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("asks for every station and keys the answers by id", async () => {
+    const bodies = {
+      9410230: {
+        predictions: [{ t: "2026-08-17 01:41", v: "1.4", type: "L" }],
+      },
+      TWC0405: { error: { message: "No Predictions data was found." } },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url) => {
+        const id = new URL(url).searchParams.get("station");
+        return { ok: true, status: 200, json: async () => bodies[id] };
+      }),
+    );
+
+    const measured = await measureAll(
+      { 9410230: { delivers: true }, TWC0405: { delivers: false } },
+      { beginDate: "20260817", endDate: "20260818" },
+    );
+
+    expect(measured["9410230"].outcome).toBe(DELIVERING);
+    expect(measured.TWC0405.outcome).toBe(NOT_DELIVERING);
+  });
+
+  it("measures the rest of the table when one station is unreachable", async () => {
+    // One station refusing a connection must not cost the other eight their
+    // measurement, or a single blip reports the whole table as unknown.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url) => {
+        if (new URL(url).searchParams.get("station") === "TWC0413") {
+          throw new TypeError("fetch failed");
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            predictions: [{ t: "2026-08-17 01:41", v: "1.4", type: "L" }],
+          }),
+        };
+      }),
+    );
+
+    const measured = await measureAll(
+      {
+        9410230: { delivers: true },
+        TWC0413: { delivers: true },
+        TWC0405: { delivers: false },
+      },
+      { beginDate: "20260817", endDate: "20260818" },
+    );
+
+    expect(measured.TWC0413.outcome).toBe(UNREACHABLE);
+    expect(measured["9410230"].outcome).toBe(DELIVERING);
+    expect(measured.TWC0405.outcome).toBe(DELIVERING);
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -81,11 +81,23 @@ export default defineConfig({
       // Same event, second half: retiring the sky JOIN as well as the reading.
       // Three rose and branches fell again, still reason 2 -- sky-join.mjs was
       // at 100% and is deleted, along with the parser's visibility branches.
+      //
+      // LOWERED 2026-08-27 under reason 1, when probe-tide-stations.mjs
+      // arrived. The uncovered statements are lines 364-392 and 399 of that
+      // file and nothing else: main(), which reads the committed table, asks
+      // nine stations for predictions and calls process.exit, plus the
+      // `import.meta.url === pathToFileURL(argv[1])` guard below it. Everything
+      // with a rule in it is tested directly -- coopsPredictionsUrl,
+      // classifyPayload, predictionsWindow, verdict, formatRows, measureStation
+      // and measureAll, the last two against a stubbed fetch, at 81.8% of the
+      // file. They stay uncovered for the reason probe-grid-cells.mjs's main()
+      // does: covering them means either a gate row that needs the internet or
+      // a seam around process.exit that would exist only for the test.
       thresholds: {
-        statements: 89.3,
-        branches: 90.02,
-        functions: 94.9,
-        lines: 88.95,
+        statements: 88.98,
+        branches: 89.87,
+        functions: 94.41,
+        lines: 88.73,
       },
     },
   },


### PR DESCRIPTION
Closes #159

`tide-stations.json` records a `delivers` flag per station, measured by hand on
2026-08-18 and never re-checked. Three of the five station/line bindings have a
re-runnable probe; tide had none. This adds the fourth.

## Slices

**1. `Record that a station table with prose gets a checker`** (346f75c) —
`docs/adr/0021-a-station-table-with-prose-gets-a-checker.md`

**2. `Measure tide-station delivery against the committed flags`** (4b560d7) —
`scripts/probe-tide-stations.mjs`, its test, and the coverage floor.

## The probe's own run, against the committed table

This is the acceptance evidence, and it **fails**:

```
$ node scripts/probe-tide-stations.mjs
Asking 9 stations for 20260827-20260828 predictions, datum=MLLW units=english time_zone=gmt interval=hilo...
9410120  committed=true   delivering  agrees
         8 turning points
9410135  committed=true   delivering  agrees
         8 turning points
9410152  committed=true   delivering  agrees
         8 turning points
9410166  committed=true   delivering  agrees
         8 turning points
9410170  committed=true   delivering  agrees
         8 turning points
9410196  committed=true   delivering  agrees
         8 turning points
9410230  committed=true   delivering  agrees
         8 turning points
TWC0413  committed=true   delivering  agrees
         8 turning points
TWC0405  committed=false  delivering  DISAGREES
         8 turning points

1 station(s) disagree with the committed delivers flag and 0 could not be measured. tide-stations.json is edited by hand: read the rows above, and say in the commit message what changed upstream.

PROBE EXIT=1
```

TWC0405 alone, and nothing else. That independently reproduces triage's
2026-08-27 measurement from the probe rather than by hand. Nothing in
`tide-stations.json` was edited to make it green — #161 owns that correction,
and it is blocked on this precisely so the flag is flipped from a measurement.

## Decisions carried out of the brief

**Check-only.** There is no `--write` mode and no `--check` flag, because a mode
that regenerates this file cannot reproduce it. The ADR records both reasons.
The second one is worth repeating here because it is easy to get wrong: reading
the file with `JSON.parse` and printing `Object.keys` shows the *reordered*
order, so the committed north-to-south ordering is only visible in the bytes.

```
committed order:    9410230 9410196 TWC0413 9410170 9410166 9410152 9410135 9410120 TWC0405
after a round-trip: 9410120 9410135 9410152 9410166 9410170 9410196 9410230 TWC0413 TWC0405
```

**Four outcomes.** `delivering`, `not-delivering`, `drift`, `unreachable`. The
first three are what a reader's request would hit and are named by
`coops-predictions.ts`. `unreachable` — a refused connection, a timeout, a
non-200 — is not a delivery measurement and is never folded into
`not-delivering`; a station reported as `NOT MEASURED` never reads as
`DISAGREES`.

**Not a gate row.** It reaches the network, like its three siblings. #160 runs it.

## ADR number

**Filed at 0021 rather than at the next number derived on this branch.** The
brief says to derive the next free number; that advice assumes serial work. #160
is in flight on a branch that cannot see this one and would derive 0021 too.
That is the #102 collision the `adr-numbers` gate reports and cannot fix. 0021
here, 0022 there, assigned rather than derived.

## The two copies of the request contract

The probe runs under node unbuilt and cannot import TypeScript, so the datum,
units, time zone, application identifier and URL builder are spelled in both
`src/lib/coops-predictions.ts` and the probe. `generated-date.mjs` already makes
the same trade for `pacific-time.ts`.

What is new is that the duplication is not left on trust. The test imports both
sides and asserts:

- the probe and the site build **the same URL** for the same station and range,
  for two different stations and ranges;
- each pinned constant is spelled the same, named individually so a failure says
  which one moved;
- the probe **classifies the same payload the same way the site's parser does**,
  across nine payloads — the committed fixture, a CO-OPS error object under HTTP
  200, an empty `predictions` array, a non-array, a body with neither key, a
  non-object, and three malformed rows. `asSiteOutcome` runs the real
  `parseCoopsHiLo` and maps `CoopsUpstreamError`/`CoopsDriftError` onto the
  probe's outcomes.

That last one is the substantive guard: a probe measuring a contract the site
does not read measures nothing.

## Gate

Run at `4b560d7`, the head of this branch:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

46 tests in `probe-tide-stations.test.mjs`. None reaches the network — the
fetching half is exercised through `vi.stubGlobal("fetch", …)`, the pattern
`probe-observation-stations.test.mjs` already uses — and none writes a file.

## Coverage floor

Lowered under **reason 1** in `vitest.config.mts`'s own rules: the denominator
grew with deliberately-untested entry plumbing.

```
statements 89.3  -> 88.98
branches   90.02 -> 89.87
functions  94.9  -> 94.41
lines      88.95 -> 88.73
```

The uncovered statements are named rather than absorbed: **lines 364–392 and 399
of `probe-tide-stations.mjs`, and nothing else** — `main()`, which reads the
table, asks nine stations and calls `process.exit`, plus the
`import.meta.url === pathToFileURL(argv[1])` guard below it. The file is at
81.8% and everything with a rule in it is tested directly, including
`measureStation` and `measureAll` against a stubbed fetch. Covering the rest
means either a gate row that needs the internet or a seam around `process.exit`
that would exist only for the test — the same call `probe-grid-cells.mjs`'s
`main()` got on 2026-08-26.

## Not done, and why

- **No plan file.** Per `CLAUDE.md` and the brief: one script, its test and a
  one-page ADR do not need `docs/plans/`. The issue and this body are the
  durable record.
- **No `delivers` value changed**, no `dead_note` edited, no `unresolved` prose
  touched. #161.
- **Not added to the gate table.** It reaches the network.
- **No schedule.** #160.
- **Wave buoys still have no probe.** Separate table, separate binding.
- **`tide-join.mjs` untouched.** The join is correct; it was the freshness of
  its input that was unguarded.

## Noticed, not filed

The probe reports stations in `JSON.parse` order (numeric ids ascending, then
`TWC0413`, `TWC0405`), not the file's north-to-south order — the same
reordering the ADR describes. It affects only the order of printed rows, never
the file, so it is left as is rather than sorted back.
