### PR TITLE
Rebuild the week grid's day cell around the daylight window

### DIFF
--- a/docs/adr/0023-the-week-shows-only-the-daylight-window.md
+++ b/docs/adr/0023-the-week-shows-only-the-daylight-window.md
@@ -1,0 +1,120 @@
+# 0023 — The week states its window once, in the day header
+
+Date: 2026-08-27. Status: accepted. Supersedes part of ADR-0017.
+
+## Context
+
+ADR-0017 established that every product row leads with the extreme that falls
+between sunrise and sunset, because on this coast the day's own extreme is
+usually unreachable — six of seven tide lows and six of seven swell peaks fell
+outside daylight on the week measured. That decision was right and is not
+reopened here.
+
+It made two commitments that have not held up:
+
+**The label names the selection.** "Lowest daylight tide" and "Biggest daylight
+swell". ADR-0017 anticipated these would wrap and accepted about 30px of the
+108px for it. Measured on the rendered page at 10px with `tracking-widest`,
+they are 170px and 187px wide, against:
+
+| viewport | columns | content width per cell |
+| -------- | ------- | ---------------------- |
+| 1024     | 7       | 88px                   |
+| 1280     | 7       | 125px                  |
+| 1536     | 7       | 161px                  |
+
+They do not fit at any width the grid has ever had, and they were never going
+to. The consequence went further than height: the four cell components each
+grew a hard-coded `lg:block` line break and a paragraph of docstring defending
+it, and the grid rendered 84px **taller** at 1024 than at 1536.
+
+**The day's own extreme is kept, not dropped.** So each cell carried a second
+figure under an "all day" prefix, and the day block ran to eleven or fourteen
+lines with no separation between the four products in it.
+
+Together these are why the grid reads as an undifferentiated column of numbers.
+
+## Decision
+
+**The daylight window is stated once, in the day's header, and the rows carry
+only the figures inside it.**
+
+```
+THU, AUG 27
+☀ 6:20 AM to 7:20 PM     <- the scope, said once
+─────────────────────
+LOW TIDE   3:13 PM 1.6 ft
+SWELL      11:00 AM 0.7 ft · 6 s
+CLOUDS     40%
+```
+
+- **The header scopes the cell**, so the labels do not have to. "Low tide" is
+  70px, "Swell" 47px, "Clouds" 56px: one line each at every seven-column width.
+  Nothing is hidden by the shortening, because the qualification a reader needs
+  is on the line above rather than removed.
+- **The window is not a `WeekRow`.** A row states a figure; this states the
+  scope figures are selected within. It is a slot on the day, printed above the
+  `<dl>` rather than inside it.
+- **The day's own extreme leaves this grid**, and does not leave the site.
+  `TideToday` and `WavesToday` still print "Lowest all day" and "Biggest all
+  day" for today on the cards above, so what is lost is the overnight figure for
+  the six **future** days, until a day view carries them.
+- **The loss is stated, not silent.** One sentence sits with the grid's other
+  notes: the week shows what falls between sunrise and sunset, overnight lows
+  and swells are real and often bigger, and today's are on the cards above.
+  This sentence is the condition the drop is allowed under. Removing it while
+  keeping the drop reintroduces exactly the failure ADR-0017 objected to.
+- **Seven columns start at `xl` rather than `lg`.** The 88px cell above is what
+  every forced line break in the grid was really describing. Four columns at
+  1024 give 189px of content, all seven days still stand on one screen as 4 + 3,
+  and the four cell components drop their breaks.
+
+## Alternatives considered
+
+**Shorten the labels without moving the window.** Fits, and leaves three
+unqualified superlatives — "Low tide" over a figure with no stated scope is the
+hidden judgement ADR-0017 exists to prevent. The header is what makes the
+shortening honest; neither half works alone.
+
+**Keep both figures and compress the second to one line.** Preserves ADR-0017
+intact and needs no decision at all. Rejected: it costs two lines per cell back
+and keeps "daylight" load-bearing in the labels, which is the thing that does
+not fit. It solves the height and not the legibility.
+
+**Drop the overnight figures silently.** Cheapest and the cleanest cell.
+Rejected under this repo's rule that nothing fails silently: a reader who saw a
+−0.2 ft last week would find it gone with nothing to explain the change.
+
+**Wait for the day view, and change nothing until it exists.** The honest
+sequencing, and it leaves the grid unreadable for however long that takes. The
+sentence beneath the grid is what makes shipping in this order defensible: it
+tells a reader the figure exists and where today's is, rather than pretending
+the week is the whole picture.
+
+**Keep seven columns at `lg` and set the header line smaller.** The window is
+109px at 11px and the cell is 88px; the sizes below 11px are the label register,
+and a clock time in it would be unreadable. The cell has to get wider.
+
+## Consequences
+
+- **The grid is shorter and the cell is legible.** Measured at La Jolla Shores:
+  1280 goes 414px to 371px before any styling change, 1024 goes to four columns
+  at 221px per cell from 120px, and 375 goes 1655px against 1780px. The day
+  block runs six lines instead of eleven.
+- **The overnight extreme is missing for six days of seven** until the day view
+  ships. This is the cost, it is stated on the page, and it is the first thing
+  to check if that view slips.
+- **`lib/conditions.ts` is untouched.** `allDay` stays on `TideWeekDay` and
+  `WaveWeekDay` and is still computed; only the week cells stopped rendering it.
+  The day view will want the data, and removing it would have made this decision
+  expensive to reverse.
+- **`SkyWeek`'s label lost the distinction it was carrying.** "Cloud by day"
+  said, against two superlatives, that this row is a mean rather than a peak.
+  With the superlatives gone from the other labels there is nowhere to draw that
+  in three words, so `ConditionsNotes` carries it and the component's docstring
+  flags it to whoever edits the wording next.
+- **Anything that restores an "all day" figure to a week cell reverses this**,
+  and will look like restoring information. The measurement above is the
+  argument: the label that figure needs does not fit the cell it would live in.
+- **The week is two rows between 1024 and 1279**, which is a real loss for
+  comparing across days and was taken knowingly against 88px cells.

--- a/docs/adr/0024-the-cloud-row-shows-the-day-in-thirds.md
+++ b/docs/adr/0024-the-cloud-row-shows-the-day-in-thirds.md
@@ -1,0 +1,126 @@
+# 0024 — The cloud row shows the day in thirds, and computes no words
+
+Date: 2026-08-28. Status: accepted. Supersedes part of ADR-0020.
+
+## Context
+
+The cloud row printed one figure: the mean cloud cover across the daylight
+window. ADR-0020 chose a mean rather than an extreme, and that reasoning still
+holds — cloud has no unreachable hours, so there is no 3:14 AM to route around.
+
+What it did not check is whether one number describes the day.
+
+Measured against the live gridpoint `SGX/54,21` on 2026-08-28, every one of the
+next seven days is a marine-layer burn-off:
+
+| day    | what the row showed | first third | middle | last third |
+| ------ | ------------------- | ----------- | ------ | ---------- |
+| Aug 28 | 38%                 | 48%         | 36%    | 22%        |
+| Aug 29 | 35%                 | 40%         | 33%    | 29%        |
+| Aug 30 | **46%**             | **65%**     | 32%    | 31%        |
+| Aug 31 | 38%                 | 48%         | 32%    | 27%        |
+| Sep 1  | 54%                 | 53%         | 46%    | 69%        |
+| Sep 2  | 61%                 | 70%         | 54%    | 55%        |
+| Sep 3  | **56%**             | **72%**     | 49%    | 34%        |
+
+Sunday is the clearest case. "46%" is the average of a 65% morning and a 32%
+afternoon, and it describes neither. A parent deciding whether to drive out
+after breakfast or after lunch is asking precisely the question that average
+destroys — and on this coast, in this season, that is not an edge case. It is
+the shape of the week.
+
+The single figure was also the one thing on the page a reader could not act on.
+A tide time says when to go; a swell height says what the water is doing; "46%"
+says nothing a person can use without knowing what 46% feels like.
+
+## Decision
+
+**The row shows the daylight window in three parts, and the mean is gone.**
+
+- **Thirds of the window, not named clock hours.** The window is already
+  computed here from the beach's own coordinates, so dividing it is arithmetic.
+  Drawing a boundary at 11 AM instead would be this site inventing a fact about
+  the sky, and it would not track the season: a 13-hour August window gives
+  roughly 6:20–10:40, 10:40–3:00, 3:00–7:20, and a 10-hour December one narrows
+  all three together.
+- **Labelled AM, Mid and Eve.** "Mid" rather than "PM", because the third part
+  is also PM and a column headed "PM" beside one headed "Eve" reads as a
+  contradiction rather than a sequence. They are approximations and the
+  component says so: a third of an August window runs to about 10:40, which is
+  late for "AM", and the alternative is naming hours.
+- **The mean is dropped rather than kept beside the parts.** It was the
+  misleading figure. Printing it next to three numbers that do not obviously
+  average to it would be noise defending a number nobody should read.
+- **A third the forecast did not reach is an em dash, never a zero.** The
+  product does not run backwards, so on the day the reader is standing in the
+  first third is usually gone. A 0% there would report a cloudless morning
+  nobody observed.
+- **The phenomenon still leads.** "Patchy fog" is the fact a parent plans
+  around, and it is the National Weather Service's word rather than ours.
+
+**No band word is computed here, and that is a finding rather than an
+omission.** "46% Partly cloudy" was the obvious companion fix — a percentage
+is confusing, words are not — and it was tested before it was built. Banding
+the daylight mean on the National Weather Service's own sky-condition scale
+contradicts the National Weather Service's own published wording:
+
+| day    | mean | we would print | its forecast endpoint says |
+| ------ | ---- | -------------- | -------------------------- |
+| Aug 28 | 38%  | Partly cloudy  | **Mostly Sunny**           |
+| Aug 29 | 35%  | Mostly sunny   | Mostly Sunny               |
+| Aug 30 | 46%  | Partly cloudy  | **Mostly Sunny**           |
+| Aug 31 | 38%  | Partly cloudy  | **Mostly Sunny**           |
+| Sep 2  | 61%  | Partly cloudy  | Partly Sunny               |
+| Sep 3  | 56%  | Partly cloudy  | Partly Sunny               |
+
+Three of six disagree. A site that names a source and then contradicts it in
+the source's own vocabulary has said something worse than nothing.
+
+The words exist and they are the publisher's to give: `shortForecast` on
+`/gridpoints/{cell}/forecast` carries them, transitions included — "Patchy Fog
+then Mostly Sunny". That is a second upstream read with its own outage path and
+its own provenance, and it is deliberately not taken here.
+
+## Alternatives considered
+
+**Band the mean into words and keep one figure.** Cheapest, no height cost, and
+it fixes the confusion the row was reported for. Rejected on the measurement
+above: it disagrees with the National Weather Service on half the sample, and it
+leaves the mean — which is the misleading part — in place.
+
+**Band the middle third instead.** It matches the National Weather Service on
+all six measured days, which is suspicious rather than reassuring: it is a rule
+fitted to six points, and the next reader would have no way to tell whether it
+holds because it is right or because the sample was small.
+
+**Read `shortForecast` and print the publisher's own wording.** The best
+version of the row, and it is what this should become. Deferred rather than
+rejected: it is a second request, a second failure mode, a second provenance
+line and its own decision about what happens when the two products disagree
+about the same day. A day view is planned that will want that read anyway, and
+taking it once, in the shape that view needs, is better than taking it twice.
+
+**Morning / Midday / Evening spelled out.** Each column is about 42px at 1280
+and "Morning" alone is wider than that at the label register. Going under 10px
+to fit a word would break the size scale — 10px is already this page's floor.
+The long form belongs in the day view.
+
+**Leave the row alone and put the split in the day view only.** Defensible: the
+grid is meant to be at a glance. Rejected because the figure on the page is not
+merely thin, it is wrong about every day of the week measured, and a day view
+nobody has opened yet does not fix what the grid says.
+
+## Consequences
+
+- **The grid is taller.** Measured at La Jolla Shores: 256px to 288px at 1280,
+  about 12%. That is the cost of the row saying something usable.
+- **`SkyWeekDay.cloudPercent` is replaced by `SkyWeekDay.thirds`.** Anything
+  wanting the daylight mean must now average the parts, and should ask first
+  whether it wants a figure this decision found misleading.
+- **The row still computes no judgement**, which is what ADR-0009 requires.
+  Three means are three measurements; the words on the row are the publisher's.
+- **ADR-0020's "mean rather than extreme" survives** and its "one figure for the
+  day" does not. The reasoning that chose a mean was about reachability and is
+  untouched; what changed is how many means one day needs.
+- **Anything that restores a single daylight figure to this row reverses this**,
+  and will look like a simplification. The table at the top is the argument.

--- a/docs/plans/week-grid-legibility.md
+++ b/docs/plans/week-grid-legibility.md
@@ -1,0 +1,260 @@
+# The week grid's day cell, rebuilt around the daylight window
+
+Planned 2026-08-27. Issue #169.
+
+## The problem, from the reader's side
+
+A parent opens `/conditions/<beach>` to decide which afternoon this week is
+worth driving to. The week grid is where they answer that, and it currently
+asks them to read fourteen lines per day and work out for themselves which
+lines belong together.
+
+Measured on the rendered page at La Jolla Shores, 2026-08-27:
+
+| viewport | columns | cell width | **content width** | grid height |
+| -------- | ------- | ---------- | ----------------- | ----------- |
+| 1024     | 7       | 120px      | **88px**          | 498px       |
+| 1280     | 7       | 157px      | **125px**         | 414px       |
+| 1536     | 7       | 193px      | **161px**         | 414px       |
+
+And the strings that have to live in that width, at the sizes the grid sets
+them in (10px `font-extrabold tracking-widest uppercase` for a label, 13px for
+a value):
+
+| string                          | rendered width |
+| ------------------------------- | -------------- |
+| `LOWEST DAYLIGHT TIDE`          | 170px          |
+| `BIGGEST DAYLIGHT SWELL`        | 187px          |
+| `TODAY · THU, AUG 27`           | 151px          |
+| `THU, AUG 27`                   | 88px           |
+| `6:20 AM to 7:20 PM` (13px)     | 123px          |
+| `11:00 AM 0.7 ft · 6 s` (13px)  | 117px          |
+| `LOW TIDE` / `SWELL` / `CLOUDS` | 70 / 47 / 56px |
+| `6:20 AM – 7:20 PM` (11px)      | 98px           |
+
+Two facts fall out of that table and they are the whole plan.
+
+**The two long labels never fit.** Not at 1024, not at 1280, not at 1536.
+ADR-0017 predicted the wrap and accepted it ("about 30px of the 108px"),
+reasoning that the label is what names the selection and could not be
+shortened without hiding the cell's judgement. That reasoning was right about
+the constraint and wrong about the only way out of it: the selection can be
+named **once, in the header**, instead of three times in three labels.
+
+**Seven columns at 1024 gives a cell 88px — one pixel less than the day name
+it has to hold.** This is the root cause of every hard-coded `lg:block` in
+`DaylightWeek`, `TideWeek`, `WaveWeek` and `SkyWeek`. Each of those components
+carries a paragraph of docstring justifying a forced line break, and each of
+those paragraphs is really describing this measurement. The grid is 84px
+_taller_ at 1024 than at 1536, which is the tell.
+
+## The solution, from the reader's side
+
+The day cell becomes a header and three readings.
+
+```
+┌──────────────────────────────┐
+│ TODAY                        │  yellow chip, reserved on every day
+│ THU, AUG 27                  │  band: mist / ocean-on-today
+│ ☀ 6:20 AM – 7:20 PM          │
+├──────────────────────────────┤
+│ LOW TIDE                     │  ocean label
+│ 3:13 PM 1.6 ft               │
+├──────────────────────────────┤  hairline, border-lavender
+│ SWELL                        │  purple label
+│ 11:00 AM 0.7 ft · 6 s        │
+├──────────────────────────────┤
+│ CLOUDS                       │  fog label
+│ 40% Patchy fog               │
+└──────────────────────────────┘
+```
+
+**The header scopes the cell.** Once the day block opens with the daylight
+window, every figure under it is understood to be inside that window, and
+"Lowest daylight tide" can become "Low tide" without hiding anything. This is
+the load-bearing move: the short labels are not a cosmetic trim, they are
+what the header pays for. Reverting the header without reverting the labels
+would leave three unqualified superlatives, which is the failure ADR-0017 was
+written to prevent.
+
+**Six lines per day instead of eleven.** The `all day` overnight figures leave
+(see the decision below), the forced line breaks go, and the three readings
+are separated rather than run together.
+
+## Implementation decisions
+
+### The daylight window is not a row
+
+`DaylightWeek` stops being a `WeekRow` and becomes the day header's second
+line. `WeekGrid` grows a per-day `daylight: ReactNode` slot rather than
+accepting it in `rows`, because a row is a thing repeated in every day block
+under a `<dt>`, and this is now one line in the header.
+
+`WeekPanel` still reads daylight first and still takes the week's columns from
+it — an outage there costs the grid rather than a row, which is the property
+that read was chosen for. Nothing about the read changes.
+
+### The mark is an SVG, not an emoji
+
+ADR-0015 records that a full-colour emoji at 10px "is not a mark; it is a
+smudge", which is why the week grid has no glyphs at all today. A ☀️ in the
+header at 11px would walk straight back into that. An inline SVG at 12px on
+`currentColor` goes white on today's ocean band and fog on mist, renders
+identically on every OS rather than as whatever the visitor's emoji font
+draws, and is `aria-hidden`.
+
+This does not reopen ADR-0015. That decision is about _which glyph means which
+product_ in the site's emoji vocabulary; a stroked icon in `currentColor` is
+not in that vocabulary and claims no product.
+
+### The window is named to a screen reader, not to a pointer
+
+The header's daylight line takes `role="img"` with
+`aria-label="Daylight, 6:20 AM to 7:20 PM"`. The visible text is the two clock
+times; the accessible name carries the word the visible text drops.
+
+Rejected: a `title` tooltip. It does not appear on touch, where most of this
+site's readers are; it is not keyboard-reachable; and this grid's stated
+principle is that nothing is hidden behind an affordance. Rejected too:
+`sr-only` — the repo does not use it, and `ReadingCard` records why.
+`role="img"` + `aria-label` is already the `Placeholder.tsx` idiom here.
+
+### The `Today` chip gets its own reserved line
+
+`TODAY · THU, AUG 27` is 151px and does not fit 125px, so today's header wraps
+where the other six do not — the misalignment the existing `lg:min-h-8`
+reservation exists to prevent. Keeping a reservation is unavoidable at 1280.
+
+What changes is that it stops looking like a missing line: inside a tinted
+band, an empty first row reads as the band's padding. The chip is
+`bg-yellow text-dark`, which is the first of the brand's colours to reach this
+grid and the same move ADR-0015 made for the reading cards' eyebrow.
+
+Rejected: dropping `Thu,` from today's column to make it fit (`TODAY · AUG 27`
+is about 116px). A weekday is the more useful of the two tokens in a week
+grid, and dropping it from the one column a reader most needs named is what
+`WeekGrid`'s own comment already argues against.
+
+### Separation is a hairline, not a box
+
+`border-t border-lavender` between readings; the header band's bottom edge is
+the heavier `1.5px` rule that separates header from body. Lavender because it
+is the tile's own border colour, so the rule reads as the same system.
+
+Rejected: boxing each reading. The tile is already a box, and three nested
+boxes inside a 157px cell is a grey mess. Rejected: a 3px accent bar per
+reading — built and measured, it takes 9 of the 125px and wraps the swell line
+at 1280.
+
+### Colour is per product, never per value
+
+Labels take a constant colour across all seven days: ocean tide, purple swell,
+fog cloud. Measured against the cell's `white/60` over cream: ocean 8.5:1,
+purple 5.3:1, fog 5.0:1 — all clear of the 4.5:1 this page holds itself to.
+
+ADR-0009 forbids this site judging whether conditions are good, and ADR-0015
+already draws the line that matters: what makes colour a verdict is
+_differential_ colour. Every day's swell label is the same purple whether the
+swell is 0.7 ft or 6 ft, so nothing here asserts anything about the water.
+
+### Columns step 1 / 2 / 4 / 7
+
+At `md`, `lg` and `xl` respectively. Still one CSS property, so the transpose
+argument in `WeekGrid`'s header stands unchanged and nothing renders twice.
+
+The cost is that between 1024 and 1279 the week reads as 4 + 3 rather than one
+row of seven, which is a real loss for comparing across days. It buys 223px
+cells instead of 120px, and with them the deletion of four components' worth
+of forced line breaks. Below `md` a day is a full-width row and nothing wraps,
+which is why none of these breaks were ever needed there.
+
+### The variable-length line goes last
+
+`Clouds` keeps its phenomenon words ("Slight chance rain showers", 203px, two
+lines) and is allowed to wrap, because it is the last reading in the cell.
+A wrap on the final line makes one column's content taller; the tiles are grid
+items and stay equal height, and there is no row beneath it to push out of
+alignment. That is what lets `SkyWeek` drop its `lg:block`.
+
+## The decision that needs an ADR
+
+**The week grid stops printing the day's own extreme.** ADR-0017 considered
+exactly this and rejected it: "a page that silently declines to mention a
+−0.2 ft is withholding the figure a tidepooler came for."
+
+That objection is weaker than it was, for two reasons ADR-0017 could not have
+weighed:
+
+- **Today's overnight extremes are still on the page.** `TideToday` prints
+  "Lowest all day" and `WavesToday` prints "Biggest all day" as stat pairs on
+  the cards above the grid. Only the six future days lose theirs.
+- **A day view is planned** that shows every reading for one day, overnight
+  included, which is where these figures are going rather than away.
+
+It is still a loss in the interim, so it is not taken silently: one sentence
+beneath the grid says the week shows only what falls between sunrise and
+sunset. That is the pattern the grid's `notes` prop already establishes — one
+fact about the grid, printed once, rather than seven facts in seven days.
+
+`lib/conditions.ts` is not touched. `allDay` stays on `TideWeekDay` and
+`WaveWeekDay`; the week components simply stop rendering it, and the day view
+will want the data intact.
+
+## Test seams
+
+All existing, none new:
+
+- **`WeekGrid`** renders from `days` + `rows` + the new per-day `daylight`
+  slot. Assert the header's structure and its `aria-label`, that the chip line
+  is reserved on every day, and that the `<dl>` holds three pairs rather than
+  four.
+- **`DaylightWeek`, `TideWeek`, `WaveWeek`, `SkyWeek`** each render one cell
+  from a plain view model. Assert the shortened labels, and that the dropped
+  `all day` text is absent.
+- **`WeekPanel`** composes them from stubbed reads. Assert the daylight slot
+  is populated from the daylight read, that the note appears, and that a
+  failing read still costs a row rather than the grid.
+
+jsdom applies no stylesheets (ADR-0001), so the class-level facts — the band's
+colours, the hairlines, the column steps — are asserted as classnames and
+confirmed by eye at the review viewport, which is the compromise ADR-0004 and
+ADR-0014 already record. The `stylesheet` gate row is what proves a named
+utility compiles.
+
+## Slices
+
+1. **This plan file.**
+2. **Daylight moves into the day header.** `WeekGrid` gains the slot,
+   `DaylightWeek` becomes the header line and gains the sun mark, `WeekPanel`
+   stops pushing it as a row.
+3. **The rows carry only what daylight reaches.** `TideWeek` and `WaveWeek`
+   drop the `all day` line, all four cells drop `lg:block`, the labels shorten,
+   `WeekPanel` gains the note. **ADR: the week shows only the daylight
+   window.**
+4. **The tile gets a header band and hairline rules**, and labels take the
+   colour key. Presentation only.
+5. **Columns step 1 / 2 / 4 / 7.**
+
+Dependencies are linear: 3 is only honest once 2 has put the window in the
+header, and 4 is styling the structure 2 and 3 build. 5 is independent of 4
+but wants 3's shorter strings to be worth measuring.
+
+## Out of scope
+
+The reading cards and their `all day` stat pairs, the provenance lines beneath
+the grid, the reserved surf-zone slot, `lib/conditions.ts`, and the day view
+itself.
+
+## What was considered and rejected
+
+- **Shorten the labels alone**, without moving daylight. Fits, and leaves
+  three unqualified superlatives — the exact hidden judgement ADR-0017 forbids.
+- **A tooltip on a sun icon** for the daylight window, as first sketched.
+  Rejected on touch reachability; see above.
+- **Keep `all day`, compressed to one line.** Preserves ADR-0017 intact and
+  needs no new ADR, but costs two lines per cell back and keeps the word
+  "daylight" load-bearing in the labels, which undoes the point of the work.
+- **Seven columns from `xl` only, one column below it.** Every seven-column
+  case then has at least 125px, but a full-width stacked day from 768 to 1279
+  is a great deal of scroll on a tablet.
+- **Accent bar per reading.** Measured; wraps the swell line at 1280.

--- a/docs/plans/week-grid-legibility.md
+++ b/docs/plans/week-grid-legibility.md
@@ -239,6 +239,19 @@ Dependencies are linear: 3 is only honest once 2 has put the window in the
 header, and 4 is styling the structure 2 and 3 build. 5 is independent of 4
 but wants 3's shorter strings to be worth measuring.
 
+### Addendum, 2026-08-27: slices 2 and 5 shipped as one
+
+**5 is not independent of 2 — it is a prerequisite.** The daylight line is
+`whitespace-nowrap`, because a clock range broken across two lines is two half
+times. Measured as shipped it is 109px, and at the old breakpoints the cell it
+lands in at 1024 has 88px of content: it would have overflowed rather than
+wrapped, for as long as the two slices were apart. A slice is supposed to leave
+the repo working, so they went in together.
+
+The plan said "5 is independent of 4", which is still true, and implied it was
+independent of 2, which the measurement disproved. Recorded rather than
+quietly reordered.
+
 ## Out of scope
 
 The reading cards and their `all day` stat pairs, the provenance lines beneath

--- a/docs/plans/week-grid-legibility.md
+++ b/docs/plans/week-grid-legibility.md
@@ -2,6 +2,11 @@
 
 Planned 2026-08-27. Issue #169.
 
+> **Historical.** Planned 2026-08-27, shipped in PR #170 on 2026-08-27.
+> It records what was intended then, not what the code does now, and is not
+> maintained. The decision it turns on is ADR-0023, which is kept current.
+> See [`README.md`](README.md).
+
 ## The problem, from the reader's side
 
 A parent opens `/conditions/<beach>` to decide which afternoon this week is

--- a/src/components/conditions/ConditionsNotes.test.tsx
+++ b/src/components/conditions/ConditionsNotes.test.tsx
@@ -102,7 +102,7 @@ test("the safety framing is not repeated here, it is above the readings", () => 
   // figure -- which is what the heading above them promises.
   expect(screen.getByText("Tide heights")).toBeDefined();
   expect(screen.getByText("Wave heights")).toBeDefined();
-  expect(screen.getByText("Clouds")).toBeDefined();
+  expect(screen.getByText("Cloud cover")).toBeDefined();
   // The airport entry is gone with the figures it explained. A note about a
   // reading the page no longer carries would be prose describing nothing.
   expect(screen.queryByText("Sky and visibility")).toBeNull();

--- a/src/components/conditions/ConditionsNotes.test.tsx
+++ b/src/components/conditions/ConditionsNotes.test.tsx
@@ -102,7 +102,7 @@ test("the safety framing is not repeated here, it is above the readings", () => 
   // figure -- which is what the heading above them promises.
   expect(screen.getByText("Tide heights")).toBeDefined();
   expect(screen.getByText("Wave heights")).toBeDefined();
-  expect(screen.getByText("Cloud by day")).toBeDefined();
+  expect(screen.getByText("Clouds")).toBeDefined();
   // The airport entry is gone with the figures it explained. A note about a
   // reading the page no longer carries would be prose describing nothing.
   expect(screen.queryByText("Sky and visibility")).toBeNull();
@@ -240,14 +240,16 @@ test("the notes lay out in columns, each keeping its own measure", () => {
   }
 });
 
-test("the reader is told why the leading figure is not the day's lowest", () => {
-  // The cell says "Lowest daylight tide" and shows a higher number than the one
-  // beneath it. Without this, that reads as a fault -- see docs/adr/0017.
+test("the reader is told why the week leaves the overnight extremes out", () => {
+  // ADR-0017 put the daylight extreme first and the day's own beneath it, and
+  // this entry explained the pair. ADR-0023 removed the second figure from the
+  // week, so what needs explaining changed: not why the leading number is the
+  // higher one, but where the lower one went. Left unsaid, a reader who saw a
+  // -0.2 ft last week finds it gone with nothing to account for it.
   render(<ConditionsNotes entries={ENTRIES} reach={REACH} />);
 
-  expect(
-    screen.getByText(/because those are the ones you can be there for/),
-  ).toBeDefined();
+  expect(screen.getByText(/so the week leaves them out/)).toBeDefined();
+  expect(screen.getByText(/on the cards above/)).toBeDefined();
   expect(
     screen.getByText(/nothing here is a judgement about when you should go/),
   ).toBeDefined();

--- a/src/components/conditions/ConditionsNotes.tsx
+++ b/src/components/conditions/ConditionsNotes.tsx
@@ -60,12 +60,12 @@ const NOTES = [
   {
     term: "Daylight first",
     detail:
-      "The tide and swell figures lead with the lowest and biggest that fall between " +
-      "sunrise and sunset, because those are the ones you can be there for. The day's own " +
-      "lowest and biggest sit beneath them, marked “all day” — on this coast they " +
-      "are usually in the small hours, which is why they are not what leads. Sunrise and " +
-      "sunset are computed for this beach; nothing here is a judgement about when you " +
-      "should go.",
+      "Every figure in the week is the lowest or biggest that falls between sunrise and " +
+      "sunset, which is why each day opens with the window itself. On this coast the " +
+      "day's own lowest tide and biggest swell are usually in the small hours — real, " +
+      "and not something you can plan a morning around — so the week leaves them out. " +
+      "Today's are on the cards above, marked “all day”. Sunrise and sunset are computed " +
+      "for this beach; nothing here is a judgement about when you should go.",
   },
   {
     term: "Wave heights",
@@ -81,16 +81,18 @@ const NOTES = [
       "Scripps Institution of Oceanography, computes it at 10 m depth close to this shore " +
       "from the directional spectra real buoys report and the way the islands shelter and " +
       "bend the swell on its way in. It steps every three hours, so the time shown is the " +
-      "three-hour step that carried the day's biggest swell rather than a peak located to " +
-      "the minute — unlike a tide time, which is a turning point. So a beach page carries " +
+      "three-hour step that carried the biggest swell of the daylight window rather than a " +
+      "peak located to the minute — unlike a tide time, which is a turning point. So a " +
+      "beach page carries " +
       "two wave numbers: one an instrument measured out at sea, one a model computed near " +
       "the sand. The lines naming each source say which is which.",
   },
   {
-    term: "Cloud by day",
+    term: "Clouds",
     detail:
       "A forecast for this beach's own square of the National Weather Service's map, about " +
-      "2.5 km across, rather than a reading taken anywhere. It averages the forecast hours " +
+      "2.5 km across, rather than a reading taken anywhere. Unlike the tide and swell beside " +
+      "it, this figure is an average rather than an extreme: it means the forecast hours " +
       "between sunrise and sunset, so it describes the day you would be there rather than " +
       "the cloudiest hour of it, and it names fog on the days fog is expected. There is no " +
       "reading of what the sky is doing right now anywhere on this page, and no visibility " +

--- a/src/components/conditions/ConditionsNotes.tsx
+++ b/src/components/conditions/ConditionsNotes.tsx
@@ -88,7 +88,7 @@ const NOTES = [
       "the sand. The lines naming each source say which is which.",
   },
   {
-    term: "Clouds",
+    term: "Cloud cover",
     detail:
       "A forecast for this beach's own square of the National Weather Service's map, about " +
       "2.5 km across, rather than a reading taken anywhere. Unlike the tide and swell beside " +

--- a/src/components/conditions/ConditionsNotes.tsx
+++ b/src/components/conditions/ConditionsNotes.tsx
@@ -92,9 +92,12 @@ const NOTES = [
     detail:
       "A forecast for this beach's own square of the National Weather Service's map, about " +
       "2.5 km across, rather than a reading taken anywhere. Unlike the tide and swell beside " +
-      "it, this figure is an average rather than an extreme: it means the forecast hours " +
-      "between sunrise and sunset, so it describes the day you would be there rather than " +
-      "the cloudiest hour of it, and it names fog on the days fog is expected. There is no " +
+      "it, these are averages rather than extremes: the daylight window is split in three and " +
+      "each figure means the forecast hours in its own third, so the row describes the shape " +
+      "of the day rather than the cloudiest hour of it. On this coast that shape is usually a " +
+      "cloudy morning burning off, which one figure for the whole day hides. A dash means the " +
+      "forecast did not cover that part, which is normal for a morning already past. It names " +
+      "fog on the days fog is expected. There is no " +
       "reading of what the sky is doing right now anywhere on this page, and no visibility " +
       "figure at all: the only stations in this county publishing either one are airports, " +
       "and an airport describes its own field rather than a beach kilometres away.",

--- a/src/components/conditions/DaylightWeek.test.tsx
+++ b/src/components/conditions/DaylightWeek.test.tsx
@@ -3,14 +3,14 @@ import { render, screen } from "@testing-library/react";
 import { DaylightWeek } from "./DaylightWeek";
 
 test("names both ends of the day rather than its length", () => {
-  render(
+  const { container } = render(
     <DaylightWeek day={{ sunriseLabel: "6:14 AM", sunsetLabel: "7:32 PM" }} />,
   );
 
   // A duration would be the same information arranged so nobody can use it:
   // the reader is deciding when to leave the house.
-  expect(screen.getByText("6:14 AM")).toBeDefined();
-  expect(screen.getByText("to 7:32 PM")).toBeDefined();
+  expect(container.textContent).toContain("6:14 AM");
+  expect(container.textContent).toContain("7:32 PM");
 });
 
 test("sunrise leads, and sunset follows it in reading order", () => {
@@ -22,39 +22,72 @@ test("sunrise leads, and sunset follows it in reading order", () => {
 });
 
 /**
- * Regression. The two clock times were set on one line, which fitted six days
- * of the week and wrapped on the seventh, taking that column's rows out of line
- * with its neighbours. Breaking them deliberately fixed the grid and, on the
- * first attempt, silently joined the words: two `block` spans with no text node
- * between them read aloud as "6:48 AMto 4:47 PM". A line break a reader can see
- * must not become a word break a reader can hear.
+ * Regression. The two clock times were once set on two lines because at 13px
+ * they did not fit the 88px cell seven columns gave them at 1024. Both halves
+ * of that are gone -- the line is 11px and seven columns start at `xl` -- so a
+ * `block` here would be reintroducing a break nothing is asking for, and it
+ * would cost the height on every one of the seven days.
  */
-test("breaking the line does not join the words", () => {
+test("the window sets on one line, at every width", () => {
   const { container } = render(
     <DaylightWeek day={{ sunriseLabel: "6:48 AM", sunsetLabel: "4:47 PM" }} />,
   );
 
-  expect(container.textContent).toContain("6:48 AM to 4:47 PM");
+  const classes = [...container.querySelectorAll("span")].flatMap((span) =>
+    span.className.split(/\s+/),
+  );
+  expect(classes).not.toContain("block");
+  expect(classes).not.toContain("lg:block");
+  expect(classes).toContain("whitespace-nowrap");
+});
+
+/**
+ * Regression, and it outlived the break that caused it. Two `block` spans with
+ * no text node between them read aloud as "6:48 AMto 4:47 PM" -- the
+ * concatenation `ReadingCard` records hitting in the accessible-name
+ * algorithm. The `aria-label` below is the primary name now, but the fallback
+ * must still be a sentence.
+ */
+test("the visible text does not join the words", () => {
+  const { container } = render(
+    <DaylightWeek day={{ sunriseLabel: "6:48 AM", sunsetLabel: "4:47 PM" }} />,
+  );
+
   expect(container.textContent).not.toContain("AMto");
 });
 
 /**
- * Regression. The two lines exist so that seven columns line up across each
- * other at `lg`. Below `lg` the grid is one column and a day is a full-width
- * row, where nothing was wrapping and there is no neighbour to align with — so
- * the break there was pure cost: 35px per day, seven days, 242px of extra
- * scroll on a phone. Measured 968px to 1210px at 375 before this was scoped.
+ * The word "Daylight" is not printed -- it would not fit beside the times in a
+ * 125px cell -- so the line has to carry it some other way. `role="img"` with
+ * an `aria-label` is how `Placeholder` already names a thing whose visible
+ * content is not its name; a `title` tooltip was rejected because it does not
+ * appear on touch and is not keyboard-reachable.
  */
-test("the deliberate line break applies only where there are columns", () => {
-  const { container } = render(
-    <DaylightWeek day={{ sunriseLabel: "6:48 AM", sunsetLabel: "4:47 PM" }} />,
+test("a reader who cannot see the mark is still told what the window is", () => {
+  render(
+    <DaylightWeek day={{ sunriseLabel: "6:20 AM", sunsetLabel: "7:20 PM" }} />,
   );
 
-  const spans = [...container.querySelectorAll("span")];
-  expect(spans.length).toBe(2);
-  for (const span of spans) {
-    expect(span.className).toContain("lg:block");
-    // Inline below lg, so the two times sit on one line on a phone.
-    expect(span.className.split(/\s+/)).not.toContain("block");
-  }
+  expect(screen.getByRole("img").getAttribute("aria-label")).toBe(
+    "Daylight, 6:20 AM to 7:20 PM",
+  );
+});
+
+/**
+ * ADR-0015: a full-colour emoji at this size is a smudge rather than a mark,
+ * which is why no row in this grid carries one. A stroked SVG on
+ * `currentColor` is the thing that does work here, and it must stay decorative
+ * -- the `aria-label` above is the whole accessible name, and a second one
+ * inside it would be read twice.
+ */
+test("the sun is an SVG on currentColor, and it is decorative", () => {
+  const { container } = render(
+    <DaylightWeek day={{ sunriseLabel: "6:20 AM", sunsetLabel: "7:20 PM" }} />,
+  );
+
+  const svg = container.querySelector("svg");
+  expect(svg).not.toBeNull();
+  expect(svg?.getAttribute("stroke")).toBe("currentColor");
+  expect(svg?.getAttribute("aria-hidden")).toBe("true");
+  expect(container.textContent).not.toMatch(/[☀-➿]/);
 });

--- a/src/components/conditions/DaylightWeek.tsx
+++ b/src/components/conditions/DaylightWeek.tsx
@@ -1,59 +1,97 @@
 /**
- * One day's daylight, as the week grid prints it.
+ * One day's daylight window, as the week grid's day header prints it.
  *
- * **It used to be here to make the tide row mean something**, and it is not any
- * more. A lowest low at 2:23 AM and one at 2:23 PM are the same number and not
- * the same trip, and for a while this row was the only thing on the page that
- * said which. ADR-0017 moved that into the rows themselves: they now lead with
- * the extreme daylight reaches and name it, so this is no longer the correction
- * to the figure above it.
+ * **It is the header rather than a row, and that is what pays for the rest of
+ * the cell.** It began as a correction to the tide row — a lowest low at 2:23
+ * AM and one at 2:23 PM are the same number and not the same trip — and
+ * ADR-0017 took that job off it by moving the constraint into the rows
+ * themselves, which then had to say so in their labels: "Lowest daylight tide",
+ * "Biggest daylight swell". Those labels never fitted. At 10px with
+ * `tracking-widest` they render 170px and 187px wide against 125px of cell at
+ * 1280 and 161px at 1536, so both wrapped at every width the grid has.
  *
- * **What it still answers is the question no other row does** — when you can be
- * down there at all, and how much of the day is left once the tide window
- * closes. That is narrower than the job it was built for and it is why the row
- * stayed when the alternative was to drop it and buy back 380px of phone
- * scroll. It offers no verdict about any of it, which ADR-0009 forbids and this
- * deliberately stops short of.
+ * Opening the day with the window says it once instead. Everything under this
+ * line is understood to fall between these two times, so the rows below can be
+ * called "Low tide" and "Swell" without hiding the judgement their old labels
+ * were carrying. See `docs/plans/week-grid-legibility.md`.
+ *
+ * **What it still answers on its own** is the question no row does — when you
+ * can be down there at all, and how much of the day is left once the tide
+ * window closes. It offers no verdict about any of it, which ADR-0009 forbids.
  *
  * **Both ends, not a duration.** "13h 18m of daylight" is the same information
  * arranged so that nobody can use it: the reader is choosing when to leave the
  * house, and the two clock times are what that turns on.
  *
- * **Two lines at `lg`, one below it.** Set on one line this is about nineteen
- * characters against a 124px cell, so at seven columns it fits on six days and
- * wraps on the seventh -- and the wrap pushed that column's rows out of line
- * with its neighbours, which is the thing a grid exists to prevent. Breaking it
- * on purpose costs the same height on every day and buys back the alignment.
+ * **One line at every width, which the old two-line break existed to avoid.**
+ * Set at 13px, `6:20 AM to 7:20 PM` is 123px and did not fit the 88px cell
+ * seven columns gave it at 1024 — hence the `lg:block` this no longer carries.
+ * At 11px it measures 109px, inside the narrowest cell the grid now has: 125px
+ * at 1280, after seven columns were moved to `xl` so that 1024 gives four
+ * columns and 189px rather than seven and 88px. The break is gone because the
+ * measurement that forced it is, and both halves had to move together — at the
+ * old breakpoints this line would have overflowed its cell rather than wrapped,
+ * because it is `whitespace-nowrap`.
  *
- * Only at `lg`, because only at `lg` is there a column to align with. Below it
- * the grid is one column and a day is a full-width row: nothing wraps, no
- * neighbour is being lined up against, and the break was 35px per day across
- * seven days -- 242px of extra scroll on a phone, on a grid an earlier review
- * had already called too tall there. The sunrise leads because it is the one a
- * reader plans against.
+ * That `nowrap` is deliberate and it is the reason the two moves are one slice.
+ * A clock range broken across lines is two half-times, and no width this grid
+ * has is narrow enough to need it: 109px against 189px is the tightest case.
  *
- * The space between the two spans stays. Two blocks collapse it visually, but
- * it is still a text node, and without it the accessible text runs together as
- * "6:48 AMto 4:47 PM" -- the same concatenation `ReadingCard` records hitting
- * in the accessible-name algorithm. A line break a reader can see must not be
- * a word break a reader can hear.
+ * **The mark is an SVG, not an emoji.** ADR-0015 records that a full-colour
+ * emoji at this size is not a mark but a smudge, which is why no row in this
+ * grid carries a glyph. A stroked icon in `currentColor` is a different thing:
+ * it takes the colour of whatever band it stands on -- white on today's ocean,
+ * fog on mist -- and draws the same on every machine, where an emoji is
+ * whatever the visitor's OS font happens to hold. It claims no product, so it
+ * does not enter the vocabulary ADR-0015 governs.
  *
- * **No glyph.** This row carried 🌅, and the tide row beside it 🐚, at the 10px
- * the week grid's labels are set in. See ADR-0015: at that size a full-colour
- * emoji is not a mark, and the shell in particular rendered as a grey smudge on
- * the pale cell. A glyph marks a panel on this page; a row inside one is named
- * in words.
+ * **The word "Daylight" is spoken, not shown.** The visible text is the two
+ * clock times; `role="img"` with an `aria-label` gives the line the name the
+ * visible text drops. A `title` tooltip was the other option and is worse in
+ * every direction that matters here: it does not appear on touch, it is not
+ * keyboard-reachable, and this grid's whole argument is that nothing is hidden
+ * behind an affordance. `sr-only` is the third, and this repo does not use it
+ * (`ReadingCard` records why). `role="img"` with a label is already how
+ * `Placeholder` names a thing whose visible content is not its name.
  *
- * **A cell rather than a row**, for the reason `TideWeek` gives: the grid is
- * day-major, so a row is seven of these rather than one subtree.
+ * The space between sunrise and sunset stays a text node. Without it the
+ * accessible text would run together as "6:48 AMto 4:47 PM" -- the same
+ * concatenation `ReadingCard` records hitting in the accessible-name
+ * algorithm. That the label is now explicit does not make the fallback safe to
+ * break.
  */
 
 import type { DaylightWeekDay } from "@/lib/conditions";
 
-/** What every day of this row shares: the words that name it. */
-export const DAYLIGHT_WEEK_ROW = {
-  label: "Daylight",
-} as const;
+/** The word the visible line drops, and the one a screen reader is given. */
+export const DAYLIGHT_LABEL = "Daylight";
+
+/**
+ * The sun, at the size a 10px eyebrow can stand beside.
+ *
+ * `currentColor` and no fill: the header band is mist under ocean text on six
+ * days and ocean under white text on the seventh, and a mark with its own
+ * colour would have to be measured against both. Inheriting means it cannot be
+ * wrong on either.
+ */
+function SunMark() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      aria-hidden="true"
+      className="flex-none"
+    >
+      <circle cx="12" cy="12" r="4.2" />
+      <path d="M12 1.6v2.2M12 20.2v2.2M4.6 4.6l1.6 1.6M17.8 17.8l1.6 1.6M1.6 12h2.2M20.2 12h2.2M4.6 19.4l1.6-1.6M17.8 6.2l1.6-1.6" />
+    </svg>
+  );
+}
 
 export function DaylightWeek({
   day,
@@ -61,9 +99,15 @@ export function DaylightWeek({
   day: Pick<DaylightWeekDay, "sunriseLabel" | "sunsetLabel">;
 }) {
   return (
-    <>
-      <span className="font-extrabold lg:block">{day.sunriseLabel}</span>{" "}
-      <span className="text-fog lg:block">to {day.sunsetLabel}</span>
-    </>
+    <p
+      role="img"
+      aria-label={`${DAYLIGHT_LABEL}, ${day.sunriseLabel} to ${day.sunsetLabel}`}
+      className="mt-1 flex items-center gap-1.5 text-xs font-bold"
+    >
+      <SunMark />
+      <span className="whitespace-nowrap">
+        {day.sunriseLabel} to {day.sunsetLabel}
+      </span>
+    </p>
   );
 }

--- a/src/components/conditions/SkyWeek.test.tsx
+++ b/src/components/conditions/SkyWeek.test.tsx
@@ -1,20 +1,121 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { SkyWeek, SKY_WEEK_ROW } from "./SkyWeek";
-import { gridCellCaveat, phenomenonWords } from "./gridCell";
+import { SKY_WEEK_ROW, SkyWeek } from "./SkyWeek";
 
-test("the day's figure is a percentage, and it leads", () => {
+/** A burn-off day: cloudy first third, clear after. The shape of every day measured. */
+const BURN_OFF = { am: 65, mid: 32, eve: 31 };
+
+test("the day is shown in three parts, in reading order", () => {
   const { container } = render(
-    <SkyWeek day={{ cloudPercent: 44, phenomenon: null }} />,
+    <SkyWeek day={{ thirds: BURN_OFF, phenomenon: null }} />,
   );
 
-  expect(screen.getByText("44%")).toBeDefined();
-  // The lead figure is the bold one, the way every other cell in this grid
-  // leads with its own first fact.
-  expect(container.querySelector(".font-extrabold")?.textContent).toBe("44%");
+  expect(container.textContent).toContain("AM");
+  expect(container.textContent).toContain("Mid");
+  expect(container.textContent).toContain("Eve");
+  expect(container.textContent).toMatch(
+    /AM[\s\S]*65%[\s\S]*Mid[\s\S]*32%[\s\S]*Eve[\s\S]*31%/,
+  );
 });
 
-test("the label claims no superlative, because this row is a mean", () => {
+/**
+ * ADR-0024, and the reason the row changed at all. The mean of this day is
+ * 43%, a figure that describes neither the foggy morning nor the clear
+ * afternoon. Measured against the live cell on 2026-08-28, all seven days of
+ * the week were this shape.
+ *
+ * Asserted as an absence because restoring the mean will look like restoring
+ * information.
+ */
+test("the daylight mean is not printed beside the parts", () => {
+  const { container } = render(
+    <SkyWeek day={{ thirds: BURN_OFF, phenomenon: null }} />,
+  );
+
+  expect(container.textContent).not.toContain("43%");
+  expect(container.textContent?.match(/%/g)).toHaveLength(3);
+});
+
+/**
+ * "46% Partly cloudy" was the obvious companion fix, and banding the mean on
+ * the National Weather Service's own sky-condition scale contradicts its own
+ * published wording on three of six measured days -- we would print "Partly
+ * cloudy" where its forecast endpoint says "Mostly Sunny". The words exist and
+ * they are the National Weather Service's to give, from a second endpoint this
+ * page does not yet read.
+ */
+test("no band word is computed here, on any figure", () => {
+  for (const thirds of [
+    { am: 5, mid: 4, eve: 3 },
+    { am: 30, mid: 28, eve: 25 },
+    { am: 46, mid: 50, eve: 44 },
+    { am: 95, mid: 92, eve: 90 },
+  ]) {
+    const { container } = render(
+      <SkyWeek day={{ thirds, phenomenon: null }} />,
+    );
+    expect(container.textContent).not.toMatch(/sunny|cloudy|overcast|clear/i);
+  }
+});
+
+test("a day with fog forecast says so, above the figures", () => {
+  const { container } = render(
+    <SkyWeek
+      day={{
+        thirds: BURN_OFF,
+        phenomenon: { weather: "fog", coverage: "patchy" },
+      }}
+    />,
+  );
+
+  // A parent plans around fog rather than around a percentage, so it leads.
+  expect(screen.getByText("Patchy fog")).toBeDefined();
+  expect(container.textContent).toMatch(/Patchy fog[\s\S]*AM/);
+});
+
+test("a day with no phenomenon prints no empty line for one", () => {
+  // Most days. An ordinary day rather than a missing reading: the figures
+  // still answer, and a blank line would read as something that failed.
+  const { container } = render(
+    <SkyWeek day={{ thirds: BURN_OFF, phenomenon: null }} />,
+  );
+
+  expect(container.textContent?.startsWith("AM")).toBe(true);
+});
+
+/**
+ * The forecast does not run backwards, so on the day the reader is standing in
+ * the first third is usually gone. A zero there would report a cloudless
+ * morning that nobody observed -- the exact failure a blank cell in this grid
+ * is built to avoid.
+ */
+test("a third the forecast did not reach is a dash, never a zero", () => {
+  const { container } = render(
+    <SkyWeek
+      day={{ thirds: { am: null, mid: 32, eve: 31 }, phenomenon: null }}
+    />,
+  );
+
+  expect(container.textContent).toContain("—");
+  expect(container.textContent).not.toContain("0%");
+  // The label stays, so the three columns still line up across the week.
+  expect(container.textContent).toContain("AM");
+});
+
+test("the three parts are equal columns, so the figures compare by eye", () => {
+  const { container } = render(
+    <SkyWeek day={{ thirds: BURN_OFF, phenomenon: null }} />,
+  );
+
+  const parts = [...container.querySelectorAll("span.flex > span")];
+  expect(parts).toHaveLength(3);
+  for (const part of parts) {
+    expect(part.className).toContain("flex-1");
+    expect(part.className).toContain("text-center");
+  }
+});
+
+test("the label claims no superlative, because these are means", () => {
   // It used to say "Cloud by day" against two labels opening "Lowest" and
   // "Biggest", and that contrast was what said this row is an average rather
   // than a peak. ADR-0023 shortened those two, so the contrast is gone and
@@ -28,83 +129,12 @@ test("the label claims no superlative, because this row is a mean", () => {
   expect(SKY_WEEK_ROW.label).not.toMatch(/coverage/i);
 });
 
-test("a day with fog forecast says so, under the figure", () => {
-  render(
-    <SkyWeek
-      day={{
-        cloudPercent: 67,
-        phenomenon: { weather: "fog", coverage: "patchy" },
-      }}
-    />,
-  );
-
-  expect(screen.getByText("Patchy fog")).toBeDefined();
-});
-
-test("a day with no phenomenon renders the figure alone, not an empty line", () => {
+test("no glyph rides along with the figures", () => {
+  // ADR-0015: at the 10px this grid's labels are set in, a full-colour emoji is
+  // a smudge rather than a mark. A row inside a panel is named in words.
   const { container } = render(
-    <SkyWeek day={{ cloudPercent: 30, phenomenon: null }} />,
-  );
-
-  // Most days name nothing. A blank second line would read as a reading that
-  // failed rather than as an ordinary day.
-  expect(container.textContent?.trim()).toBe("30%");
-});
-
-test("the accessible text does not run the two facts together", () => {
-  // The space between the spans is a real text node; two blocks collapse it
-  // visually but a screen reader still needs it, or this reads "67%Patchy fog".
-  const { container } = render(
-    <SkyWeek
-      day={{
-        cloudPercent: 67,
-        phenomenon: { weather: "fog", coverage: "patchy" },
-      }}
-    />,
-  );
-
-  expect(container.textContent).toContain("67% Patchy fog");
-});
-
-test("no glyph and no attribution inside the cell", () => {
-  const { container } = render(
-    <SkyWeek day={{ cloudPercent: 44, phenomenon: null }} />,
+    <SkyWeek day={{ thirds: BURN_OFF, phenomenon: null }} />,
   );
 
   expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
-  expect(container.textContent).not.toMatch(/National Weather Service/);
-});
-
-/* =========================================================================
- * gridCell.ts
- * ========================================================================= */
-
-test("a phenomenon is relayed in the service's own words", () => {
-  // ADR-0009: this site relays a forecaster's judgement rather than forming
-  // one. The underscore and the capital are the only changes made.
-  expect(phenomenonWords({ weather: "fog", coverage: "patchy" })).toBe(
-    "Patchy fog",
-  );
-  expect(phenomenonWords({ weather: "rain_showers", coverage: "chance" })).toBe(
-    "Chance rain showers",
-  );
-});
-
-test("a phenomenon with no coverage still reads as a sentence fragment", () => {
-  expect(phenomenonWords({ weather: "fog", coverage: null })).toBe("Fog");
-});
-
-test("only a cell that covers the bluff carries the caveat", () => {
-  // Three beaches read one: Torrey Pines State at 102 m, Torrey Pines City at
-  // 117 m and La Jolla Cove at 106 m, against a median of 2.1 m across the
-  // inventory. ADR-0020 serves them and discloses rather than withholding, and
-  // this sentence is the half of that decision no gate can assert.
-  expect(gridCellCaveat(117.0432)).toMatch(/covers the bluff/);
-  expect(gridCellCaveat(117.0432)).toMatch(/117 m/);
-  expect(gridCellCaveat(2.1336)).toBeNull();
-  expect(gridCellCaveat(0)).toBeNull();
-});
-
-test("a cell with no published elevation makes no claim either way", () => {
-  expect(gridCellCaveat(null)).toBeNull();
 });

--- a/src/components/conditions/SkyWeek.test.tsx
+++ b/src/components/conditions/SkyWeek.test.tsx
@@ -14,11 +14,13 @@ test("the day's figure is a percentage, and it leads", () => {
   expect(container.querySelector(".font-extrabold")?.textContent).toBe("44%");
 });
 
-test("the label names an average, not a superlative", () => {
-  // `TideWeek` and `WaveWeek` say "Lowest" and "Biggest" because they show one
-  // of a day's estimates. This shows all of them, averaged, and a reader who
-  // read the label as a superlative would be wrong about the number.
-  expect(SKY_WEEK_ROW.label).toBe("Cloud by day");
+test("the label claims no superlative, because this row is a mean", () => {
+  // It used to say "Cloud by day" against two labels opening "Lowest" and
+  // "Biggest", and that contrast was what said this row is an average rather
+  // than a peak. ADR-0023 shortened those two, so the contrast is gone and
+  // `ConditionsNotes` carries the distinction. What is still assertable here,
+  // and still the risk, is that the label never claims an extreme.
+  expect(SKY_WEEK_ROW.label).toBe("Clouds");
   expect(SKY_WEEK_ROW.label).not.toMatch(/cloudiest|clearest|most|least/i);
 });
 

--- a/src/components/conditions/SkyWeek.test.tsx
+++ b/src/components/conditions/SkyWeek.test.tsx
@@ -20,8 +20,12 @@ test("the label claims no superlative, because this row is a mean", () => {
   // than a peak. ADR-0023 shortened those two, so the contrast is gone and
   // `ConditionsNotes` carries the distinction. What is still assertable here,
   // and still the risk, is that the label never claims an extreme.
-  expect(SKY_WEEK_ROW.label).toBe("Clouds");
+  expect(SKY_WEEK_ROW.label).toBe("Cloud cover");
   expect(SKY_WEEK_ROW.label).not.toMatch(/cloudiest|clearest|most|least/i);
+  // "Cover" rather than "coverage": the term the National Weather Service uses
+  // for this quantity, and 100px against 133px of cell where "cloud coverage"
+  // is 128px and leaves five.
+  expect(SKY_WEEK_ROW.label).not.toMatch(/coverage/i);
 });
 
 test("a day with fog forecast says so, under the figure", () => {

--- a/src/components/conditions/SkyWeek.tsx
+++ b/src/components/conditions/SkyWeek.tsx
@@ -1,45 +1,54 @@
 /**
- * One day's cloud cover, as the week grid prints it.
+ * One day's cloud cover, as the week grid prints it: the phenomenon, then the
+ * day in three parts.
  *
  * **The label is "Cloud cover", and it names a different kind of selection from
- * the two rows above it.** "Cloud cover" rather than "cloud coverage": it is the
- * term the National Weather Service uses for the quantity this reads, and at
- * 100px it leaves a quarter of the 133px cell spare where "cloud coverage"
- * would leave 5px. `TideWeek` and `WaveWeek` each show one of a day's
+ * the two rows above it.** `TideWeek` and `WaveWeek` each show one of a day's
  * estimates, and which one is a judgement the day header now states for all
- * three. This shows all of them, averaged. That difference used to live in the
- * label — "Cloud by day" against two superlatives — and after ADR-0023 the
- * superlatives are gone from the labels too, so the distinction has nowhere to
- * be drawn in three words. It is drawn in `ConditionsNotes` instead, which is
- * where the page already explains that a tide time and a swell time are
- * different kinds of figure. A reader who took this for a peak would be wrong
- * about the number, and that is the risk this paragraph exists to flag to
- * whoever changes the wording next.
+ * three. These are means. That difference used to live in the label — "Cloud by
+ * day" against two superlatives — and after ADR-0023 shortened those, the
+ * distinction has nowhere to be drawn in three words. `ConditionsNotes` carries
+ * it instead, which is where the page already explains that a tide time and a
+ * swell time are different kinds of figure. A reader who took these for peaks
+ * would be wrong about the number, and that is the risk this paragraph exists
+ * to flag to whoever changes the wording next.
  *
- * **Why an average where the rows above take an extreme.** ADR-0017 selects for
- * reachability: a lowest low at 3:14 AM is a number nobody planning a trip with
- * children can use, so the row leads with the extreme that falls between
- * sunrise and sunset. Cloud cover has no unreachable hours — the daylight
- * window *is* the trip — so there is no extreme to route around, and taking one
- * anyway would import that ADR's pessimism without its reason. Measured at
- * `SGX/54,21`, the cloudiest daylight step on 2026-08-30 was 62% against a
- * daylight mean of 39%. The plan's 2026-08-27 addendum records the decision.
+ * "Cover" rather than "coverage": it is the term the National Weather Service
+ * uses for the quantity this reads, and at 100px it leaves a quarter of the
+ * 133px cell spare where "cloud coverage" is 128px and leaves five.
  *
- * **The phenomenon carries the "when" the percentage cannot.** Every other row
- * in this grid leads with a time. This one has none to lead with, because a
- * mean is about a window rather than an instant — and a parent does not plan
- * around 44% cloud, they plan around fog. So the phenomenon follows the
- * percentage when one is forecast for a daylight hour, and is absent when none
- * is, which is most days. An absent phenomenon is an ordinary day rather than a
- * missing reading: the percentage still answers.
+ * **Three figures rather than one, because on this coast one was misleading.**
+ * The row shipped a single daylight mean, and measured against the live cell on
+ * 2026-08-28 every one of seven days was a marine-layer burn-off — Sunday ran
+ * 65% / 32% / 31% and averaged to 46%, which describes neither half of the day.
+ * The mean is gone rather than kept beside the parts: it was the misleading
+ * figure, and printing it next to three that do not obviously average to it
+ * would be noise defending a number nobody should read. ADR-0024.
+ *
+ * **No band word, and that is a finding rather than an omission.** "46% Partly
+ * cloudy" was the obvious companion fix and it was tested before it was built:
+ * banding the daylight mean on the National Weather Service's own sky-condition
+ * scale contradicts the National Weather Service's own published wording on
+ * three of six measured days — we would print "Partly cloudy" where its
+ * forecast endpoint says "Mostly Sunny". A site that names a source and then
+ * disagrees with it has said something worse than nothing. The words exist and
+ * they are theirs to give: `shortForecast` on `/gridpoints/{cell}/forecast`
+ * carries them, transitions included ("Patchy Fog then Mostly Sunny"), and that
+ * is a second upstream read with its own outage rather than something to
+ * compute here.
+ *
+ * **The phenomenon still leads, and still carries the "when" the numbers
+ * cannot.** Every other row in this grid opens with a time. This one has none,
+ * because a mean is about a window rather than an instant — and a parent does
+ * not plan around 44% cloud, they plan around fog. It is absent on most days,
+ * which is an ordinary day rather than a missing reading: the three figures
+ * below still answer.
  *
  * **This is the row allowed to wrap, and it is last for that reason.** The
  * phenomenon is the only free text in the cell: "Patchy fog" is 101px and
- * "Slight chance rain showers" is 203px, against 125px in the narrowest
- * seven-column cell. It used to be forced onto its own line at `lg` so the
- * columns stayed in step, which cost the height on every day to protect rows
- * that no longer exist beneath it. Nothing follows this row, the day blocks are
- * grid items and stay equal height regardless, so a second line here makes one
+ * "Slight chance rain showers" is 203px, against 133px in the narrowest
+ * seven-column cell. Nothing follows this row, and the day blocks are grid
+ * items that stay equal height regardless, so a second line here makes one
  * column's text taller and misaligns nothing.
  *
  * **No visibility figure, and that is the point rather than an omission.** The
@@ -60,7 +69,7 @@
  * **A cell rather than a row**, because the grid is day-major.
  */
 
-import type { SkyWeekDay } from "@/lib/conditions";
+import type { SkyThirds, SkyWeekDay } from "@/lib/conditions";
 import { phenomenonWords } from "./gridCell";
 import { CLOUD_TONE } from "./weekTone";
 
@@ -70,22 +79,74 @@ export const SKY_WEEK_ROW = {
   tone: CLOUD_TONE,
 } as const;
 
+/**
+ * What each third is called, in reading order.
+ *
+ * **"Mid" rather than "PM"**, because the third part is also PM and a column
+ * headed "PM" beside one headed "Eve" reads as a contradiction rather than as a
+ * sequence.
+ *
+ * Three short words rather than "Morning / Midday / Evening": each column is
+ * about 42px wide at 1280 and "Morning" alone is wider than that at the label
+ * register, so the full words would wrap. They are set in `text-2xs`, the size
+ * every label on this page uses, rather than a new smaller token -- 10px is
+ * already the floor here and going under it to fit a word is how a size scale
+ * stops being one. The long form belongs in the day view, where there is room
+ * to say what a third is.
+ *
+ * They are approximations on purpose. A third of a 13-hour August window runs
+ * to about 10:40, which is late for "AM" — but the alternative is naming clock
+ * hours, and a boundary at 11 AM would be this site inventing a fact about the
+ * sky. `SkyThirds` records why the window is the divisor.
+ */
+const THIRDS: readonly { key: keyof SkyThirds; label: string }[] = [
+  { key: "am", label: "AM" },
+  { key: "mid", label: "Mid" },
+  { key: "eve", label: "Eve" },
+];
+
 export function SkyWeek({
   day,
 }: {
-  day: Pick<SkyWeekDay, "cloudPercent" | "phenomenon">;
+  day: Pick<SkyWeekDay, "thirds" | "phenomenon">;
 }) {
   return (
     <>
-      {/*
-        The space between the spans stays a text node. Without it the
-        accessible text runs together as "44%Patchy fog" -- the concatenation
-        `ReadingCard` records hitting in the accessible-name algorithm.
-      */}
-      <span className="font-extrabold">{day.cloudPercent}%</span>{" "}
       {day.phenomenon !== null && (
-        <span className="text-fog">{phenomenonWords(day.phenomenon)}</span>
+        <span className="block text-fog">
+          {phenomenonWords(day.phenomenon)}
+        </span>
       )}
+
+      {/*
+        A row of three rather than a sentence, because the figures are being
+        compared to each other and a reader scanning for the burn-off wants
+        them in a line. `text-center` on equal columns is what makes the
+        comparison visual: 65 / 32 / 31 reads as a slope, "65% then 32% then
+        31%" reads as three facts.
+      */}
+      <span className="mt-0.5 flex gap-1.5">
+        {THIRDS.map(({ key, label }) => (
+          <span key={key} className="flex-1 text-center">
+            <span className="text-2xs block font-extrabold tracking-wide text-fog uppercase">
+              {label}
+            </span>
+            {/*
+              An em dash rather than a zero where the forecast did not reach.
+              The product does not run backwards, so on the day the reader is
+              standing in the first third is usually gone -- and a 0% there
+              would report a cloudless morning that nobody observed.
+            */}
+            <span className="block font-extrabold">
+              {day.thirds[key] === null ? (
+                <span className="text-fog">&mdash;</span>
+              ) : (
+                `${day.thirds[key]}%`
+              )}
+            </span>
+          </span>
+        ))}
+      </span>
     </>
   );
 }

--- a/src/components/conditions/SkyWeek.tsx
+++ b/src/components/conditions/SkyWeek.tsx
@@ -59,10 +59,12 @@
 
 import type { SkyWeekDay } from "@/lib/conditions";
 import { phenomenonWords } from "./gridCell";
+import { CLOUD_TONE } from "./weekTone";
 
-/** What every day of this row shares: the words that name it. */
+/** What every day of this row shares: the words that name it, and its colour. */
 export const SKY_WEEK_ROW = {
   label: "Clouds",
+  tone: CLOUD_TONE,
 } as const;
 
 export function SkyWeek({

--- a/src/components/conditions/SkyWeek.tsx
+++ b/src/components/conditions/SkyWeek.tsx
@@ -1,8 +1,11 @@
 /**
  * One day's cloud cover, as the week grid prints it.
  *
- * **The label is "Clouds", and it names a different kind of selection from the
- * two rows above it.** `TideWeek` and `WaveWeek` each show one of a day's
+ * **The label is "Cloud cover", and it names a different kind of selection from
+ * the two rows above it.** "Cloud cover" rather than "cloud coverage": it is the
+ * term the National Weather Service uses for the quantity this reads, and at
+ * 100px it leaves a quarter of the 133px cell spare where "cloud coverage"
+ * would leave 5px. `TideWeek` and `WaveWeek` each show one of a day's
  * estimates, and which one is a judgement the day header now states for all
  * three. This shows all of them, averaged. That difference used to live in the
  * label — "Cloud by day" against two superlatives — and after ADR-0023 the
@@ -63,7 +66,7 @@ import { CLOUD_TONE } from "./weekTone";
 
 /** What every day of this row shares: the words that name it, and its colour. */
 export const SKY_WEEK_ROW = {
-  label: "Clouds",
+  label: "Cloud cover",
   tone: CLOUD_TONE,
 } as const;
 

--- a/src/components/conditions/SkyWeek.tsx
+++ b/src/components/conditions/SkyWeek.tsx
@@ -44,12 +44,14 @@
  * which is an ordinary day rather than a missing reading: the three figures
  * below still answer.
  *
- * **This is the row allowed to wrap, and it is last for that reason.** The
- * phenomenon is the only free text in the cell: "Patchy fog" is 101px and
- * "Slight chance rain showers" is 203px, against 133px in the narrowest
- * seven-column cell. Nothing follows this row, and the day blocks are grid
- * items that stay equal height regardless, so a second line here makes one
- * column's text taller and misaligns nothing.
+ * **Nothing here wraps, and the phenomenon is why that took work.** It is the
+ * only free text in the cell -- "Patchy fog" is 69px and "Slight chance rain
+ * showers" is 174px at the value register, against 133px of cell at 1280 and
+ * 169px at 1536. It wrapped at every seven-column width the grid has, and a
+ * cell one line taller than its neighbours puts its own rows out of line with
+ * theirs, which is the misalignment this grid exists to prevent. The line takes
+ * the subordinate size and truncates rather than reflowing; the words
+ * themselves cannot shorten, for the reason `phenomenonWords` records.
  *
  * **No visibility figure, and that is the point rather than an omission.** The
  * gridpoint declares `visibility` and publishes nothing for it at any cell
@@ -112,8 +114,28 @@ export function SkyWeek({
 }) {
   return (
     <>
+      {/*
+        **One line, always, and the words are not shortened to get there.**
+        `phenomenonWords` records why they cannot be: they are the National
+        Weather Service's own plain-language rendering, and rewording them
+        would be this site forming a forecaster's judgement rather than
+        relaying one -- ADR-0009's rule.
+
+        So the line takes the subordinate size and truncates. `Slight chance
+        rain showers` is the longest string this inventory publishes and
+        measures 174px at 13px, against 133px of cell at 1280 and 169px at
+        1536: it wrapped at every seven-column width, and a cell one line
+        taller than its neighbours is the misalignment this grid is built to
+        prevent. At 11px it is 147px and sets whole from about 1400 up.
+
+        `truncate` is the guarantee rather than the plan. Below roughly 1400
+        the longest phenomenon ends in an ellipsis, which is a visible signal
+        that there is more rather than a silent trim -- and the National
+        Weather Service's vocabulary is an open enumeration, so a combination
+        longer than anything measured here must degrade rather than reflow.
+      */}
       {day.phenomenon !== null && (
-        <span className="block text-fog">
+        <span className="text-xs block truncate text-fog">
           {phenomenonWords(day.phenomenon)}
         </span>
       )}

--- a/src/components/conditions/SkyWeek.tsx
+++ b/src/components/conditions/SkyWeek.tsx
@@ -1,12 +1,17 @@
 /**
  * One day's cloud cover, as the week grid prints it.
  *
- * **The label names the selection, like every row above it, and names a
- * different kind of selection.** `TideWeek` and `WaveWeek` say "Lowest daylight
- * tide" and "Biggest daylight swell" because they show one of a day's estimates
- * and which one is a judgement. This shows all of them, averaged, and "Cloud by
- * day" says that — a reader who reads it as a superlative would be wrong about
- * the number in a way the tide and swell labels are built to prevent.
+ * **The label is "Clouds", and it names a different kind of selection from the
+ * two rows above it.** `TideWeek` and `WaveWeek` each show one of a day's
+ * estimates, and which one is a judgement the day header now states for all
+ * three. This shows all of them, averaged. That difference used to live in the
+ * label — "Cloud by day" against two superlatives — and after ADR-0023 the
+ * superlatives are gone from the labels too, so the distinction has nowhere to
+ * be drawn in three words. It is drawn in `ConditionsNotes` instead, which is
+ * where the page already explains that a tide time and a swell time are
+ * different kinds of figure. A reader who took this for a peak would be wrong
+ * about the number, and that is the risk this paragraph exists to flag to
+ * whoever changes the wording next.
  *
  * **Why an average where the rows above take an extreme.** ADR-0017 selects for
  * reachability: a lowest low at 3:14 AM is a number nobody planning a trip with
@@ -20,10 +25,19 @@
  * **The phenomenon carries the "when" the percentage cannot.** Every other row
  * in this grid leads with a time. This one has none to lead with, because a
  * mean is about a window rather than an instant — and a parent does not plan
- * around 44% cloud, they plan around fog. So the second line is the phenomenon
- * when one is forecast for a daylight hour, and absent when none is, which is
- * most days. An absent line is an ordinary day rather than a missing reading:
- * the percentage above it still answers.
+ * around 44% cloud, they plan around fog. So the phenomenon follows the
+ * percentage when one is forecast for a daylight hour, and is absent when none
+ * is, which is most days. An absent phenomenon is an ordinary day rather than a
+ * missing reading: the percentage still answers.
+ *
+ * **This is the row allowed to wrap, and it is last for that reason.** The
+ * phenomenon is the only free text in the cell: "Patchy fog" is 101px and
+ * "Slight chance rain showers" is 203px, against 125px in the narrowest
+ * seven-column cell. It used to be forced onto its own line at `lg` so the
+ * columns stayed in step, which cost the height on every day to protect rows
+ * that no longer exist beneath it. Nothing follows this row, the day blocks are
+ * grid items and stay equal height regardless, so a second line here makes one
+ * column's text taller and misaligns nothing.
  *
  * **No visibility figure, and that is the point rather than an omission.** The
  * gridpoint declares `visibility` and publishes nothing for it at any cell
@@ -48,7 +62,7 @@ import { phenomenonWords } from "./gridCell";
 
 /** What every day of this row shares: the words that name it. */
 export const SKY_WEEK_ROW = {
-  label: "Cloud by day",
+  label: "Clouds",
 } as const;
 
 export function SkyWeek({
@@ -59,15 +73,13 @@ export function SkyWeek({
   return (
     <>
       {/*
-        The space between the spans stays, for the reason `DaylightWeek`
-        records: two blocks collapse it visually and it is still a text node,
-        and without it the accessible text runs together as "44%Patchy fog".
+        The space between the spans stays a text node. Without it the
+        accessible text runs together as "44%Patchy fog" -- the concatenation
+        `ReadingCard` records hitting in the accessible-name algorithm.
       */}
-      <span className="font-extrabold lg:block">{day.cloudPercent}%</span>{" "}
+      <span className="font-extrabold">{day.cloudPercent}%</span>{" "}
       {day.phenomenon !== null && (
-        <span className="text-fog lg:block">
-          {phenomenonWords(day.phenomenon)}
-        </span>
+        <span className="text-fog">{phenomenonWords(day.phenomenon)}</span>
       )}
     </>
   );

--- a/src/components/conditions/TideWeek.test.tsx
+++ b/src/components/conditions/TideWeek.test.tsx
@@ -18,16 +18,28 @@ test("a reading leads with the daylight low, time first", () => {
   expect(screen.getByText("0.9 ft")).toBeDefined();
 });
 
-test("the day's lowest follows it rather than replacing it", () => {
-  // A -0.4 ft at 3:14 AM is a real prediction and a useless plan, but it is
-  // exactly the figure a tidepooler willing to set an alarm wants to exist.
+/**
+ * ADR-0023. The cell used to carry the day's own lowest under an "all day"
+ * prefix, and the label that distinguished the two — "Lowest daylight tide" —
+ * renders 170px against 125px of cell. The window is stated once in the day
+ * header now, so there is no second figure for it to distinguish this one
+ * from.
+ *
+ * The figure is not gone from the site: `TideToday` prints "Lowest all day"
+ * for today, and `WeekPanel` says in a sentence beneath the grid where the
+ * other six went. Asserted here as an absence because restoring it will look
+ * like restoring information.
+ */
+test("the day's own lowest is not in this cell", () => {
   const { container } = render(
     <TideWeek
       state={{ kind: "reading", daylight: DAYLIGHT, allDay: ALL_DAY }}
     />,
   );
 
-  expect(container.textContent).toContain("all day 3:14 AM -0.4 ft");
+  expect(container.textContent).toBe("6:41 PM 0.9 ft");
+  expect(container.textContent).not.toContain("all day");
+  expect(container.textContent).not.toContain("3:14 AM");
 });
 
 test("a negative height keeps its sign, which is the figure a tidepooler reads", () => {
@@ -46,43 +58,56 @@ test("a negative height keeps its sign, which is the figure a tidepooler reads",
   expect(screen.getByText("-0.4 ft")).toBeDefined();
 });
 
-test("a daylight low that is also the day's lowest says so, rather than repeating", () => {
-  // Printing the same figure twice would read as a fault rather than as
-  // agreement.
-  const { container } = render(
+test("whether the two extremes agree changes nothing a reader sees", () => {
+  // `allDay` is null when the daylight low is also the day's lowest. That
+  // distinction drove the old second line ("none lower" against a figure) and
+  // now drives nothing, so the two must render identically.
+  const agreed = render(
     <TideWeek state={{ kind: "reading", daylight: DAYLIGHT, allDay: null }} />,
   );
+  const differed = render(
+    <TideWeek
+      state={{ kind: "reading", daylight: DAYLIGHT, allDay: ALL_DAY }}
+    />,
+  );
 
-  expect(container.textContent).toContain("all day none lower");
-  expect(container.textContent).not.toContain("6:41 PM 0.9 ft all day 6:41 PM");
+  expect(agreed.container.textContent).toBe(differed.container.textContent);
+  expect(agreed.container.textContent).not.toContain("none lower");
 });
 
-test("a day with no low in daylight still answers, from the line below", () => {
+test("a day with no low in daylight says so rather than falling back", () => {
   // Close to unreachable on this coast -- two lows twelve and a half hours
-  // apart against ten to fourteen hours of daylight -- and a named absence
-  // rather than a blank, because the day's lowest is still there to give.
+  // apart against ten to fourteen hours of daylight. A named absence rather
+  // than a blank, because an empty cell in a tide row reads as a flat sea, and
+  // rather than the overnight low, which is the figure this grid no longer
+  // shows.
   const { container } = render(
     <TideWeek state={{ kind: "reading", daylight: null, allDay: ALL_DAY }} />,
   );
 
   expect(screen.getByText("None")).toBeDefined();
-  expect(container.textContent).toContain("all day 3:14 AM -0.4 ft");
+  expect(container.textContent).not.toContain("3:14 AM");
 });
 
-test("the second line takes the same two lines whichever branch it took", () => {
-  // A cell whose height depends on its branch puts every row beneath it out of
-  // line with its neighbours, which is the thing a grid exists to prevent. The
-  // break is scoped to lg, where the columns being aligned exist.
+/**
+ * Regression. Every branch of this cell was two lines at `lg`, because a cell
+ * whose height depended on which branch it took put every row beneath it out
+ * of line with its neighbours. With one line there is no branch to equalise,
+ * and a `block` left behind would cost height on all seven days for nothing.
+ */
+test("no branch of the cell forces a line break", () => {
   for (const state of [
     { kind: "reading", daylight: DAYLIGHT, allDay: ALL_DAY },
     { kind: "reading", daylight: DAYLIGHT, allDay: null },
     { kind: "reading", daylight: null, allDay: ALL_DAY },
+    { kind: "no-low" },
   ] as const) {
     const { container } = render(<TideWeek state={state} />);
-    const prefix = [...container.querySelectorAll("span")].find(
-      (span) => span.textContent === "all day",
+    const classes = [...container.querySelectorAll("span")].flatMap((span) =>
+      span.className.split(/\s+/),
     );
-    expect(prefix?.className).toContain("lg:block");
+    expect(classes).not.toContain("block");
+    expect(classes).not.toContain("lg:block");
   }
 });
 
@@ -100,9 +125,10 @@ test("a day the window did not cover says so rather than rendering a blank", () 
  * exact pale-on-pale failure the card was given a dark surface to escape. The
  * row is named in words instead, so there is no glyph here to keep in step.
  */
-test("the week's tide row names the selection in words, and carries no glyph", () => {
-  // The label has to say "daylight", because the cell no longer shows the
-  // day's lowest low as its leading figure and a reader must not assume it.
-  expect(TIDE_WEEK_ROW.label).toBe("Lowest daylight tide");
+test("the week's tide row is named in words, and carries no glyph", () => {
+  // ADR-0023: two words, because the day header says which window they fall
+  // in. "Lowest daylight tide" said it in the label and rendered 170px wide
+  // against a 125px cell, so it wrapped at every width the grid has had.
+  expect(TIDE_WEEK_ROW.label).toBe("Low tide");
   expect(TIDE_WEEK_ROW).not.toHaveProperty("emoji");
 });

--- a/src/components/conditions/TideWeek.tsx
+++ b/src/components/conditions/TideWeek.tsx
@@ -49,10 +49,12 @@
  */
 
 import type { TideWeekDay } from "@/lib/conditions";
+import { TIDE_TONE } from "./weekTone";
 
-/** What every day of this row shares: the words that name it. */
+/** What every day of this row shares: the words that name it, and its colour. */
 export const TIDE_WEEK_ROW = {
   label: "Low tide",
+  tone: TIDE_TONE,
 } as const;
 
 export function TideWeek({ state }: { state: TideWeekDay["state"] }) {

--- a/src/components/conditions/TideWeek.tsx
+++ b/src/components/conditions/TideWeek.tsx
@@ -1,84 +1,76 @@
 /**
- * One day's lowest low tide, as the week grid prints it.
+ * One day's lowest low tide inside the daylight window, as the week grid
+ * prints it.
  *
  * **A row in a day-major grid is not a subtree, so this is a cell rather than a
  * row.** `WeekGrid` renders seven day blocks and each block asks every product
  * for its figure, which is what makes the grid transpose with one CSS property
  * and read day-then-values to a screen reader. The tide "row" is therefore
  * seven instances of this component, and `TIDE_WEEK_ROW` carries the identity
- * they share so the label and the glyph live beside the thing they label.
+ * they share so the label lives beside the thing it labels.
  *
  * **Timing leads, height supports.** The same order `TideToday` argues for and
  * for the same reason: a parent plans around when to leave the house, and the
  * height is what separates a good tidepooling day from an ordinary one rather
  * than the number they are looking for first.
  *
- * **The daylight low leads, and the day's lowest follows it.** The row used to
- * print the day's lowest low full stop, which on this coast in summer is before
- * sunrise on most days -- six of the seven measured on 2026-08-26. That is a
- * real prediction and a useless plan, and the page left the reader to notice it
- * by checking the daylight row two lines down. Now the row does that itself and
- * still says what it passed over, because a -0.2 ft at 3:14 AM is exactly the
- * figure a tidepooler willing to set an alarm wants to know exists.
+ * **The label is "Low tide", and the day's own lowest is no longer here.**
+ * ADR-0017 put both figures in this cell and named the first one "Lowest
+ * daylight tide" so a reader could tell which was which. That label renders
+ * 170px wide against 125px of cell at 1280 and 161px at 1536 — it wrapped at
+ * every width the grid has ever had. ADR-0023 says the selection once, in the
+ * day header: everything under a window that reads `6:20 AM to 7:20 PM` is
+ * inside it, so the label does not have to repeat the word and the second line
+ * has nothing to distinguish itself from.
  *
- * **The second line is always two lines at `lg`, whichever branch it takes.**
- * "all day" is broken onto its own line there for the reason `DaylightWeek`
- * records: a cell whose height depends on which branch it took puts every row
- * beneath it out of line with its neighbours, and a grid whose rows do not line
- * up across is a table pretending. Below `lg` a day is a full-width row, so the
- * break is scoped and the line reads as one sentence.
+ * **The overnight low is not dropped from the site, only from this grid.**
+ * `TideToday` still prints "Lowest all day" for today, and the day view is
+ * where the other six are going. `WeekPanel` says so in a sentence beneath the
+ * grid rather than letting the figure vanish quietly — ADR-0023 records why
+ * that sentence is the condition this was allowed under.
  *
- * **"None lower" rather than a repeat.** When the day's lowest low does fall in
- * daylight the two figures are the same reading, and printing it twice would
- * read as a fault rather than as agreement.
+ * **One line, at every width.** The old second line was two lines at `lg` on
+ * purpose, because a cell whose height depended on which branch it took put
+ * every row beneath it out of line with its neighbours. With one line there is
+ * no branch to equalise: `3:13 PM 1.6 ft` is 79px against 125px in the
+ * narrowest seven-column cell, and 189px at 1024 where the grid now shows four.
  *
  * **An absent day says so.** `no-low` means the range we asked NOAA for did not
- * cover that date — a fact about our request, never about the sea. Rendered as
- * words because a blank cell in a tide row reads as a calm, flat day, which is
- * the failure this whole page is built to avoid.
+ * cover that date — a fact about our request, never about the sea. `None` means
+ * the sea did not put a low between sunrise and sunset, which is close to
+ * unreachable on this coast. Both are words rather than a blank, because a
+ * blank cell in a tide row reads as a calm, flat day, which is the failure this
+ * whole page is built to avoid.
  *
  * **What is not here is a caveat per cell.** Which station these predictions
  * come from, how far away it is and what the datum means are all said once, on
- * the card above and in the notes block below, and both are on this page
- * already. Seven columns each repeating an attribution would bury the figures
- * they qualify.
+ * the card above and in the notes block below. Seven columns each repeating an
+ * attribution would bury the figures they qualify.
  */
 
-import type { TideReading, TideWeekDay } from "@/lib/conditions";
+import type { TideWeekDay } from "@/lib/conditions";
 
 /** What every day of this row shares: the words that name it. */
 export const TIDE_WEEK_ROW = {
-  label: "Lowest daylight tide",
+  label: "Low tide",
 } as const;
-
-/** `3:14 AM -0.2 ft`, the one wording both lines of this cell use. */
-function worded({ timeLabel, feet }: TideReading): string {
-  return `${timeLabel} ${feet.toFixed(1)} ft`;
-}
 
 export function TideWeek({ state }: { state: TideWeekDay["state"] }) {
   if (state.kind === "no-low") {
     return <span className="text-fog italic">Not in range</span>;
   }
 
+  if (state.daylight === null) {
+    // No low between sunrise and sunset. Close to unreachable on this coast --
+    // two lows about twelve and a half hours apart against ten to fourteen
+    // hours of daylight -- and a named absence rather than a blank.
+    return <span className="text-fog italic">None</span>;
+  }
+
   return (
     <>
-      {state.daylight === null ? (
-        // No low between sunrise and sunset. Close to unreachable on this
-        // coast, and a named absence rather than a blank: the day's lowest is
-        // on the line below, so the cell still answers.
-        <span className="text-fog italic">None</span>
-      ) : (
-        <>
-          <span className="font-extrabold">{state.daylight.timeLabel}</span>{" "}
-          <span className="text-fog">{state.daylight.feet.toFixed(1)} ft</span>
-        </>
-      )}
-
-      <span className="block text-fog">
-        <span className="lg:block">all day</span>{" "}
-        {state.allDay === null ? "none lower" : worded(state.allDay)}
-      </span>
+      <span className="font-extrabold">{state.daylight.timeLabel}</span>{" "}
+      <span className="text-fog">{state.daylight.feet.toFixed(1)} ft</span>
     </>
   );
 }

--- a/src/components/conditions/WaveWeek.test.tsx
+++ b/src/components/conditions/WaveWeek.test.tsx
@@ -4,12 +4,16 @@ import { WaveWeek, WAVE_WEEK_ROW } from "./WaveWeek";
 
 const DAYLIGHT = { timeLabel: "2:00 PM", heightFt: 2.618, periodS: 13.333333 };
 
-test("the row is named in one word, since the header states the window", () => {
+test("the label keeps the superlative and drops only the window", () => {
   // ADR-0023. Fifty-six three-hourly estimates stand behind one cell and which
-  // one is shown is a judgement, which "Biggest daylight swell" named in the
-  // label -- at 187px against a 125px cell, so it wrapped at every width the
-  // grid has had. The day header says the window once for all three rows now.
-  expect(WAVE_WEEK_ROW.label).toBe("Swell");
+  // one is shown is a judgement, so "Biggest" has to stay: "Swell" over a
+  // single figure invites a reader to take it for the day's typical swell.
+  // What goes is "daylight", which the day header states for all three rows --
+  // "Biggest daylight swell" rendered 187px against a 133px cell and wrapped at
+  // every width the grid has had. This is 112px.
+  expect(WAVE_WEEK_ROW.label).toBe("Biggest swell");
+  expect(WAVE_WEEK_ROW.label).toMatch(/^Biggest/);
+  expect(WAVE_WEEK_ROW.label).not.toMatch(/daylight/i);
 });
 
 test("the daylight swell leads: time, then height and period", () => {

--- a/src/components/conditions/WaveWeek.test.tsx
+++ b/src/components/conditions/WaveWeek.test.tsx
@@ -3,33 +3,36 @@ import { render, screen } from "@testing-library/react";
 import { WaveWeek, WAVE_WEEK_ROW } from "./WaveWeek";
 
 const DAYLIGHT = { timeLabel: "2:00 PM", heightFt: 2.618, periodS: 13.333333 };
-const ALL_DAY = { timeLabel: "2:00 AM", heightFt: 4.1, periodS: 5 };
 
-test("the row's name states which estimate of the day this is", () => {
-  // Fifty-six three-hourly estimates stand behind one cell. Which two are shown
-  // is a judgement, and a superlative stated is one a reader can discount.
-  expect(WAVE_WEEK_ROW.label).toBe("Biggest daylight swell");
+test("the row is named in one word, since the header states the window", () => {
+  // ADR-0023. Fifty-six three-hourly estimates stand behind one cell and which
+  // one is shown is a judgement, which "Biggest daylight swell" named in the
+  // label -- at 187px against a 125px cell, so it wrapped at every width the
+  // grid has had. The day header says the window once for all three rows now.
+  expect(WAVE_WEEK_ROW.label).toBe("Swell");
 });
 
 test("the daylight swell leads: time, then height and period", () => {
   // Every row of this grid opens with a time -- the lowest daylight low,
   // sunrise -- so a reader scanning down one day reads "when, when, when".
-  const { container } = render(
-    <WaveWeek day={{ daylight: DAYLIGHT, allDay: ALL_DAY }} />,
-  );
+  const { container } = render(<WaveWeek day={{ daylight: DAYLIGHT }} />);
 
   expect(container.textContent).toContain("2:00 PM 2.6 ft · 13 s");
 });
 
-test("the day's biggest follows it, without repeating the period", () => {
-  // The period qualifies the swell a reader is deciding about; the day's own
-  // estimate is context for that decision rather than a second one to weigh.
-  const { container } = render(
-    <WaveWeek day={{ daylight: DAYLIGHT, allDay: ALL_DAY }} />,
-  );
+/**
+ * ADR-0023, the counterpart of the assertion in `TideWeek.test.tsx`. The day's
+ * own biggest fell outside daylight on six of seven days measured -- four of
+ * those at 11 PM or 2 AM -- so the cell carried it under an "all day" prefix
+ * and the label had to say which figure was which. It is on the card above for
+ * today and in the day view for the rest; here it is an absence, because
+ * restoring it will look like restoring information.
+ */
+test("the day's own biggest is not in this cell", () => {
+  const { container } = render(<WaveWeek day={{ daylight: DAYLIGHT }} />);
 
-  expect(container.textContent).toContain("all day 2:00 AM 4.1 ft");
-  expect(container.textContent).not.toContain("4.1 ft · 5 s");
+  expect(container.textContent).toBe("2:00 PM 2.6 ft · 13 s");
+  expect(container.textContent).not.toContain("all day");
 });
 
 test("the height keeps one decimal, matching the card above", () => {
@@ -37,7 +40,6 @@ test("the height keeps one decimal, matching the card above", () => {
     <WaveWeek
       day={{
         daylight: { ...DAYLIGHT, heightFt: 0.6402116 * 3.280839895 },
-        allDay: null,
       }}
     />,
   );
@@ -50,39 +52,25 @@ test("the period is rounded to whole seconds", () => {
   // frequency bin, not a measurement to six decimal places -- and the buoy card
   // beside this one prints whole seconds because NDBC publishes whole seconds.
   const { container } = render(
-    <WaveWeek
-      day={{ daylight: { ...DAYLIGHT, periodS: 16.666668 }, allDay: null }}
-    />,
+    <WaveWeek day={{ daylight: { ...DAYLIGHT, periodS: 16.666668 } }} />,
   );
 
   expect(container.textContent).toContain("17 s");
 });
 
-test("a daylight swell that is also the day's biggest says so, rather than repeating", () => {
-  const { container } = render(
-    <WaveWeek day={{ daylight: DAYLIGHT, allDay: null }} />,
-  );
-
-  expect(container.textContent).toContain("all day none bigger");
-});
-
-test("a day with no estimate in daylight still answers, from the line below", () => {
+test("a day with no estimate in daylight says so rather than rendering blank", () => {
   // A ragged forecast can cover only part of a day. A named absence rather
-  // than a blank, because the day's biggest is still there to give.
-  const { container } = render(
-    <WaveWeek day={{ daylight: null, allDay: ALL_DAY }} />,
-  );
+  // than a blank, for the reason `TideWeek` gives: an empty cell in a forecast
+  // row reads as a flat, quiet day.
+  render(<WaveWeek day={{ daylight: null }} />);
 
   expect(screen.getByText("None")).toBeDefined();
-  expect(container.textContent).toContain("all day 2:00 AM 4.1 ft");
 });
 
 test("the time is emphasised and the figures beneath it are not", () => {
   // The same weighting the tide cell uses for its own leading figure, so a
   // reader scanning the grid finds the same thing in the same place.
-  const { container } = render(
-    <WaveWeek day={{ daylight: DAYLIGHT, allDay: ALL_DAY }} />,
-  );
+  const { container } = render(<WaveWeek day={{ daylight: DAYLIGHT }} />);
 
   const spans = [...container.querySelectorAll("span")];
   expect(spans[0].className).toContain("font-extrabold");
@@ -90,32 +78,27 @@ test("the time is emphasised and the figures beneath it are not", () => {
   expect(spans[1].className).toContain("text-fog");
 });
 
-test("every deliberate break is scoped to lg, where the columns it aligns exist", () => {
-  // Below lg a day is a full-width row: nothing wraps, no neighbour is being
-  // lined up against, and the break is 35px a day across seven days.
-  const { container } = render(
-    <WaveWeek day={{ daylight: DAYLIGHT, allDay: ALL_DAY }} />,
-  );
+/**
+ * Regression. This cell carried three forced breaks at `lg`, which kept seven
+ * columns in step while it ran to four lines. It is one line now --
+ * `11:00 AM 0.7 ft · 6 s` is 117px, the longest line the cell has, against
+ * 125px in the narrowest seven-column cell -- so a `block` left behind would
+ * cost height on all seven days for nothing.
+ */
+test("nothing in the cell forces a line break", () => {
+  const { container } = render(<WaveWeek day={{ daylight: DAYLIGHT }} />);
 
-  const spans = [...container.querySelectorAll("span")];
-  const broken = spans.filter((span) =>
-    span.className.split(/\s+/).includes("lg:block"),
+  const classes = [...container.querySelectorAll("span")].flatMap((span) =>
+    span.className.split(/\s+/),
   );
-
-  // The leading time, the figures under it, and the "all day" prefix.
-  expect(broken).toHaveLength(3);
-  for (const span of broken) {
-    expect(span.className.split(/\s+/)).not.toContain("block");
-  }
-  expect(broken.at(-1)!.textContent).toBe("all day");
+  expect(classes).not.toContain("block");
+  expect(classes).not.toContain("lg:block");
 });
 
 test("no glyph rides along with the figures", () => {
   // ADR-0015: at the 10px the grid's labels are set in, a full-colour emoji is
   // a smudge rather than a mark. A row inside a panel is named in words.
-  const { container } = render(
-    <WaveWeek day={{ daylight: DAYLIGHT, allDay: ALL_DAY }} />,
-  );
+  const { container } = render(<WaveWeek day={{ daylight: DAYLIGHT }} />);
 
   expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
 });
@@ -123,9 +106,7 @@ test("no glyph rides along with the figures", () => {
 test("the time stays a separate word from the height it precedes", () => {
   // The same concatenation `ReadingCard` records hitting in the accessible-name
   // algorithm: without the text node between them this reads "2:00 PM2.6 ft".
-  const { container } = render(
-    <WaveWeek day={{ daylight: DAYLIGHT, allDay: ALL_DAY }} />,
-  );
+  const { container } = render(<WaveWeek day={{ daylight: DAYLIGHT }} />);
 
   expect(container.textContent).toContain("PM 2.6");
 });

--- a/src/components/conditions/WaveWeek.tsx
+++ b/src/components/conditions/WaveWeek.tsx
@@ -63,10 +63,12 @@
  */
 
 import type { WaveWeekDay } from "@/lib/conditions";
+import { SWELL_TONE } from "./weekTone";
 
-/** What every day of this row shares: the words that name it. */
+/** What every day of this row shares: the words that name it, and its colour. */
 export const WAVE_WEEK_ROW = {
   label: "Swell",
+  tone: SWELL_TONE,
 } as const;
 
 export function WaveWeek({ day }: { day: Pick<WaveWeekDay, "daylight"> }) {

--- a/src/components/conditions/WaveWeek.tsx
+++ b/src/components/conditions/WaveWeek.tsx
@@ -1,28 +1,29 @@
 /**
- * One day's biggest swell, as the week grid prints it.
+ * One day's biggest swell inside the daylight window, as the week grid prints
+ * it.
  *
- * **The label names the selection, and that is not a stylistic choice.** A day
- * has fifty-six three-hourly estimates behind it and this cell shows two of
- * them; which two is a judgement, and on two of ten sampled days the day's
- * smallest and largest fell either side of one of `WavesToday`'s plain-language
- * bands. "Biggest daylight swell" is the same contract `TideWeek`'s label
- * makes, for the same reason: a superlative stated is a superlative a reader
- * can discount, and a bare number is one they cannot.
+ * **The label is "Swell", and the selection it names is stated in the day
+ * header.** A day has fifty-six three-hourly estimates behind it and this cell
+ * shows one of them; which one is a judgement, and on two of ten sampled days
+ * the day's smallest and largest fell either side of one of `WavesToday`'s
+ * plain-language bands. ADR-0017 put that judgement in the label — "Biggest
+ * daylight swell" — and the label never fitted: 187px against 125px of cell at
+ * 1280 and 161px at 1536. ADR-0023 moves the daylight half of it into the
+ * header, where it is said once for all three rows.
  *
- * **The daylight swell leads and the day's own follows it**, exactly as the
- * tide cell does and for the same reason. On the seven days measured on
- * 2026-08-26 the biggest estimate fell outside daylight on six of them -- four
- * of those at 11 PM or 2 AM -- so a row printing the day's biggest full stop
- * was answering a question nobody planning a trip had asked.
+ * **The day's own biggest is no longer here.** On the seven days measured on
+ * 2026-08-26 it fell outside daylight on six of them — four of those at 11 PM
+ * or 2 AM — which is what made the daylight estimate the one worth leading
+ * with. It is not dropped from the site: `WavesToday` still prints "Biggest all
+ * day" for today, the day view is where the other six are going, and
+ * `WeekPanel` says so in a sentence beneath the grid.
  *
  * **The time leads, the way it does in every other row of this grid.** An
  * earlier draft led with the height, on the argument that a swell is a decision
  * about whether to go rather than when. That was wrong about what the grid is:
- * the tide row leads with the time of the lowest low and the daylight row with
- * sunrise, so a reader scanning down one day reads "when, when, when" and then
- * a fourth row that opened with a number would break the column they are
- * reading. The height and the period follow on the line beneath, which is the
- * shape `TideWeek` and `DaylightWeek` already share.
+ * the tide row leads with the time of the lowest low, so a reader scanning down
+ * one day reads "when, when" and then a cloud figure about the whole day, and a
+ * row that opened with a number would break the column they are reading.
  *
  * **The time is a three-hour step, not a peak located to the minute.** MOP
  * publishes every three hours, so this is the step that carried the day's
@@ -31,33 +32,29 @@
  * alike in a column — which is why `ConditionsNotes` says which is which rather
  * than leaving a reader to assume they are the same kind of figure.
  *
- * **Whole seconds.** CDIP publishes the peak period as a float -- 16.666668 --
+ * **Whole seconds.** CDIP publishes the peak period as a float — 16.666668 —
  * because it is the reciprocal of a spectral frequency bin, not a measurement
  * to six decimal places. The buoy card beside this one prints whole seconds
  * because NDBC publishes whole seconds, and two wave products on one page
  * printing periods to different precisions would imply one of them is the more
  * exact.
  *
- * **Two lines at `lg`, one below it**, and an interpunct between the two
- * figures rather than a space -- "0.8 ft 5 s" is two numbers a reader has to
- * separate, and ` · ` is what `ProvenanceLine` already uses to separate facts
- * in running text. Measured at 1280: the second line sets to about 12
- * characters against a 124px cell, inside the budget `DaylightWeek` recorded
- * when nineteen characters wrapped there.
- *
- * The break is scoped to `lg` for the reason that cell records: it exists to
- * keep seven columns aligned across, and there are only seven columns at `lg`.
- * Below it a day is a full-width row, nothing wraps, and forcing the break
- * bought nothing and cost 35px a day.
+ * **One line, at every width**, with an interpunct between the two figures
+ * rather than a space — "0.8 ft 5 s" is two numbers a reader has to separate,
+ * and ` · ` is what `ProvenanceLine` already uses to separate facts in running
+ * text. Measured: `11:00 AM 0.7 ft · 6 s` is 117px against 125px in the
+ * narrowest seven-column cell the grid now has, and 189px at 1024. This is the
+ * longest line in the cell and the one that decided seven columns could not
+ * start before `xl`.
  *
  * **No cell where the forecast does not reach.** That is the caller's doing
- * rather than this component's: `readWaveWeek` returns only the days it has, and
- * `WeekGrid` draws no pair for a day a row has nothing for. A forecast that
- * stops on Sunday is a forecast, and a label sitting over a gap would read as an
- * instrument that failed.
+ * rather than this component's: `readWaveWeek` returns only the days it has,
+ * and `WeekGrid` draws no pair for a day a row has nothing for. A forecast that
+ * stops on Sunday is a forecast, and a label sitting over a gap would read as
+ * an instrument that failed.
  *
- * **No glyph, and no attribution here.** ADR-0015 for the first -- a full-colour
- * emoji at 10px is a smudge rather than a mark -- and `WeekGrid`'s single
+ * **No glyph, and no attribution here.** ADR-0015 for the first — a full-colour
+ * emoji at 10px is a smudge rather than a mark — and `WeekGrid`'s single
  * provenance line for the second. Which model this came from is one fact about
  * a feed, printed once beneath the grid rather than seven times inside it.
  *
@@ -65,56 +62,33 @@
  * day-major, so a row is seven of these rather than one subtree.
  */
 
-import type { WaveReading, WaveWeekDay } from "@/lib/conditions";
+import type { WaveWeekDay } from "@/lib/conditions";
 
 /** What every day of this row shares: the words that name it. */
 export const WAVE_WEEK_ROW = {
-  label: "Biggest daylight swell",
+  label: "Swell",
 } as const;
 
-/** `2:00 AM 1.1 ft`, which is the day's own estimate without its period. */
-function worded({ timeLabel, heightFt }: WaveReading): string {
-  return `${timeLabel} ${heightFt.toFixed(1)} ft`;
-}
+export function WaveWeek({ day }: { day: Pick<WaveWeekDay, "daylight"> }) {
+  if (day.daylight === null) {
+    // No estimate between sunrise and sunset, which a ragged forecast can
+    // produce. A named absence rather than a blank, for the reason `TideWeek`
+    // gives: an empty cell in a forecast row reads as a flat, quiet day.
+    return <span className="text-fog italic">None</span>;
+  }
 
-export function WaveWeek({
-  day,
-}: {
-  day: Pick<WaveWeekDay, "daylight" | "allDay">;
-}) {
   return (
     <>
       {/*
-        The space between the spans stays, for the reason `DaylightWeek`
-        records: two blocks collapse it visually and it is still a text node,
-        and without it the accessible text runs together as "2:00 PM0.8 ft".
+        The space between the spans stays a text node. It is one line now, so
+        nothing collapses it visually, but the accessible text would still run
+        together as "2:00 PM0.8 ft" without it -- the same concatenation
+        `ReadingCard` records hitting in the accessible-name algorithm.
       */}
-      {day.daylight === null ? (
-        // No estimate between sunrise and sunset, which a ragged forecast can
-        // produce. A named absence rather than a blank: the day's biggest is
-        // on the line below, so the cell still answers.
-        <span className="text-fog italic">None</span>
-      ) : (
-        <>
-          <span className="font-extrabold lg:block">
-            {day.daylight.timeLabel}
-          </span>{" "}
-          <span className="text-fog lg:block">
-            {day.daylight.heightFt.toFixed(1)} ft ·{" "}
-            {Math.round(day.daylight.periodS)} s
-          </span>
-        </>
-      )}
-
-      {/*
-        The period is not repeated here. It qualifies the swell a reader is
-        deciding about, and the day's own estimate is context for that decision
-        rather than a second one to weigh -- the same reason the tide cell's
-        second line carries no datum note.
-      */}
-      <span className="block text-fog">
-        <span className="lg:block">all day</span>{" "}
-        {day.allDay === null ? "none bigger" : worded(day.allDay)}
+      <span className="font-extrabold">{day.daylight.timeLabel}</span>{" "}
+      <span className="text-fog">
+        {day.daylight.heightFt.toFixed(1)} ft ·{" "}
+        {Math.round(day.daylight.periodS)} s
       </span>
     </>
   );

--- a/src/components/conditions/WaveWeek.tsx
+++ b/src/components/conditions/WaveWeek.tsx
@@ -2,14 +2,18 @@
  * One day's biggest swell inside the daylight window, as the week grid prints
  * it.
  *
- * **The label is "Swell", and the selection it names is stated in the day
- * header.** A day has fifty-six three-hourly estimates behind it and this cell
- * shows one of them; which one is a judgement, and on two of ten sampled days
- * the day's smallest and largest fell either side of one of `WavesToday`'s
- * plain-language bands. ADR-0017 put that judgement in the label — "Biggest
- * daylight swell" — and the label never fitted: 187px against 125px of cell at
- * 1280 and 161px at 1536. ADR-0023 moves the daylight half of it into the
- * header, where it is said once for all three rows.
+ * **The label is "Biggest swell", and the half of the selection it drops is
+ * stated in the day header.** A day has fifty-six three-hourly estimates behind
+ * it and this cell shows one of them; which one is a judgement, and on two of
+ * ten sampled days the day's smallest and largest fell either side of one of
+ * `WavesToday`'s plain-language bands. So the superlative has to be in the
+ * label: "Swell" over a single figure invites a reader to take it for the
+ * day's typical swell, which is the one thing it is not.
+ *
+ * What the label does not have to carry is the window, because the header
+ * states it. ADR-0017 put both in — "Biggest daylight swell" — and it rendered
+ * 187px against 133px of cell at 1280, so it wrapped at every width the grid
+ * has had. "Biggest swell" is 112px and fits.
  *
  * **The day's own biggest is no longer here.** On the seven days measured on
  * 2026-08-26 it fell outside daylight on six of them — four of those at 11 PM
@@ -67,7 +71,7 @@ import { SWELL_TONE } from "./weekTone";
 
 /** What every day of this row shares: the words that name it, and its colour. */
 export const WAVE_WEEK_ROW = {
-  label: "Swell",
+  label: "Biggest swell",
   tone: SWELL_TONE,
 } as const;
 

--- a/src/components/conditions/WeekGrid.test.tsx
+++ b/src/components/conditions/WeekGrid.test.tsx
@@ -509,7 +509,7 @@ test("the label sits beside its value until there are columns to stack in", () =
   expect(pair.className).toContain("lg:block");
 
   const label = pair.querySelector("dt")!;
-  expect(label.className).toContain("w-19");
+  expect(label.className).toContain("w-29");
   expect(label.className).toContain("shrink-0");
   expect(label.className).toContain("lg:w-auto");
 });

--- a/src/components/conditions/WeekGrid.test.tsx
+++ b/src/components/conditions/WeekGrid.test.tsx
@@ -44,11 +44,12 @@ test("names every day it was given, in the order it was given them", () => {
   const headings = [...container.querySelectorAll("h3")].map(
     (heading) => heading.textContent,
   );
-  expect(headings).toEqual([
-    "Today · Mon, Aug 17",
-    "Tue, Aug 18",
-    "Wed, Aug 19",
-  ]);
+  // "Today" is a chip on its own line rather than a prefix joined by an
+  // interpunct, and the space between it and the date is a real text node: two
+  // block elements with nothing between them read aloud as "TodayMon, Aug 17",
+  // the concatenation `ReadingCard` records hitting in the accessible-name
+  // algorithm.
+  expect(headings).toEqual(["Today Mon, Aug 17", "Tue, Aug 18", "Wed, Aug 19"]);
 });
 
 test("a day's values follow that day, so the reading order is day then value", () => {
@@ -60,7 +61,7 @@ test("a day's values follow that day, so the reading order is day then value", (
   // `[\s\S]*` rather than `.*` with the dotAll flag, which this TypeScript
   // target does not compile.
   expect(container.textContent).toMatch(
-    /Today · Mon, Aug 17[\s\S]*Lowest tide[\s\S]*6:41 PM[\s\S]*Tue, Aug 18[\s\S]*Lowest tide[\s\S]*7:10 AM/,
+    /Today Mon, Aug 17[\s\S]*Lowest tide[\s\S]*6:41 PM[\s\S]*Tue, Aug 18[\s\S]*Lowest tide[\s\S]*7:10 AM/,
   );
 });
 
@@ -74,9 +75,13 @@ test("a day this row cannot fill gets no pair at all, rather than an empty one",
 });
 
 test("today is named in words, not carried by a colour alone", () => {
-  renderGrid();
+  const { container } = renderGrid();
 
-  expect(screen.getByText(/Today · Mon, Aug 17/)).toBeDefined();
+  // Three things mark today -- an ocean edge, an ocean header band, a yellow
+  // chip -- and the word is what survives if a reader sees none of them.
+  const heading = container.querySelector("ol > li h3")!;
+  expect(heading.textContent).toBe("Today Mon, Aug 17");
+  expect(screen.getByText("Today").className).toContain("bg-yellow");
 });
 
 /**
@@ -264,13 +269,18 @@ test("a day cell takes the radius of a box its own size", () => {
  * a day across seven days — 242px of extra scroll on a phone, on a grid an
  * earlier review had already called too tall there.
  */
-test("the header reserves its second line only where the cell is too narrow", () => {
+test("the chip's line is reserved only where the cell is too narrow", () => {
   const { container } = renderGrid();
 
-  const header = container.querySelector("ol > li h3");
-  expect(header?.className).toContain("xl:min-h-8");
-  expect(header?.className.split(/\s+/)).not.toContain("min-h-8");
-  expect(header?.className.split(/\s+/)).not.toContain("lg:min-h-8");
+  // Reserved on every day, so the six without a chip do not sit a line higher
+  // than the one with it. Only at `xl`: at 1024 the chip and the date measure
+  // about 141px against 221px and share a line, where the reserve would be
+  // 22px a day for nothing.
+  const slot = container.querySelector("ol > li h3 > span")!;
+  expect(slot.className).toContain("xl:min-h-4.5");
+  expect(slot.className).toContain("xl:block");
+  expect(slot.className.split(/\s+/)).not.toContain("block");
+  expect(slot.className.split(/\s+/)).not.toContain("min-h-4.5");
 });
 
 /**
@@ -386,5 +396,120 @@ test("a day given no window renders a header of just its date", () => {
   const { container } = renderGrid();
 
   const header = container.querySelector("ol > li > div")!;
-  expect(header.textContent).toBe("Today · Mon, Aug 17");
+  expect(header.textContent).toBe("Today Mon, Aug 17");
+});
+
+/* =========================================================================
+ * The band, the rules and the colour key
+ * ========================================================================= */
+
+/**
+ * The header is a filled band rather than more text on the same white field,
+ * which is what says "this is the day" without a word. Four labelled pairs run
+ * together on one surface was the shape the 2026-08-27 review called
+ * undifferentiated.
+ *
+ * jsdom applies no stylesheets (ADR-0001), so what is assertable is which
+ * classes compose. That ocean at 8.5:1 and mist at 5.0:1 read as intended is a
+ * human check at the review viewport -- the compromise ADR-0004 and ADR-0014
+ * already record.
+ */
+test("the day header is a band, and today's is the saturated one", () => {
+  const { container } = renderGrid();
+
+  const bands = [...container.querySelectorAll("ol > li > div:first-child")];
+  expect(bands).toHaveLength(3);
+
+  expect(bands[0].className).toContain("bg-ocean");
+  expect(bands[0].className).toContain("text-white/85");
+  expect(bands[1].className).toContain("bg-mist");
+  expect(bands[1].className).toContain("text-fog");
+
+  // Every band carries the same border width, so the marked day is not
+  // narrower inside than its neighbours -- the property the cell's own edge
+  // has always held and the band now has to hold too.
+  for (const band of bands) {
+    expect(band.className).toContain("border-b-[1.5px]");
+  }
+});
+
+test("the band is clipped by the tile's corner rather than squaring it off", () => {
+  const { container } = renderGrid();
+
+  const cell = container.querySelector("ol > li")!;
+  expect(cell.className).toContain("rounded-tile");
+  expect(cell.className).toContain("overflow-hidden");
+});
+
+test("a hairline separates the readings, and none sits above the first", () => {
+  const { container } = renderGrid({ rows: [TIDE_ROW, WAVE_ROW] });
+
+  const pairs = [...container.querySelectorAll("ol > li:first-child dl > div")];
+  expect(pairs).toHaveLength(2);
+  for (const pair of pairs) {
+    expect(pair.className).toContain("border-t");
+    expect(pair.className).toContain("border-lavender");
+  }
+  // `first:border-t-0` rather than a rule on all but the first, because rows
+  // are ragged: which reading comes first differs by day.
+  expect(pairs[0].className).toContain("first:border-t-0");
+});
+
+/**
+ * Colour per product and constant across all seven days, which is what keeps
+ * it clear of ADR-0009. A row that brings no tone keeps fog, the colour every
+ * label in this grid had before there was a key -- so a caller that has not
+ * thought about it cannot accidentally assert anything.
+ */
+test("a row's label takes the row's own colour, in every day", () => {
+  const { container } = renderGrid({
+    rows: [
+      { ...TIDE_ROW, tone: "text-ocean" },
+      { ...WAVE_ROW, tone: "text-purple" },
+    ],
+  });
+
+  const tide = [...container.querySelectorAll("dt")].filter(
+    (dt) => dt.textContent === "Lowest tide",
+  );
+  expect(tide).toHaveLength(2);
+  for (const dt of tide) {
+    expect(dt.className).toContain("text-ocean");
+  }
+
+  expect(
+    [...container.querySelectorAll("dt")]
+      .filter((dt) => dt.textContent === "Biggest swell")
+      .every((dt) => dt.className.includes("text-purple")),
+  ).toBe(true);
+});
+
+test("a row with no colour of its own stays fog", () => {
+  const { container } = renderGrid();
+
+  const label = container.querySelector("dt")!;
+  expect(label.className).toContain("text-fog");
+});
+
+/**
+ * A 10px label alone on a 303px line is most of the line wasted, and below
+ * `lg` a day is a full-width block. `LOW TIDE` is 70px, so a 76px column holds
+ * every label the grid has and leaves 217px at 375 — enough for the longest
+ * value in the cell. Measured: a day goes 214px to 169px at 375.
+ *
+ * Not the `lg:block` the four cell components lost. Those forced a break
+ * inside one value to keep seven narrow columns in step; this chooses where a
+ * label sits relative to its value.
+ */
+test("the label sits beside its value until there are columns to stack in", () => {
+  const { container } = renderGrid();
+
+  const pair = container.querySelector("ol > li dl > div")!;
+  expect(pair.className).toContain("flex");
+  expect(pair.className).toContain("lg:block");
+
+  const label = pair.querySelector("dt")!;
+  expect(label.className).toContain("w-19");
+  expect(label.className).toContain("shrink-0");
+  expect(label.className).toContain("lg:w-auto");
 });

--- a/src/components/conditions/WeekGrid.test.tsx
+++ b/src/components/conditions/WeekGrid.test.tsx
@@ -120,7 +120,9 @@ test("the transpose is one property, so there is no hidden copy to keep in step"
   const { container } = renderGrid();
 
   const grid = container.querySelector("ol");
-  expect(grid?.className).toContain("lg:grid-cols-7");
+  expect(grid?.className).toContain("md:grid-cols-2");
+  expect(grid?.className).toContain("lg:grid-cols-4");
+  expect(grid?.className).toContain("xl:grid-cols-7");
   expect(container.innerHTML).not.toContain("lg:hidden");
 });
 
@@ -188,10 +190,10 @@ test("the reserved band says it belongs to the week above it", () => {
 test("the reserved band steps at the same width the days do", () => {
   renderGrid({ reserved: RESERVED });
 
-  // The day blocks are `lg:grid-cols-7`, so at `sm` the live week is stacked
-  // full-width. Three slots side by side from 640px gave roughly 26 characters
-  // over five ragged lines at 768 -- the page's own responsive logic
-  // disagreeing with itself in adjacent bands of the same section.
+  // `lg` is where the days above first go wider than two. Three slots side by
+  // side from 640px gave roughly 26 characters over five ragged lines at 768,
+  // while the live week was still stacked full-width -- the page's own
+  // responsive logic disagreeing with itself in adjacent bands of one section.
   const band = reservedSlot()?.parentElement;
   expect(band?.className).toContain("lg:grid-cols-3");
   expect(band?.className).not.toContain("sm:grid-cols-3");
@@ -253,17 +255,38 @@ test("a day cell takes the radius of a box its own size", () => {
 });
 
 /**
- * Regression, paired with the one in `DaylightWeek.test.tsx`. The reserved
- * header line keeps seven columns in step at `lg`. Below `lg` there is one
- * column and nothing to be in step with, and the header does not wrap at that
- * width either — so the reserve was pure height on a phone.
+ * Regression. `TODAY · THU, AUG 27` is 151px against 125px of cell at 1280, so
+ * the marked day wraps where the other six do not and every row beneath it
+ * sits a line lower than the same row beside it. The reserve buys that back.
+ *
+ * Scoped to `xl` because that is where seven columns start. Below it there are
+ * at most four, the header fits on one line, and an unscoped reserve was 35px
+ * a day across seven days — 242px of extra scroll on a phone, on a grid an
+ * earlier review had already called too tall there.
  */
-test("the header reserves its second line only where there are columns", () => {
+test("the header reserves its second line only where the cell is too narrow", () => {
   const { container } = renderGrid();
 
   const header = container.querySelector("ol > li h3");
-  expect(header?.className).toContain("lg:min-h-8");
+  expect(header?.className).toContain("xl:min-h-8");
   expect(header?.className.split(/\s+/)).not.toContain("min-h-8");
+  expect(header?.className.split(/\s+/)).not.toContain("lg:min-h-8");
+});
+
+/**
+ * The measurement the breakpoint step exists for. Seven columns at 1024 give a
+ * cell 120px wide and 88px of content — narrower than `THU, AUG 27` renders at
+ * 89px — which is what forced every hard-coded line break the four cell
+ * components used to carry. jsdom applies no stylesheets (ADR-0001), so what
+ * is assertable here is that seven columns wait for `xl` and that the widths
+ * between are filled rather than jumping straight from one.
+ */
+test("seven columns wait for the width that can hold them", () => {
+  const { container } = renderGrid();
+
+  const grid = container.querySelector("ol")!;
+  expect(grid.className).not.toContain("lg:grid-cols-7");
+  expect(grid.className).not.toContain("sm:grid-cols");
 });
 
 /* =========================================================================
@@ -320,4 +343,48 @@ test("a row with no source prints no line at all", () => {
   const { container } = renderGrid({ rows: [TIDE_ROW] });
 
   expect(container.querySelectorAll("p").length).toBe(0);
+});
+
+/* =========================================================================
+ * The daylight window: the day's header, not a row inside it
+ * ========================================================================= */
+
+/** The same three days, each carrying the window its figures are selected in. */
+const DAYS_WITH_DAYLIGHT: WeekDay[] = DAYS.map((day, i) => ({
+  ...day,
+  daylight: <p>{`6:2${i} AM to 7:2${i} PM`}</p>,
+}));
+
+test("the daylight window sits in the header, above every pair in the day", () => {
+  // Not a `WeekRow`: a row states a figure, and this states the scope the
+  // figures are selected within. That is what lets the labels below be "Low
+  // tide" rather than "Lowest daylight tide" -- see the plan.
+  const { container } = renderGrid({ days: DAYS_WITH_DAYLIGHT });
+
+  const window = screen.getByText("6:20 AM to 7:20 PM");
+  const day = container.querySelector("ol > li")!;
+  expect(day.contains(window)).toBe(true);
+  expect(day.querySelector("dl")!.contains(window)).toBe(false);
+
+  const heading = day.querySelector("h3")!;
+  expect(
+    heading.compareDocumentPosition(window) & Node.DOCUMENT_POSITION_FOLLOWING,
+  ).toBeTruthy();
+});
+
+test("every day carries its own window, since sunset moves across the week", () => {
+  renderGrid({ days: DAYS_WITH_DAYLIGHT });
+
+  expect(screen.getByText("6:20 AM to 7:20 PM")).toBeDefined();
+  expect(screen.getByText("6:21 AM to 7:21 PM")).toBeDefined();
+  expect(screen.getByText("6:22 AM to 7:22 PM")).toBeDefined();
+});
+
+test("a day given no window renders a header of just its date", () => {
+  // The grid must not draw a gap where a line would be: `WeekPanel` computes
+  // daylight and cannot fail, but the grid is not the thing that knows that.
+  const { container } = renderGrid();
+
+  const header = container.querySelector("ol > li > div")!;
+  expect(header.textContent).toBe("Today · Mon, Aug 17");
 });

--- a/src/components/conditions/WeekGrid.test.tsx
+++ b/src/components/conditions/WeekGrid.test.tsx
@@ -4,9 +4,24 @@ import { REGION_HEADING } from "./headingRank";
 import { WeekGrid, type WeekDay, type WeekRow } from "./WeekGrid";
 
 const DAYS: WeekDay[] = [
-  { localDate: "2026-08-17", dayLabel: "Mon, Aug 17", isToday: true },
-  { localDate: "2026-08-18", dayLabel: "Tue, Aug 18", isToday: false },
-  { localDate: "2026-08-19", dayLabel: "Wed, Aug 19", isToday: false },
+  {
+    localDate: "2026-08-17",
+    dayLabel: "Mon, Aug 17",
+    dateLabel: "Aug 17",
+    isToday: true,
+  },
+  {
+    localDate: "2026-08-18",
+    dayLabel: "Tue, Aug 18",
+    dateLabel: "Aug 18",
+    isToday: false,
+  },
+  {
+    localDate: "2026-08-19",
+    dayLabel: "Wed, Aug 19",
+    dateLabel: "Aug 19",
+    isToday: false,
+  },
 ];
 
 /** Deliberately ragged: the 19th is missing, which is a row this product cannot fill that far out. */
@@ -44,12 +59,13 @@ test("names every day it was given, in the order it was given them", () => {
   const headings = [...container.querySelectorAll("h3")].map(
     (heading) => heading.textContent,
   );
-  // "Today" is a chip on its own line rather than a prefix joined by an
-  // interpunct, and the space between it and the date is a real text node: two
-  // block elements with nothing between them read aloud as "TodayMon, Aug 17",
-  // the concatenation `ReadingCard` records hitting in the accessible-name
-  // algorithm.
-  expect(headings).toEqual(["Today Mon, Aug 17", "Tue, Aug 18", "Wed, Aug 19"]);
+  // Today's column reads its date without a weekday, because the chip beside
+  // it already says which day this is -- and dropping that token is what lets
+  // the chip sit on the date's line instead of reserving a line above it in all
+  // seven columns. The space before "Today" is a real text node: two elements
+  // with nothing between them read aloud as "Aug 17Today", the concatenation
+  // `ReadingCard` records hitting in the accessible-name algorithm.
+  expect(headings).toEqual(["Aug 17 Today", "Tue, Aug 18", "Wed, Aug 19"]);
 });
 
 test("a day's values follow that day, so the reading order is day then value", () => {
@@ -61,7 +77,7 @@ test("a day's values follow that day, so the reading order is day then value", (
   // `[\s\S]*` rather than `.*` with the dotAll flag, which this TypeScript
   // target does not compile.
   expect(container.textContent).toMatch(
-    /Today Mon, Aug 17[\s\S]*Lowest tide[\s\S]*6:41 PM[\s\S]*Tue, Aug 18[\s\S]*Lowest tide[\s\S]*7:10 AM/,
+    /Aug 17 Today[\s\S]*Lowest tide[\s\S]*6:41 PM[\s\S]*Tue, Aug 18[\s\S]*Lowest tide[\s\S]*7:10 AM/,
   );
 });
 
@@ -80,7 +96,7 @@ test("today is named in words, not carried by a colour alone", () => {
   // Three things mark today -- an ocean edge, an ocean header band, a yellow
   // chip -- and the word is what survives if a reader sees none of them.
   const heading = container.querySelector("ol > li h3")!;
-  expect(heading.textContent).toBe("Today Mon, Aug 17");
+  expect(heading.textContent).toBe("Aug 17 Today");
   expect(screen.getByText("Today").className).toContain("bg-yellow");
 });
 
@@ -269,18 +285,41 @@ test("a day cell takes the radius of a box its own size", () => {
  * a day across seven days — 242px of extra scroll on a phone, on a grid an
  * earlier review had already called too tall there.
  */
-test("the chip's line is reserved only where the cell is too narrow", () => {
+/**
+ * Regression. The chip had a reserved line above it, because
+ * `TODAY · THU, AUG 28` is 151px against 133px of band at 1280 and wrapped on
+ * the marked day alone. Reserving fixed the alignment and cost 22px of empty
+ * band at the top of the other six columns, which is what a reader saw.
+ *
+ * `dateLabel` is what replaced it: `AUG 28` is 51px and the chip 54px, so the
+ * pair comes to 111px and fits. Nothing is reserved anywhere now, and the six
+ * days without a chip must not carry a slot for one.
+ */
+test("no column reserves a line for a chip it does not have", () => {
   const { container } = renderGrid();
 
-  // Reserved on every day, so the six without a chip do not sit a line higher
-  // than the one with it. Only at `xl`: at 1024 the chip and the date measure
-  // about 141px against 221px and share a line, where the reserve would be
-  // 22px a day for nothing.
-  const slot = container.querySelector("ol > li h3 > span")!;
-  expect(slot.className).toContain("xl:min-h-4.5");
-  expect(slot.className).toContain("xl:block");
-  expect(slot.className.split(/\s+/)).not.toContain("block");
-  expect(slot.className.split(/\s+/)).not.toContain("min-h-4.5");
+  const headings = [...container.querySelectorAll("ol > li h3")];
+  for (const heading of headings) {
+    expect(heading.className).not.toContain("min-h");
+    for (const span of heading.querySelectorAll("span")) {
+      expect(span.className).not.toContain("min-h");
+    }
+  }
+
+  // Only today has a child element in its heading at all: the chip.
+  expect(headings[0].querySelectorAll("span")).toHaveLength(1);
+  expect(headings[1].querySelectorAll("span")).toHaveLength(0);
+});
+
+test("the chip follows the date rather than sitting above it", () => {
+  const { container } = renderGrid();
+
+  const heading = container.querySelector("ol > li h3")!;
+  const chip = screen.getByText("Today");
+  expect(
+    chip.compareDocumentPosition(heading.firstChild!) &
+      Node.DOCUMENT_POSITION_PRECEDING,
+  ).toBeTruthy();
 });
 
 /**
@@ -396,7 +435,7 @@ test("a day given no window renders a header of just its date", () => {
   const { container } = renderGrid();
 
   const header = container.querySelector("ol > li > div")!;
-  expect(header.textContent).toBe("Today Mon, Aug 17");
+  expect(header.textContent).toBe("Aug 17 Today");
 });
 
 /* =========================================================================

--- a/src/components/conditions/WeekGrid.tsx
+++ b/src/components/conditions/WeekGrid.tsx
@@ -114,6 +114,16 @@ export type WeekRow = {
    */
   cells: Readonly<Record<string, ReactNode>>;
   /**
+   * The colour this row's label takes, in every day of the week.
+   *
+   * A text-colour utility rather than a token, and the set of them lives in
+   * `weekTone.ts` with the contrast figures and the argument that colour per
+   * product is not the verdict ADR-0009 forbids. Optional, and fog without it:
+   * a caller that has not thought about the key gets the colour every label in
+   * this grid had before there was one.
+   */
+  tone?: string;
+  /**
    * Where this row's figures came from, printed once beneath the grid.
    *
    * Optional because most rows do not need one. The tide row's station is
@@ -183,89 +193,151 @@ export function WeekGrid({
         could not be reached has a note above and nothing to tabulate, and an
         empty list announced as a list would be worse than no list.
 
-        Today is marked by a border and by the word "Today", never by a surface.
-        `bg-lavender` was tried and removed: fog on lavender is 4.29:1, under
-        the 4.5:1 this page holds itself to, and it would have reintroduced on
-        one column the exact failure `globals.css` records fog being darkened to
-        escape. A border is a boundary rather than text, and ocean clears 7:1 as
-        one. Every block carries the same border width so the marked day is not
-        wider than its neighbours -- what changes is only its colour.
+        Today is marked three ways and none of them is a bare fill behind
+        running text. Its edge is ocean where the others are lavender, its
+        header band is ocean where the others are mist, and it carries the word
+        "Today" on a yellow chip. `bg-lavender` behind the whole cell was tried
+        and removed once: fog on lavender is 4.29:1, under the 4.5:1 this page
+        holds itself to. The band escapes that because the text on it is white
+        rather than fog -- 8.5:1 for the day name on ocean, 6.7:1 for the window
+        beneath it at `white/85`.
 
-        `rounded-tile` with a `lavender` edge on `white/60`, which is the
-        treatment `SessionSchedule` and `/art` already use for a box this size,
-        rather than `rounded-card` on `bg-mist`. Two things were wrong with
-        that. The radius is a 520px hero card's, and on a 159x148 cell it is 15%
-        of the width -- the corner stops being a corner. And `mist` sits at
-        1.10:1 against the cream page, so the fill was never visible and the
-        corner arc was most of what the eye had to go on: a large radius on an
-        invisible surface is what reads as a blob. The reading cards escaped
-        this by going dark (ADR-0015); a cell this size takes the edge instead,
-        because seven dark blocks under a dark band is a different page.
+        Every cell carries the same border width so the marked day is not
+        narrower inside than its neighbours; only the colour changes.
+
+        **The header is a band rather than more text on the same surface**, and
+        that is what the reading below turns on. Four labelled pairs run
+        together on one white field was the shape the 2026-08-27 review called
+        undifferentiated, and it had no way to say which line was the day and
+        which was a figure. A filled band says "this is the day" without a word,
+        and the hairline rules inside the body say where one reading stops and
+        the next begins. Rules rather than boxes: the tile is already a box, and
+        three more nested inside a 157px cell is the mess this is escaping.
+
+        The band is ADR-0015's vocabulary one row down. That decision put the
+        reading cards on a saturated surface with a yellow eyebrow because the
+        page "does not look like the site it belongs to", left the week grid
+        pale, and said in as many words that if the difference ever read as an
+        oversight rather than a distinction, this is the decision it gets
+        converted against. It did. The grid keeps its own register -- a pale
+        tile with one filled band, not a dark card -- because "now" and
+        "planning" are still different things.
+
+        `rounded-tile` with `overflow-hidden`, so the band is clipped by the
+        corner rather than squaring it off. The radius is the one
+        `SessionSchedule` and `/art` already use for a box this size, rather
+        than the 520px hero card's `rounded-card`: on a 157px cell that is 15%
+        of the width and the corner stops being a corner.
       */}
       {days.length > 0 && (
         <ol className="mb-4 grid gap-3 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-7">
           {days.map((day) => (
             <li
               key={day.localDate}
-              className={`rounded-tile border-[1.5px] bg-white/60 px-4 py-3 ${
+              className={`overflow-hidden rounded-tile border-[1.5px] bg-white/60 ${
                 day.isToday ? "border-ocean" : "border-lavender"
               }`}
             >
-              {/*
-                `min-h-8` holds two lines whether or not this day needs them.
-                `TODAY · THU, AUG 27` renders 151px against 125px of cell at
-                1280, so the marked day wraps where the other six do not -- and
-                every row beneath it in that column then sits a line lower than
-                the same row beside it. Reserving the line is what keeps the
-                seven columns readable across rather than only down.
+              <div
+                className={`border-b-[1.5px] px-3 py-2 ${
+                  day.isToday
+                    ? "border-ocean bg-ocean text-white/85"
+                    : "border-lavender bg-mist text-fog"
+                }`}
+              >
+                <h3
+                  className={`text-2xs font-extrabold tracking-widest uppercase ${
+                    day.isToday ? "text-white" : "text-ocean"
+                  }`}
+                >
+                  {/*
+                    The chip's line is reserved on every day at `xl` and shared
+                    with the date below it. `TODAY · THU, AUG 27` renders 151px
+                    against 125px of cell at 1280, so the marked day wraps where
+                    the other six do not, and every row beneath it in that column
+                    then sits a line lower than the same row beside it. Reserving
+                    the line is what keeps seven columns readable across rather
+                    than only down.
 
-                It costs one line. Together with the daylight cell's
-                deliberate break, the grid goes 146px to 163px at 1280 -- no
-                cell had both a two-line header and a two-line value before,
-                and now every cell has both. That is the price of the seven
-                columns being identical, paid once and below the fold, and it
-                is worth it: a grid whose rows do not line up across is a table
-                pretending.
+                    Only at `xl`, because only there is the cell too narrow to
+                    hold both: at 1024 the chip and the date measure about 141px
+                    against 221px, so they sit on one line and the reserve would
+                    be 22px a day for nothing. It shipped unscoped once and put
+                    242px of extra scroll on a phone.
 
-                `xl:` because that price is only worth paying where the cell is
-                too narrow to hold the line. Below `xl` there are at most four
-                columns, the header fits on one line, and reserving a second
-                bought nothing while costing 35px a day across seven days. It
-                shipped unscoped once and put 242px of extra scroll on a phone,
-                on a grid the 2026-08-24 review had already called too tall
-                there; it was measured at 1280 and 1536 and not at 375. It
-                moved from `lg:` to `xl:` with the columns it exists to align.
-
-                Reserved rather than shortened. "Today" alone fits, and drops
-                the date from the one column a reader without the layout most
-                needs it named in; splitting the visible text from the
-                accessible one would need an `sr-only`, which this repo does
-                not use (`ReadingCard` records why).
-              */}
-              <div className="mb-2">
-                <h3 className="text-2xs font-extrabold tracking-widest text-ocean uppercase xl:min-h-8">
-                  {day.isToday ? `Today · ${day.dayLabel}` : day.dayLabel}
+                    Reserved rather than shortened. "Today" alone fits and drops
+                    the date from the one column a reader without the layout most
+                    needs it named in; splitting the visible text from the
+                    accessible one would need an `sr-only`, which this repo does
+                    not use (`ReadingCard` records why). What the band changes is
+                    how the empty line reads: on a tinted surface it is the
+                    band's padding rather than a line that failed to render.
+                  */}
+                  <span className="xl:mb-1 xl:block xl:min-h-4.5">
+                    {day.isToday && (
+                      <>
+                        <span className="rounded-pill bg-yellow px-1.5 py-0.5 tracking-wider text-dark">
+                          Today
+                        </span>{" "}
+                      </>
+                    )}
+                  </span>
+                  {day.dayLabel}
                 </h3>
                 {/*
                   Inside the header rather than in the `<dl>` below, because it
                   scopes every pair in that list rather than being one of them.
                   That is what lets the labels below drop the word "daylight" —
-                  see `WeekDay.daylight` and `DaylightWeek`.
+                  see `WeekDay.daylight` and `DaylightWeek`. It takes its colour
+                  from this band, which is why it sets none of its own.
                 */}
                 {day.daylight}
               </div>
 
-              <dl>
+              <dl className="px-3 pb-2">
                 {rows.map((row) => {
                   const cell = row.cells[day.localDate];
                   if (cell === undefined) return null;
 
                   return (
-                    <div key={row.label} className="mb-2 last:mb-0">
-                      <dt className="text-2xs font-extrabold tracking-widest text-fog uppercase">
+                    <div
+                      key={row.label}
+                      className="flex items-baseline gap-2.5 border-t border-lavender py-2 first:border-t-0 lg:block"
+                    >
+                      {/*
+                        **Label beside the value below `lg`, above it from
+                        `lg`.** A day is a full-width block at one and two
+                        columns -- 303px of content at 375, 328px at 768 -- and
+                        a 10px label alone on a line that wide is most of the
+                        line wasted. `LOW TIDE` is 70px, so a 76px column holds
+                        every label in the grid and leaves 217px at 375, which
+                        takes the longest value the cell has (`65% Slight chance
+                        rain showers`, 203px) without wrapping. Measured at
+                        375: a day goes 214px to 169px with this alone, and
+                        250px to 169px against what the grid shipped before
+                        ADR-0023 -- 1822px of week to 1256px.
+
+                        This is not the `lg:block` the four cell components just
+                        lost. Those forced a break *inside* one value to keep
+                        seven narrow columns in step; this chooses where a label
+                        sits relative to its value, and it flips at `lg` because
+                        that is where four columns make the cell 221px and the
+                        76px column stops being affordable.
+
+                        The tone is the row's, and constant across all seven
+                        days — see `weekTone.ts` for the contrast measurements
+                        and for why colour per product is not the verdict
+                        ADR-0009 forbids. A row that brings none stays fog,
+                        which is what every label here used to be.
+                      */}
+                      <dt
+                        className={`text-2xs w-19 shrink-0 font-extrabold tracking-widest uppercase lg:w-auto ${
+                          row.tone ?? "text-fog"
+                        }`}
+                      >
                         {row.label}
                       </dt>
-                      <dd className="text-base text-dark">{cell}</dd>
+                      <dd className="min-w-0 text-base text-dark">{cell}</dd>
                     </div>
                   );
                 })}

--- a/src/components/conditions/WeekGrid.tsx
+++ b/src/components/conditions/WeekGrid.tsx
@@ -3,10 +3,20 @@
  *
  * **The DOM is day-major and identical at every width.** Each of the seven days
  * is one block holding that day's figures, and the only thing that moves
- * between breakpoints is `grid-template-columns`: one column below `lg`, seven
- * at `lg` and up. So the grid transposes without reparenting anything, which is
- * why ADR-0005's render-twice allowance is not invoked here and no hidden
- * second copy exists to drift out of step with the first.
+ * between breakpoints is `grid-template-columns`: one column, then two, four
+ * and seven at `md`, `lg` and `xl`. So the grid transposes without reparenting
+ * anything, which is why ADR-0005's render-twice allowance is not invoked here
+ * and no hidden second copy exists to drift out of step with the first.
+ *
+ * **Seven columns start at `xl`, and used to start at `lg`.** At 1024 seven
+ * columns give a cell 120px, of which 88px is content -- narrower than
+ * `THU, AUG 27` renders at 89px. Every hard-coded line break the four cell
+ * components used to carry was really describing that number, and the grid was
+ * 84px *taller* at 1024 than at 1536 because of them. Four columns there give
+ * 223px, and all seven days still stand on one screen as 4 + 3. The cost is
+ * that between 1024 and 1279 the week is two rows rather than one, which is a
+ * real loss for comparing across days and the reason this is a breakpoint
+ * rather than a rewrite. See `docs/plans/week-grid-legibility.md`.
  *
  * **It transposes rather than scrolling, and that departs from a stated
  * convention on purpose.** `globals.css` says small screens swipe and large
@@ -49,6 +59,20 @@ export type WeekDay = {
   dayLabel: string;
   /** True for the day the reader is standing in. Decided upstream, so this renders no clock. */
   isToday: boolean;
+  /**
+   * The window this day's figures fall inside, printed in the header.
+   *
+   * A slot on the day rather than a `WeekRow`, because a row is a `<dt>`/`<dd>`
+   * pair repeated inside every day block and this is one line above all of
+   * them. The distinction is the point: a row states a figure, and this states
+   * the scope the figures are selected within, which is what lets their labels
+   * be "Low tide" rather than "Lowest daylight tide". See
+   * `docs/plans/week-grid-legibility.md`.
+   *
+   * Optional, so a grid with nothing to scope renders a header of just the
+   * date rather than a gap where a line should be.
+   */
+  daylight?: ReactNode;
 };
 
 /**
@@ -150,9 +174,10 @@ export function WeekGrid({
       ))}
 
       {/*
-        `grid` alone is one column; `lg:grid-cols-7` is seven. That single
-        property is the whole transpose — see this file's header for why it has
-        to be, and why nothing here is hidden at any width.
+        `grid` alone is one column; the three `grid-cols-*` steps are the rest.
+        That single property is the whole transpose — see this file's header for
+        why it has to be, why nothing here is hidden at any width, and why seven
+        columns wait for `xl`.
 
         No days at all is a real state rather than an oversight: a station that
         could not be reached has a note above and nothing to tabulate, and an
@@ -178,7 +203,7 @@ export function WeekGrid({
         because seven dark blocks under a dark band is a different page.
       */}
       {days.length > 0 && (
-        <ol className="mb-4 grid gap-3 lg:grid-cols-7">
+        <ol className="mb-4 grid gap-3 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-7">
           {days.map((day) => (
             <li
               key={day.localDate}
@@ -188,12 +213,11 @@ export function WeekGrid({
             >
               {/*
                 `min-h-8` holds two lines whether or not this day needs them.
-                "Today · " is eight characters of a 10px `tracking-widest`
-                label in a 124px cell, so the marked day wraps where the other
-                six do not -- and every row beneath it in that column then sits
-                a line lower than the same row beside it. Reserving the line is
-                what keeps the seven columns readable across rather than only
-                down.
+                `TODAY · THU, AUG 27` renders 151px against 125px of cell at
+                1280, so the marked day wraps where the other six do not -- and
+                every row beneath it in that column then sits a line lower than
+                the same row beside it. Reserving the line is what keeps the
+                seven columns readable across rather than only down.
 
                 It costs one line. Together with the daylight cell's
                 deliberate break, the grid goes 146px to 163px at 1280 -- no
@@ -203,14 +227,14 @@ export function WeekGrid({
                 is worth it: a grid whose rows do not line up across is a table
                 pretending.
 
-                `lg:` because that price is only worth paying where there are
-                columns. Below `lg` the grid is one column, a day is a
-                full-width row, and this header does not wrap -- so reserving
-                the line there bought nothing and cost 35px a day across seven
-                days. It shipped unscoped and put 242px of extra scroll on a
-                phone, on a grid the 2026-08-24 review had already reported as
-                too tall there; it was measured at 1280 and 1536 and not at
-                375.
+                `xl:` because that price is only worth paying where the cell is
+                too narrow to hold the line. Below `xl` there are at most four
+                columns, the header fits on one line, and reserving a second
+                bought nothing while costing 35px a day across seven days. It
+                shipped unscoped once and put 242px of extra scroll on a phone,
+                on a grid the 2026-08-24 review had already called too tall
+                there; it was measured at 1280 and 1536 and not at 375. It
+                moved from `lg:` to `xl:` with the columns it exists to align.
 
                 Reserved rather than shortened. "Today" alone fits, and drops
                 the date from the one column a reader without the layout most
@@ -218,9 +242,18 @@ export function WeekGrid({
                 accessible one would need an `sr-only`, which this repo does
                 not use (`ReadingCard` records why).
               */}
-              <h3 className="text-2xs mb-2 font-extrabold tracking-widest text-ocean uppercase lg:min-h-8">
-                {day.isToday ? `Today · ${day.dayLabel}` : day.dayLabel}
-              </h3>
+              <div className="mb-2">
+                <h3 className="text-2xs font-extrabold tracking-widest text-ocean uppercase xl:min-h-8">
+                  {day.isToday ? `Today · ${day.dayLabel}` : day.dayLabel}
+                </h3>
+                {/*
+                  Inside the header rather than in the `<dl>` below, because it
+                  scopes every pair in that list rather than being one of them.
+                  That is what lets the labels below drop the word "daylight" —
+                  see `WeekDay.daylight` and `DaylightWeek`.
+                */}
+                {day.daylight}
+              </div>
 
               <dl>
                 {rows.map((row) => {
@@ -299,12 +332,13 @@ export function WeekGrid({
             Each of these will join the week above as a row of its own.
           </p>
           {/*
-            `lg:grid-cols-3`, matching the days above rather than stepping a
-            breakpoint earlier. The day blocks stay one column until `lg`, so
-            at `sm` the live week was stacked full-width while these three sat
-            side by side at 216px each -- roughly 26 characters over five
-            ragged lines. The week said 768 was narrow and the slots said it
-            was wide, in adjacent bands of the same section.
+            `lg:grid-cols-3`, which is where the days above first go wider
+            than two. These three once sat side by side from `sm` at 216px
+            each -- roughly 26 characters over five ragged lines -- while the
+            live week was still stacked full-width: the week said 768 was
+            narrow and the slots said it was wide, in adjacent bands of the
+            same section. Three across beside four days is close enough that
+            neither band contradicts the other.
           */}
           <div className="grid gap-3 lg:grid-cols-3">
             {reserved.map((slot) => (

--- a/src/components/conditions/WeekGrid.tsx
+++ b/src/components/conditions/WeekGrid.tsx
@@ -57,6 +57,15 @@ export type WeekDay = {
   localDate: string;
   /** That date named for a reader, `Mon, Aug 17`. */
   dayLabel: string;
+  /**
+   * The same date without its weekday, `Aug 17`.
+   *
+   * Used only on today's column, which carries a chip reading "Today" beside
+   * it. A weekday next to that chip is the most redundant token in the grid,
+   * and dropping it is what lets the chip sit on the date's own line instead of
+   * reserving a line above it in all seven columns.
+   */
+  dateLabel: string;
   /** True for the day the reader is standing in. Decided upstream, so this renders no clock. */
   isToday: boolean;
   /**
@@ -251,38 +260,49 @@ export function WeekGrid({
                   }`}
                 >
                   {/*
-                    The chip's line is reserved on every day at `xl` and shared
-                    with the date below it. `TODAY · THU, AUG 27` renders 151px
-                    against 125px of cell at 1280, so the marked day wraps where
-                    the other six do not, and every row beneath it in that column
-                    then sits a line lower than the same row beside it. Reserving
-                    the line is what keeps seven columns readable across rather
-                    than only down.
+                    **The chip sits after the date, on the date's own line.**
+                    It had a reserved line above it, because `TODAY · THU, AUG
+                    28` is 151px against 133px of band at 1280 and would wrap
+                    on the marked day alone -- putting every row beneath it in
+                    that column a line lower than its neighbours. Reserving the
+                    line fixed the alignment and cost 22px of empty band at the
+                    top of the other six columns, which is what a reader
+                    actually saw.
 
-                    Only at `xl`, because only there is the cell too narrow to
-                    hold both: at 1024 the chip and the date measure about 141px
-                    against 221px, so they sit on one line and the reserve would
-                    be 22px a day for nothing. It shipped unscoped once and put
-                    242px of extra scroll on a phone.
+                    What makes the chip fit is `dateLabel`. Measured at 1280:
+                    the full `THU, AUG 28` is 89px and the chip is 54px, which
+                    with a space between them overruns a 133px band; `AUG 28` is
+                    51px and the pair comes to 111px. So today's column drops
+                    its weekday and nothing is reserved anywhere.
 
-                    Reserved rather than shortened. "Today" alone fits and drops
-                    the date from the one column a reader without the layout most
-                    needs it named in; splitting the visible text from the
-                    accessible one would need an `sr-only`, which this repo does
-                    not use (`ReadingCard` records why). What the band changes is
-                    how the empty line reads: on a tinted surface it is the
-                    band's padding rather than a line that failed to render.
+                    Dropping the weekday costs today's column the least useful
+                    token it has. The chip already says which day this is, and
+                    the month stays -- so the row still shows the month turning
+                    over mid-week, which was the objection to shortening this
+                    heading the first time.
+
+                    `leading-none` on the chip, so its padding fits inside the
+                    heading's own line box. Without it the chip is 16px against
+                    the other columns' 15px, and today's band renders a pixel
+                    taller than the six beside it -- which is the same
+                    misalignment in miniature that the reserved line was
+                    introduced to prevent.
+
+                    Inline rather than a flex row, and with a real space text
+                    node before the chip. Two flex items with nothing between
+                    them read aloud as "Aug 28Today", which is the
+                    concatenation `ReadingCard` records hitting in the
+                    accessible-name algorithm.
                   */}
-                  <span className="xl:mb-1 xl:block xl:min-h-4.5">
-                    {day.isToday && (
-                      <>
-                        <span className="rounded-pill bg-yellow px-1.5 py-0.5 tracking-wider text-dark">
-                          Today
-                        </span>{" "}
-                      </>
-                    )}
-                  </span>
-                  {day.dayLabel}
+                  {day.isToday ? day.dateLabel : day.dayLabel}
+                  {day.isToday && (
+                    <>
+                      {" "}
+                      <span className="leading-none rounded-pill bg-yellow px-1.5 py-0.5 align-[0.1em] text-dark">
+                        Today
+                      </span>
+                    </>
+                  )}
                 </h3>
                 {/*
                   Inside the header rather than in the `<dl>` below, because it

--- a/src/components/conditions/WeekGrid.tsx
+++ b/src/components/conditions/WeekGrid.tsx
@@ -307,15 +307,19 @@ export function WeekGrid({
                       {/*
                         **Label beside the value below `lg`, above it from
                         `lg`.** A day is a full-width block at one and two
-                        columns -- 303px of content at 375, 328px at 768 -- and
+                        columns -- 301px of content at 375, 328px at 768 -- and
                         a 10px label alone on a line that wide is most of the
-                        line wasted. `LOW TIDE` is 70px, so a 76px column holds
-                        every label in the grid and leaves 217px at 375, which
-                        takes the longest value the cell has (`65% Slight chance
-                        rain showers`, 203px) without wrapping. Measured at
-                        375: a day goes 214px to 169px with this alone, and
-                        250px to 169px against what the grid shipped before
-                        ADR-0023 -- 1822px of week to 1256px.
+                        line wasted. The column is sized to the widest label the
+                        grid has: `BIGGEST SWELL` at 112px, against `CLOUD
+                        COVER` at 100px and `LOW TIDE` at 70px. 116px holds it
+                        with a little to spare and leaves 175px for the value at
+                        375, which takes every value in the cell except the
+                        longest cloud phenomenon (`68% Slight chance rain
+                        showers`, 204px, two days of seven) -- and that is the
+                        last row, so a wrap there pushes nothing out of line.
+                        Measured at 375: a day goes 214px to 169px with this
+                        alone, and 250px to 169px against what the grid shipped
+                        before ADR-0023.
 
                         This is not the `lg:block` the four cell components just
                         lost. Those forced a break *inside* one value to keep
@@ -331,7 +335,7 @@ export function WeekGrid({
                         which is what every label here used to be.
                       */}
                       <dt
-                        className={`text-2xs w-19 shrink-0 font-extrabold tracking-widest uppercase lg:w-auto ${
+                        className={`text-2xs w-29 shrink-0 font-extrabold tracking-widest uppercase lg:w-auto ${
                           row.tone ?? "text-fog"
                         }`}
                       >

--- a/src/components/conditions/WeekPanel.test.tsx
+++ b/src/components/conditions/WeekPanel.test.tsx
@@ -171,7 +171,7 @@ test("asks for the slug it was given and renders both live rows", async () => {
     "Daylight, 6:14 AM to 7:32 PM",
   );
   // Each row's own label, which is what stops a glyph carrying the meaning.
-  expect(countOf(cellLabels(container), "Lowest daylight tide")).toBe(2);
+  expect(countOf(cellLabels(container), "Low tide")).toBe(2);
   expect(daylightWindows()).toHaveLength(2);
 });
 
@@ -207,7 +207,7 @@ test("the gridded row is live, and the slot that promised it is gone", async () 
   render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
 
   expect(readSkyWeek).toHaveBeenCalledWith("la-jolla-shores-beach");
-  expect(screen.getAllByText("Cloud by day").length).toBeGreaterThan(0);
+  expect(screen.getAllByText("Clouds").length).toBeGreaterThan(0);
   expect(screen.getByText("44%")).toBeDefined();
   expect(screen.queryByText(/A gridded forecast is coming/i)).toBeNull();
   expect(
@@ -235,7 +235,7 @@ test("a beach with no forecast cell says so, rather than dropping the row silent
   render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
 
   expect(screen.getByText(/no cloud forecast for this beach/i)).toBeDefined();
-  expect(screen.queryByText("Cloud by day")).toBeNull();
+  expect(screen.queryByText("Clouds")).toBeNull();
 });
 
 test("an outage at the National Weather Service says so, and names the reason", async () => {
@@ -341,7 +341,7 @@ test("a NOAA outage costs the tide row, not the whole grid", async () => {
   // cannot fail, so the week still stands and still answers a question.
   expect(screen.getByText("Tue, Aug 18")).toBeDefined();
   expect(daylightWindows()).toHaveLength(2);
-  expect(screen.queryByText("Lowest daylight tide")).toBeNull();
+  expect(screen.queryByText("Low tide")).toBeNull();
 });
 
 test("a beach with no station keeps its daylight, and does not read as an outage", async () => {
@@ -440,7 +440,7 @@ test("the row's label names the statistic, so the maximum is not hidden", async 
     await WeekPanel({ slug: "la-jolla-shores-beach" }),
   );
 
-  expect(countOf(cellLabels(container), "Biggest daylight swell")).toBe(2);
+  expect(countOf(cellLabels(container), "Swell")).toBe(2);
 });
 
 test("the wave row is attributed once, beneath the grid, not seven times", async () => {
@@ -464,7 +464,7 @@ test("the wave row is attributed once, beneath the grid, not seven times", async
     "a model of the swell at 10 m depth, not a measurement",
   );
   // Labelled, because the grid may carry more than one of these.
-  expect(attributions[0].textContent).toContain("Biggest daylight swell");
+  expect(attributions[0].textContent).toContain("Swell");
 });
 
 test("the row goes ragged where the forecast stops, rather than blank", async () => {
@@ -482,7 +482,7 @@ test("the row goes ragged where the forecast stops, rather than blank", async ()
 
   // One cell, one label. A label over a gap would read as an instrument that
   // failed rather than as a forecast that does not reach that far.
-  expect(countOf(cellLabels(container), "Biggest daylight swell")).toBe(1);
+  expect(countOf(cellLabels(container), "Swell")).toBe(1);
   expect(daylightWindows()).toHaveLength(2);
 });
 
@@ -505,7 +505,7 @@ test("a beach with no MOP line says so, and keeps the rest of the grid", async (
   render(await WeekPanel({ slug: "mission-bay" }));
 
   expect(screen.getByText(/no wave forecast for this beach/i)).toBeDefined();
-  expect(screen.queryByText("Biggest daylight swell")).toBeNull();
+  expect(screen.queryByText("Swell")).toBeNull();
   expect(screen.queryByText(/MOP line/)).toBeNull();
   expect(daylightWindows()).toHaveLength(2);
 });
@@ -535,8 +535,8 @@ test("a CDIP outage costs the wave row and nothing else", async () => {
   // Said in full here rather than pointed at a card, because CDIP is read here
   // and nowhere else on the page.
   expect(screen.getByText(/HTTP 503 for MOP line D0498/)).toBeDefined();
-  expect(screen.queryByText("Biggest daylight swell")).toBeNull();
-  expect(countOf(cellLabels(container), "Lowest daylight tide")).toBe(2);
+  expect(screen.queryByText("Swell")).toBeNull();
+  expect(countOf(cellLabels(container), "Low tide")).toBe(2);
   expect(daylightWindows()).toHaveLength(2);
 });
 
@@ -578,8 +578,8 @@ test("NOAA going quiet does not take the wave row with it", async () => {
     await WeekPanel({ slug: "la-jolla-shores-beach" }),
   );
 
-  expect(screen.queryByText("Lowest daylight tide")).toBeNull();
-  expect(countOf(cellLabels(container), "Biggest daylight swell")).toBe(2);
+  expect(screen.queryByText("Low tide")).toBeNull();
+  expect(countOf(cellLabels(container), "Swell")).toBe(2);
 });
 
 test("the rows run tide, swell, cloud, inside the window the header states", async () => {
@@ -602,11 +602,7 @@ test("the rows run tide, swell, cloud, inside the window the header states", asy
   // Cloud last, and last for a reason: it is the only row with no time in it,
   // so a reader scanning a column reads two "when"s and then the one figure
   // about the whole day.
-  expect(labels).toEqual([
-    "Lowest daylight tide",
-    "Biggest daylight swell",
-    "Cloud by day",
-  ]);
+  expect(labels).toEqual(["Low tide", "Swell", "Clouds"]);
 });
 
 test("a line with no recorded distance is still named, without one", async () => {
@@ -629,4 +625,54 @@ test("a line with no recorded distance is still named, without one", async () =>
     "CDIP, Scripps Institution of Oceanography",
   );
   expect(line.textContent).not.toContain("km from this beach");
+});
+
+/**
+ * ADR-0023 dropped the day's own extremes from the week's cells, and this
+ * sentence is the condition it was allowed under. Without it a reader who saw a
+ * -0.2 ft at 3:38 AM last week finds it gone with nothing to explain the
+ * change -- the silent failure this repo is built to avoid.
+ *
+ * Asserted here rather than in `WeekGrid`, because the grid prints whatever
+ * notes it is handed and the decision to hand it this one is the panel's.
+ */
+test("the week says it shows only the daylight window, once", async () => {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
+  });
+
+  render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
+
+  expect(
+    screen.getAllByText(/shows what falls between sunrise and sunset/i),
+  ).toHaveLength(1);
+  // And says where the missing figure went, rather than only that it is gone.
+  expect(screen.getByText(/today's are on the cards above/i)).toBeDefined();
+});
+
+test("the scope sentence stands whether or not a feed also failed", async () => {
+  // It qualifies every figure in the grid rather than reporting one feed's
+  // trouble, so an outage must not displace it -- and it leads, because a
+  // reader hits it before the figures it qualifies.
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: {
+      kind: "unavailable",
+      detail: "NOAA returned HTTP 503.",
+      drift: false,
+    },
+  });
+
+  const { container } = render(
+    await WeekPanel({ slug: "la-jolla-shores-beach" }),
+  );
+
+  const notes = [...container.querySelectorAll("section > p")].map(
+    (node) => node.textContent,
+  );
+  expect(notes[0]).toMatch(/shows what falls between sunrise and sunset/i);
+  expect(
+    notes.some((note) => /could not get this week/i.test(note ?? "")),
+  ).toBe(true);
 });

--- a/src/components/conditions/WeekPanel.test.tsx
+++ b/src/components/conditions/WeekPanel.test.tsx
@@ -59,7 +59,10 @@ const CELL = { id: "SGX/54,21", elevationM: 0 };
 function skyWeek(
   days: {
     index: number;
-    cloudPercent: number;
+    /** The day's three thirds. A single number fills all three, for the cases
+     *  that are not about the shape of the day. */
+    cloud:
+      number | { am: number | null; mid: number | null; eve: number | null };
     phenomenon?: { weather: string; coverage: string | null };
   }[],
   cell = CELL,
@@ -69,9 +72,12 @@ function skyWeek(
     cell,
     state: {
       kind: "week",
-      days: days.map(({ index, cloudPercent, phenomenon = null }) => ({
+      days: days.map(({ index, cloud, phenomenon = null }) => ({
         ...DATES[index],
-        cloudPercent,
+        thirds:
+          typeof cloud === "number"
+            ? { am: cloud, mid: cloud, eve: cloud }
+            : cloud,
         phenomenon,
       })),
     },
@@ -133,10 +139,10 @@ beforeEach(() => {
   readSkyWeek.mockReset();
   readSkyWeek.mockResolvedValue(
     skyWeek([
-      { index: 0, cloudPercent: 44 },
+      { index: 0, cloud: 44 },
       {
         index: 1,
-        cloudPercent: 67,
+        cloud: 67,
         phenomenon: { weather: "fog", coverage: "patchy" },
       },
     ]),
@@ -208,7 +214,9 @@ test("the gridded row is live, and the slot that promised it is gone", async () 
 
   expect(readSkyWeek).toHaveBeenCalledWith("la-jolla-shores-beach");
   expect(screen.getAllByText("Cloud cover").length).toBeGreaterThan(0);
-  expect(screen.getByText("44%")).toBeDefined();
+  // Three figures, not one: the fixture gives this day 44% in all three
+  // thirds, so the row rendering the day's shape prints it three times.
+  expect(screen.getAllByText("44%")).toHaveLength(3);
   expect(screen.queryByText(/A gridded forecast is coming/i)).toBeNull();
   expect(
     screen.queryByText(/grid cell, instead of the nearest airport/i),
@@ -297,7 +305,7 @@ test("a bluff cell says the square covers the cliff as well as the shore", async
     state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
   });
   readSkyWeek.mockResolvedValue(
-    skyWeek([{ index: 0, cloudPercent: 44 }], {
+    skyWeek([{ index: 0, cloud: 44 }], {
       id: "SGX/55,22",
       elevationM: 117.0432,
     }),

--- a/src/components/conditions/WeekPanel.test.tsx
+++ b/src/components/conditions/WeekPanel.test.tsx
@@ -207,7 +207,7 @@ test("the gridded row is live, and the slot that promised it is gone", async () 
   render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
 
   expect(readSkyWeek).toHaveBeenCalledWith("la-jolla-shores-beach");
-  expect(screen.getAllByText("Clouds").length).toBeGreaterThan(0);
+  expect(screen.getAllByText("Cloud cover").length).toBeGreaterThan(0);
   expect(screen.getByText("44%")).toBeDefined();
   expect(screen.queryByText(/A gridded forecast is coming/i)).toBeNull();
   expect(
@@ -235,7 +235,7 @@ test("a beach with no forecast cell says so, rather than dropping the row silent
   render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
 
   expect(screen.getByText(/no cloud forecast for this beach/i)).toBeDefined();
-  expect(screen.queryByText("Clouds")).toBeNull();
+  expect(screen.queryByText("Cloud cover")).toBeNull();
 });
 
 test("an outage at the National Weather Service says so, and names the reason", async () => {
@@ -440,7 +440,7 @@ test("the row's label names the statistic, so the maximum is not hidden", async 
     await WeekPanel({ slug: "la-jolla-shores-beach" }),
   );
 
-  expect(countOf(cellLabels(container), "Swell")).toBe(2);
+  expect(countOf(cellLabels(container), "Biggest swell")).toBe(2);
 });
 
 test("the wave row is attributed once, beneath the grid, not seven times", async () => {
@@ -464,7 +464,7 @@ test("the wave row is attributed once, beneath the grid, not seven times", async
     "a model of the swell at 10 m depth, not a measurement",
   );
   // Labelled, because the grid may carry more than one of these.
-  expect(attributions[0].textContent).toContain("Swell");
+  expect(attributions[0].textContent).toContain("Biggest swell");
 });
 
 test("the row goes ragged where the forecast stops, rather than blank", async () => {
@@ -482,7 +482,7 @@ test("the row goes ragged where the forecast stops, rather than blank", async ()
 
   // One cell, one label. A label over a gap would read as an instrument that
   // failed rather than as a forecast that does not reach that far.
-  expect(countOf(cellLabels(container), "Swell")).toBe(1);
+  expect(countOf(cellLabels(container), "Biggest swell")).toBe(1);
   expect(daylightWindows()).toHaveLength(2);
 });
 
@@ -505,7 +505,7 @@ test("a beach with no MOP line says so, and keeps the rest of the grid", async (
   render(await WeekPanel({ slug: "mission-bay" }));
 
   expect(screen.getByText(/no wave forecast for this beach/i)).toBeDefined();
-  expect(screen.queryByText("Swell")).toBeNull();
+  expect(screen.queryByText("Biggest swell")).toBeNull();
   expect(screen.queryByText(/MOP line/)).toBeNull();
   expect(daylightWindows()).toHaveLength(2);
 });
@@ -535,7 +535,7 @@ test("a CDIP outage costs the wave row and nothing else", async () => {
   // Said in full here rather than pointed at a card, because CDIP is read here
   // and nowhere else on the page.
   expect(screen.getByText(/HTTP 503 for MOP line D0498/)).toBeDefined();
-  expect(screen.queryByText("Swell")).toBeNull();
+  expect(screen.queryByText("Biggest swell")).toBeNull();
   expect(countOf(cellLabels(container), "Low tide")).toBe(2);
   expect(daylightWindows()).toHaveLength(2);
 });
@@ -579,7 +579,7 @@ test("NOAA going quiet does not take the wave row with it", async () => {
   );
 
   expect(screen.queryByText("Low tide")).toBeNull();
-  expect(countOf(cellLabels(container), "Swell")).toBe(2);
+  expect(countOf(cellLabels(container), "Biggest swell")).toBe(2);
 });
 
 test("the rows run tide, swell, cloud, inside the window the header states", async () => {
@@ -602,7 +602,7 @@ test("the rows run tide, swell, cloud, inside the window the header states", asy
   // Cloud last, and last for a reason: it is the only row with no time in it,
   // so a reader scanning a column reads two "when"s and then the one figure
   // about the whole day.
-  expect(labels).toEqual(["Low tide", "Swell", "Clouds"]);
+  expect(labels).toEqual(["Low tide", "Biggest swell", "Cloud cover"]);
 });
 
 test("a line with no recorded distance is still named, without one", async () => {

--- a/src/components/conditions/WeekPanel.test.tsx
+++ b/src/components/conditions/WeekPanel.test.tsx
@@ -103,6 +103,18 @@ function waveWeek(
   };
 }
 
+/**
+ * Every day's daylight window, found by the name only a screen reader hears.
+ *
+ * Daylight is the day's header rather than a `<dt>` label now, so counting
+ * `cellLabels` no longer finds it. The `aria-label` is the thing under test
+ * anyway: the visible line is two clock times and the word is what a reader
+ * who cannot see the sun mark is given.
+ */
+function daylightWindows() {
+  return screen.getAllByLabelText(/^Daylight, /);
+}
+
 /** Daylight always answers, which is what the panel leans on for its columns. */
 function daylightWeek() {
   return {
@@ -155,10 +167,12 @@ test("asks for the slug it was given and renders both live rows", async () => {
   expect(readDaylightWeek).toHaveBeenCalledWith("la-jolla-shores-beach");
   expect(screen.getByText("7:10 AM")).toBeDefined();
   expect(screen.getByText("-0.4 ft")).toBeDefined();
-  expect(screen.getByText("to 7:32 PM")).toBeDefined();
+  expect(daylightWindows()[0].getAttribute("aria-label")).toBe(
+    "Daylight, 6:14 AM to 7:32 PM",
+  );
   // Each row's own label, which is what stops a glyph carrying the meaning.
   expect(countOf(cellLabels(container), "Lowest daylight tide")).toBe(2);
-  expect(screen.getAllByText("Daylight")).toHaveLength(2);
+  expect(daylightWindows()).toHaveLength(2);
 });
 
 test("the forecasts that are not built yet are named, and waves are no longer among them", async () => {
@@ -326,7 +340,7 @@ test("a NOAA outage costs the tide row, not the whole grid", async () => {
   // The reason the columns come from the daylight read: it is computed here and
   // cannot fail, so the week still stands and still answers a question.
   expect(screen.getByText("Tue, Aug 18")).toBeDefined();
-  expect(screen.getAllByText("Daylight")).toHaveLength(2);
+  expect(daylightWindows()).toHaveLength(2);
   expect(screen.queryByText("Lowest daylight tide")).toBeNull();
 });
 
@@ -343,7 +357,7 @@ test("a beach with no station keeps its daylight, and does not read as an outage
   expect(screen.queryByText(/try again/i)).toBeNull();
   // A permanent fact about the place takes the tide row and nothing else: the
   // sun still rises there.
-  expect(screen.getAllByText("Daylight")).toHaveLength(2);
+  expect(daylightWindows()).toHaveLength(2);
 });
 
 test("a failure to resolve the beach is not swallowed into a rendered nothing", async () => {
@@ -362,6 +376,11 @@ test("a failure to resolve the beach is not swallowed into a rendered nothing", 
  * it: rows in this grid carry no glyph at all -- a full-colour emoji at 10px is
  * a smudge rather than a mark -- and the only glyph left in this band belongs
  * to the one slot still reserved.
+ *
+ * The day headers now carry a decorative sun, which is why this counts *text*
+ * rather than every `aria-hidden` node. That mark is a stroked SVG on
+ * `currentColor` and contributes no characters, so it cannot be the smudge the
+ * rule is about; the assertion below is that it stays that way.
  */
 test("the filled row brings no glyph, and only the reserved slot still has one", async () => {
   readWeekOfLowestLows.mockResolvedValue({
@@ -374,10 +393,17 @@ test("the filled row brings no glyph, and only the reserved slot still has one",
     await WeekPanel({ slug: "la-jolla-shores-beach" }),
   );
 
-  const glyphs = [...container.querySelectorAll('[aria-hidden="true"]')].map(
-    (node) => node.textContent,
-  );
+  const glyphs = [...container.querySelectorAll('[aria-hidden="true"]')]
+    .map((node) => node.textContent)
+    .filter((text) => text !== "");
   expect(glyphs).toEqual(["🏖️"]);
+
+  // The header's mark draws rather than spells, so a day block contributes no
+  // glyph text of its own.
+  const day = container.querySelector("ol > li");
+  expect(day?.querySelector("svg")?.getAttribute("stroke")).toBe(
+    "currentColor",
+  );
 });
 
 /* =========================================================================
@@ -457,7 +483,7 @@ test("the row goes ragged where the forecast stops, rather than blank", async ()
   // One cell, one label. A label over a gap would read as an instrument that
   // failed rather than as a forecast that does not reach that far.
   expect(countOf(cellLabels(container), "Biggest daylight swell")).toBe(1);
-  expect(countOf(cellLabels(container), "Daylight")).toBe(2);
+  expect(daylightWindows()).toHaveLength(2);
 });
 
 test("a beach with no MOP line says so, and keeps the rest of the grid", async () => {
@@ -481,7 +507,7 @@ test("a beach with no MOP line says so, and keeps the rest of the grid", async (
   expect(screen.getByText(/no wave forecast for this beach/i)).toBeDefined();
   expect(screen.queryByText("Biggest daylight swell")).toBeNull();
   expect(screen.queryByText(/MOP line/)).toBeNull();
-  expect(screen.getAllByText("Daylight")).toHaveLength(2);
+  expect(daylightWindows()).toHaveLength(2);
 });
 
 test("a CDIP outage costs the wave row and nothing else", async () => {
@@ -511,7 +537,7 @@ test("a CDIP outage costs the wave row and nothing else", async () => {
   expect(screen.getByText(/HTTP 503 for MOP line D0498/)).toBeDefined();
   expect(screen.queryByText("Biggest daylight swell")).toBeNull();
   expect(countOf(cellLabels(container), "Lowest daylight tide")).toBe(2);
-  expect(screen.getAllByText("Daylight")).toHaveLength(2);
+  expect(daylightWindows()).toHaveLength(2);
 });
 
 test("a drifted CDIP payload says the bug is here, not at the model", async () => {
@@ -556,10 +582,11 @@ test("NOAA going quiet does not take the wave row with it", async () => {
   expect(countOf(cellLabels(container), "Biggest daylight swell")).toBe(2);
 });
 
-test("the wave row sits under daylight, not between it and the tide", async () => {
-  // `DaylightWeek` is there to make the tide row mean something -- a lowest low
-  // at 2:23 is a different trip depending on AM or PM -- so a third product
-  // between them would take away the thing it is for.
+test("the rows run tide, swell, cloud, inside the window the header states", async () => {
+  // Daylight is no longer among them. It was between the tide and the swell so
+  // that a reader could tell a 2:23 AM low from a 2:23 PM one; the header does
+  // that for all three rows at once now, which is what lets these labels drop
+  // the word.
   readWeekOfLowestLows.mockResolvedValue({
     ...BINDING,
     state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
@@ -573,11 +600,10 @@ test("the wave row sits under daylight, not between it and the tide", async () =
     (node) => node.textContent,
   );
   // Cloud last, and last for a reason: it is the only row with no time in it,
-  // so a reader scanning a column reads three "when"s and then the one figure
+  // so a reader scanning a column reads two "when"s and then the one figure
   // about the whole day.
   expect(labels).toEqual([
     "Lowest daylight tide",
-    "Daylight",
     "Biggest daylight swell",
     "Cloud by day",
   ]);

--- a/src/components/conditions/WeekPanel.tsx
+++ b/src/components/conditions/WeekPanel.tsx
@@ -30,7 +30,7 @@ import {
   readWaveWeek,
   readWeekOfLowestLows,
 } from "@/lib/conditions";
-import { DaylightWeek, DAYLIGHT_WEEK_ROW } from "./DaylightWeek";
+import { DaylightWeek } from "./DaylightWeek";
 import {
   MOP_MODEL_NOTE,
   MOP_NETWORK,
@@ -104,8 +104,18 @@ export async function WeekPanel({ slug }: { slug: string }) {
     takes a row off the grid instead of taking the grid off the page. Both reads
     build their days from the same helper, so the two rows cannot disagree about
     which day is Tuesday.
+
+    It rides on the day rather than in `rows`, because it is the window the
+    other three rows' figures are selected inside rather than a fourth figure.
+    Putting it in the header is what lets those rows be called "Low tide" and
+    "Swell": the scope is stated once above them instead of three times in three
+    labels that never fitted the cell. See
+    `docs/plans/week-grid-legibility.md`.
   */
-  const days = daylight.days;
+  const days = daylight.days.map((day) => ({
+    ...day,
+    daylight: <DaylightWeek day={day} />,
+  }));
 
   const rows: WeekRow[] = [];
 
@@ -122,23 +132,12 @@ export async function WeekPanel({ slug }: { slug: string }) {
     });
   }
 
-  rows.push({
-    ...DAYLIGHT_WEEK_ROW,
-    cells: Object.fromEntries(
-      daylight.days.map((day) => [
-        day.localDate,
-        <DaylightWeek key={day.localDate} day={day} />,
-      ]),
-    ),
-  });
-
   /*
-    Last, under daylight rather than between it and the tide. `DaylightWeek`'s
-    whole argument is that it sits beside the tide row -- a lowest low at 2:23
-    is a different trip depending on whether it is AM or PM, and the daylight
-    row is what answers that -- so putting a third product between them would
-    take away the thing it is there for. It also puts the row that carries a
-    provenance line closest to the line itself.
+    Second of three, under the tide. The order down a day block is tide, swell,
+    cloud -- what the sea does, what the swell does, what the sky does -- inside
+    the window the header states. Daylight used to sit between the first two so
+    that a reader could tell a 2:23 AM low from a 2:23 PM one; it is in the
+    header now, where it does that for all three rows at once.
 
     Ragged by construction: only the days the forecast reached become cells, and
     the grid draws no pair where a row has none.
@@ -166,12 +165,12 @@ export async function WeekPanel({ slug }: { slug: string }) {
   }
 
   /*
-    Last of the four, under the wave row. The order down a day block is tide,
-    daylight, swell, cloud -- what the sea does, when the sun is up, what the
-    swell does, what the sky does. Cloud goes last because it is the only row
-    with no time in it: a reader scanning a column reads three "when"s and then
-    the one figure that is about the whole day, and putting it between two
-    timed rows would break that reading.
+    Last of the three, under the wave row. Cloud goes last because it is the
+    only row with no time in it: a reader scanning a column reads two "when"s
+    and then the one figure that is about the whole day, and putting it between
+    two timed rows would break that reading. It is also the row whose second
+    line varies most in length, and a variable line does least damage at the
+    bottom of the cell -- see `SkyWeek`.
 
     Ragged like the wave row, and for the same reason: the product reaches about
     seven and a half days and the far column may have none.

--- a/src/components/conditions/WeekPanel.tsx
+++ b/src/components/conditions/WeekPanel.tsx
@@ -205,6 +205,26 @@ export async function WeekPanel({ slug }: { slug: string }) {
     the same moment — repeating it here would be the same failure twice.
   */
   const notes: string[] = [];
+
+  /*
+    First, because it qualifies every figure in the grid rather than reporting
+    one feed's trouble. ADR-0023 dropped the day's own extremes from these
+    cells -- a lowest low at 3:38 AM is a real prediction and a useless plan,
+    and the labels naming it never fitted -- and this sentence is the condition
+    that was allowed under. Without it a reader who saw a -0.2 ft here last
+    week finds it gone with nothing to explain the change, which is the silent
+    failure this repo is built to avoid.
+
+    Unconditional, and one sentence rather than seven: the scope is a fact
+    about the grid, the same shape as every other note here. It says where the
+    figure went as well as that it is missing, because "not shown" alone reads
+    as an omission rather than a decision.
+  */
+  notes.push(
+    "This week shows what falls between sunrise and sunset. Lows and swells " +
+      "overnight are real and often bigger — today's are on the cards above.",
+  );
+
   if (view.state.kind === "unavailable") {
     notes.push(
       "We could not get this week's tide predictions from NOAA just now. " +

--- a/src/components/conditions/weekTone.ts
+++ b/src/components/conditions/weekTone.ts
@@ -1,0 +1,47 @@
+/**
+ * The colour each reading takes in the week grid, named once.
+ *
+ * **Colour is per product and never per value, which is what keeps it out of
+ * ADR-0009's way.** That decision forbids this site judging whether conditions
+ * are good, and ADR-0015 drew the line that matters when it put the reading
+ * cards on `bg-dark`: what makes colour a verdict is *differential* colour — a
+ * green card and a red one. Every day's swell label is the same purple whether
+ * the swell is 0.7 ft or 6 ft, so nothing here asserts anything about the
+ * water. A reader gains a way to find one reading across seven columns; they
+ * gain no opinion.
+ *
+ * **Three colours, because there are three readings and no more free ones.**
+ * Measured against the cell's `white/60` over the cream page, which computes to
+ * about #fdfcfa:
+ *
+ * - **`TIDE_TONE`** — ocean #1a4e8a, **8.5:1**.
+ * - **`SWELL_TONE`** — purple #6b5faa, **5.3:1**.
+ * - **`CLOUD_TONE`** — fog #6b5f7d, **5.0:1**, and the colour every label in
+ *   this grid used to be. Cloud keeps it rather than taking a third saturated
+ *   hue: pink is 2.1:1 here and yellow is unreadable on any pale surface, so
+ *   the palette has exactly two label colours to spend and this is the row that
+ *   does not need one. It is also the row that is an average rather than an
+ *   extreme, so the odd one out is the right one to leave in the neutral.
+ *
+ * All three clear the 4.5:1 this page holds itself to.
+ *
+ * **Named here rather than beside each label**, because the argument above is
+ * one argument about a set and not three unrelated colour choices. Spelling it
+ * three times is the drift `cardText.ts`, `headingRank.ts` and `touchTarget.ts`
+ * each exist to stop — and a fourth reading joining the grid needs to find the
+ * measurement before picking a colour, which it can only do if the set lives
+ * somewhere.
+ *
+ * A utility class rather than a token, for the reason `cardText.ts` gives: a
+ * new palette entry would mean one convention on this page and a different one
+ * everywhere else on the site.
+ */
+
+/** The lowest tide the daylight window reaches. */
+export const TIDE_TONE = "text-ocean";
+
+/** The biggest swell the daylight window reaches. */
+export const SWELL_TONE = "text-purple";
+
+/** The mean cloud across the daylight window. */
+export const CLOUD_TONE = "text-fog";

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -1068,12 +1068,17 @@ test("a day's figure is the mean of its daylight hours, not of the whole day", a
 
   expect(view.state.kind).toBe("week");
   if (view.state.kind !== "week") throw new Error("expected a week");
-  expect(view.state.days[0].cloudPercent).toBe(50);
+  // 08:00 and 16:00 Pacific are the two daylight steps, and they fall in the
+  // first and last thirds of a 6:20-to-7:25 window. The middle third has no
+  // step, which is a null rather than a zero.
+  expect(view.state.days[0].thirds).toEqual({ am: 20, mid: null, eve: 80 });
 });
 
-test("the mean is not the cloudiest step, which is what ADR-0017 would have taken", async () => {
-  // Measured at SGX/54,21 for 2026-08-30: daylight steps spanning 21 to 62,
-  // mean 39. An extreme-selecting row would publish 62 for this day.
+test("each third is a mean of its own hours, not the cloudiest of them", async () => {
+  // Measured at SGX/54,21 for 2026-08-30: daylight steps spanning 21 to 62.
+  // ADR-0017 selects extremes for reachability, and this row does not, for the
+  // reason `SkyWeekDay` records -- the daylight window is the trip, so there
+  // are no unreachable hours to route around.
   gridOk([
     { atMs: hourUtc(17, 14), percent: 21 },
     { atMs: hourUtc(17, 17), percent: 34 },
@@ -1084,8 +1089,9 @@ test("the mean is not the cloudiest step, which is what ADR-0017 would have take
   const view = await readSkyWeek(BEACH, NOON_PACIFIC_20260817);
   if (view.state.kind !== "week") throw new Error("expected a week");
 
-  expect(view.state.days[0].cloudPercent).toBe(39);
-  expect(view.state.days[0].cloudPercent).not.toBe(62);
+  // 07:00 and 10:00 Pacific share the first third and average to 28; 13:00 is
+  // the middle third alone and 16:00 the last.
+  expect(view.state.days[0].thirds).toEqual({ am: 28, mid: 39, eve: 62 });
 });
 
 test("a day with fog in its daylight carries the phenomenon", async () => {
@@ -1164,7 +1170,7 @@ test("two phenomena on one day are grouped, not overwritten", async () => {
   const view = await readSkyWeek(BEACH, NOON_PACIFIC_20260817);
   if (view.state.kind !== "week") throw new Error("expected a week");
 
-  expect(view.state.days[0].cloudPercent).toBe(50);
+  expect(view.state.days[0].thirds.am).toBe(40);
   // The first of the daylight window, which is the one a parent plans around.
   expect(view.state.days[0].phenomenon?.weather).toBe("fog");
 });

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -1013,21 +1013,50 @@ export async function readWaveWeek(
  * The week's cloud cover, from the beach's own forecast cell
  * ========================================================================= */
 
+/**
+ * Mean cloud cover for each third of one day's daylight window, 0 to 100.
+ *
+ * **Thirds of the window, not named clock hours.** "Morning" is not a fact
+ * about the sky, and any boundary drawn at 11 AM would be this site inventing
+ * one; the window is already computed here from the beach's own coordinates,
+ * so dividing it is arithmetic rather than judgement. It also tracks the
+ * season: a 13-hour August window gives roughly 6:20-10:40, 10:40-3:00,
+ * 3:00-7:20, and a 10-hour December one narrows all three together.
+ *
+ * **A third can be null**, which is why these are not plain numbers. The
+ * forecast does not reach backwards: on the day the reader is standing in, the
+ * hours before now are gone and the first third is often empty. A null says
+ * "no forecast covered it", and rendering a zero there would say "cloudless".
+ */
+export interface SkyThirds {
+  /** The first third of the daylight window. */
+  am: number | null;
+  /** The middle third. */
+  mid: number | null;
+  /** The last third, ending at sunset. */
+  eve: number | null;
+}
+
 /** One day of the cloud row. */
 export interface SkyWeekDay extends WeekDayFrame {
   /**
-   * Mean cloud cover across the day's daylight hours, 0 to 100, rounded.
+   * Cloud cover across the day, in three parts.
    *
-   * A mean rather than an extreme, which is a deliberate departure from
-   * ADR-0017 and the one place this row differs from the tide and swell rows
+   * **Means rather than extremes, which is a deliberate departure from
+   * ADR-0017** and the one place this row differs from the tide and swell rows
    * above it. Those take the daylight extreme because a lowest low at 3:14 AM
    * is a number nobody planning a trip with children can use -- the extreme is
    * selected for *reachability*. Cloud cover has no unreachable hours: the
-   * daylight window is the trip. Measured over seven days at one cell, the
-   * daylight spread runs 20 to 41 points, and taking the cloudiest step would
-   * have reported 2026-08-30 at 62% against a daylight mean of 39%.
+   * daylight window is the trip.
+   *
+   * **Three parts rather than one, because on this coast one is misleading.**
+   * The row shipped a single daylight mean, and measured against the live cell
+   * on 2026-08-28 every one of seven days was a marine-layer burn-off: Sunday
+   * ran 65% / 32% / 31% and averaged to 46%, a figure that describes neither
+   * half of the day. A parent deciding whether to drive out after breakfast is
+   * asking exactly the question the mean destroys. See ADR-0024.
    */
-  cloudPercent: number;
+  thirds: SkyThirds;
   /**
    * The phenomenon forecast for any daylight hour of this day, or null.
    *
@@ -1048,25 +1077,44 @@ export interface SkyWeekView {
     | { kind: "unavailable"; detail: string; drift: boolean };
 }
 
+/** The mean of some hours, rounded, or null when there are none to average. */
+function meanPercent(hours: readonly SkyCoverHour[]): number | null {
+  if (hours.length === 0) return null;
+  const total = hours.reduce((sum, hour) => sum + hour.percent, 0);
+  return Math.round(total / hours.length);
+}
+
 /**
- * The daylight mean for one day, and the phenomenon if one was forecast.
+ * The day's cloud in three parts, and the phenomenon if one was forecast.
  *
- * Returns null when no forecast hour falls in this day's daylight, which is
- * what the far end of the week does as the product's reach runs out. A day with
- * no hours is dropped rather than rendered as zero -- a zero here would read as
- * a cloudless day.
+ * Returns null when no forecast hour falls in this day's daylight at all,
+ * which is what the far end of the week does as the product's reach runs out.
+ * A day with no hours is dropped rather than rendered as zeroes -- a zero here
+ * would read as a cloudless day, which is the specific failure this row exists
+ * to avoid.
+ *
+ * A day with *some* hours keeps them and nulls the thirds it cannot fill. That
+ * is the ordinary state of today's column: the forecast does not reach
+ * backwards, so the hours before now are gone.
+ *
+ * The boundaries are open at the top and closed at the bottom, so an hour
+ * landing exactly on a boundary belongs to the later third and no hour is
+ * counted twice. Sunset itself is included, which is why the last comparison
+ * is the only one that is not strict.
  */
 function skyReadingOn(
   hours: readonly SkyCoverHour[],
   weather: readonly WeatherHour[],
   daylight: Daylight,
-): { cloudPercent: number; phenomenon: SkyWeekDay["phenomenon"] } | null {
+): { thirds: SkyThirds; phenomenon: SkyWeekDay["phenomenon"] } | null {
   const inDaylight = hours.filter(
     (hour) => hour.atMs >= daylight.sunriseMs && hour.atMs <= daylight.sunsetMs,
   );
   if (inDaylight.length === 0) return null;
 
-  const total = inDaylight.reduce((sum, hour) => sum + hour.percent, 0);
+  const third = (daylight.sunsetMs - daylight.sunriseMs) / 3;
+  const firstEndsMs = daylight.sunriseMs + third;
+  const secondEndsMs = daylight.sunriseMs + third * 2;
 
   // The first phenomenon of the daylight window rather than the most common
   // one: "patchy fog" at 7 AM is the fact a parent is deciding on, and a day
@@ -1077,7 +1125,15 @@ function skyReadingOn(
   );
 
   return {
-    cloudPercent: Math.round(total / inDaylight.length),
+    thirds: {
+      am: meanPercent(inDaylight.filter((hour) => hour.atMs < firstEndsMs)),
+      mid: meanPercent(
+        inDaylight.filter(
+          (hour) => hour.atMs >= firstEndsMs && hour.atMs < secondEndsMs,
+        ),
+      ),
+      eve: meanPercent(inDaylight.filter((hour) => hour.atMs >= secondEndsMs)),
+    },
     phenomenon:
       named === undefined
         ? null

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -25,6 +25,7 @@ import type { TideExtreme } from "./coops-predictions";
 import {
   addLocalDays,
   localDateOf,
+  localDateLabel,
   localDayLabel,
   localTimeOf,
 } from "./pacific-time";
@@ -111,6 +112,8 @@ const WEEK_DAYS = 7;
 interface WeekDayFrame {
   localDate: string;
   dayLabel: string;
+  /** The same date with no weekday, for the column that carries a "Today" chip. */
+  dateLabel: string;
   isToday: boolean;
 }
 
@@ -146,6 +149,7 @@ function weekOfDays(nowMs: number): WeekDayFrame[] {
     return {
       localDate,
       dayLabel: localDayLabel(localDate),
+      dateLabel: localDateLabel(localDate),
       isToday: localDate === today,
     };
   });

--- a/src/lib/pacific-time.ts
+++ b/src/lib/pacific-time.ts
@@ -126,3 +126,30 @@ export function localDayLabel(localDate: string): string {
     day: "numeric",
   }).format(new Date(Date.UTC(year, month - 1, day)));
 }
+
+/**
+ * The same date without its weekday: `Aug 28`.
+ *
+ * For the one column that does not need a weekday. The week grid marks today
+ * with a chip reading "Today", and a weekday beside that chip is the most
+ * redundant token on the page -- nobody needs to be told which day today is.
+ * Dropping it is what makes the chip fit: at the 10px the grid's day headings
+ * are set in, `THU, AUG 28` is 89px and the chip is 54px against a 133px cell
+ * at 1280, where `AUG 28` is 51px and the pair fits with room.
+ *
+ * The month stays, on today's column and every other, so the row still shows
+ * the month turning over mid-week.
+ *
+ * Beside `localDayLabel` rather than inside it, because a caller wants one or
+ * the other and a boolean parameter would make every call site read
+ * `localDayLabel(date, false)` without saying what false means. Same UTC
+ * round-trip, for the reason that function records.
+ */
+export function localDateLabel(localDate: string): string {
+  const [year, month, day] = partsOf(localDate);
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: "UTC",
+    month: "short",
+    day: "numeric",
+  }).format(new Date(Date.UTC(year, month - 1, day)));
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -112,24 +112,33 @@ export default defineConfig({
       // Covering what is left means faking spawn, fetch and the GitHub API at
       // once, which costs more than it returns and is the trade ADR-0002 already
       // made for run-gates.mjs.
-      // LOWERED 2026-08-27, lines only, by one hundredth of a point: 85.73 to
-      // 85.72. Not reason 1 and not a file going uncovered. Moving the daylight
-      // window out of `WeekPanel`'s rows and into the day header **deleted two
-      // fully-covered lines**, and deleting covered code from a repo whose
-      // global ratio is 85.7% lowers that ratio -- 1726/2013 was 85.74%,
-      // 1724/2011 is 85.72%.
+      // LOWERED 2026-08-27, twice, by hundredths, and neither time because
+      // anything went uncovered. ADR-0023 **deleted covered code** from the
+      // week grid, and deleting covered code from a repo whose global ratio is
+      // 86% lowers that ratio.
       //
-      // Recorded because it is the first drop here that is not about coverage
-      // at all, and the ratchet will do it again: every slice that removes
-      // tested code costs a hundredth. All five files that changed sit at 100%
-      // lines, which is the thing worth checking before touching this block --
-      // a genuine regression and this arithmetic look identical from the
-      // failure message alone.
+      // The arithmetic is the check, and it is available in the failure output
+      // rather than needing to be trusted:
+      //
+      // - lines 1726/2013 -> 1724/2011, the daylight window leaving
+      //   `WeekPanel`'s rows for the day header. Two lines removed, two of them
+      //   covered.
+      // - branches 1300/1483 -> 1296/1479 and functions 429/463 -> 427/461,
+      //   the `allDay` ternaries and the two `worded` helpers going with the
+      //   overnight figures. Four branches and two functions removed; the
+      //   numerator fell by exactly the same amount, which is what says every
+      //   one of them was covered.
+      //
+      // **Numerator and denominator falling together is the signature of this
+      // and not of a regression**, which drops the numerator alone. Check that
+      // before touching these numbers again: the failure message reads the same
+      // either way, and the ratchet will do this on every slice that removes
+      // tested code.
       thresholds: {
-        statements: 86.14,
-        branches: 87.66,
-        functions: 92.64,
-        lines: 85.72,
+        statements: 86.16,
+        branches: 87.62,
+        functions: 92.62,
+        lines: 85.74,
       },
     },
   },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -112,11 +112,24 @@ export default defineConfig({
       // Covering what is left means faking spawn, fetch and the GitHub API at
       // once, which costs more than it returns and is the trade ADR-0002 already
       // made for run-gates.mjs.
+      // LOWERED 2026-08-27, lines only, by one hundredth of a point: 85.73 to
+      // 85.72. Not reason 1 and not a file going uncovered. Moving the daylight
+      // window out of `WeekPanel`'s rows and into the day header **deleted two
+      // fully-covered lines**, and deleting covered code from a repo whose
+      // global ratio is 85.7% lowers that ratio -- 1726/2013 was 85.74%,
+      // 1724/2011 is 85.72%.
+      //
+      // Recorded because it is the first drop here that is not about coverage
+      // at all, and the ratchet will do it again: every slice that removes
+      // tested code costs a hundredth. All five files that changed sit at 100%
+      // lines, which is the thing worth checking before touching this block --
+      // a genuine regression and this arithmetic look identical from the
+      // failure message alone.
       thresholds: {
         statements: 86.14,
         branches: 87.66,
         functions: 92.64,
-        lines: 85.73,
+        lines: 85.72,
       },
     },
   },


### PR DESCRIPTION
Closes #169.

The week grid's day cell was eleven to fourteen undifferentiated lines under
four labels, two of which wrapped at every width the grid has ever had. It is
now a day header and three separated readings.

## What changed, by slice

**1 · The plan** — `docs/plans/week-grid-legibility.md`, written first and as
its own commit, because the work reverses a bullet of ADR-0017 and the rejected
options are the part worth keeping.

**2 · The daylight window moves into the day header, and the columns step.**
It is the header rather than a `WeekRow` because it states the *scope* the
other rows' figures are selected within rather than a fourth figure. It carries
a stroked SVG sun on `currentColor` and names itself through `role="img"`,
because "Daylight" does not fit beside two clock times in a 125px cell.

**3 · The rows carry only what daylight reaches.** `Lowest daylight tide` →
`Low tide`, `Biggest daylight swell` → `Swell`, `Cloud by day` → `Clouds`. The
day's own overnight extremes leave the grid. **ADR-0023** records this, because
it reverses ADR-0017.

**4 · The tile gets a header band, hairline rules and a colour key.**

## The measurements the whole thing turns on

Rendered at La Jolla Shores, 10px `font-extrabold tracking-widest` for a label:

| string                   | width |
| ------------------------ | ----- |
| `LOWEST DAYLIGHT TIDE`   | 170px |
| `BIGGEST DAYLIGHT SWELL` | 187px |
| `LOW TIDE` / `SWELL` / `CLOUDS` | 70 / 47 / 56px |

against the cell they had to fit in:

| viewport | columns (before → after) | content width (before → after) |
| -------- | ------------------------ | ------------------------------ |
| 1024     | 7 → 4                    | **88px** → 189px               |
| 1280     | 7 → 7                    | 125px                          |
| 1536     | 7 → 7                    | 161px                          |

The two long labels never fitted anywhere. And 88px — narrower than
`THU, AUG 27` renders at 89px — is what every hard-coded `lg:block` in
`DaylightWeek`, `TideWeek`, `WaveWeek` and `SkyWeek` was really describing; the
grid rendered 84px *taller* at 1024 than at 1536 because of them. All four are
gone.

**Grid height, before → after:**

| viewport | before | after |
| -------- | ------ | ----- |
| 1280     | 414px  | 256px |
| 1536     | 414px  | 256px |
| 1024     | 498px  | 460px |
| 375      | ~1822px (250px/day) | 1256px (169px/day) |

No width from 375 to 1536 overflows horizontally.

## Contrast, measured rather than assumed

| pair | ratio |
| ---- | ----- |
| day name white on ocean band | 8.5:1 |
| daylight window `white/85` on ocean band | 6.7:1 |
| day name ocean on mist band | 7.3:1 |
| `Today` chip dark on yellow | 15.2:1 |
| tide label ocean on cell | 8.5:1 |
| swell label purple on cell | 5.3:1 |
| cloud label fog on cell | 5.0:1 |

All clear the 4.5:1 this page holds itself to. Colour is per product and
constant across all seven days — every day's swell label is the same purple
whether the swell is 0.7 ft or 6 ft — so nothing asserts anything about the
water, which is the line ADR-0015 already drew for the reading cards.

Every new utility was confirmed present in the built stylesheet as real CSS
rather than silently resolving to nothing: `.min-h-4\.5`, `.xl\:min-h-4\.5`,
`.border-b-\[1\.5px\]`, `.first\:border-t-0:first-child`, `.text-white\/85`,
`.w-19`, `.rounded-pill`, `.bg-yellow`, `.text-purple`.

## The decision worth arguing about

**ADR-0023 reverses ADR-0017's "the day's own extreme is kept, not dropped."**
That ADR rejected showing only the daylight extreme, because "a page that
silently declines to mention a −0.2 ft is withholding the figure a tidepooler
came for."

Two things weaken that here, and one condition makes it defensible:

- `TideToday` and `WavesToday` still print "Lowest all day" and "Biggest all
  day", so **today's overnight extremes are still on the page.** Six future days
  lose theirs.
- `lib/conditions.ts` is untouched — `allDay` is still computed and still on the
  view models, so the planned day view has the data and this is cheap to
  reverse.
- **It is not silent.** One sentence leads the grid's notes: "This week shows
  what falls between sunrise and sunset. Lows and swells overnight are real and
  often bigger — today's are on the cards above." Removing that sentence while
  keeping the drop restores exactly the failure ADR-0017 objected to, so it has
  a test of its own.

## Noticed, not done

- **`TideToday`'s card is still titled "Lowest daylight tide" while the grid row
  below says "Low tide".** The figures agree — both are the daylight extreme —
  and the card needs its qualifier because it sits outside the header that
  scopes the grid. But the two wordings for one selection are worth a look by a
  person. The reading cards were out of scope here.
- **`ConditionsNotes` contradicted the page** until slice 3: its "Daylight
  first" entry described the "all day" second line as something a reader would
  see. Rewritten, along with two other entries whose wording assumed the old
  labels. This was in scope — my change caused it.

## Coverage floor

`vitest.config.mts` moves twice, and neither time is a regression. Deleting
covered code from a repo whose global ratio is 86% lowers that ratio: branches
went 1300/1483 → 1296/1479 and functions 429/463 → 427/461, so **numerator and
denominator fell by the same amount**, which is the signature of removal rather
than of something going uncovered. The config now spells that tell out, because
the failure message reads identically either way. Lines and statements both
ratcheted up.

## No issue split

Every slice touches `WeekGrid`. Two people could not have picked up two of them
without colliding, which is the test `CLAUDE.md` sets — so this is one issue and
one branch, with the plan file as the durable record.

## Plan changed in flight

Slice 5 (the column steps) shipped inside slice 2 rather than last. The daylight
line is `whitespace-nowrap` and measures 109px; at the old breakpoints the 1024
cell had 88px of content, so the two apart would have left the grid overflowing
for a commit. Recorded as a dated addendum in the plan file rather than
reordered quietly.

## Gate

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  test
  PASS  build
  PASS  stylesheet
```

```
 Test Files  81 passed (81)
      Tests  1128 passed (1128)

Statements   : 86.18% ( 1903/2208 )
Branches     : 87.67% ( 1302/1485 )
Functions    : 92.62% ( 427/461 )
Lines        : 85.77% ( 1730/2017 )
```

## Needs a human

The band colours, the chip, the colour key and the sun mark are all things
jsdom cannot assert (ADR-0001 — no stylesheets), so the tests assert which
classes compose and a person confirms they read. Worth a look at 375 and at the
639px-tall review viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
