### PR TITLE
Run every probe weekly and report what moved

### DIFF
--- a/.github/workflows/probe.yml
+++ b/.github/workflows/probe.yml
@@ -1,0 +1,54 @@
+# Weekly check that the data this repo owns still matches what upstream
+# publishes. ADR-0009 promised this and nothing ran the probes; ADR-0022
+# records what it does when it finds something.
+#
+# Separate from gate.yml on purpose. Every gate is offline so a fresh clone
+# with no credentials can run it; every probe here reaches the network. Mixing
+# them would make the gate need the internet.
+name: probe
+
+on:
+  schedule:
+    # 07:00 UTC on Mondays — midnight Pacific in summer, 23:00 Sunday in winter.
+    # A weekly job whose exact minute matters is a job with a different problem.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+# The repo's default workflow token is read-only, so an omitted block fails at
+# the API call rather than at parse time. `issues: write` covers both filing and
+# commenting. Nothing else is granted: this workflow commits nothing, pushes
+# nothing and opens no pull request.
+permissions:
+  contents: read
+  issues: write
+
+# One run at a time. Two overlapping runs would each see no open issue for a
+# moved probe and file two.
+concurrency:
+  group: probe
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          # The same pin gate.yml carries. CLAUDE.md asks that CI and local
+          # share one runtime; two workflows disagreeing would be the same bug
+          # one step further out.
+          node-version: "22.18.0"
+          cache: npm
+
+      # ci, not install, for the reason gate.yml gives: it installs exactly the
+      # lockfile and fails if that has drifted from package.json.
+      - run: npm ci
+
+      - name: Run every probe and report what moved
+        run: node scripts/run-probes.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/adr/0022-drift-is-reported-as-an-issue.md
+++ b/docs/adr/0022-drift-is-reported-as-an-issue.md
@@ -1,0 +1,131 @@
+# 0022 — Drift is reported as an issue, and the run that reports it passes
+
+Date: 2026-08-27. Status: accepted.
+
+## Context
+
+ADR-0009 promised a weekly probe and was explicit that it was not an
+aspiration. Four probes exist. Until now nothing ran them: `gate.yml` was the
+only workflow and has no `schedule`, and no row in the gate table touches the
+network — correctly, because the gate must pass on a fresh clone with no
+credentials.
+
+So the probes ran when someone remembered, which since 2026-08-18 was never.
+That is measurable rather than rhetorical: `TWC0405` Point Loma went from dead
+to answering in those nine days and nothing noticed, which is issues #159 and
+#161.
+
+Three things constrain what a scheduled run can do.
+
+**The probes share exactly one contract: the exit code.** Non-zero when what
+was measured disagrees with what is committed. Nothing else is uniform —
+`probe-grid-cells.mjs` throws a Node stack trace where `probe-mop-lines.mjs`
+and `probe-observation-stations.mjs` print a sentence and call `process.exit`,
+and `probe-tide-stations.mjs` has no `--check` flag at all because it has no
+other mode (ADR-0021). Rewriting them into a common shape is a bigger change
+than this and would have to be justified on its own.
+
+**Regenerating and opening a pull request cannot be uniform either.**
+`probe-tide-stations.mjs` never writes, by design: its table carries
+hand-written prose no probe can reproduce. So "open a PR with the regenerated
+file" covers three of the four probes at best. More decisively, every
+generator's own failure message asks the reader to _"read the diff, and say in
+the commit message what changed upstream."_ A bot can produce the diff. It
+cannot say why, and that sentence is the thing being asked for.
+
+**The default workflow token is read-only.**
+`default_workflow_permissions` is `read`, so a workflow that omits an explicit
+`permissions:` block fails at the API call rather than at parse time.
+
+## Decision
+
+**A weekly workflow runs every probe, and drift is reported as a GitHub
+issue.** Not a pull request, and not a red build.
+
+**Every probe runs on every invocation, and every outcome is reported** —
+including the clean ones. One probe failing must not stop the rest, so the
+reporting of each is wrapped individually and its error is carried into that
+probe's row rather than thrown.
+
+**Three outcomes, kept distinct: `unchanged`, `moved`, `unreachable`.**
+
+**A probe's upstream hosts are a column in its table row.** This is the part
+worth arguing, because it is the only way the three outcomes can be told apart
+under the constraint above. The shared contract is the exit code, and an exit
+code cannot separate "upstream changed" from "upstream is having a bad day" —
+both are 1. So the runner asks the question the probes cannot: _if a probe
+failed, is its publisher answering at all?_ A probe that failed while its
+publisher answered measured something and disagrees; a probe that failed while
+its publisher did not answer measured nothing. That check needs the hosts, so
+the hosts live in the row rather than as knowledge inside the runner, and
+adding a probe stays "add a row".
+
+Any HTTP response counts as answering, a 400 or a 500 included. The question is
+whether the publisher is there, not whether it is happy — CO-OPS retired
+`product=datums` and it now answers HTTP 400 forever, which is a real change
+worth reporting rather than a bad connection to write off.
+
+**A failure is retried once before it is believed.** The cheapest explanation
+for a probe failing once is that a publisher blinked, and a retry that comes
+back clean costs one run and saves an issue nobody should have read.
+
+**De-duplication is keyed on a marker in the issue body, not on its title.** A
+probe still reporting drift next week comments on the open issue rather than
+filing a second. The marker is `<!-- probe-drift:<name> -->`, because whoever
+triages the issue will rewrite the title and a match on title text would file a
+fresh issue the moment somebody made the first one clearer.
+
+**The run passes when it reports successfully, whatever it found.** This is the
+first thing someone will want to change, so it is stated here. A run that found
+drift and successfully filed it has done its job. Failing as well delivers the
+same news twice — once as an issue somebody can act on, once as a red X on a
+repo with no open PR that nobody can — and the red X is the copy that trains
+people to ignore both. Failure is reserved for the reporting itself failing: an
+API call rejected, a probe that could not be spawned.
+
+**The workflow commits nothing, pushes nothing, and opens no pull request.** It
+is granted `contents: read` and `issues: write` and nothing else.
+
+**The gate table is untouched.** It stays offline so it passes on a fresh
+clone. This is a separate workflow for that reason.
+
+## Consequences
+
+**Something finally runs the probes.** That is the whole point, and everything
+below is the cost of it.
+
+**A probe that crashes on a refused connection is still reported as `moved`,
+not `unreachable`, if its publisher recovers before the runner's own check.**
+The window is seconds and the retry narrows it further, but it is real, and it
+is a direct consequence of consuming exit codes rather than parsing output. The
+honest fix is for the probes to signal the difference themselves — a distinct
+exit code for "could not measure" — which is deliberately not done here because
+changing four probes' contracts is its own decision. `probe-tide-stations.mjs`
+already draws this line internally, per station; it just has no way to say so
+through an exit code.
+
+**The reachability check is a second network call per failing probe**, made to
+an origin the probe just used. It runs only when a probe has already failed, so
+a quiet week costs nothing.
+
+**An unreachable publisher files an issue too.** A run that swallowed it would
+be the silent failure this repo forbids, and a publisher that stays unreachable
+is exactly the rot worth chasing. A publisher having one bad morning is
+absorbed by the retry; one having a bad week produces one issue, not five,
+because of the marker.
+
+**Issues filed by this workflow accumulate if nobody closes them.** That is
+intended — an open issue is the record that a probe is still reporting drift,
+and the comment thread is its history. It does mean a probe left unfixed grows
+a comment a week.
+
+**The probe list can drift from the scripts.** A row naming a renamed script
+would go quiet rather than fail, which is the exact failure this workflow
+exists to remove. `probes.test.mjs` asserts every row names a file that exists,
+which is why that test reaches the filesystem when nothing else in the table
+does.
+
+**`workflow_dispatch` is on it as well as the schedule**, so a run can be
+triggered by hand rather than waited for. Note the GitHub constraint that
+follows: a workflow is only dispatchable once it is on the default branch, so
+the first by-hand run of any new workflow is necessarily after it merges.

--- a/scripts/probes.mjs
+++ b/scripts/probes.mjs
@@ -1,0 +1,305 @@
+/**
+ * The probe table and the rules for reading a weekly run.
+ *
+ * Nothing in this file spawns a process, touches the filesystem or reaches the
+ * network. That is the seam: what a run's outcomes mean, whether to file or to
+ * comment, and what the issue says are the parts that can be wrong, and they
+ * are decided by pure functions tests call directly. `run-probes.mjs` is the
+ * process half. Same split as `gates.mjs` and `run-gates.mjs`, ADR-0002.
+ *
+ * Add a probe by adding a row. See docs/adr/0022-drift-is-reported-as-an-issue.md.
+ *
+ * WHY A ROW CARRIES ITS UPSTREAM HOSTS. The only contract the four probes share
+ * is the exit code: non-zero when what was measured disagrees with what is
+ * committed. Nothing else is uniform -- one throws a Node stack trace where the
+ * others print a sentence and exit -- so their output is captured wholesale for
+ * a reader and never parsed for meaning.
+ *
+ * That contract cannot tell drift from a bad day upstream. Both are exit 1. So
+ * the runner asks the question the probes cannot answer: if a probe failed, is
+ * its publisher answering at all? A probe that failed while its upstream is
+ * reachable measured something and disagrees. A probe that failed while its
+ * upstream is not reachable measured nothing. That check needs the hosts, so
+ * the hosts are a column rather than knowledge inside the runner.
+ */
+
+/**
+ * @typedef {object} Probe
+ * @property {string} name       Names the probe in the run and in its issue marker.
+ * @property {string} command    Run through a shell, from this table and never from input.
+ * @property {string[]} upstream Origins the probe reads. All must answer for a
+ *   failure to count as drift rather than as an unreachable publisher.
+ */
+
+/** @type {Probe[]} */
+export const PROBES = [
+  {
+    name: "grid-cells",
+    command: "node scripts/probe-grid-cells.mjs --check",
+    upstream: ["https://api.weather.gov"],
+  },
+  {
+    name: "mop-lines",
+    command: "node scripts/probe-mop-lines.mjs --check",
+    upstream: ["https://thredds.cdip.ucsd.edu"],
+  },
+  {
+    name: "observation-stations",
+    command: "node scripts/probe-observation-stations.mjs --check",
+    upstream: ["https://api.weather.gov", "https://www.ndbc.noaa.gov"],
+  },
+  {
+    // No --check: this one has no other mode. See ADR-0021.
+    name: "tide-stations",
+    command: "node scripts/probe-tide-stations.mjs",
+    upstream: ["https://api.tidesandcurrents.noaa.gov"],
+  },
+];
+
+/** Upstream answered and agrees with what is committed. */
+export const UNCHANGED = "unchanged";
+
+/** Upstream answered and disagrees with what is committed. */
+export const MOVED = "moved";
+
+/** No measurement was taken, so nothing can be said about drift. */
+export const UNREACHABLE = "unreachable";
+
+/** Report nothing: this probe is clean. */
+export const NOTHING = "nothing";
+
+/** No issue is open for this probe. File one. */
+export const CREATE = "create";
+
+/** One is already open. Add to it rather than filing a second. */
+export const COMMENT = "comment";
+
+/**
+ * What a finished attempt means.
+ *
+ * `upstreamReachable` is the runner's own answer, not the probe's, for the
+ * reason in the header: exit codes cannot separate drift from a publisher
+ * having a bad day, and reporting the second as the first is how a weekly job
+ * teaches its readers to ignore it.
+ *
+ * @param {number} exitCode          The probe's exit status.
+ * @param {boolean} upstreamReachable Whether every origin in its row answered.
+ * @returns {typeof UNCHANGED | typeof MOVED | typeof UNREACHABLE}
+ */
+export function classify(exitCode, upstreamReachable) {
+  if (exitCode === 0) return UNCHANGED;
+  return upstreamReachable ? MOVED : UNREACHABLE;
+}
+
+/**
+ * Whether a finished attempt is worth one more try before it is believed.
+ *
+ * Only a clean run is believed first time. Everything else gets a second
+ * attempt, because the cheapest explanation for a probe failing once is that a
+ * publisher blinked -- and a retry that comes back clean costs one request and
+ * saves an issue nobody should have read.
+ *
+ * @param {string} outcome
+ * @returns {boolean}
+ */
+export function shouldRetry(outcome) {
+  return outcome !== UNCHANGED;
+}
+
+/**
+ * The marker that ties an issue to a probe.
+ *
+ * Deliberately not the title. Whoever triages an issue renames it, and a
+ * de-duplication keyed on title text would file a second issue the moment
+ * somebody made the first one clearer.
+ *
+ * @param {string} probeName
+ * @returns {string}
+ */
+export function marker(probeName) {
+  return `<!-- probe-drift:${probeName} -->`;
+}
+
+/**
+ * File a new issue, add to the open one, or say nothing.
+ *
+ * `unreachable` reports too. A publisher that is down this morning is noise,
+ * which the retry absorbs; one that answers HTTP 400 forever because the
+ * product was retired is exactly the rot this job exists to surface, and it
+ * would never appear if only drift were reported.
+ *
+ * @param {string} outcome
+ * @param {number | null} openIssue  The open issue's number, or null if none.
+ * @returns {{action: string, issue?: number}}
+ */
+export function decide(outcome, openIssue) {
+  if (outcome === UNCHANGED) return { action: NOTHING };
+  if (openIssue === null || openIssue === undefined) return { action: CREATE };
+  return { action: COMMENT, issue: openIssue };
+}
+
+/**
+ * The open issue already filed for this probe, out of everything the issues
+ * endpoint returned.
+ *
+ * Pure, over a list, so the two things that can be wrong here are both tested:
+ * that the match is on the marker and not the title, and that pull requests are
+ * skipped -- `GET /issues` returns them too, and a PR whose body quoted the
+ * marker would otherwise be commented on instead of the issue.
+ *
+ * @param {Array<{number: number, body?: string | null, pull_request?: unknown}>} issues
+ * @param {string} probeName
+ * @returns {number | null}
+ */
+export function findOpenIssue(issues, probeName) {
+  const found = issues.find(
+    (issue) =>
+      !issue.pull_request && (issue.body ?? "").includes(marker(probeName)),
+  );
+  return found ? found.number : null;
+}
+
+/**
+ * The URL of the run doing the reporting, or null when this is not a workflow.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @returns {string | null}
+ */
+export function runUrlFrom(env) {
+  const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = env;
+  if (!GITHUB_SERVER_URL || !GITHUB_REPOSITORY || !GITHUB_RUN_ID) return null;
+  return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+}
+
+/**
+ * @param {string} probeName
+ * @param {string} outcome
+ * @returns {string}
+ */
+export function issueTitle(probeName, outcome) {
+  return outcome === UNREACHABLE
+    ? `probe ${probeName}: upstream did not answer`
+    : `probe ${probeName}: upstream has moved`;
+}
+
+const OUTCOME_SENTENCE = {
+  [MOVED]:
+    "The probe completed a measurement and it disagrees with what is committed. " +
+    "Its publisher answered, so this is a change upstream rather than a bad day.",
+  [UNREACHABLE]:
+    "The probe could not complete a measurement: at least one of its publishers " +
+    "did not answer, on two attempts. This says nothing about whether the data " +
+    "has drifted -- only that it could not be checked. A publisher that stays " +
+    "unreachable is itself worth chasing, which is why this is reported and not " +
+    "swallowed.",
+};
+
+/**
+ * The body of a newly filed issue.
+ *
+ * The probe's own output is carried verbatim rather than summarised, because
+ * every generator's failure message asks the reader to "read the diff, and say
+ * in the commit message what changed upstream" -- and the diff is the thing a
+ * bot can supply and the explanation is the thing it cannot.
+ *
+ * @param {{probe: Probe, outcome: string, output: string, measuredOn: string,
+ *   runUrl?: string | null}} report
+ * @returns {string}
+ */
+export function issueBody(report) {
+  const { probe, outcome, output, measuredOn, runUrl = null } = report;
+  return [
+    marker(probe.name),
+    "",
+    `**Probe:** \`${probe.command}\``,
+    `**Outcome:** ${outcome}`,
+    `**Measured:** ${measuredOn}`,
+    `**Upstream:** ${probe.upstream.join(", ")}`,
+    runUrl ? `**Run:** ${runUrl}` : null,
+    "",
+    OUTCOME_SENTENCE[outcome],
+    "",
+    "What the probe printed:",
+    "",
+    "```",
+    output.trim() || "(the probe printed nothing)",
+    "```",
+    "",
+    "This issue was filed by the weekly probe workflow, which commits nothing " +
+      "and opens no pull request. Re-run the probe locally, read the diff, and " +
+      "say in the commit message what changed upstream.",
+    "",
+    "While this issue stays open, later runs that find the same probe still " +
+      "moved will comment here rather than file another.",
+  ]
+    .filter((line) => line !== null)
+    .join("\n");
+}
+
+/**
+ * The body of a comment added to an issue already open for this probe.
+ *
+ * @param {{outcome: string, output: string, measuredOn: string,
+ *   runUrl?: string | null}} report
+ * @returns {string}
+ */
+export function commentBody(report) {
+  const { outcome, output, measuredOn, runUrl = null } = report;
+  return [
+    `Still **${outcome}** on ${measuredOn}.`,
+    runUrl ? `\nRun: ${runUrl}` : null,
+    "",
+    "```",
+    output.trim() || "(the probe printed nothing)",
+    "```",
+  ]
+    .filter((line) => line !== null)
+    .join("\n");
+}
+
+/**
+ * Reduce a run to the rows to print and the process exit code.
+ *
+ * THE RUN PASSES WHEN IT REPORTS. A run that found drift and successfully filed
+ * it has done its job; failing as well would deliver every notification twice,
+ * once as an issue somebody can act on and once as a red X nobody can. Failure
+ * is reserved for the reporting itself failing -- an API call rejected, a probe
+ * that could not be spawned.
+ *
+ * @param {Array<{probe: Probe, outcome: string, action: string,
+ *   error?: string | null}>} results
+ * @returns {{exitCode: number, rows: Array<{name: string, outcome: string,
+ *   action: string, ok: boolean, error: string | null}>}}
+ */
+export function evaluate(results) {
+  const rows = results.map((result) => ({
+    name: result.probe.name,
+    outcome: result.outcome,
+    action: result.action,
+    ok: !result.error,
+    error: result.error ?? null,
+  }));
+  return { exitCode: rows.every((row) => row.ok) ? 0 : 1, rows };
+}
+
+/**
+ * One line per probe, whatever it found. A clean probe is reported too: a run
+ * that printed only its complaints would leave a reader unable to tell a quiet
+ * week from a week half the table never ran.
+ *
+ * @param {ReturnType<typeof evaluate>["rows"]} rows
+ * @returns {string}
+ */
+export function formatRows(rows) {
+  const width = Math.max(...rows.map((row) => row.name.length));
+  return rows
+    .map((row) => {
+      // The action, not a past-tense claim about it. `run-probes.mjs --dry-run`
+      // decides an action and takes none, and a row reading "filed an issue"
+      // there would be this table's own output lying to a reader.
+      const reported = row.action === NOTHING ? "" : `  (${row.action})`;
+      const failure = row.error ? `  REPORTING FAILED: ${row.error}` : "";
+      return `  ${row.name.padEnd(width)}  ${row.outcome}${reported}${failure}`;
+    })
+    .join("\n");
+}

--- a/scripts/probes.test.mjs
+++ b/scripts/probes.test.mjs
@@ -1,0 +1,360 @@
+import { describe, expect, it } from "vitest";
+import { existsSync } from "node:fs";
+import {
+  classify,
+  COMMENT,
+  commentBody,
+  CREATE,
+  decide,
+  evaluate,
+  findOpenIssue,
+  formatRows,
+  issueBody,
+  issueTitle,
+  marker,
+  MOVED,
+  NOTHING,
+  PROBES,
+  runUrlFrom,
+  shouldRetry,
+  UNCHANGED,
+  UNREACHABLE,
+} from "./probes.mjs";
+
+describe("the probe table", () => {
+  it("names a script that exists, for every row", () => {
+    // The table is the thing that decides what runs weekly. A row naming a
+    // script that was renamed would go quiet rather than fail, which is the
+    // failure mode this whole workflow exists to remove.
+    for (const probe of PROBES) {
+      const script = probe.command.split(/\s+/)[1];
+      expect(script, `${probe.name} names ${script}`).toMatch(
+        /^scripts\/probe-.+\.mjs$/,
+      );
+      expect(existsSync(script), `${script} exists`).toBe(true);
+    }
+  });
+
+  it("holds all four probes, including the tide probe with no --check", () => {
+    expect(PROBES.map((probe) => probe.name)).toEqual([
+      "grid-cells",
+      "mop-lines",
+      "observation-stations",
+      "tide-stations",
+    ]);
+    // probe-tide-stations.mjs never writes, so it has no --check to ask for.
+    // A row carries its own command precisely so this is a row and not a
+    // special case in the runner. See ADR-0021.
+    const tide = PROBES.find((probe) => probe.name === "tide-stations");
+    expect(tide.command).not.toContain("--check");
+  });
+
+  it("gives every row at least one upstream origin to test", () => {
+    for (const probe of PROBES) {
+      expect(probe.upstream.length).toBeGreaterThan(0);
+      for (const origin of probe.upstream) {
+        expect(origin).toMatch(/^https:\/\/[^/]+$/);
+      }
+    }
+  });
+
+  it("gives every row a unique name, since the marker is keyed on it", () => {
+    const names = PROBES.map((probe) => probe.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});
+
+describe("classifying an attempt", () => {
+  it("reads a clean exit as unchanged", () => {
+    expect(classify(0, true)).toBe(UNCHANGED);
+  });
+
+  it("reads a failure with a reachable upstream as moved", () => {
+    expect(classify(1, true)).toBe(MOVED);
+  });
+
+  it("reads a failure with an unreachable upstream as unreachable", () => {
+    // The distinction the exit code cannot make. Both are exit 1; only the
+    // runner's own request to the publisher separates them.
+    expect(classify(1, false)).toBe(UNREACHABLE);
+  });
+
+  it("never reports an unreachable publisher as drift", () => {
+    expect(classify(1, false)).not.toBe(MOVED);
+  });
+
+  it("trusts a clean exit even if the reachability check failed", () => {
+    // A probe that completed and agreed has already proved it reached its
+    // publisher. The runner's own check is the less authoritative of the two.
+    expect(classify(0, false)).toBe(UNCHANGED);
+  });
+});
+
+describe("retrying", () => {
+  it("believes a clean run first time", () => {
+    expect(shouldRetry(UNCHANGED)).toBe(false);
+  });
+
+  it("tries again before believing either kind of failure", () => {
+    expect(shouldRetry(MOVED)).toBe(true);
+    expect(shouldRetry(UNREACHABLE)).toBe(true);
+  });
+});
+
+describe("deciding whether to file or to comment", () => {
+  it("says nothing at all when a probe is clean", () => {
+    expect(decide(UNCHANGED, null)).toEqual({ action: NOTHING });
+    expect(decide(UNCHANGED, 42)).toEqual({ action: NOTHING });
+  });
+
+  it("files the first time a probe moves", () => {
+    expect(decide(MOVED, null)).toEqual({ action: CREATE });
+  });
+
+  it("comments the second time rather than filing again", () => {
+    // A probe still reporting drift next week must not grow the tracker a row
+    // a week.
+    expect(decide(MOVED, 42)).toEqual({ action: COMMENT, issue: 42 });
+  });
+
+  it("reports an unreachable publisher rather than swallowing it", () => {
+    // A retired product answering HTTP 400 forever would otherwise never
+    // surface.
+    expect(decide(UNREACHABLE, null)).toEqual({ action: CREATE });
+    expect(decide(UNREACHABLE, 7)).toEqual({ action: COMMENT, issue: 7 });
+  });
+});
+
+describe("the marker that de-duplicates", () => {
+  it("is keyed on the probe, not on anything a person edits", () => {
+    expect(marker("grid-cells")).toBe("<!-- probe-drift:grid-cells -->");
+  });
+
+  it("differs between probes, so two can be open at once", () => {
+    expect(marker("grid-cells")).not.toBe(marker("mop-lines"));
+  });
+
+  it("is carried in the body of the issue it files", () => {
+    // The body is what the runner searches. If these two ever disagreed, every
+    // run would file a fresh issue and the de-duplication would be silent.
+    const body = issueBody({
+      probe: PROBES[0],
+      outcome: MOVED,
+      output: "grid-cells.json has moved.",
+      measuredOn: "2026-08-27",
+    });
+    expect(body).toContain(marker("grid-cells"));
+  });
+});
+
+describe("finding the issue already open for a probe", () => {
+  const issue = (number, body) => ({ number, body });
+
+  it("finds the one whose body carries the marker", () => {
+    const issues = [
+      issue(1, "unrelated"),
+      issue(2, `${marker("grid-cells")}\n\nsomething moved`),
+    ];
+    expect(findOpenIssue(issues, "grid-cells")).toBe(2);
+  });
+
+  it("is null when no issue carries it, so the run files one", () => {
+    expect(findOpenIssue([issue(1, "unrelated")], "grid-cells")).toBeNull();
+  });
+
+  it("does not match another probe's marker", () => {
+    const issues = [issue(1, marker("mop-lines"))];
+    expect(findOpenIssue(issues, "grid-cells")).toBeNull();
+  });
+
+  it("ignores the title entirely", () => {
+    // Whoever triages the issue renames it. A match on title text would file a
+    // second issue the moment somebody made the first one clearer.
+    const issues = [
+      { number: 3, title: "probe grid-cells: upstream has moved", body: "" },
+    ];
+    expect(findOpenIssue(issues, "grid-cells")).toBeNull();
+  });
+
+  it("skips pull requests, which the issues endpoint also returns", () => {
+    const issues = [
+      { number: 4, body: marker("grid-cells"), pull_request: { url: "…" } },
+      issue(5, marker("grid-cells")),
+    ];
+    expect(findOpenIssue(issues, "grid-cells")).toBe(5);
+  });
+
+  it("survives an issue with no body at all", () => {
+    expect(findOpenIssue([{ number: 6, body: null }], "grid-cells")).toBeNull();
+  });
+});
+
+describe("the run url", () => {
+  it("is built from the workflow's own environment", () => {
+    expect(
+      runUrlFrom({
+        GITHUB_SERVER_URL: "https://github.com",
+        GITHUB_REPOSITORY: "cweber12/wild-coast-kids",
+        GITHUB_RUN_ID: "42",
+      }),
+    ).toBe("https://github.com/cweber12/wild-coast-kids/actions/runs/42");
+  });
+
+  it("is null off a workflow, so a local run files no broken link", () => {
+    expect(runUrlFrom({})).toBeNull();
+    expect(runUrlFrom({ GITHUB_SERVER_URL: "https://github.com" })).toBeNull();
+  });
+});
+
+describe("the issue it files", () => {
+  const REPORT = {
+    probe: PROBES[0],
+    outcome: MOVED,
+    output: "grid-cells.json has moved. Re-run without --check.",
+    measuredOn: "2026-08-27",
+    runUrl: "https://github.com/cweber12/wild-coast-kids/actions/runs/1",
+  };
+
+  it("carries the measurement, verbatim", () => {
+    expect(issueBody(REPORT)).toContain(
+      "grid-cells.json has moved. Re-run without --check.",
+    );
+  });
+
+  it("carries the date it was taken", () => {
+    expect(issueBody(REPORT)).toContain("2026-08-27");
+  });
+
+  it("names the probe, its command and its publishers", () => {
+    const body = issueBody(REPORT);
+    expect(body).toContain("node scripts/probe-grid-cells.mjs --check");
+    expect(body).toContain("https://api.weather.gov");
+  });
+
+  it("links the run that produced it", () => {
+    expect(issueBody(REPORT)).toContain("/actions/runs/1");
+  });
+
+  it("holds together when there is no run url", () => {
+    const body = issueBody({ ...REPORT, runUrl: null });
+    expect(body).not.toContain("**Run:**");
+    expect(body).toContain("grid-cells.json has moved.");
+  });
+
+  it("says so rather than showing an empty block when nothing was printed", () => {
+    expect(issueBody({ ...REPORT, output: "   " })).toContain(
+      "the probe printed nothing",
+    );
+  });
+
+  it("says an unreachable publisher is not a claim about drift", () => {
+    const body = issueBody({ ...REPORT, outcome: UNREACHABLE });
+    expect(body).toContain("could not complete a measurement");
+    expect(body).toContain("says nothing about whether the data has drifted");
+  });
+
+  it("titles the two outcomes differently", () => {
+    expect(issueTitle("grid-cells", MOVED)).toContain("has moved");
+    expect(issueTitle("grid-cells", UNREACHABLE)).toContain("did not answer");
+  });
+
+  it("promises no commit and no pull request, because it makes neither", () => {
+    expect(issueBody(REPORT)).toContain("commits nothing");
+  });
+});
+
+describe("the comment it adds instead", () => {
+  it("says the drift is still there, and when it was re-measured", () => {
+    const body = commentBody({
+      outcome: MOVED,
+      output: "still moved",
+      measuredOn: "2026-09-03",
+    });
+    expect(body).toContain("moved");
+    expect(body).toContain("2026-09-03");
+    expect(body).toContain("still moved");
+  });
+});
+
+describe("the run's own verdict", () => {
+  const result = (name, outcome, action, error = null) => ({
+    probe: { name },
+    outcome,
+    action,
+    error,
+  });
+
+  it("passes when it found drift and successfully reported it", () => {
+    // The decision worth stating: a run that did its job is green even though
+    // what it found is not. Otherwise every notification arrives twice, and the
+    // red X is the copy nobody can act on.
+    const { exitCode } = evaluate([
+      result("grid-cells", MOVED, CREATE),
+      result("mop-lines", UNCHANGED, NOTHING),
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  it("passes on a completely quiet week", () => {
+    expect(evaluate([result("grid-cells", UNCHANGED, NOTHING)]).exitCode).toBe(
+      0,
+    );
+  });
+
+  it("fails when the reporting itself failed", () => {
+    const { exitCode, rows } = evaluate([
+      result("grid-cells", MOVED, CREATE, "HTTP 403 from the issues API"),
+      result("mop-lines", UNCHANGED, NOTHING),
+    ]);
+    expect(exitCode).toBe(1);
+    expect(rows.find((row) => row.name === "grid-cells").ok).toBe(false);
+  });
+
+  it("reports every probe, including the quiet ones", () => {
+    const { rows } = evaluate([
+      result("grid-cells", MOVED, CREATE),
+      result("mop-lines", UNCHANGED, NOTHING),
+      result("observation-stations", UNREACHABLE, COMMENT),
+      result("tide-stations", UNCHANGED, NOTHING),
+    ]);
+    expect(rows).toHaveLength(4);
+    expect(rows.map((row) => row.outcome)).toEqual([
+      MOVED,
+      UNCHANGED,
+      UNREACHABLE,
+      UNCHANGED,
+    ]);
+  });
+
+  it("prints all three outcomes and the reporting failure", () => {
+    const printed = formatRows(
+      evaluate([
+        result("grid-cells", MOVED, CREATE),
+        result("mop-lines", UNCHANGED, NOTHING),
+        result("observation-stations", UNREACHABLE, COMMENT, "HTTP 403"),
+      ]).rows,
+    );
+    expect(printed).toContain("grid-cells");
+    expect(printed).toContain(MOVED);
+    expect(printed).toContain(UNCHANGED);
+    expect(printed).toContain(UNREACHABLE);
+    expect(printed).toContain("REPORTING FAILED: HTTP 403");
+    // A clean probe gets a line, not silence.
+    expect(printed.split("\n")).toHaveLength(3);
+  });
+
+  it("names the action without claiming it already happened", () => {
+    // --dry-run decides an action and takes none. A row reading "filed an
+    // issue" there would be this output lying to the reader it exists for.
+    const printed = formatRows(
+      evaluate([
+        result("grid-cells", MOVED, CREATE),
+        result("mop-lines", UNCHANGED, NOTHING),
+      ]).rows,
+    );
+    expect(printed).toContain(`(${CREATE})`);
+    expect(printed).not.toMatch(/filed|created an issue/);
+    // A clean probe is not decorated with an action it does not have.
+    expect(printed).toMatch(/mop-lines\s+unchanged\s*$/m);
+  });
+});

--- a/scripts/run-probes.mjs
+++ b/scripts/run-probes.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+/**
+ * Runs every probe in the table, reports what each found, and exits non-zero
+ * only if the reporting itself failed.
+ *
+ *   node scripts/run-probes.mjs             run and report to GitHub Issues
+ *   node scripts/run-probes.mjs --dry-run   run and print what would be reported
+ *
+ * This file is the subprocess, network and API plumbing, and stays deliberately
+ * thin: everything that decides an outcome lives in probes.mjs, where it is
+ * unit-tested. Same split as run-gates.mjs, ADR-0002.
+ *
+ * See docs/adr/0022-drift-is-reported-as-an-issue.md.
+ */
+import { spawn } from "node:child_process";
+import {
+  classify,
+  COMMENT,
+  commentBody,
+  CREATE,
+  decide,
+  evaluate,
+  findOpenIssue,
+  formatRows,
+  issueBody,
+  issueTitle,
+  NOTHING,
+  PROBES,
+  runUrlFrom,
+  shouldRetry,
+  UNCHANGED,
+} from "./probes.mjs";
+import { generatedDate } from "./generated-date.mjs";
+import { normalizeDriveCasing } from "./gates.mjs";
+
+/** One attempt's ceiling. The slowest probe takes seconds; this is for a hang. */
+const PROBE_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** How long a publisher gets to answer the runner's own reachability request. */
+const REACHABILITY_TIMEOUT_MS = 15_000;
+
+const USER_AGENT =
+  "wild-coast-kids/0.1 (+https://github.com/cweber12/wild-coast-kids) probe-runner";
+
+const dryRun = process.argv.includes("--dry-run");
+
+/**
+ * Run one probe to completion, capturing everything it printed.
+ *
+ * A probe that cannot be spawned, or that outruns the timeout, yields a
+ * non-zero code like any other failure -- what it means is decided by
+ * `classify`, not here.
+ *
+ * @param {string} command
+ * @returns {Promise<{exitCode: number, output: string}>}
+ */
+function run(command) {
+  return new Promise((resolve) => {
+    // shell: true so the command resolves the same way it does in run-gates.mjs.
+    // Commands come from the table in this repo, never from input. cwd is
+    // normalized for the same reason the gate runner normalizes it (issue #4).
+    const child = spawn(command, {
+      shell: true,
+      cwd: normalizeDriveCasing(process.cwd()),
+    });
+
+    let output = "";
+    let settled = false;
+    const finish = (exitCode) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ exitCode, output });
+    };
+
+    const timer = setTimeout(() => {
+      output += `\nThe runner stopped this probe after ${PROBE_TIMEOUT_MS / 1000}s.\n`;
+      child.kill();
+      finish(124);
+    }, PROBE_TIMEOUT_MS);
+
+    child.stdout.on("data", (chunk) => (output += chunk));
+    child.stderr.on("data", (chunk) => (output += chunk));
+    child.on("error", (error) => {
+      output += `\nThe runner could not start this probe: ${error.message}\n`;
+      finish(127);
+    });
+    child.on("close", (code) => finish(code ?? 1));
+  });
+}
+
+/**
+ * Whether every publisher a probe reads answered the runner at all.
+ *
+ * ANY HTTP RESPONSE COUNTS AS ANSWERING, including a 400 or a 500. The question
+ * is whether the publisher is there, not whether it is happy: a product that
+ * was retired and now answers HTTP 400 forever is a real change this job should
+ * report as drift, not something to write off as a bad connection. Only a
+ * transport failure or a timeout says nothing was measured.
+ *
+ * @param {string[]} origins
+ * @returns {Promise<boolean>}
+ */
+async function reachable(origins) {
+  for (const origin of origins) {
+    try {
+      await fetch(origin, {
+        headers: { "User-Agent": USER_AGENT },
+        signal: AbortSignal.timeout(REACHABILITY_TIMEOUT_MS),
+      });
+    } catch {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * The GitHub REST API, or a refusal that names what is missing.
+ *
+ * @param {string} path
+ * @param {object} [init]
+ * @returns {Promise<unknown>}
+ */
+async function api(path, init = {}) {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!token) {
+    throw new Error(
+      "GITHUB_TOKEN is not set, so nothing can be reported. The workflow must " +
+        "declare `permissions: issues: write` -- this repo's default token is " +
+        "read-only and an omitted block fails here rather than at parse time.",
+    );
+  }
+  if (!repository) {
+    throw new Error("GITHUB_REPOSITORY is not set, so no repo can be named.");
+  }
+
+  const response = await fetch(
+    `https://api.github.com/repos/${repository}${path}`,
+    {
+      ...init,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "User-Agent": USER_AGENT,
+        "X-GitHub-Api-Version": "2022-11-28",
+        ...(init.body ? { "Content-Type": "application/json" } : {}),
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub answered HTTP ${response.status} for ${init.method ?? "GET"} ${path}: ` +
+        `${(await response.text()).slice(0, 300)}`,
+    );
+  }
+  return response.json();
+}
+
+/**
+ * The open issue already filed for this probe, found by its marker.
+ *
+ * The fetch is here; which issue matches is `findOpenIssue`, next door and
+ * tested.
+ *
+ * @param {string} probeName
+ * @returns {Promise<number | null>}
+ */
+async function openIssueFor(probeName) {
+  return findOpenIssue(await api("/issues?state=open&per_page=100"), probeName);
+}
+
+const measuredOn = generatedDate(new Date());
+const runUrl = runUrlFrom(process.env);
+
+const results = [];
+
+for (const probe of PROBES) {
+  console.log(`… ${probe.name}`);
+
+  let attempt = await run(probe.command);
+  let outcome = classify(
+    attempt.exitCode,
+    attempt.exitCode === 0 ? true : await reachable(probe.upstream),
+  );
+
+  // One retry before a failure is believed. The cheapest explanation for a
+  // probe failing once is that a publisher blinked, and a retry that comes back
+  // clean costs one run and saves an issue nobody should have read.
+  if (shouldRetry(outcome)) {
+    console.log(
+      `  ${probe.name}: ${outcome} on the first attempt, retrying once`,
+    );
+    attempt = await run(probe.command);
+    outcome = classify(
+      attempt.exitCode,
+      attempt.exitCode === 0 ? true : await reachable(probe.upstream),
+    );
+  }
+
+  // Every probe runs on every invocation, so one probe's outcome -- including a
+  // failure to report it -- must not stop the rest. Hence the try around the
+  // reporting alone, with the error carried into the row rather than thrown.
+  let action = NOTHING;
+  let error = null;
+  try {
+    const openIssue =
+      outcome === UNCHANGED || dryRun ? null : await openIssueFor(probe.name);
+    const decision = decide(outcome, openIssue);
+    action = decision.action;
+
+    if (dryRun && action !== NOTHING) {
+      console.log(
+        `  ${probe.name}: would ${action} an issue titled ` +
+          `"${issueTitle(probe.name, outcome)}"`,
+      );
+    } else if (action === CREATE) {
+      const created = await api("/issues", {
+        method: "POST",
+        body: JSON.stringify({
+          title: issueTitle(probe.name, outcome),
+          body: issueBody({
+            probe,
+            outcome,
+            output: attempt.output,
+            measuredOn,
+            runUrl,
+          }),
+        }),
+      });
+      console.log(`  ${probe.name}: filed #${created.number}`);
+    } else if (action === COMMENT) {
+      await api(`/issues/${decision.issue}/comments`, {
+        method: "POST",
+        body: JSON.stringify({
+          body: commentBody({
+            outcome,
+            output: attempt.output,
+            measuredOn,
+            runUrl,
+          }),
+        }),
+      });
+      console.log(`  ${probe.name}: commented on #${decision.issue}`);
+    }
+  } catch (cause) {
+    error = cause instanceof Error ? cause.message : String(cause);
+    console.error(`  ${probe.name}: reporting failed -- ${error}`);
+  }
+
+  results.push({ probe, outcome, action, error });
+}
+
+const { exitCode, rows } = evaluate(results);
+
+console.log(
+  `\nProbe run ${measuredOn}${dryRun ? " (dry run, nothing reported)" : ""}:`,
+);
+console.log(formatRows(rows));
+
+// The run passes when it reported successfully, whatever it found. A red X on a
+// repo with no open PR is easy to miss, and delivering the same news twice
+// makes the copy nobody can act on the louder one.
+if (exitCode !== 0) {
+  console.error(
+    "\nThis run failed because reporting failed, not because a probe moved.",
+  );
+}
+
+process.exit(exitCode);

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -48,8 +48,8 @@ export default defineConfig({
       //   2. covered code was deleted, which pulls the whole-project ratio
       //      toward the 0% plumbing even though no test was lost.
       // Nothing is excluded to flatter the number: run-gates.mjs,
-      // run-vitest.mjs, check-built-css.mjs, check-db.mjs and
-      // check-adr-numbers.mjs sit at 0% on purpose, and all five drag these
+      // run-probes.mjs, run-vitest.mjs, check-built-css.mjs, check-db.mjs and
+      // check-adr-numbers.mjs sit at 0% on purpose, and all six drag these
       // figures down in plain sight rather than quietly.
       //
       // LOWERED 2026-08-26 under reason 1, when probe-grid-cells.mjs arrived.
@@ -93,11 +93,30 @@ export default defineConfig({
       // file. They stay uncovered for the reason probe-grid-cells.mjs's main()
       // does: covering them means either a gate row that needs the internet or
       // a seam around process.exit that would exist only for the test.
+      //
+      // LOWERED 2026-08-27 under reason 1, when the weekly probe runner
+      // arrived. This is the largest single drop the denominator has taken and
+      // it is one file: run-probes.mjs, 0% across lines 2-272, which is the
+      // process half of the ADR-0002 split -- spawning four probes, the
+      // reachability request, and the GitHub Issues calls. It joins run-gates.mjs
+      // in the list above for the same reason and is the same kind of file.
+      //
+      // Its pure half took the opposite path and is at 100% statements, 100%
+      // functions, 95.1% branches: the probe table, classify, shouldRetry,
+      // decide, marker, findOpenIssue, runUrlFrom, issueTitle, issueBody,
+      // commentBody, evaluate and formatRows all sit in probes.mjs and are
+      // called directly by 42 tests. Logic was moved OUT of the runner to get
+      // there -- findOpenIssue and runUrlFrom were inline in the plumbing
+      // first -- rather than the floor being dropped to cover for it.
+      //
+      // Covering what is left means faking spawn, fetch and the GitHub API at
+      // once, which costs more than it returns and is the trade ADR-0002 already
+      // made for run-gates.mjs.
       thresholds: {
-        statements: 88.98,
-        branches: 89.87,
-        functions: 94.41,
-        lines: 88.73,
+        statements: 86.14,
+        branches: 87.66,
+        functions: 92.64,
+        lines: 85.73,
       },
     },
   },


### PR DESCRIPTION
Closes #160

ADR-0009 promised a weekly probe. Four probes existed and nothing ran them,
which is why TWC0405 went from dead to answering over nine days with nothing
noticing.

## ⚠️ One acceptance criterion cannot be met before this merges

The brief asks for:

> - [ ] A real `workflow_dispatch` run is triggered and its result pasted in the
>       PR body — a workflow that has never run is not evidence

**That is not possible for a new workflow.** GitHub only registers
`workflow_dispatch` for workflows already on the default branch. Tested on this
branch rather than asserted from the docs:

```
$ gh workflow run probe.yml --ref issue-160-weekly-probe-workflow
HTTP 404: workflow probe.yml not found on the default branch
  (https://api.github.com/repos/cweber12/wild-coast-kids/actions/workflows/probe.yml)

$ gh api -X POST repos/cweber12/wild-coast-kids/actions/workflows/probe.yml/dispatches -f ref=…
{"message":"Not Found","status":"404"}

$ gh workflow list --all
gate	active	332416256
```

GitHub's own error names the reason. **I have not worked around it** — no
`push:` trigger added to make it fire, no `pull_request:` trigger, nothing that
would change what the workflow is in order to manufacture the evidence.

The criterion's intent — *a workflow that has never run is not evidence* — is
right, and I have satisfied as much of it as is possible pre-merge by running
the runner end to end locally against the real publishers (below). **Your call**
on which you want: merge and I trigger a real dispatch and paste the result as a
follow-up, or something else.

## What the runner found, running for real

`node scripts/run-probes.mjs --dry-run` — real probes, real network, no API
calls:

```
… grid-cells
… mop-lines
… observation-stations
  observation-stations: moved on the first attempt, retrying once
  observation-stations: would create an issue titled "probe observation-stations: upstream has moved"
… tide-stations
  tide-stations: moved on the first attempt, retrying once
  tide-stations: would create an issue titled "probe tide-stations: upstream has moved"

Probe run 2026-08-27 (dry run, nothing reported):
  grid-cells            unchanged
  mop-lines             unchanged
  observation-stations  moved  (create)
  tide-stations         moved  (create)

RUNNER EXIT=0
```

Note the exit code: it found drift, decided how to report it, and **passed**.
That is ADR-0022's decision working.

**`observation-stations` is real, live drift this run discovered.** An earlier
dry run 25 minutes before showed it `unchanged`; it has read `moved` on every
check since, three consecutive runs:

```
$ node scripts/probe-observation-stations.mjs --check   (×3)
run 1 EXIT=1 : observation-stations.json has moved.
run 2 EXIT=1 : observation-stations.json has moved.
run 3 EXIT=1 : observation-stations.json has moved.
```

I have **not** diagnosed what moved and have not regenerated the file — that is
this workflow's job to report and somebody's job to read, and re-seeding would
put an unrelated data change in this PR. What I can say without regenerating:
the committed file holds 62 stations from 2026-08-18, and this run counted 56
NWS candidates plus 6 NDBC, which is the same 62 — so the change is in what the
stations were measured to publish, not in which exist.

That is the entire thesis of ADR-0009 landing on its first use: a real change
upstream that nothing in the repo would otherwise have noticed.

`tide-stations` reads `moved` **only because this branch predates #161** — it
still carries `delivers: false` for a station that answers. See the merge-order
note at the bottom.

## Slices

**1. `Record how this repo learns that its data has rotted`** (75a8e95) —
`docs/adr/0022-drift-is-reported-as-an-issue.md`.

**2. `Add the probe table and the rules for reading a run`** (733c312) —
`scripts/probes.mjs` + 42 tests. No process, no filesystem, no network.

**3. `Run every probe weekly and report what moved`** (d03424f) —
`scripts/run-probes.mjs`, `.github/workflows/probe.yml`, coverage floor.

## The decision worth arguing

The probes share exactly one contract: the exit code. An exit code cannot
separate *upstream changed* from *upstream is having a bad day* — both are 1 —
and the brief forbids parsing their output or rewriting them.

So **a probe's upstream hosts are a column in its table row**, and when a probe
fails the runner asks the question the probes cannot: *is this publisher
answering at all?* Failed + publisher answered → `moved`. Failed + publisher
silent → `unreachable`. That keeps "adding a probe is adding a row" true, since
the hosts travel with the row rather than living inside the runner.

Any HTTP response counts as answering, 400 and 500 included — the question is
whether the publisher is there, not whether it is happy. CO-OPS retiring
`product=datums` into a permanent HTTP 400 is a real change to report, not a bad
connection to write off.

**This is not exact, and ADR-0022 says so in its consequences**: a probe that
crashes on a refused connection which recovers before the runner's own check is
reported as `moved`. The window is seconds and the retry narrows it. The honest
fix is a distinct exit code from the probes, which is a change to four
contracts and deliberately not made here.

## Acceptance, item by item

| Criterion | Where |
|---|---|
| Weekly schedule + `workflow_dispatch`, separate from the gate | `probe.yml`, `cron: "0 7 * * 1"` |
| Every probe runs; one failing does not stop the rest | reporting wrapped per probe, error carried into the row |
| Three outcomes, all in the output | `classify`, `formatRows`; the dry run above shows two of them and a clean pair |
| Exactly one open issue per probe — created then commented | `findOpenIssue` + `decide`, 6 + 4 tests |
| Body carries the measurement and the date | `issueBody`, verbatim output |
| Retried once, then reported as unreachable not drift | `shouldRetry` + `classify`; visible in the dry run's "retrying once" |
| Classification, file-or-comment and body rendering are pure, tested directly, no network or filesystem | `probes.mjs`, 100% statements and functions |
| Adding a probe is adding a row | `PROBES`; #159's tide probe is a row with no `--check` |
| Commits nothing, opens no PR | `permissions: contents: read, issues: write` |
| `npm run gate` green, pasted | below |
| **A real `workflow_dispatch` run** | **blocked pre-merge — see the top** |

## Gate

Run at `d03424f`, the head of this branch:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

Also run and green at `733c312` with the **original** floor, confirming slices 1
and 2 stand on their own and only slice 3 needs the floor moved.

## Coverage floor

```
statements 88.98 -> 86.14
branches   89.87 -> 87.66
functions  94.41 -> 92.64
lines      88.73 -> 85.73
```

**The largest single drop the denominator has taken**, and it is one file:
`run-probes.mjs`, 0% across lines 2–272 — the process half of the ADR-0002
split, spawning probes, the reachability request and the Issues API. It joins
`run-gates.mjs` on the list the config already keeps of entry plumbing that
drags these figures down in plain sight; the comment adds it to that sentence.

Its pure half went the other way: `probes.mjs` is at **100% statements, 100%
functions, 95.1% branches**. `findOpenIssue` and `runUrlFrom` were inline in the
plumbing first and were moved out to get there, rather than the floor being
dropped to cover for them.

## Merge order matters here

**If this merges before #161**, the first run will file an issue for
`tide-stations` that duplicates #161 — this branch still carries
`delivers: false` for a station that answers. Merging #161 first makes that
probe read `unchanged` and the first run files only the
`observation-stations` issue.

## Not done, and why

- **No plan file.** Three slices on one branch; the issue, the brief and this
  body are the durable record.
- **`probe-observation-stations`'s drift is not diagnosed or fixed.** Reporting
  it is what this issue builds; reading it is somebody's next issue.
- **No probe's output format or exit convention changed.** Consumed as found.
- **No network row added to the gate table.** It stays offline.
- **`seed-beaches.mjs --check` is not on the schedule.** It asks a different
  question, per the brief.
