### PR TITLE
Admit the six beaches TWC0405 brings back

### DIFF
--- a/docs/adr/0019-a-modelled-source-may-qualify-a-beach.md
+++ b/docs/adr/0019-a-modelled-source-may-qualify-a-beach.md
@@ -217,3 +217,37 @@ it affects.
   historical, the four beaches stay out, and #146 closes with the measurement
   recorded — which is worth something on its own, because the next person to ask
   will otherwise re-measure it.
+
+### Note added 2026-08-27: the modelled-only population is four no longer
+
+**Every figure above is left exactly as it was measured on 2026-08-26.** They are
+what motivated this decision and rewriting them would rewrite history. This note
+is what stops the stated consequences drifting from the code instead.
+
+`TWC0405` Point Loma was recorded as not delivering when those figures were
+taken. It began answering again, and the change was measured on 2026-08-27 —
+nine days in which nothing in the repo noticed. Six beaches around Point Loma
+and Coronado came inside `SERVICE_TOLERANCE_M` as a result, and every one of
+them reaches its waves from a MOP line rather than a buoy, because the buoy that
+would serve them is the one this ADR already refused. So, as of that date:
+
+- the site answers for **51** beaches, not 45, and `_excluded` holds **22**, not
+  28;
+- **ten** beaches publish no measured wave height under this rule, not four.
+
+**The decision itself is unchanged, and this is an argument for it rather than
+against it.** The case for was stated here as:
+
+> one instrument's failure silently deletes a stretch of public coastline from a
+> site whose reach is meant to be a measurement of the networks rather than an
+> artifact of one station's uptime
+
+This is that same sentence a second time, running the other way: a station's
+uptime moved and six beaches appeared, under rules that did not move.
+`dropReplacedBuoy`, `SERVICE_TOLERANCE_M` and `MODELLED_SOURCE_TOLERANCE_M` are
+all untouched — the six qualify under this ADR exactly as written, which is the
+finding rather than a workaround.
+
+The uptime is now watched rather than assumed: `scripts/probe-tide-stations.mjs`
+(ADR-0021) re-measures every tide station's delivery against what the table
+records. See issues #159 and #161.

--- a/scripts/seed-beaches.mjs
+++ b/scripts/seed-beaches.mjs
@@ -736,7 +736,8 @@ export function document(built, now = new Date()) {
         `than listed with a reading from out of range. The farthest any listed beach reads is ` +
         `${farthest.name}'s, at ${kilometres(farthest.tide_station_distance_m)}. See ` +
         `tide-stations.json, whose own unresolved list records that the one open-coast station ` +
-        `between La Jolla and Imperial Beach does not deliver predictions.`,
+        `between La Jolla and Imperial Beach has failed once already and is now re-measured ` +
+        `rather than assumed.`,
       `${beaches.filter((b) => b.wave_buoy === null).length} of these beaches get no MEASURED wave ` +
         `height, for two different reasons that their wave_buoy_null_reason tells apart. At ` +
         `${beaches.filter((b) => b.wave_buoy === null && b.mop_line === null).length} of them the ` +

--- a/src/app/conditions/[slug]/page.test.tsx
+++ b/src/app/conditions/[slug]/page.test.tsx
@@ -39,6 +39,26 @@ test("a slug outside the inventory is a 404, not an apology page", async () => {
   expect(notFound).toHaveBeenCalled();
 });
 
+test("the six beaches TWC0405 brought back are reachable at their routes", async () => {
+  // Every one of these 404'd until Point Loma started answering again. No join
+  // rule moved: their tide station came inside SERVICE_TOLERANCE_M because the
+  // station revived, and ADR-0019 already covered the buoy being out of range.
+  // The route is what a reader actually has, so the route is what is asserted
+  // rather than the inventory the route reads.
+  for (const slug of [
+    "sunset-cliffs-park",
+    "ocean-beach",
+    "dog-beach-o-b",
+    "coronado-north-beach",
+    "coronado-central-beach",
+    "coronado-city-beaches",
+  ]) {
+    const { unmount } = render(await BeachConditions(params(slug)));
+    expect(screen.getByText(`panel for ${slug}`)).toBeDefined();
+    unmount();
+  }
+});
+
 test("the title names the beach, so a shared link says where it is about", async () => {
   const metadata = await generateMetadata(params("torrey-pines-state-beach"));
   expect(metadata.title).toBe("Torrey Pines State Beach conditions");

--- a/src/app/conditions/page.test.tsx
+++ b/src/app/conditions/page.test.tsx
@@ -36,10 +36,11 @@ test("a reader can choose another beach from here", () => {
 
   const select = screen.getByLabelText("Choose a beach") as HTMLSelectElement;
   expect(select.value).toBe(DEFAULT_BEACH_SLUG);
-  // Every beach in the inventory is offered, not a curated subset. It is 45
+  // Every beach in the inventory is offered, not a curated subset. It is 51
   // rather than the county's 73 because the inventory itself is bounded by the
-  // stations that reach it, not because the chooser hides any of it.
-  expect(select.querySelectorAll("option").length).toBe(45);
+  // stations that reach it, not because the chooser hides any of it -- and it
+  // is 51 rather than 45 because one of those stations came back.
+  expect(select.querySelectorAll("option").length).toBe(51);
 });
 
 test("the page revalidates often enough that 'today' does not go stale", () => {

--- a/src/components/conditions/Caveats.test.tsx
+++ b/src/components/conditions/Caveats.test.tsx
@@ -5,7 +5,7 @@ import { DISCLOSURE_TARGET } from "./disclosure";
 
 const ENTRIES = [
   "beach_type is UNKNOWN upstream for most of these beaches.",
-  "TWC0405 Point Loma does not deliver predictions.",
+  "TWC0405 Point Loma failed once and is now re-measured rather than assumed.",
 ];
 
 const REACH = {

--- a/src/components/conditions/ConditionsNotes.test.tsx
+++ b/src/components/conditions/ConditionsNotes.test.tsx
@@ -5,7 +5,7 @@ import { REGION_HEADING } from "./headingRank";
 
 const ENTRIES = [
   "beach_type is UNKNOWN upstream for most of these beaches.",
-  "TWC0405 Point Loma does not deliver predictions.",
+  "TWC0405 Point Loma failed once and is now re-measured rather than assumed.",
 ];
 
 const REACH = {

--- a/src/data/beaches.json
+++ b/src/data/beaches.json
@@ -1,6 +1,6 @@
 {
   "version": "0.2.0",
-  "generated": "2026-08-26",
+  "generated": "2026-08-27",
   "time_zone": "America/Los_Angeles",
   "_provenance": "Seeded from the Beach Detail Information resource of \"Beach Advisories (Postings and Closures) and Beach Water Quality Monitoring\", published by the California State Water Resources Control Board: https://data.cnra.ca.gov/dataset/beach-advisories-postings-and-closures-and-beach-water-quality-monitoring, resource cc674e59-036c-45c3-bec2-5d3d294e0e3d. The data.ca.gov copy (resource fcbc9250-06e3-437d-b0c6-3cc5ddde93fc) serves identical content and is the mirror. Rebuilt by scripts/seed-beaches.mjs; re-runnable and diffable with --check. Field values are reproduced as the resource serves them, including BeachType \"UNKNOWN\".",
   "_inclusion": "County San Diego, Status Active, BeachAccess PUBLIC, CountAsBeach 1. A predicate over published fields rather than a judgement about which beaches are worth listing.",
@@ -1516,6 +1516,90 @@
       "air_station_from_end": "lower"
     },
     {
+      "slug": "dog-beach-o-b",
+      "name": "Dog Beach, O.B.",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.75617,
+          "lon": -117.252734
+        },
+        "lower": {
+          "lat": 32.747069,
+          "lon": -117.254253
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA316627",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0405",
+      "tide_station_distance_m": 9149,
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "the nearest delivering buoy 46254 is 12.5 km away, further than this site publishes a reading from, so it is not read here; MOP line D0347 answers for the waves at 0.9 km, and it is a model rather than a measurement",
+      "mop_line": "D0347",
+      "mop_line_distance_m": 870,
+      "mop_line_from_end": "lower",
+      "grid_cell": null,
+      "grid_cell_from_end": null,
+      "grid_cell_elevation_m": null,
+      "grid_cell_null_reason": "the forecast-cell table does not list dog-beach-o-b; it covers the beaches this site serves, because resolving a cell needs a coordinate and an excluded beach has none recorded",
+      "air_station": "E9951",
+      "air_station_distance_m": 4460,
+      "air_station_from_end": "lower"
+    },
+    {
+      "slug": "ocean-beach",
+      "name": "Ocean Beach",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.756524,
+          "lon": -117.251911
+        },
+        "lower": {
+          "lat": 32.735192,
+          "lon": -117.255806
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA799523",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0405",
+      "tide_station_distance_m": 7902,
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "the nearest delivering buoy 46254 is 12.5 km away, further than this site publishes a reading from, so it is not read here; MOP line D0333 answers for the waves at 0.8 km, and it is a model rather than a measurement",
+      "mop_line": "D0333",
+      "mop_line_distance_m": 776,
+      "mop_line_from_end": "lower",
+      "grid_cell": null,
+      "grid_cell_from_end": null,
+      "grid_cell_elevation_m": null,
+      "grid_cell_null_reason": "the forecast-cell table does not list ocean-beach; it covers the beaches this site serves, because resolving a cell needs a coordinate and an excluded beach has none recorded",
+      "air_station": "E9951",
+      "air_station_distance_m": 3607,
+      "air_station_from_end": "lower"
+    },
+    {
       "slug": "spanish-landing-park",
       "name": "Spanish Landing Park",
       "region": "Bays, lagoons and inlets",
@@ -1555,6 +1639,48 @@
       "grid_cell_elevation_m": 2.1336,
       "air_station": "KSAN",
       "air_station_distance_m": 1615,
+      "air_station_from_end": "lower"
+    },
+    {
+      "slug": "sunset-cliffs-park",
+      "name": "Sunset Cliffs Park",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.735192,
+          "lon": -117.255806
+        },
+        "lower": {
+          "lat": 32.713183,
+          "lon": -117.256222
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA628494",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0405",
+      "tide_station_distance_m": 5596,
+      "tide_station_from_end": "lower",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "the nearest delivering buoy 46254 is 14.8 km away, further than this site publishes a reading from, so it is not read here; MOP line D0333 answers for the waves at 0.8 km, and it is a model rather than a measurement",
+      "mop_line": "D0333",
+      "mop_line_distance_m": 776,
+      "mop_line_from_end": "upper",
+      "grid_cell": null,
+      "grid_cell_from_end": null,
+      "grid_cell_elevation_m": null,
+      "grid_cell_null_reason": "the forecast-cell table does not list sunset-cliffs-park; it covers the beaches this site serves, because resolving a cell needs a coordinate and an excluded beach has none recorded",
+      "air_station": "E9951",
+      "air_station_distance_m": 2866,
       "air_station_from_end": "lower"
     },
     {
@@ -1639,6 +1765,132 @@
       "grid_cell_elevation_m": 0,
       "air_station": "E9951",
       "air_station_distance_m": 1329,
+      "air_station_from_end": "upper"
+    },
+    {
+      "slug": "coronado-north-beach",
+      "name": "Coronado north beach",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.683267,
+          "lon": -117.223496
+        },
+        "lower": {
+          "lat": 32.6864,
+          "lon": -117.194
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA604254",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "San Diego"
+      },
+      "tide_station": "TWC0405",
+      "tide_station_distance_m": 2058,
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "the nearest delivering buoy 46254 is 20.9 km away, further than this site publishes a reading from, so it is not read here; MOP line D0228 answers for the waves at 0.6 km, and it is a model rather than a measurement",
+      "mop_line": "D0228",
+      "mop_line_distance_m": 635,
+      "mop_line_from_end": "upper",
+      "grid_cell": null,
+      "grid_cell_from_end": null,
+      "grid_cell_elevation_m": null,
+      "grid_cell_null_reason": "the forecast-cell table does not list coronado-north-beach; it covers the beaches this site serves, because resolving a cell needs a coordinate and an excluded beach has none recorded",
+      "air_station": "E9951",
+      "air_station_distance_m": 3531,
+      "air_station_from_end": "upper"
+    },
+    {
+      "slug": "coronado-central-beach",
+      "name": "Coronado, Central beach",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.684744,
+          "lon": -117.19049
+        },
+        "lower": {
+          "lat": 32.680392,
+          "lon": -117.18199
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA594160",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Coronado"
+      },
+      "tide_station": "TWC0405",
+      "tide_station_distance_m": 4481,
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "the nearest delivering buoy 46254 is 21.6 km away, further than this site publishes a reading from, so it is not read here; MOP line D0177 answers for the waves at 0.9 km, and it is a model rather than a measurement",
+      "mop_line": "D0177",
+      "mop_line_distance_m": 930,
+      "mop_line_from_end": "lower",
+      "grid_cell": null,
+      "grid_cell_from_end": null,
+      "grid_cell_elevation_m": null,
+      "grid_cell_null_reason": "the forecast-cell table does not list coronado-central-beach; it covers the beaches this site serves, because resolving a cell needs a coordinate and an excluded beach has none recorded",
+      "air_station": "E9951",
+      "air_station_distance_m": 4704,
+      "air_station_from_end": "upper"
+    },
+    {
+      "slug": "coronado-city-beaches",
+      "name": "Coronado City beaches",
+      "region": "Point Loma and Ocean Beach",
+      "segment": {
+        "upper": {
+          "lat": 32.6867,
+          "lon": -117.1976
+        },
+        "lower": {
+          "lat": 32.6739,
+          "lon": -117.1721
+        }
+      },
+      "upstream": {
+        "usepa_id": "CA204955",
+        "agency": "County of San Diego Department of Environmental Health",
+        "water_body_name": "Pacific Ocean",
+        "water_body_type": "Open Coast",
+        "beach_type": "UNKNOWN",
+        "beach_access": "PUBLIC",
+        "status": "Active",
+        "nearest_city": "Coronado"
+      },
+      "tide_station": "TWC0405",
+      "tide_station_distance_m": 4014,
+      "tide_station_from_end": "upper",
+      "wave_buoy": null,
+      "wave_buoy_distance_m": null,
+      "wave_buoy_from_end": null,
+      "wave_buoy_null_reason": "the nearest delivering buoy 46254 is 21.2 km away, further than this site publishes a reading from, so it is not read here; MOP line D0167 answers for the waves at 0.8 km, and it is a model rather than a measurement",
+      "mop_line": "D0167",
+      "mop_line_distance_m": 833,
+      "mop_line_from_end": "lower",
+      "grid_cell": null,
+      "grid_cell_from_end": null,
+      "grid_cell_elevation_m": null,
+      "grid_cell_null_reason": "the forecast-cell table does not list coronado-city-beaches; it covers the beaches this site serves, because resolving a cell needs a coordinate and an excluded beach has none recorded",
+      "air_station": "E9951",
+      "air_station_distance_m": 4096,
       "air_station_from_end": "upper"
     },
     {
@@ -1987,39 +2239,9 @@
       "why": "its tide station 9410230 is 10.4 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
     },
     {
-      "slug": "dog-beach-o-b",
-      "name": "Dog Beach, O.B.",
-      "why": "its tide station 9410230 is 12.3 km away and its wave buoy 46254 is 12.5 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
-    },
-    {
-      "slug": "ocean-beach",
-      "name": "Ocean Beach",
-      "why": "its tide station 9410230 is 12.3 km away and its wave buoy 46254 is 12.5 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
-    },
-    {
-      "slug": "sunset-cliffs-park",
-      "name": "Sunset Cliffs Park",
-      "why": "its tide station 9410230 is 14.6 km away and its wave buoy 46254 is 14.8 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
-    },
-    {
       "slug": "tide-beach-park",
       "name": "Tide Beach Park",
-      "why": "its tide station 9410120 is 12.5 km away and its wave buoy 46254 is 21.8 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for. A model can answer for the waves where no buoy is in range, but not here: the nearest MOP line is 2.6 km away, and every beach on this coast binds one inside 1.0 km"
-    },
-    {
-      "slug": "coronado-north-beach",
-      "name": "Coronado north beach",
-      "why": "its tide station 9410120 is 13.2 km away and its wave buoy 46254 is 20.9 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
-    },
-    {
-      "slug": "coronado-central-beach",
-      "name": "Coronado, Central beach",
-      "why": "its tide station 9410120 is 12.2 km away and its wave buoy 46254 is 21.6 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
-    },
-    {
-      "slug": "coronado-city-beaches",
-      "name": "Coronado City beaches",
-      "why": "its tide station 9410120 is 11.2 km away and its wave buoy 46254 is 21.2 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for"
+      "why": "its wave buoy 46254 is 21.8 km away, and this site does not publish a reading taken more than 10.0 km from the beach it is shown for. A model can answer for the waves where no buoy is in range, but not here: the nearest MOP line is 2.6 km away, and every beach on this coast binds one inside 1.0 km"
     },
     {
       "slug": "tijana-river",
@@ -2034,9 +2256,9 @@
   ],
   "unresolved": [
     "beach_type is UNKNOWN upstream for most of these beaches. That is a gap in the resource, not a shorthand for sand, and nothing may render it as a description of what the shore is made of.",
-    "The join binds by nearest station of matching water class, and a beach whose nearest is further than 10.0 km away is not listed here at all rather than listed with a reading from out of range. The farthest any listed beach reads is Del Mar City Beach's, at 9.2 km. See tide-stations.json, whose own unresolved list records that the one open-coast station between La Jolla and Imperial Beach does not deliver predictions.",
-    "30 of these beaches get no MEASURED wave height, for two different reasons that their wave_buoy_null_reason tells apart. At 26 of them the join bound no buoy: every NDBC wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so binding one to the nearest buoy would put an open-ocean number on enclosed water. Their water temperature is missing for the same reason and is not yet filled from another source. At the other 4 the join DID bind a buoy and this site declined to publish it, because the only one left is far past 10.0 km -- 46235 Imperial Beach Nearshore died in May 2026 and was the only buoy south of Point Loma. Those beaches are open coast and do get a wave figure, from a model rather than an instrument, and the page says which it is. See docs/adr/0019-a-modelled-source-may-qualify-a-beach.md.",
-    "26 beaches get no wave forecast, and the refusal costs more here than it does for the buoy: MOP lines sit about 100 m apart, so the nearest one to an enclosed beach is close enough to look right. It would still be describing the open coast outside. The median bound beach reads a line 503 m away and the farthest reads one 910 m away, at Tourmaline Surfing Park. Every one is inside a kilometre, and that closeness is now load-bearing rather than merely reassuring: where no buoy is in range, a line within 1.0 km answers for the beach on its own and the beach is listed on the strength of it. A model deciding what this site covers is a change of kind, and it is argued in docs/adr/0019-a-modelled-source-may-qualify-a-beach.md rather than assumed here.",
+    "The join binds by nearest station of matching water class, and a beach whose nearest is further than 10.0 km away is not listed here at all rather than listed with a reading from out of range. The farthest any listed beach reads is Del Mar City Beach's, at 9.2 km. See tide-stations.json, whose own unresolved list records that the one open-coast station between La Jolla and Imperial Beach has failed once already and is now re-measured rather than assumed.",
+    "36 of these beaches get no MEASURED wave height, for two different reasons that their wave_buoy_null_reason tells apart. At 26 of them the join bound no buoy: every NDBC wave buoy sits on the open coast, and ocean swell does not reach into a bay or lagoon, so binding one to the nearest buoy would put an open-ocean number on enclosed water. Their water temperature is missing for the same reason and is not yet filled from another source. At the other 10 the join DID bind a buoy and this site declined to publish it, because the only one left is far past 10.0 km -- 46235 Imperial Beach Nearshore died in May 2026 and was the only buoy south of Point Loma. Those beaches are open coast and do get a wave figure, from a model rather than an instrument, and the page says which it is. See docs/adr/0019-a-modelled-source-may-qualify-a-beach.md.",
+    "26 beaches get no wave forecast, and the refusal costs more here than it does for the buoy: MOP lines sit about 100 m apart, so the nearest one to an enclosed beach is close enough to look right. It would still be describing the open coast outside. The median bound beach reads a line 644 m away and the farthest reads one 930 m away, at Coronado, Central beach. Every one is inside a kilometre, and that closeness is now load-bearing rather than merely reassuring: where no buoy is in range, a line within 1.0 km answers for the beach on its own and the beach is listed on the strength of it. A model deciding what this site covers is a change of kind, and it is argued in docs/adr/0019-a-modelled-source-may-qualify-a-beach.md rather than assumed here.",
     "A tide prediction is for the station, not for the beach. It is the best published figure for that stretch of shore and it is not a measurement taken there.",
     "Cloud comes from a forecast rather than a reading, and there is no visibility figure at all. The ten stations in this county publishing either one are airport METARs, and an aerodrome observation describes its own field: this site read one until 2026-08-27 and stopped. The week grid shows cloud forecast for each beach's own square of the National Weather Service's map instead. See docs/adr/0020-sky-leaves-the-card-for-the-week.md.",
     "Air temperature and wind come from the station nearest the shore, and the page names it with its distance. The median beach reads its air station 3.7 km away. That binding exists separately because requiring one station to supply sky as well meant the scarcest value decided where the temperature was measured, which put an inland reading on a coastal beach; the sky binding has since gone entirely and this one is what it was protecting. See docs/adr/0010-two-provenances-in-the-air-panel.md.",

--- a/src/data/tide-stations.json
+++ b/src/data/tide-stations.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
-  "generated": "2026-08-18",
-  "_provenance": "Station ids, names and coordinates read from NOAA CO-OPS metadata, https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?type=tidepredictions, filtered to 32.5-33.4N and -117.5 to -117.0E, on 2026-08-18. Nine stations answered. Delivery was then measured one station at a time against the same predictions endpoint this site reads, rather than inferred from the station list: eight serve predictions and one does not.",
+  "generated": "2026-08-27",
+  "_provenance": "Station ids, names and coordinates read from NOAA CO-OPS metadata, https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json?type=tidepredictions, filtered to 32.5-33.4N and -117.5 to -117.0E, on 2026-08-18. Nine stations answered. Delivery was then measured one station at a time against the same predictions endpoint this site reads, rather than inferred from the station list: eight served predictions and one did not. Re-measured on 2026-08-27 by scripts/probe-tide-stations.mjs, which asks every station the same question under the same contract: all nine serve predictions. TWC0405 Point Loma is the one that changed, and the nine days it took to notice are why the probe exists.",
   "_water_is_an_input_not_a_result": "The `water` field is hand-written, and that is deliberate in a file whose values otherwise come from upstream. NOAA publishes no open-coast/bay classification, so no authority can state it, and a join has to be told which stations are candidates for which beaches. It has the same standing as the scope field on a join rather than the standing of a joined value. What it prevents is concrete: an ocean-facing beach near the bay mouth is geometrically closer to a bay station than to any coastal one, and a bay tide curve at an ocean beach is a wrong number that looks entirely right.",
   "_measured_spread": "Station choice is not cosmetic. For the low tide around 02:4x GMT on 2026-08-18 the eight working stations predicted between 1.442 and 1.700 ft, across 13 minutes of timing. A quarter of a foot is the difference between a reef being out and not.",
   "_schema": {
@@ -84,12 +84,11 @@
       "lon": -117.2333,
       "kind": "S",
       "water": "open-coast",
-      "delivers": false,
-      "dead_note": "Asked for hilo predictions on 2026-08-18 it answered HTTP 200 carrying {\"error\":{\"message\":\"No Predictions data was found. Please make sure the Datum input is valid.\"}} -- a dead response wearing a success code, which is the failure this stack pins the parser against. It is listed in NOAA's tide-prediction station metadata all the same, so a join built from that list without measuring delivery would have bound the middle of the open coast to a station that never answers. Kept and marked rather than deleted: if it starts answering, that is a change a human should see."
+      "delivers": true
     }
   },
   "unresolved": [
-    "TWC0405 Point Loma is the only tide-prediction station on the open coast between La Jolla and Imperial Beach, and it does not deliver. So every open-coast beach from Point Loma through Ocean Beach and Pacific Beach binds to a station some distance away, and the join records that distance rather than hiding it. This is a gap in NOAA's published predictions, not one this site can close.",
+    "TWC0405 Point Loma is the only tide-prediction station on the open coast between La Jolla and Imperial Beach, and it is a station this site has already watched fail. Asked for predictions on 2026-08-18 it answered an error under a success code; asked the same question on 2026-08-27 it answered normally, and six beaches around Point Loma and Coronado are listed here because it did. Nine days passed between those two measurements with nothing checking, which is why scripts/probe-tide-stations.mjs now re-measures every station's delivery against what this file records. If it goes quiet again those beaches show an unavailable reading rather than a wrong one, and the probe is what says so.",
     "The open-coast/bay classification of each station is an author judgement, written by hand because no upstream authority publishes one. It has not been checked against a tidal-datum study, and the case it most affects is the bay mouth, where the two classes are closest together."
   ]
 }

--- a/src/data/wave-buoys.json
+++ b/src/data/wave-buoys.json
@@ -101,7 +101,7 @@
       "lon": -117.274,
       "delivers": false,
       "publishes_waves": false,
-      "dead_note": "Listed in NDBC's active station list on 2026-08-18 and answered 404 on realtime2 the same day. Its entry carries met=n. Listed but not delivering is the same trap TWC0405 sets in the tide join, and the reason delivery is measured here rather than read off the list."
+      "dead_note": "Listed in NDBC's active station list on 2026-08-18 and answered 404 on realtime2 the same day. Its entry carries met=n. Listed but not delivering is the same trap TWC0405 set in the tide join when this was measured, and the reason delivery is measured here rather than read off the list."
     },
     "46235": {
       "name": "Imperial Beach Nearshore",

--- a/src/lib/beaches.test.ts
+++ b/src/lib/beaches.test.ts
@@ -14,10 +14,12 @@ import {
 
 describe("the inventory", () => {
   test("holds only the beaches the station networks reach", () => {
-    // The county lists 73. The other 28 are in beaches.json's `_excluded`
+    // The county lists 73. The other 22 are in beaches.json's `_excluded`
     // block, each with the binding distance that removed it; see
-    // docs/adr/0011-inventory-bounded-by-station-networks.md.
-    expect(allBeaches()).toHaveLength(45);
+    // docs/adr/0011-inventory-bounded-by-station-networks.md. It was 45 and 28
+    // until TWC0405 Point Loma started answering again: six beaches around
+    // Point Loma and Coronado came inside tolerance without any rule moving.
+    expect(allBeaches()).toHaveLength(51);
   });
 
   test("holds the four beaches no buoy reaches, which a model answers for", () => {
@@ -280,7 +282,7 @@ describe("the MOP line binding", () => {
   test("every beach with a buoy also has a line, but not the reverse", () => {
     // This used to be an equivalence: two joins over two tables, agreeing about
     // which water ocean swell reaches. ADR-0019 broke the second direction on
-    // purpose -- four beaches carry a line and no buoy, because the buoy the
+    // purpose -- ten beaches carry a line and no buoy, because the buoy the
     // join bound is further away than this site will publish. The first
     // direction still holds and is the half that catches the two joins
     // disagreeing about the water, which is what the equivalence was for: a
@@ -298,7 +300,7 @@ describe("the MOP line binding", () => {
     const modelledOnly = allBeaches().filter(
       (beach) => beach.wave_buoy === null && beach.mop_line !== null,
     );
-    expect(modelledOnly).toHaveLength(4);
+    expect(modelledOnly).toHaveLength(10);
 
     for (const beach of modelledOnly) {
       expect(beach.mop_line_distance_m).toBeLessThanOrEqual(1_000);


### PR DESCRIPTION
Closes #161

TWC0405 Point Loma was recorded as not delivering, measured 2026-08-18. It
answers again. Six beaches were excluded on a tide station that is no longer
their nearest available one, and a caveat shown to readers said the open-coast
station does not deliver.

The flag is flipped **from the probe's measurement**, not by hand — #159 merged
first for exactly that reason.

## Slices

**1. `Admit the six beaches TWC0405 brings back`** (0572e3c) — the flag, the four
stale statements, the seeding script's literal, the re-seed, the three pinned
counts.

**2. `Record on ADR-0019 that its four beaches are now ten`** (c0c1135).

The station table and the inventory move in one commit on purpose: splitting
them would leave a commit where two committed files disagree about which
stations deliver, which is the defect class this closes.

## Acceptance, measured

```
$ node scripts/probe-tide-stations.mjs
...
TWC0405  committed=true   delivering  agrees
         8 turning points

All 9 stations deliver what tide-stations.json says they deliver.
PROBE EXIT=0
```

```
$ node scripts/seed-beaches.mjs --check
beaches.json is current: 51 beaches, join unchanged.
SEED CHECK EXIT=0
```

The re-seed, verified against a snapshot of the pre-seed inventory rather than
assumed:

```
beaches   45 -> 51
_excluded 28 -> 22

existing beaches that changed any field: 0 of 45

added (6): dog-beach-o-b, ocean-beach, sunset-cliffs-park,
           coronado-north-beach, coronado-central-beach, coronado-city-beaches
added set matches the six the brief names: true

sunset-cliffs-park       tide=TWC0405  5596 m  mop=D0333  776 m  buoy=null
ocean-beach              tide=TWC0405  7902 m  mop=D0333  776 m  buoy=null
dog-beach-o-b            tide=TWC0405  9149 m  mop=D0347  870 m  buoy=null
coronado-north-beach     tide=TWC0405  2058 m  mop=D0228  635 m  buoy=null
coronado-central-beach   tide=TWC0405  4481 m  mop=D0177  930 m  buoy=null
coronado-city-beaches    tide=TWC0405  4014 m  mop=D0167  833 m  buoy=null

modelled-only population: 4 -> 10
every modelled-only beach within 1000 m: true
```

Every distance matches the brief to the metre. **`0 of 45` is the one worth
noting** — it was compared field by field against the snapshot, not inferred
from "nothing else should have moved".

Each of the six carries the two-part `wave_buoy_null_reason`, e.g. Coronado
North:

> the nearest delivering buoy 46254 is 20.9 km away, further than this site
> publishes a reading from, so it is not read here; MOP line D0228 answers for
> the waves at 0.6 km, and it is a model rather than a measurement

**No join rule moved.** `dropReplacedBuoy`, `bindTideStation`, `servesBeach`,
`SERVICE_TOLERANCE_M` and `MODELLED_SOURCE_TOLERANCE_M` are untouched. All six
qualify under ADR-0011 and ADR-0019 exactly as written.

## Reachability

The routes are not prerendered — `generateStaticParams()` returns `[]` by
design — so "reachable" turns on `beachBySlug` resolving rather than
`notFound()`. The new test renders each of the six through the real route
component and asserts the panel appears, which is what a reader actually has.

## The statements that went false

| # | Where | Done |
|---|---|---|
| 1 | `delivers` + `dead_note` | flipped; `dead_note` removed, which the schema allows only when `delivers` is false |
| 2 | `generated` | 2026-08-18 → 2026-08-27 |
| 3 | `_provenance` "eight serve predictions and one does not" | rewritten, naming the probe and the re-measurement |
| 4 | `unresolved` entry — **rendered to readers** | rewritten |
| 5 | `seed-beaches.mjs`'s hardcoded copy of the same claim | rewritten |

`_measured_spread` is left alone: it is explicitly dated 2026-08-18 and reads as
a dated record.

The rewritten `unresolved` entry still names TWC0405, as `beaches.test.ts`
requires, and is honest about the history rather than quietly dropping it:

> TWC0405 Point Loma is the only tide-prediction station on the open coast
> between La Jolla and Imperial Beach, and it is a station this site has already
> watched fail. Asked for predictions on 2026-08-18 it answered an error under a
> success code; asked the same question on 2026-08-27 it answered normally, and
> six beaches around Point Loma and Coronado are listed here because it did.
> Nine days passed between those two measurements with nothing checking, which
> is why `scripts/probe-tide-stations.mjs` now re-measures every station's
> delivery against what this file records. If it goes quiet again those beaches
> show an unavailable reading rather than a wrong one, and the probe is what
> says so.

Two further edits, both to satisfy "no statement **anywhere** still says TWC0405
does not deliver":

- `Caveats.test.tsx` and `ConditionsNotes.test.tsx` each carried
  `"TWC0405 Point Loma does not deliver predictions."` as sample caveat content.
  Only used as an entry to render, so the string was corrected.
- `wave-buoys.json`'s `dead_note` for 46235 said the trap "TWC0405 **sets** in
  the tide join". **Only the tense was changed** — to "set … when this was
  measured". The note is a dated record of a different table's measurement and
  that table has no probe, so rewriting the measurement was not on; leaving a
  present-tense claim was not either.

## ADR-0019

A **dated note appended to Consequences, not an edit**: 34 insertions, 0
deletions, so none of its figures were rewritten. It records that four beaches
became ten and 45 became 51, that the decision stands, and that the revival
argues for the decision rather than against it — its own "case for" sentence
running the other way.

## Gate

Run at `c0c1135`, the head of this branch:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

## Flagged, not filed

**`regionOf` bands by latitude with a boundary at 32.65**, so all three Coronado
beaches land in the region labelled "Point Loma and Ocean Beach", which grows
from two beaches to eight. Coronado is neither Point Loma nor Ocean Beach. It
changes no binding and is a label question for a person, per the brief.

**Three prose mentions of "45" are now stale**, all in comments, none rendered:
`src/lib/beaches.ts:83` ("17 of 45 beaches straddle" a cell boundary),
`src/lib/conditions.ts:690` ("20 of the 45" beyond 10 km) and
`src/components/conditions/WindToday.tsx:15` ("the 45 beaches served"). Each
pairs 45 with a second figure that this issue did not re-measure, so changing
only the 45 would produce a sentence that is more wrong, not less. Left for
whoever re-measures the air provenance.

## Not done, and why

- **No plan file.** Two slices on one branch; the issue, the brief and this body
  are the durable record.
- **No new ADR.** ADR-0019 gets a dated note, per the brief. No number consumed.
- **`SERVICE_TOLERANCE_M` not raised.** ADR-0019 considered and rejected it, and
  nothing here needed it.
- **No other excluded beach touched.** 22 remain, Carlsbad Municipal among them,
  for reasons that still hold.
- **Nothing about the MSL epoch drift** (#127) or the scheduled probe (#160).
