### PR TITLE
Draw the shore map, and check which side of it is the sea

### DIFF
--- a/.design/conditions-day-view/DESIGN_REVIEW.md
+++ b/.design/conditions-day-view/DESIGN_REVIEW.md
@@ -1,0 +1,318 @@
+# Design Review: The Conditions Day View
+
+Reviewed against: `.design/conditions-day-view/DESIGN_BRIEF.md`
+Philosophy: Coastal pop editorial, with instrument-panel restraint inside the plot
+Date: 2026-08-29
+Reviewed at: `main` @ `16780b3`, after #175 and #176 merged and #172 closed
+Page: `/conditions/la-jolla-shores-beach`, built and served from a cleared `.next/`
+
+`TASKS.md` scheduled this "once PR 2 has merged". PR 2 became 2a and 2b and both
+are in, so this is the first time the page has reached the shape the brief
+describes. It is run **before** #173 rather than after, because three findings
+below land on PR 3's last task — _The row_ — and finding them afterwards would
+mean rebuilding it.
+
+**Routing, decided 2026-08-29.** #173 is worked first and these findings are
+filed as issues when it merges. None of them is #173's work under CLAUDE.md's
+one-issue-per-branch rule, and the map #173 draws closes half of the ragged
+right edge on its own. The cost of that order is stated where it applies: from
+now until finding 1 is worked, the page runs ADR-0029's permitted duplication
+without the attribution clause that licenses it.
+
+## Screenshots captured
+
+Written to the session scratchpad rather than into the repo. They are pictures
+of a page that #173 changes next, and `.design/` is committed — a stale PNG of a
+superseded layout is worse than no PNG. The findings below carry their own
+measurements, which are the durable part.
+
+`…\scratchpad\shots\`
+
+| File                          | Viewport | What it shows                                              |
+| ----------------------------- | -------- | ---------------------------------------------------------- |
+| `review-1536x639-full.png`    | 1536×639 | The whole page at the review machine's own viewport        |
+| `review-1536x639-day.png`     | 1536×639 | The day region alone — chart, cards, the empty right band  |
+| `state-swell-tab.png`         | 1536×639 | Swell selected: a 1.5 ft curve above a card reading 3.0 ft |
+| `state-temp-tab.png`          | 1536×639 | Temp selected: a 3 °F day drawn as a full-height mountain  |
+| `state-wind-tab.png`          | 1536×639 | Wind selected                                              |
+| `state-other-day.png`         | 1536×639 | Wed, Sep 2 selected — and #177 visible                     |
+| `desktop-1280-full.png`       | 1280×800 | Standard desktop                                           |
+| `tablet-768-full.png`, `-day` | 768×1024 | The `lg` stack                                             |
+| `mobile-375-full.png`, `-day` | 375×812  | One column, 44px targets                                   |
+| `week-cell-1536.png`          | 1536×639 | One week cell, magnified — the sparkline in place          |
+
+## Summary
+
+**The page works, and the brief's hardest bet came off.** The week reads as seven
+small multiples over one large one, the tabs are quiet inside a loud frame, every
+failure state survived the move, nothing overflows at any width, and every text
+pair on the page clears AA when measured from painted pixels.
+
+**The one real defect is attribution.** The day chart draws four series from three
+publishers and names none of them. The only provenance line adjacent to the plot
+says `Sky, in words · this beach's own grid cell · National Weather Service`,
+which is right for two tabs and wrong for the other two — and ADR-0029 already
+states, as a load-bearing clause, that "the chart's provenance names the cell."
+It does not. This is the same class of defect as the tide-station regression #176
+caught by diffing rendered text, and no test can fail on it for the same reason.
+
+Everything else is smaller: a filled area whose baseline is not zero, a heading
+rank that flattened when the cards moved, a three-column band holding one slot,
+and a day control 15px tall.
+
+---
+
+## Must fix
+
+### 1. The chart's four series carry no provenance line
+
+The day region's reading order at 1536, verbatim from `document.body.innerText`:
+
+```
+Today, hour by hour
+TONIGHT Partly Cloudy then Patchy Fog
+Sky, in words  this beach's own grid cell · National Weather Service, San Diego
+               — a forecast, not a reading taken at the beach
+TIDE SWELL WIND TEMP
+[the plot]
+Low 0.2 ft, high 5.3 ft today. Night is shaded; cloud is the band above.
+WAVES AND WATER 🏄 3.0 ft …  Measured now  Buoy Scripps Nearshore · NDBC
+AIR 💨 75°F …               Temperature and wind  Scripps Pier · about 1.4 km
+```
+
+`HourChart.tsx` renders no `ProvenanceLine` — confirmed by grep; the name appears
+only in a docstring. `DayPanel.tsx` likewise. The four curves are attributed
+nowhere in their own region.
+
+**Why this is Must Fix and not a preference.** ADR-0029's third load-bearing
+clause reads:
+
+> **Each keeps its own attribution, and one never covers both.** ADR-0010's rule
+> is unchanged: one `StatGroup` never spans two sources, and **the chart's
+> provenance names the cell** while the card's names the station.
+
+The ADR describes a page that does not exist. The clause is not aspirational — it
+is what makes the two-winds duplication defensible, so the duplication is
+currently running without the condition that licenses it.
+
+**It is worse than merely missing, on two of four tabs.** The nearest provenance
+above the plot names the NWS grid cell. The tide curve is NOAA Tides & Currents;
+the swell curve is CDIP's MOP model at 10 m depth. A reader who takes the line
+above the plot as the plot's source is misinformed on half the tabs.
+
+**And on the swell tab the nearest line below names a different instrument.** See
+`state-swell-tab.png`: the curve tops at 1.5 ft under "Low 0.8 ft, high 1.5 ft
+today", and 40px beneath it the sea card leads with **3.0 ft** and
+"Measured now Buoy Scripps Nearshore · NDBC". Two figures, one sea, one screen —
+and the only source named belongs to the one that is not drawn. ADR-0029 permits
+exactly this pair, and permits it _on condition that each is attributed_.
+
+**Wind and temperature are attributed nowhere on the page at all.** The week grid
+carries three provenance lines — low tide, biggest swell, cloud cover. There is no
+fourth for the gridpoint wind or temperature. The only wind attribution on the
+page is the air card's "Temperature and wind · Scripps Pier", which names the
+station the curve did **not** come from.
+
+_Fix:_ a `ProvenanceLine` under the plot, keyed to the selected tab, naming that
+tab's own publisher — NOAA for tide, CDIP for swell, the grid cell for wind and
+temp. `series.ts` already assembles per-series metadata and `mopLine.ts`,
+`gridCell.ts` and `tideStation.ts` are three modules of the same shape that
+already resolve exactly these three sources. The line changes with the tab, which
+is additive under ADR-0027 and takes nothing out from behind a gesture.
+
+---
+
+## Should fix
+
+### 2. The filled area asserts a baseline the axis does not have
+
+`HourChart` scales each series to its own day's min and max, and fills the area
+from the curve down to the foot of the frame. Both halves are separately
+reasoned in the docstring — the range so "a calm day" is not "a line across the
+middle of an empty frame", the fill because "the line alone left the plot reading
+as an empty field with a thread across it". Neither argument addresses the other.
+
+On the temperature tab the combination is stark. See `state-temp-tab.png`:
+
+| Tab   | Axis floor | Axis top | What the fill implies        |
+| ----- | ---------- | -------- | ---------------------------- |
+| Tide  | 0.2 ft     | 5.3 ft   | honest, floor ≈ 0            |
+| Swell | 0.8 ft     | 1.5 ft   | mildly overstated            |
+| Wind  | 2.3 mph    | 8.1 mph  | overstated                   |
+| Temp  | 74.0 °F    | 77.0 °F  | **a 3 °F day as a mountain** |
+
+The fill's stated purpose is "weight, not a second reading" — an explicit claim
+that it carries no quantitative meaning. Filled to the frame's foot on a floating
+baseline it carries one anyway, and principle 2 makes form the primary channel:
+"a reader can tell which kind of claim they are looking at before reading a word."
+The words are right — the axis reads 74.0 and the summary says "Low 74.0 °F, high
+77.0 °F today" — but the drawing outruns them, and this brief's own rule for
+`DaySpark` was that a drawn zero is a stronger lie than a blank figure. This is
+that rule on the other axis.
+
+Note the asymmetry that makes it visible: the week's sparklines share one scale
+across all seven days (`sharedRange` in `WeekPanel.tsx`) **and carry no fill**.
+The fill exists only on the plot whose baseline floats.
+
+**Ruled 2026-08-29: fade the fill toward the floor.** A gradient from the curve
+down to transparent — keeping the body the fill was added for, and removing the
+hard edge at the foot that is what reads as a quantity.
+
+The two alternatives were weighed and rejected. _Drop the fill wherever the floor
+is not near zero_ would leave tide filled and the other three as bare lines, so
+four tabs would look like two chart styles — which cuts against principle 1's
+"same layers, same shape". _Label the floor as a floor_ answers a form problem
+with words, which is the thing principle 2 exists to avoid.
+
+### 3. The measured cards' heading rank flattened when they moved
+
+The outline at 1536:
+
+```
+H1  Check conditions first.
+H2    The week ahead
+H3      Aug 29 Today … Fri, Sep 4
+H2    Today, hour by hour
+H2      Waves and water     ← inside the day region
+H2      Air                 ← inside the day region
+H2    How to read these numbers
+```
+
+`ReadingCard.tsx:107` hardcodes `<h2>`. That was correct while the cards were
+page-level regions. #176 moved them inside the day region without moving the rank,
+so two card headings are now siblings-in-outline of the region heading that
+contains them.
+
+ADR-0014 described the outline it was fixing as "a card `<h2>` and the day `<h3>`
+inside its **sibling** grid" — cards as siblings of regions is the arrangement the
+ADR was written against, and it no longer holds. The visual rank is fine
+(`REGION_HEADING` at 34px against the label register at 10px); it is the semantic
+one that flattened.
+
+_Fix:_ give `ReadingCard` a heading-level prop, as `WeekGrid` already effectively
+has for its `<h3>` day headings, and pass `h3` from `MeasuredToday`.
+
+### 4. The week's reserved band is a three-column grid holding one slot
+
+`WeekGrid.tsx:677` lays the reserved rows out as `grid gap-3 lg:grid-cols-3`, with
+a comment explaining the choice against **three** slots side by side.
+`WeekPanel.tsx:104` now holds exactly **one**. At 1536 that renders a 472px dashed
+box in a 1440px band with 968px empty to its right, directly under a full-width
+seven-column grid. See `review-1536x639-full.png`.
+
+This is not a taste call — the container no longer matches its contents. It is
+also the half of the page's ragged right edge that #173's map does **not** fix.
+
+_Fix:_ let the band size to its content — full width at one slot, three across when
+there are three — or drop to `lg:grid-cols-3` only when `reserved.length > 1`.
+
+### 5. The day control is a 15px strip inside a 275px cell
+
+The brief: "Each of the seven day cells is a control." Built, the control is the
+day _heading_ only. Measured at 1536:
+
+| Day         | Button    | Cell    |
+| ----------- | --------- | ------- |
+| Aug 29      | 49×**15** | 195×275 |
+| Sun, Aug 30 | 86×**15** | 195×275 |
+| Wed, Sep 2  | 79×**15** | 195×275 |
+
+At 375 the same buttons are 44px tall via `TOUCH_TARGET`, so ADR-0004's floor is
+met where it applies and this is a pointer-comfort issue above `md`, not an
+accessibility failure. Selection state is sound: `aria-current="date"` moves to
+the picked day, the underline moves with it, and today keeps its own TODAY chip
+independently — verified by clicking Sep 2.
+
+**The obvious fix is the wrong one.** Wrapping the cell in a `<button>` would make
+its figures presentational and hide them from the accessibility tree — the trap
+this repo has already recorded. _Fix:_ grow the control within the cell instead —
+full cell width and the header band's height — leaving the figures outside it.
+
+---
+
+## The question the handoff asked: is the ragged right edge tolerable?
+
+Measured at 1536, content column 1440px wide from x=48 to x=1488:
+
+| Block                       | Width   | Right edge |
+| --------------------------- | ------- | ---------- |
+| Week grid                   | 1440    | 1488       |
+| **Week's reserved band**    | **472** | **520**    |
+| Chart card (`max-w-4xl`)    | 896     | 944        |
+| Measured cards (two)        | 1440    | 1488       |
+| Sighting reserved slot      | 1440    | 1488       |
+| "How to read these numbers" | 1440    | 1488       |
+
+**Yes for the chart, no for the reserved band.** They are two different problems
+that look like one.
+
+The chart's 544px of empty ground is a **reservation** — the plan's addendum of
+2026-08-28 records that an uncapped chart drew 440px tall, and #173's map goes in
+exactly that space. Widening it now means drawing a taller chart, reviewing it,
+and narrowing it again one PR later. Leave it; #173 is next and closes it.
+
+The reserved band's 968px is **finding 4**, has no map coming, and predates this
+work's last two PRs only in the sense that it used to hold three slots. It should
+be fixed regardless of #173 and is a one-line change.
+
+**What this means for PR 3's _The row_ task:** the two-thirds/one-third split at
+`xl` is sound as specified, and 896 + gap + ~500 lands the pair on the 1440 edge
+the cards below already sit on. No change to that task.
+
+---
+
+## Could improve
+
+- **Two "…is coming" slots on one page**, ~1,000px apart, in the same dashed
+  treatment. #173 moves the second inside the map, which halves this on its own.
+- **#177 is visible and worth doing soon.** On Wed, Sep 2 the plot reads "Low 8.1
+  mph, high 13.8 mph **today**" under a heading reading "Wed, Sep 2, hour by hour"
+  and four lines above "Nothing has been measured for Wed, Sep 2: the day has not
+  happened." See `state-other-day.png`. Already filed; not this review's to fix.
+- **The cloud legend inside the plot** ("Cloud cover 0% 50% 100%") is the only
+  legend on the page. It is unboxed and in the label register, so it clears the
+  brief's "no boxed legend" anti-reference — but it is the one element inside the
+  frame that is chrome rather than data.
+
+---
+
+## Checked, and deliberately not findings
+
+Recorded so the next reviewer does not re-raise them.
+
+- **The week's sparklines do not follow the selected tab.** This contradicts the
+  brief's principle 1 and _Key Interactions_ — and it is a **recorded decision**,
+  argued at `docs/plans/conditions-day-view.md:442–475` with two alternatives
+  weighed and rejected on measurement. Verified built: 0 of 14 sparkline paths
+  changed when Swell was picked. Not a defect.
+- **Two winds and two air temperatures** — ADR-0029, on purpose.
+- **A swell curve above a measured wave height** — ADR-0016, ADR-0019, ADR-0029.
+- **The week keeps cloud thirds** — ADR-0028; the curve is more resolution, not a
+  reversal.
+- **No `noscript` under the tabs** — ADR-0027; there is nothing to fall back to.
+- **The compass does not follow the selected hour** — ADR-0027's "what this does
+  not license", still standing for #173.
+
+## Verified and passing
+
+- **Contrast, from painted pixels, not the CSS tree.** Both documented controls
+  reproduced exactly — provenance in `ReadingCard` **5.96:1**, card prose
+  **10.02:1** — which is what says the method was right. Everything new clears AA:
+  unselected tab on ocean **5.53:1**, selected tab **8.40:1**, chart summary
+  **5.76:1**, hour readout **8.20:1**, cloud legend **5.76:1**, Earlier/Later
+  **8.40:1**, sky provenance **5.57:1**, reserved headline **5.76:1**.
+- **No horizontal overflow** at 375, 768, 1280 or 1536 — `scrollWidth` equals
+  `clientWidth` at all four.
+- **Touch targets** — every real control is ≥44px tall at 375. The per-hour columns
+  are 10×119 there, which ADR-0027 declares an enhancement guarded by the 44px
+  prev/next pair.
+- **Keyboard and announcement** — `role="tablist"` labelled "What to plot for this
+  day", roving tabindex (0 / −1), one `aria-live="polite"` readout, focus ring
+  inherited from `globals.css` (`outline: 2px solid currentColor`) and redefined
+  nowhere in the day components.
+- **Colour is never the only channel** — published points are marked and
+  interpolated ones are not (shape); night is shaded _and_ stated in the summary
+  line; the selected day is underlined _and_ carries `aria-current`.
+- **`prefers-reduced-motion`** — not engaged; no transitions were added.
+- **Every failure state survived the move**, and the absence sentence names its
+  day: "Nothing has been measured for Wed, Sep 2: the day has not happened."

--- a/.design/conditions-day-view/TASKS.md
+++ b/.design/conditions-day-view/TASKS.md
@@ -294,6 +294,19 @@ nothing the chart touches. **`Compass` is not independent** — it needs the
 gridpoint wind direction that PR 2's first task adds, so it cannot start until
 that has merged. `ShoreMap` can be built and reviewed before it.
 
+**Cut in two on 2026-08-30, at the compass**, the way PR 2 was cut the day
+before and for the same reason: eight tasks against CLAUDE.md's guide of about
+five slices. **PR 3a is everything except `Compass`** — the geometry, the
+checker, `ShoreMap`, the sighting slot moving onto it, the two ADRs, the row
+and the floor. It ends with a map a reader can see, so it is a complete path
+rather than a layer. **PR 3b is `Compass` alone**, which adds needles to a map
+that already exists and is vertical for the same reason.
+
+Two consequences of the cut. `docs/plans/conditions-day-view.md` is marked
+historical by **3b**, not by 3a, because 3b is now the last of the work that
+plan covers. And 3a says `Part of #173` rather than `Closes #173`, which is the
+form the condition actually supports.
+
 - [x] **Coastline geometry.** A module in `src/lib/` that de-duplicates
       consecutive identical points, windows the polyline around a beach, and
       projects lat/lon to plot coordinates. **The de-duplication is not
@@ -331,7 +344,7 @@ that has merged. `ShoreMap` can be built and reviewed before it.
       the open coast only. That is the number `ShoreMap` has to answer for, and
       it is 23 rather than the one degenerate beach the brief anticipated.
 
-- [ ] **`ShoreMap`.** This beach's coast drawn from the windowed polyline, its own
+- [x] **`ShoreMap`.** This beach's coast drawn from the windowed polyline, its own
       segment marked, the sea shaded, and the four sources plotted at their real
       distances — the MOP line, the wave buoy, the tide station, the air station.
       Distances come from `beaches.json`, which already holds them; nothing is
@@ -352,22 +365,24 @@ that has merged. `ShoreMap` can be built and reviewed before it.
       has an upper equal to its lower, renders without a shore reference and says
       why rather than drawing a confident wrong dial.
 
-- [ ] **The sighting layer stays reserved.** `ReservedSlot` moves inside the map:
+- [x] **The sighting layer stays reserved.** `ReservedSlot` moves inside the map:
       the frame is real content now, and what is coming is the sightings drawn on
       it. The copy names what lands there and carries no issue number, per the
       standing rule. _Reuses `ReservedSlot`._
 
-- [ ] **ADR: the map becomes real and reserves a layer.** Amends what a reserved
+- [x] **ADR: the map becomes real and reserves a layer.** Amends what a reserved
       slot is in this repo — a stand-in for content, which may now sit inside real
       content rather than instead of it. CONTEXT.md's `Reserved slot` entry is
       updated in the same PR, since it is the glossary that defines the term.
 
-- [ ] **The row.** Chart and map side by side at `xl` at roughly two thirds and
+- [x] **The row.** Chart and map side by side at `xl` at roughly two thirds and
       one third; stacked at `lg` with the map at reduced height; one column below
       that, chart then map. _Modifies `ConditionsSection`._ **Depends on:
       `HourChart` (PR 2), `ShoreMap`.**
 
-- [ ] **Coverage floor.** As PR 1.
+- [x] **Coverage floor.** As PR 1. Moved in PR 3a's last commit, and every
+      figure rose: this half added only tested code, and `coastline.ts` and
+      `shore.ts` each finished fully covered.
 
 ---
 
@@ -385,6 +400,9 @@ that has merged. `ShoreMap` can be built and reviewed before it.
       picks one word for each — the sparkline, the day panel, the dial, the shore
       map. The glossary is the thing kept current; a term used in three components
       under two names is the drift it exists to prevent.
+      **Three of the four landed in PR 3a**, plus `hour chart`, which the list
+      above did not name and which had the same problem. The **dial** is the one
+      left and belongs with the compass in PR 3b.
 
 - [ ] **Plan file.** `docs/plans/conditions-day-view.md`, committed as its own
       first commit before PR 1's first slice. Required here rather than optional:
@@ -394,7 +412,7 @@ that has merged. `ShoreMap` can be built and reviewed before it.
 
 ## Review
 
-- [ ] **Design review.** Run `/design-review` against the brief once PR 2 has
+- [x] **Design review.** Run `/design-review` against the brief once PR 2 has
       merged and there is something to look at. Capture at 1536×639 as well as the
       standard breakpoints — that is the viewport this is reviewed on, and a
       layout that only works taller is not finished.

--- a/.design/conditions-day-view/TASKS.md
+++ b/.design/conditions-day-view/TASKS.md
@@ -294,7 +294,7 @@ nothing the chart touches. **`Compass` is not independent** — it needs the
 gridpoint wind direction that PR 2's first task adds, so it cannot start until
 that has merged. `ShoreMap` can be built and reviewed before it.
 
-- [ ] **Coastline geometry.** A module in `src/lib/` that de-duplicates
+- [x] **Coastline geometry.** A module in `src/lib/` that de-duplicates
       consecutive identical points, windows the polyline around a beach, and
       projects lat/lon to plot coordinates. **The de-duplication is not
       housekeeping**: 123 of the 1,210 MOP lines repeat their neighbour's
@@ -307,13 +307,29 @@ that has merged. `ShoreMap` can be built and reviewed before it.
       fails loudly; a zero-length segment is never returned; the projection is
       stable for a fixed window.
 
-- [ ] **Checker: which side is the sea.** With duplicates removed, all 13 wave
+- [x] **Checker: which side is the sea.** With duplicates removed, all 13 wave
       buoys fall on the left of the polyline walked south to north. That rule is
       load-bearing for the map's water shading and too important to assume, so it
       gets a script in the shape ADR-0021 established, plus a row in the gate
       table. _New script and gate row._ **Depends on: coastline geometry.**
       **Tests assert:** the checker fails when a buoy is moved to the wrong side,
       not merely when it errors.
+      **The sentence above is false as written, and the checker is what found
+      it.** Walked end to end the polyline is not monotonic: it wraps Point
+      Loma, and 39 of its 1,209 steps run north to south. Buoy 46232 sits
+      22.9 km off that peninsula, matches a segment on the wrap, and lands on
+      the **right**. So the whole-county form of the check fails — 12 of 13, not
+      13 of 13 — and it is the check that is wrong rather than the data, because
+      the map never asks the question that way. It asks inside one beach's
+      window, where the coast runs one way, and there the rule holds without
+      exception. That is what shipped.
+      **Two counts the task did not have, both measured.** Only **15 of 51**
+      beaches bind a wave buoy at all, so 36 cannot be asked the question — the
+      gate row reports them grouped rather than one line each. And **23 of 51**
+      have no coast in their window at all: every Mission Bay and San Diego Bay
+      beach, 2.6 to 5.4 km from the nearest MOP line, because this file traces
+      the open coast only. That is the number `ShoreMap` has to answer for, and
+      it is 23 rather than the one degenerate beach the brief anticipated.
 
 - [ ] **`ShoreMap`.** This beach's coast drawn from the windowed polyline, its own
       segment marked, the sea shaded, and the four sources plotted at their real

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,6 +41,10 @@ _Avoid_: email list, mailing list, the community, the loop
 A labeled stand-in for content that has been decided on but not yet written or
 built — a schedule, a booking scheduler, the conditions tool. Renders as a
 dashed frame with an emoji and a "coming soon" line naming what lands there.
+It may stand **instead of** the content, which is where five of the six sit, or
+**inside** content that already exists, holding open a layer of it rather than
+the whole — the sightings on the shore map (ADR-0031). Either way it names what
+lands there and never an issue number.
 _Avoid_: coming-soon box, empty state, placeholder (that word is taken, below)
 
 **Placeholder**:
@@ -170,3 +174,31 @@ calls it what it is: "MOP line D0498". A beach binds one for the week ahead and
 a wave buoy for now; the two are separate joins over separate tables and refuse
 the same water.
 _Avoid_: MOP station, model buoy, virtual buoy, forecast point
+
+**Sparkline**:
+The 24-hour shape drawn behind the figures in one cell of the week grid. It
+draws the tide, with night shaded, at a range shared across all seven days so
+the cells stay comparable. It carries no cloud (ADR-0026) and does not follow
+the day chart's tab — the week is the tide's shape at a glance, and the chart
+is four products at reading size.
+_Avoid_: mini chart, thumbnail, micro graph, spark
+
+**Day panel**:
+The region below the week, showing one chosen day: its heading, the
+publisher's sky wording, the hour chart, the shore map, and — on today alone —
+what was measured. The week grid is the control that picks which day; the panel
+is what redraws.
+_Avoid_: day view, detail panel, today panel (it is any of seven days)
+
+**Hour chart**:
+The large plot inside the day panel: twenty-four hours across, night shaded,
+cloud as a band above, one of four series drawn at a time behind four tabs.
+_Avoid_: graph, the plot, day chart, timeline
+
+**Shore map**:
+The square picture beside the hour chart: this beach's stretch of coast, the
+sea washed in beside it, and the four sources its figures come from plotted at
+their real distances. The line it draws is CDIP's model line rather than a
+shoreline, so the wash fades rather than ending at it (ADR-0030). It reads no
+feed — every position on it is committed.
+_Avoid_: locator, mini map, station map, chart (that word is the plot's)

--- a/docs/adr/0030-the-map-draws-a-model-line-not-a-shore.md
+++ b/docs/adr/0030-the-map-draws-a-model-line-not-a-shore.md
@@ -1,0 +1,119 @@
+# 0030 — The map draws a model line, not a shore, and says so
+
+Date: 2026-08-30. Status: accepted. Extends ADR-0010 from a sentence to a
+picture, and adds a condition to it.
+
+## Context
+
+`ShoreMap` draws this beach's coast, its own stretch of it, and the four places
+every figure on the page comes from, each at its real distance. That is
+ADR-0010's requirement — "no figure is ever shown without the reader being able
+to see where it came from" — answered by drawing instead of by writing.
+
+The only geometry this repo holds for the county's coast is
+`src/data/mop-lines.json`: 1,210 CDIP model lines at about 98 m spacing,
+committed by `scripts/probe-mop-lines.mjs`. Nothing had ever read that file as
+a shape before; `beaches.ts` reads it one key at a time to answer which line a
+beach binds.
+
+**Read as a shape, it turns out not to be a shoreline.** CDIP computes MOP
+lines at 10 m depth, and their published positions sit offshore of the sand.
+
+### What was measured
+
+Across the 25 beaches that bind a MOP line, `mop_line_distance_m` runs:
+
+| min   | p25   | median | p75   | max   |
+| ----- | ----- | ------ | ----- | ----- |
+| 117 m | 466 m | 644 m  | 776 m | 930 m |
+
+At La Jolla Shores, directly: at latitude 32.8665 the MOP lines sit at
+longitude −117.2609 to −117.2587, and the beach's own committed coordinate at
+that latitude is −117.2592. The bound line D0498 is about 310 m seaward of the
+beach's own position.
+
+**The consequence is visible on the page the site opens on.** The Scripps tide
+gauge (9410230) and the Scripps Pier air station (LJAC1) are at −117.2571 and
+−117.2570 — both on a pier, both over water, and both **landward** of the drawn
+line. A map that shaded one side as sea and the other as land put two
+instruments that are in the ocean onto the beach.
+
+## Decision
+
+**The line is drawn, and the map declines to say where the water stops.**
+
+Three parts, and each is load-bearing:
+
+- **The wash fades rather than ending.** It is transparent where the line is
+  and reaches full strength 644 m seaward — the measured median offset itself,
+  not a chosen number. The picture says the sea is that way and refuses to say
+  the edge is here. Held as a real ground distance rather than a fraction of
+  the frame, so it scales with the map: a few plot units on `mission-beach`'s
+  20 km frame, about a sixth of the picture on La Jolla's 3.9 km one.
+
+- **The line names what it was traced from**, in a sentence under the picture.
+  The markers were attributed one at a time and the largest thing on the map
+  was not, which is ADR-0010's own rule applied everywhere except where it is
+  hardest to notice. It matters more here than for an ordinary figure: nothing
+  about looking at a line down a coast says it is a model line rather than a
+  shore, so the words are the only place a reader can learn it.
+
+- **Which side is seaward is still checked, because it is still a fact.** The
+  offset does not make the question meaningless — the sea really is west of the
+  line at every beach — it only makes the boundary imprecise. The `sea-side`
+  gate row proves the side for every beach that binds a wave buoy, 15 of 51,
+  and `sideOf` in `src/lib/coastline.ts` is what the map shades by.
+
+## Alternatives considered
+
+**Keep the hard edge; the offset is small against the frame.** 117 to 930 m
+against frames of 1.8 to 20 km is 3% to 30%. Rejected on the worst case rather
+than the average: 30% is La Jolla, which is the beach the page opens on, and
+there the error is not an abstraction — it renders a tide gauge and a pier in a
+car park. A rule that is fine on average and wrong on the default page is
+wrong.
+
+**Keep the hard edge and caption it.** Say in words that the line is CDIP's
+model line at 10 m depth. Rejected because the caption fights the form: the
+picture still looks like a coastline, so a reader who does not read the caption
+is misinformed exactly where it costs most, and this brief's second principle
+is that form carries the claim before words do. The caption is kept — it is the
+second clause above — but it is not made to do this work alone.
+
+**Drop the shading entirely.** Draw the line, mark the beach, plot the markers,
+claim nothing about which side is water. Unimpeachable and too expensive: it
+costs the strongest orientation cue on the map, and it leaves the `sea-side`
+gate row checking a fact nothing uses, which is how a checker rots.
+
+**Find a real shoreline.** No shoreline dataset is committed here, and adding
+one is a data acquisition rather than a layout decision — a new source, a new
+join, a new probe and a new checker. If one ever lands, this decision is what
+it supersedes.
+
+**Shift the line inland by the measured offset.** Tempting and worse: it would
+invent coordinates no publisher issued, and the offset is not constant — 117 to
+930 m — so the correction would be wrong nearly everywhere it was applied. This
+site does not manufacture positions, which is the same rule that keeps
+`beaches.json`'s distances a join result rather than a runtime computation.
+
+## Consequences
+
+- **The map is honest about a boundary it cannot draw, and looks slightly less
+  crisp for it.** Anyone who "fixes" the blur into a hard edge reverses this
+  decision, and it will look like tidying.
+
+- **The 644 m fade is a measurement and will go stale.** It is the median of a
+  committed table; a re-run of `probe-mop-lines.mjs` that moved the lines would
+  make it wrong without failing anything. It is named as a constant with the
+  measurement in its docstring, which is this repo's usual answer, and it is
+  the kind of figure `TASKS.md` already records as going stale within days.
+
+- **ADR-0010 gains a condition when it is discharged by drawing.** Naming a
+  station in words carries its own precision; drawing one asserts a position,
+  and a position drawn against a reference the reader cannot see is a claim
+  about that reference too. Anything else this page draws at a real position
+  owes the same disclosure.
+
+- **The `sea-side` gate row survives and means less than its name suggests.**
+  It proves which side, not where the boundary is. `scripts/sea-side.mjs` says
+  so; this is the decision that made the distinction matter.

--- a/docs/adr/0031-a-reserved-slot-may-sit-inside-real-content.md
+++ b/docs/adr/0031-a-reserved-slot-may-sit-inside-real-content.md
@@ -1,0 +1,96 @@
+# 0031 — A reserved slot may sit inside real content
+
+Date: 2026-08-30. Status: accepted. Amends the `Reserved slot` entry in
+`CONTEXT.md`, which is updated in the same pull request.
+
+## Context
+
+A reserved slot in this repo is a labelled stand-in for content that has been
+decided on but not yet built — a schedule, a booking scheduler, the conditions
+tool. It renders as a dashed frame naming what lands there, and its argument is
+that a reader can tell the difference between a feature that is coming and one
+that was never considered.
+
+Every one of the six call sites stands **instead of** something: where the
+content will go, there is a dashed box saying what it will be.
+
+The sighting map from #121 was one of those. It sat at the foot of
+`/conditions`, full width, and said "A map of what people have found here is
+coming."
+
+**Then the map arrived, and it was not the sighting map.** #173 draws this
+beach's coast and the four sources its figures come from — real content, in the
+place the reserved slot had been holding open. What is still missing is not a
+map at all: it is the _sightings_, drawn on top of one.
+
+So the slot had a choice of two wrong answers. Left where it was, the page
+carries a real map and, a few hundred pixels below it, a dashed box promising a
+map — which reads as an oversight or as two different maps. Removed, the page
+stops saying that the sightings are coming, and a reader loses the distinction
+the component exists to draw.
+
+## Decision
+
+**A reserved slot may stand for a layer of something that exists, not only for
+the whole of something that does not.**
+
+The sighting slot moves inside the map's own column, beneath the picture it
+annotates, at `row` density. Its copy changes from naming the container to
+naming the layer: "Sightings will be drawn on this map."
+
+Two things do **not** change, and the amendment is only worth making because
+they do not:
+
+- **The claim stays exactly what #121 fixed.** iNaturalist records where people
+  with phones went rather than where animals are, so the slot promises a record
+  of reports and never a survey, and it says what the layer _will_ show rather
+  than what was found. That sentence survived the move verbatim — confirmed by
+  diffing the page's rendered text against `main`, where it appears on neither
+  side of the diff.
+
+- **No issue number in the copy.** A reader is owed what is coming, not our
+  backlog. The standing rule, unchanged.
+
+## Alternatives considered
+
+**Delete the slot when the map lands, and re-add it with the sightings.** The
+simplest, and it is the thing this component exists to prevent: between the two
+pull requests the page would say nothing about the sightings, and a reader in
+that window cannot tell a deferred feature from one nobody thought of. It also
+loses the copy #121 spent an argument getting right, which would have to be
+rebuilt from the issue.
+
+**Leave it where it was and change nothing.** Cheapest, and it puts a dashed
+box promising a map directly under a map. The failure is not subtle.
+
+**Overlay the slot on the map itself**, inside the SVG frame. The most literal
+reading of "inside the map", and it obscures the thing it is annotating —
+trading real content for a stand-in, which is the exact inversion this decision
+is meant to license against.
+
+**Keep it full width, below the day region.** Preserves the current layout and
+breaks the association: a slot describing a layer of a specific picture has to
+sit with that picture, or the reader has to work out which map it means. The
+map is a third of the row at `xl`, so the slot is too.
+
+## Consequences
+
+- **`ReservedSlot` gains no prop and no new tone.** The amendment is about where
+  a slot may be put and what it may stand for, not about how it renders — which
+  is why this is an ADR and not a component change. Its two closed lists are
+  untouched.
+
+- **`CONTEXT.md`'s definition widens**, and the glossary is the thing kept
+  current. A slot is a stand-in for content that has been decided on and not
+  yet built, whether that content is a region, a page or a layer of something
+  already drawn.
+
+- **A slot inside real content has a new way to be wrong**: it can start
+  describing the container rather than the layer, which is what the old copy
+  did the moment the map existed. The test that catches that is the one
+  asserting the tense and the subject, and it moved to `DayPanel.test.tsx` with
+  the slot — in `ConditionsSection.test.tsx` it would have passed whatever the
+  slot said, because that suite mocks the panel.
+
+- **The other five call sites are unaffected** and still stand instead of
+  content. This widens what is permitted; it deprecates nothing.

--- a/docs/plans/conditions-day-view.md
+++ b/docs/plans/conditions-day-view.md
@@ -744,3 +744,98 @@ and the gates green.
 
 All three are `needs-human`: each produces an artifact whose success criterion is
 that it reads to a person, and no gate asserts that.
+
+## Addendum, 2026-08-30: what the map found in the geometry
+
+Dated rather than woven in. This is #173's first half — the coastline geometry,
+the `sea-side` gate row, `ShoreMap`, the sighting slot moving onto it, two ADRs
+and the two-column row. The compass is PR 3b. Four things here were not in the
+brief, `TASKS.md` or the plan above, and three of them are corrections to
+figures those documents assert.
+
+**`TASKS.md`'s sea-side claim is false as written, and the checker built to
+prove it is what found that.** "All 13 wave buoys fall on the left of the
+polyline walked south to north" fails at 12 of 13. Walked end to end the file
+is not monotonic: it wraps Point Loma, where 39 of its 1,209 steps run north to
+south, and buoy 46232 sits 22.9 km off that peninsula, matches a segment on the
+wrap, and lands on the right.
+
+It is the check that is wrong rather than the data. The map never asks the
+question that way — it asks inside one beach's window, where the coast runs one
+way — and asked that way the rule holds without exception. That is what
+shipped, and `scripts/sea-side.mjs` carries the reasoning.
+
+**Only 15 of 51 beaches can be asked the question at all**, because only 15
+bind a wave buoy. The gate row reports the other 36 grouped by reason with a
+count rather than as 36 identical lines, which would bury the one line that
+matters.
+
+**23 of 51 beaches have no coast in their window.** Every Mission Bay and San
+Diego Bay beach, between 2.6 and 5.4 km from the nearest MOP line, because that
+file traces the open coast only. The brief anticipated exactly one beach
+without a shore reference — `mission-bay-vacation-isle` — and it is 23.
+
+Widening the frames until the ocean appears was measured and rejected. At the
+0.1 margin the map ships with, La Jolla Shores fills 83 percent of its map's
+height; at 0.5 it fills 50 and `mission-bay-vacation-isle` finally reaches
+coast; at 1.0 it fills 33 and `mission-beach`'s frame reaches 51 km. Half-fixing
+the bay beaches by shrinking every open-coast beach is the wrong trade, and
+what arrives at 0.5 is a shoreline 5 km away that is not this beach's shore
+anyway. They get the markers, which is the part ADR-0010 asked for and the part
+that works without a coastline, and the map says the traced coast does not
+reach them.
+
+### The line is not the coast, which is the finding that changed the design
+
+**CDIP computes MOP lines at 10 m depth, and they sit offshore of the sand.**
+Across the 25 beaches that bind one: 117 m to 930 m, median 644. At La Jolla,
+measured directly, the line is about 310 m seaward of the beach's own committed
+coordinate.
+
+The consequence is visible on the beach the site opens on. The Scripps tide
+gauge and the Scripps Pier air station are both on a pier, both over water, and
+both **landward** of the drawn line — so a map with a hard sea-and-land edge
+drew two instruments that are in the ocean onto the beach.
+
+ADR-0030 is the decision: the wash fades over the measured offset rather than
+ending, the line names what it was traced from, and which side is seaward stays
+a checked fact because the offset makes the boundary imprecise rather than the
+question meaningless. It also records why shifting the line inland by the
+offset was refused — it would invent coordinates no publisher issued, and the
+offset is not constant.
+
+### What the frame is sized by, and why it looks wrong at first
+
+**The sources, not the beach.** `mission-beach`'s map is 20 km tall because one
+of its stations is 9 km away, so the beach occupies a fifth of its own map.
+That is the message rather than a defect: a frame comfortably filled by the
+sand would understate exactly the distance ADR-0010 exists to disclose. The
+tightest frame in the county is `shoreline-park` at 1.8 km and the widest
+`mission-beach` at 17 km before the margin.
+
+### Three things the picture got wrong, all found by looking at it
+
+None of the three was caught by a test first, and each has one now.
+
+**The sea polygon left an unshaded wedge.** Closing straight from the last
+point to seaward and back left a diagonal edge of missing sea in a corner
+wherever the shore was not perpendicular to that normal. It runs on past both
+ends now.
+
+**The beach's own stretch was a chord.** Drawn between the two ends
+`beaches.json` carries, neither of which is a point on the MOP line, it landed
+beside the shore at an angle and read as a second, wrong coastline. It is a run
+of the drawn polyline now — except on the 23 beaches with no coast, where the
+chord is the only thing that says where the beach is and is drawn after all.
+
+**Two markers drew one smudge.** At La Jolla the tide gauge is bolted to the
+pier the air station is on, 200 m apart in a 3.9 km frame. Every marker is
+outlined in the page's ground colour now, so overlapping sources read as two
+shapes rather than one blot.
+
+### Noticed and not fixed
+
+**`MeasuredToday`'s `roundedKm` and `shore.ts`'s `shoreDistanceKm` are the same
+rule spelled twice.** One decimal under 10 km, whole kilometres above. Lifting
+it into a shared module is a refactor of two files and belongs to its own
+slice; the duplication is recorded in both docstrings meanwhile.

--- a/scripts/check-sea-side.mjs
+++ b/scripts/check-sea-side.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+/**
+ * The `sea-side` gate row: asserts the sea is on the side the map shades.
+ *
+ * Entry-point plumbing only — read, print, exit. Everything that decides the
+ * verdict lives in sea-side.mjs, where it is unit-tested against a fabricated
+ * county with a buoy moved inland (ADR 0002, same split as
+ * check-adr-numbers.mjs and check-built-css.mjs).
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { checkSeaSide } from "./sea-side.mjs";
+
+const read = (name) =>
+  JSON.parse(
+    readFileSync(
+      fileURLToPath(new URL(`../src/data/${name}`, import.meta.url)),
+      "utf8",
+    ),
+  );
+
+const { ok, lines } = checkSeaSide({
+  mopLines: read("mop-lines.json").lines,
+  beaches: read("beaches.json").beaches,
+  buoys: read("wave-buoys.json").buoys,
+  tideStations: read("tide-stations.json").stations,
+  observationStations: read("observation-stations.json").stations,
+});
+
+console.log(lines.join("\n"));
+process.exit(ok ? 0 : 1);

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -26,6 +26,12 @@ export const GATES = [
   // in milliseconds. Two decisions shared ADR-0008 for two days while every
   // gate stayed green (#102). See docs/plans/adr-number-gate.md.
   { name: "adr-numbers", command: "node scripts/check-adr-numbers.mjs" },
+  // Reads only committed JSON, so it sits with adr-numbers above the expensive
+  // rows. ShoreMap shades the sea by a one-sentence rule about which way the
+  // MOP lines run, and a rule holding up a picture is what ADR-0021 says gets a
+  // checker. See scripts/sea-side.mjs for why the whole-county form of the
+  // check is the wrong one.
+  { name: "sea-side", command: "node scripts/check-sea-side.mjs" },
   // Runs with coverage so the floor in vitest.config.mts is enforced here:
   // Vitest exits non-zero when a threshold is missed, which is the third way
   // CLAUDE.md says this command must fail.

--- a/scripts/sea-side.mjs
+++ b/scripts/sea-side.mjs
@@ -1,0 +1,240 @@
+/**
+ * The `sea-side` gate row's verdict: which side of the traced coast is water.
+ *
+ * `ShoreMap` shades the sea. To shade it, something has to know which side of
+ * the drawn coastline the water is on, and the answer this repo relies on is
+ * that `mop-lines.json` runs south to north along a west-facing county, so the
+ * sea is on the left of the walk. That claim is one sentence and it is holding
+ * up a picture, which is exactly the shape ADR-0021 says gets a checker rather
+ * than a comment.
+ *
+ * **What it checks, and why not the obvious thing.** The obvious check is that
+ * every wave buoy falls left of the whole polyline. That check fails, and it is
+ * the check that is wrong rather than the data: walked end to end the file is
+ * not monotonic -- it wraps Point Loma, where 39 of its 1,209 steps run north
+ * to south -- so buoy 46232, 22.9 km off that peninsula, matches a segment on
+ * the wrap and lands on the right. The map never asks the question that way.
+ * It asks inside one beach's window, where the coast runs one way, and inside
+ * every such window the rule holds. That is what is checked here.
+ *
+ * **Read only, and no flag that writes.** ADR-0021's first line. Nothing here
+ * can regenerate `mop-lines.json`, because nothing here measured it.
+ *
+ * **The geometry is spelled twice, and the duplication is pinned.** This runs
+ * under plain node for the gate and cannot import `src/lib/coastline.ts`;
+ * `generated-date.mjs` already makes the same trade against `pacific-time.ts`,
+ * and ADR-0021 requires the mirror be held by a test rather than by trust.
+ * `sea-side.test.mjs` runs the whole committed file through both spellings and
+ * asserts they agree, rather than sampling a case or two.
+ */
+
+/** The side of the walk the ocean is on. The whole point of the file. */
+export const SEAWARD = "left";
+
+/**
+ * The margin `ShoreMap` frames a beach with, as a fraction of the larger span.
+ *
+ * Here because the window decides the verdict: a wider frame reaches more coast
+ * and can change which segment is nearest. Checking a window the map does not
+ * draw would be checking a different claim.
+ */
+export const WINDOW_MARGIN = 0.1;
+
+/** Consecutive repeats dropped, so no segment has zero length and no direction. */
+export function coastFrom(mopLines) {
+  const points = [];
+
+  for (const id of Object.keys(mopLines)) {
+    const line = mopLines[id];
+    const last = points[points.length - 1];
+    if (last && last.lat === line.lat && last.lon === line.lon) continue;
+    points.push({ id, lat: line.lat, lon: line.lon });
+  }
+
+  return points;
+}
+
+/** The box holding every position with an even margin, or null when there is none. */
+export function boundsAround(positions, margin) {
+  if (positions.length === 0) return null;
+
+  const lats = positions.map((position) => position.lat);
+  const lons = positions.map((position) => position.lon);
+  const south = Math.min(...lats);
+  const north = Math.max(...lats);
+  const west = Math.min(...lons);
+  const east = Math.max(...lons);
+
+  if (south === north && west === east) return null;
+
+  const lonScale = Math.cos((((south + north) / 2) * Math.PI) / 180);
+  const pad = margin * Math.max(north - south, (east - west) * lonScale);
+
+  return {
+    south: south - pad,
+    north: north + pad,
+    west: west - pad / lonScale,
+    east: east + pad / lonScale,
+  };
+}
+
+/** The run of coast reaching a box, plus one point past each end. */
+export function windowAround(points, bounds) {
+  const inside = (point) =>
+    point.lat >= bounds.south &&
+    point.lat <= bounds.north &&
+    point.lon >= bounds.west &&
+    point.lon <= bounds.east;
+
+  const first = points.findIndex(inside);
+  if (first === -1) return [];
+
+  let last = first;
+  for (let index = points.length - 1; index > first; index -= 1) {
+    if (inside(points[index])) {
+      last = index;
+      break;
+    }
+  }
+
+  return points.slice(
+    Math.max(0, first - 1),
+    Math.min(points.length, last + 2),
+  );
+}
+
+/** Which side of a walked run of coast a position falls on, north being up. */
+export function sideOf(points, at) {
+  if (points.length < 2) return null;
+
+  const lonScale = Math.cos((at.lat * Math.PI) / 180);
+  const east = (lon) => lon * lonScale;
+
+  let nearest = Infinity;
+  let cross = 0;
+
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const from = points[index];
+    const to = points[index + 1];
+
+    const dx = east(to.lon) - east(from.lon);
+    const dy = to.lat - from.lat;
+    const length = dx * dx + dy * dy;
+    if (length === 0) continue;
+
+    const px = east(at.lon) - east(from.lon);
+    const py = at.lat - from.lat;
+
+    const along = Math.min(1, Math.max(0, (px * dx + py * dy) / length));
+    const offX = px - along * dx;
+    const offY = py - along * dy;
+    const distance = offX * offX + offY * offY;
+
+    if (distance < nearest) {
+      nearest = distance;
+      cross = dx * py - dy * px;
+    }
+  }
+
+  if (cross === 0) return null;
+  return cross > 0 ? "left" : "right";
+}
+
+/** Everything one beach puts on its map, so the window is the one drawn. */
+function positionsFor(beach, tables) {
+  const positions = [beach.segment.upper, beach.segment.lower];
+
+  const add = (table, key) => {
+    const row = key ? table[key] : null;
+    if (row) positions.push({ lat: row.lat, lon: row.lon });
+  };
+
+  add(tables.mopLines, beach.mop_line);
+  add(tables.buoys, beach.wave_buoy);
+  add(tables.tideStations, beach.tide_station);
+  add(tables.observationStations, beach.air_station);
+
+  return positions;
+}
+
+/**
+ * The rows to print and whether the run passes.
+ *
+ * Pure over one argument, so a test can hand it a fabricated county and move a
+ * buoy inland -- the split ADR-0002 made for the gate runner and ADR-0021
+ * repeated for the probes.
+ *
+ * A beach whose window holds no coast is reported and does not fail. 23 of the
+ * 51 committed beaches are in Mission Bay or San Diego Bay, between 2.6 and 5.4
+ * km from the nearest MOP line, and this file traces the open coast only. That
+ * is a fact about which water is mapped, not a broken rule, and failing on it
+ * would cry wolf on nearly half the county. It is still printed, because
+ * CLAUDE.md's rule is that nothing skipped is silent.
+ */
+export function checkSeaSide(tables) {
+  const coast = coastFrom(tables.mopLines);
+  const wrong = [];
+  const skipped = new Map();
+  let checked = 0;
+
+  const skip = (reason, slug) => {
+    const named = skipped.get(reason) ?? [];
+    named.push(slug);
+    skipped.set(reason, named);
+  };
+
+  for (const beach of tables.beaches) {
+    const buoy = beach.wave_buoy ? tables.buoys[beach.wave_buoy] : null;
+    if (!buoy) {
+      skip("bind no wave buoy", beach.slug);
+      continue;
+    }
+
+    const bounds = boundsAround(positionsFor(beach, tables), WINDOW_MARGIN);
+    if (!bounds) {
+      skip("have every source at one place", beach.slug);
+      continue;
+    }
+
+    const side = sideOf(windowAround(coast, bounds), buoy);
+    if (side === null) {
+      skip("have no coast in their window", beach.slug);
+      continue;
+    }
+
+    checked += 1;
+    if (side !== SEAWARD) {
+      wrong.push(
+        `  ${beach.slug}: buoy ${beach.wave_buoy} is on the ${side} of its own ` +
+          `coast, where the sea is meant to be on the ${SEAWARD}`,
+      );
+    }
+  }
+
+  const lines = [...wrong];
+  lines.push(
+    `sea-side: ${checked - wrong.length} of ${checked} beaches put their buoy ` +
+      `${SEAWARD} of their own coast`,
+  );
+
+  // Grouped by reason with a count. One line per beach was 36 identical lines
+  // against the county as it stands, which buries the line above rather than
+  // reporting anything -- and CLAUDE.md's rule is that a skip is visible, not
+  // that it is repeated. Beaches are named only for a reason that is rare
+  // enough to be worth chasing.
+  for (const [reason, named] of skipped) {
+    const tail = named.length <= NAME_UP_TO ? `: ${named.join(", ")}` : "";
+    lines.push(`  ${named.length} ${reason}${tail}`);
+  }
+
+  return { ok: wrong.length === 0, lines };
+}
+
+/**
+ * Above this many, a reason is a category and the names stop being a lead.
+ *
+ * One or two beaches sharing a reason is an anomaly worth chasing by name.
+ * Three is the start of a class, and 36 -- which is what "binds no wave buoy"
+ * is against the county as it stands -- is a fact about the inventory.
+ */
+const NAME_UP_TO = 2;

--- a/scripts/sea-side.test.mjs
+++ b/scripts/sea-side.test.mjs
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import { checkSeaSide, coastFrom, sideOf } from "./sea-side.mjs";
+import {
+  coastline,
+  sideOf as sideOfTs,
+  boundsAround,
+  windowAround,
+} from "../src/lib/coastline.ts";
+import MOP_LINES from "../src/data/mop-lines.json" with { type: "json" };
+import BEACHES from "../src/data/beaches.json" with { type: "json" };
+import BUOYS from "../src/data/wave-buoys.json" with { type: "json" };
+import TIDE_STATIONS from "../src/data/tide-stations.json" with { type: "json" };
+import OBSERVATION_STATIONS from "../src/data/observation-stations.json" with { type: "json" };
+
+/**
+ * A coast running due north at longitude -117, and one beach on it. West of
+ * that line is the sea; east is the land.
+ */
+function fabricated(buoyLon) {
+  return {
+    mopLines: {
+      D0001: { lat: 32.0, lon: -117.0 },
+      D0002: { lat: 32.01, lon: -117.0 },
+      D0003: { lat: 32.02, lon: -117.0 },
+      D0004: { lat: 32.03, lon: -117.0 },
+      D0005: { lat: 32.04, lon: -117.0 },
+    },
+    beaches: [
+      {
+        slug: "test-beach",
+        segment: {
+          upper: { lat: 32.03, lon: -117.0 },
+          lower: { lat: 32.01, lon: -117.0 },
+        },
+        mop_line: "D0003",
+        wave_buoy: "TEST1",
+        tide_station: null,
+        air_station: null,
+      },
+    ],
+    buoys: { TEST1: { lat: 32.02, lon: buoyLon } },
+    tideStations: {},
+    observationStations: {},
+  };
+}
+
+describe("checkSeaSide", () => {
+  it("passes when the buoy is out to sea, west of a coast walked northward", () => {
+    const { ok, lines } = checkSeaSide(fabricated(-117.01));
+
+    expect(ok).toBe(true);
+    // A beach that holds the rule earns no line of its own; the summary counts it.
+    expect(lines.join("\n")).toMatch(/1 of 1 beaches/);
+  });
+
+  it("fails when a buoy is moved to the landward side", () => {
+    // The assertion this checker exists for. Not "errors" -- the arithmetic is
+    // perfectly happy with a buoy in a car park, which is why nothing catches
+    // this without a rule stated somewhere.
+    const { ok, lines } = checkSeaSide(fabricated(-116.99));
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toMatch(/test-beach.*right/);
+  });
+
+  it("reports a beach the traced coast does not reach without failing", () => {
+    // 23 of the 51 committed beaches are in Mission Bay or San Diego Bay, 2.6
+    // to 5.4 km from the nearest MOP line, so their window holds no coast at
+    // all. That is a fact about which water this file traces, not a broken
+    // rule, and a checker that failed on it would cry wolf on half the county.
+    const inland = fabricated(-117.01);
+    // No bound line either, or the box would stretch back to the coast and the
+    // window would not be empty after all.
+    inland.beaches[0].mop_line = null;
+    inland.beaches[0].segment = {
+      upper: { lat: 33.5, lon: -116.0 },
+      lower: { lat: 33.49, lon: -116.0 },
+    };
+    inland.buoys.TEST1 = { lat: 33.5, lon: -116.01 };
+
+    const { ok, lines } = checkSeaSide(inland);
+
+    expect(ok).toBe(true);
+    expect(lines.join("\n")).toMatch(/no coast/i);
+  });
+
+  it("holds for every beach in the committed data", () => {
+    const { ok } = checkSeaSide({
+      mopLines: MOP_LINES.lines,
+      beaches: BEACHES.beaches,
+      buoys: BUOYS.buoys,
+      tideStations: TIDE_STATIONS.stations,
+      observationStations: OBSERVATION_STATIONS.stations,
+    });
+
+    expect(ok).toBe(true);
+  });
+});
+
+describe("the two spellings of the geometry", () => {
+  it("dedupe to the same coast", () => {
+    // The checker runs under plain node for the gate row and cannot import
+    // TypeScript, so the geometry is spelled twice -- the trade ADR-0021 made
+    // for generated-date.mjs. What keeps it safe is this: not a sampled
+    // agreement but the whole committed file, both ways.
+    const fromScript = coastFrom(MOP_LINES.lines);
+    const fromSrc = coastline();
+
+    expect(fromScript.length).toBe(fromSrc.length);
+    expect(fromScript).toEqual(fromSrc.map((point) => ({ ...point })));
+  });
+
+  it("put every committed beach on the same side of its own window", () => {
+    const coast = coastline();
+    let compared = 0;
+
+    for (const beach of BEACHES.beaches) {
+      const buoy = beach.wave_buoy ? BUOYS.buoys[beach.wave_buoy] : null;
+      if (!buoy) continue;
+
+      const positions = [beach.segment.upper, beach.segment.lower, buoy];
+      const bounds = boundsAround(positions, 0.1);
+      if (!bounds) continue;
+
+      const window = windowAround(coast, bounds);
+      expect(sideOf(window, buoy)).toBe(sideOfTs(window, buoy));
+      compared += 1;
+    }
+
+    // A pin that compared nothing would pass forever, so the count is pinned
+    // too: 15 of the 51 committed beaches bind a wave buoy, and only those can
+    // be asked the question at all.
+    expect(compared).toBe(15);
+  });
+});
+
+describe("what the gate row prints", () => {
+  it("groups the beaches it could not check by reason, not one line each", () => {
+    // 36 of the 51 bind no wave buoy, and 36 identical lines is not a report --
+    // it buries the one line a reader needs. The reason is named once with its
+    // count, and only an unusual reason names beaches.
+    const many = fabricated(-117.01);
+    for (let index = 0; index < 3; index += 1) {
+      many.beaches.push({
+        slug: `no-buoy-${index}`,
+        segment: many.beaches[0].segment,
+        mop_line: "D0003",
+        wave_buoy: null,
+        tide_station: null,
+        air_station: null,
+      });
+    }
+
+    const { ok, lines } = checkSeaSide(many);
+    const printed = lines.join("\n");
+
+    expect(ok).toBe(true);
+    expect(printed).toMatch(/3 bind no wave buoy/);
+    expect(printed).not.toMatch(/no-buoy-0/);
+  });
+});

--- a/scripts/sea-side.test.mjs
+++ b/scripts/sea-side.test.mjs
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { checkSeaSide, coastFrom, sideOf } from "./sea-side.mjs";
+import { checkSeaSide, coastFrom, sideOf, WINDOW_MARGIN } from "./sea-side.mjs";
 import {
   coastline,
   sideOf as sideOfTs,
   boundsAround,
   windowAround,
+  SHORE_WINDOW_MARGIN,
 } from "../src/lib/coastline.ts";
 import MOP_LINES from "../src/data/mop-lines.json" with { type: "json" };
 import BEACHES from "../src/data/beaches.json" with { type: "json" };
@@ -157,5 +158,13 @@ describe("what the gate row prints", () => {
     expect(ok).toBe(true);
     expect(printed).toMatch(/3 bind no wave buoy/);
     expect(printed).not.toMatch(/no-buoy-0/);
+  });
+});
+
+describe("the window the map draws", () => {
+  it("is the window the checker measures", () => {
+    // A checker run against a different frame checks a different claim: a wider
+    // window reaches more coast and can change which segment is nearest a buoy.
+    expect(WINDOW_MARGIN).toBe(SHORE_WINDOW_MARGIN);
   });
 });

--- a/src/components/conditions/ChosenDay.tsx
+++ b/src/components/conditions/ChosenDay.tsx
@@ -70,7 +70,21 @@ export type DayView = {
   measured: ReactNode;
 };
 
-export function ChosenDay({ days }: { days: readonly DayView[] }) {
+export function ChosenDay({
+  days,
+  map,
+}: {
+  days: readonly DayView[];
+  /**
+   * The shore map, already rendered.
+   *
+   * Outside `DayView` and not inside it, because the map does not change when a
+   * reader picks a different day: the beach, its coast and the four places its
+   * figures come from are the same on all seven. Seven copies of one picture
+   * would say the opposite, and would redraw it on every click.
+   */
+  map: ReactNode;
+}) {
   const { selected } = useSelectedDay();
   const showing = resolveSelected(
     selected,
@@ -108,16 +122,35 @@ export function ChosenDay({ days }: { days: readonly DayView[] }) {
         Only the foreground changes, which is what makes the four one instrument
         rather than four charts sharing a tile.
       */}
-      <HourChart
-        startMs={day.startMs}
-        endMs={day.endMs}
-        series={day.series}
-        sunriseMs={day.sunriseMs}
-        sunsetMs={day.sunsetMs}
-        cloud={day.cloud}
-        cloudDescription={day.cloudDescription}
-        nowMs={day.nowMs}
-      />
+      {/*
+        When and where, side by side, which is the brief's third principle as a
+        layout: "time on the left, place on the right". Two thirds and one third
+        from `xl`, because the chart plots twenty-four hours and needs the width
+        while the map is square.
+
+        Below `xl` they stack, chart first. The map does not go full width when
+        it does: it is square, so a 1,184px column would draw a 1,184px-tall
+        picture and push the measured block off the screen entirely. Capping the
+        width is what "the map beneath at a reduced height" comes to for a shape
+        that is as tall as it is wide.
+      */}
+      <div className="xl:flex xl:items-start xl:gap-6">
+        <div className="min-w-0 xl:basis-2/3">
+          <HourChart
+            startMs={day.startMs}
+            endMs={day.endMs}
+            series={day.series}
+            sunriseMs={day.sunriseMs}
+            sunsetMs={day.sunsetMs}
+            cloud={day.cloud}
+            cloudDescription={day.cloudDescription}
+            nowMs={day.nowMs}
+          />
+        </div>
+        <div className="mx-auto mt-6 w-full max-w-sm min-w-0 xl:mt-0 xl:max-w-none xl:basis-1/3">
+          {map}
+        </div>
+      </div>
 
       {/*
         Under the chart, which is the order the brief lists this region in:

--- a/src/components/conditions/ConditionsSection.test.tsx
+++ b/src/components/conditions/ConditionsSection.test.tsx
@@ -89,57 +89,11 @@ test("every caveat the data files carry reaches this page", () => {
   }
 });
 
-/**
- * The sighting map is specified in #121 and deferred. The page says what lands
- * there rather than being silent about it, which is the whole point of a
- * reserved slot: a reader can tell the difference between a feature that is
- * coming and one that was never considered.
- */
-test("the page names the sighting map as coming rather than staying silent", () => {
-  render(<ConditionsSection slug={DEFAULT_BEACH_SLUG} />);
-
-  expect(
-    screen.getByText(/A map of what people have found here/),
-  ).toBeDefined();
-});
-
-/**
- * The claim the map is allowed to make, fixed in the copy before the map
- * exists. iNaturalist records where people with phones went, not where animals
- * are, and a slot promising a density surface would commit the page to
- * something the data cannot support (#121).
- */
-test("the slot promises a record of reports, never a survey", () => {
-  render(<ConditionsSection slug={DEFAULT_BEACH_SLUG} />);
-
-  expect(
-    screen.getByText(/reported by naturalists, not surveyed by us/),
-  ).toBeDefined();
-});
-
-/**
- * The tense is the claim. Named animals, a named window and a named place in
- * the past tense read as a report of what was found here, and no such report
- * exists — the map is deferred. On a page whose discipline is that every figure
- * names its station and nothing unmeasured is asserted, this was the one
- * sentence a skimming reader could come away believing.
- *
- * The three forecast slots in `WeekPanel` do not have the problem because each
- * describes a product shape — "Swell height and period for each day" — rather
- * than asserting something about the world. This slot has to read the same way.
- * The rolling week stays in the copy: a seven-day window is what the product
- * is (#121), and under "Will show" it describes the map rather than the coast.
- */
-test("the slot says what the map will show, not what was found", () => {
-  render(<ConditionsSection slug={DEFAULT_BEACH_SLUG} />);
-
-  const slot = screen.getByText(/A map of what people have found here/);
-
-  expect(slot.textContent).toContain(
-    "Will show octopus, nudibranchs, sea hares and leopard sharks logged " +
-      "near this beach in the past week",
-  );
-});
+/*
+  The three sighting-slot tests that stood here have moved to DayPanel.test.tsx,
+  with the slot itself. This file mocks DayPanel, so leaving them here would
+  have left three tests that pass whatever the slot says -- or says not at all.
+*/
 
 /**
  * The standing notice ADR-0009 rests on. That decision rejects an embed partly

--- a/src/components/conditions/ConditionsSection.tsx
+++ b/src/components/conditions/ConditionsSection.tsx
@@ -17,7 +17,6 @@ import {
 import { BeachSelector } from "./BeachSelector";
 import { ConditionsNotes } from "./ConditionsNotes";
 import { DayPanel } from "./DayPanel";
-import { ReservedSlot } from "../ui/ReservedSlot";
 import { SelectedDayProvider } from "./selectedDay";
 import { WeekPanel } from "./WeekPanel";
 
@@ -161,23 +160,6 @@ export function ConditionsSection({ slug }: { slug: string }) {
           </Suspense>
         </div>
       </SelectedDayProvider>
-
-      {/*
-        The sighting map is specified in #121 and deferred, so the page says
-        what lands here rather than being silent about it — the standing use of
-        a reserved slot in this repo. It comes out in the slice that fills it,
-        because a slot removed early leaves the page promising less than it did.
-
-        Sized into the space the map will occupy, so the layout around it is
-        designed rather than discovered when the map arrives.
-      */}
-      <div className="mb-9">
-        <ReservedSlot
-          emoji="🗺️"
-          headline="A map of what people have found here is coming."
-          detail="Will show octopus, nudibranchs, sea hares and leopard sharks logged near this beach in the past week — reported by naturalists, not surveyed by us."
-        />
-      </div>
 
       {/*
         One block for everything true of every reading — the datum, what a buoy

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -687,3 +687,48 @@ test("the measured block's loading line uses no word the glossary rejects", asyn
   expect(line.toLowerCase()).not.toContain("forecast");
   expect(line.toLowerCase()).not.toContain("surf report");
 });
+
+/**
+ * The sighting layer from #121, reserved on the map rather than instead of it.
+ *
+ * These three tests moved here with the slot. They were in
+ * `ConditionsSection.test.tsx`, which mocks this component — so left there they
+ * would pass whatever the slot said, including nothing.
+ */
+test("the day names the sighting layer as coming rather than staying silent", async () => {
+  // A reader can tell the difference between a feature that is coming and one
+  // that was never considered. That is the whole point of a reserved slot, and
+  // the map arriving is what changes the copy from "a map is coming" to "the
+  // sightings are coming, on this map".
+  render(await DayPanel({ slug: "la-jolla-shores-beach" }));
+
+  expect(screen.getByText(/Sightings will be drawn on this map/)).toBeDefined();
+});
+
+test("the slot promises a record of reports, never a survey", async () => {
+  // The claim the layer is allowed to make, fixed in the copy before it exists.
+  // iNaturalist records where people with phones went, not where animals are,
+  // and a slot promising a density surface would commit the page to something
+  // the data cannot support (#121).
+  render(await DayPanel({ slug: "la-jolla-shores-beach" }));
+
+  expect(
+    screen.getByText(/reported by naturalists, not surveyed by us/),
+  ).toBeDefined();
+});
+
+test("the slot says what the layer will show, not what was found", async () => {
+  // The tense is the claim. Named animals, a named window and a named place in
+  // the past tense read as a report of what was found here, and no such report
+  // exists. On a page whose discipline is that every figure names its station
+  // and nothing unmeasured is asserted, this is the one sentence a skimming
+  // reader could come away believing.
+  render(await DayPanel({ slug: "la-jolla-shores-beach" }));
+
+  const slot = screen.getByText(/Sightings will be drawn on this map/);
+
+  expect(slot.textContent).toContain(
+    "Will show octopus, nudibranchs, sea hares and leopard sharks logged " +
+      "near this beach in the past week",
+  );
+});

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -60,11 +60,14 @@ import {
   type WaveWeekDay,
   type WaveWeekView,
 } from "@/lib/conditions";
+import { beachBySlug } from "@/lib/beaches";
 import { localMidnightOf, addLocalDays } from "@/lib/pacific-time";
 import { ChosenDay, type DayView } from "./ChosenDay";
 import type { HourSeries } from "./HourChart";
 import { MeasuredPanel } from "./MeasuredPanel";
 import { MeasuredToday } from "./MeasuredToday";
+import { ShoreMap } from "./ShoreMap";
+import { shoreViewFor } from "./shore";
 import { SkyWording } from "./SkyWording";
 import { gridPoints, swellPoints, tidePoints } from "./series";
 
@@ -275,6 +278,22 @@ function cloudBandDescription(
   );
 }
 
+/**
+ * The spoken equivalent of the whole map.
+ *
+ * Says what the picture is and how many sources are on it, and nothing about
+ * what the shape of the coast means. A reader hearing this should learn the
+ * same thing a reader seeing it does: that these figures come from places, and
+ * roughly how many.
+ */
+function mapDescription(beachName: string, sources: number): string {
+  return (
+    `A map of ${beachName} and the ${sources} ` +
+    `${sources === 1 ? "place" : "places"} the figures on this page come from, ` +
+    `each drawn at its real distance from the beach.`
+  );
+}
+
 export async function DayPanel({ slug }: { slug: string }) {
   const daylight = readDaylightWeek(slug);
   const [hourly, waves, sky, grid, wording] = await Promise.all([
@@ -475,9 +494,36 @@ export async function DayPanel({ slug }: { slug: string }) {
     };
   });
 
+  /*
+    The map is built once and handed over, outside the seven days, because it
+    is the same picture on all seven: this beach, its coast, and the four places
+    its figures come from. It is also the one thing in this region that reads no
+    feed -- `beaches.json` and `mop-lines.json` are committed -- so it cannot go
+    quiet and does not belong behind a Suspense boundary.
+
+    A beach the inventory does not hold is not this component's error to invent
+    a map for: the route already answered that question before rendering, and
+    `beachBySlug` returning null here would mean the page is showing a beach it
+    does not have.
+  */
+  const beach = beachBySlug(slug);
+  const shore = beach === null ? null : shoreViewFor(beach);
+
   return (
     <section aria-labelledby="day-panel-heading">
-      <ChosenDay days={days} />
+      <ChosenDay
+        days={days}
+        map={
+          shore === null ? null : (
+            <ShoreMap
+              {...shore}
+              description={mapDescription(beach!.name, shore.markers.length)}
+              absence="We cannot place this beach on a map: every source we have for it is at the same point."
+              noCoast="The coastline this site traces is the open coast, and it does not reach this beach."
+            />
+          )
+        }
+      />
     </section>
   );
 }

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -66,6 +66,7 @@ import { ChosenDay, type DayView } from "./ChosenDay";
 import type { HourSeries } from "./HourChart";
 import { MeasuredPanel } from "./MeasuredPanel";
 import { MeasuredToday } from "./MeasuredToday";
+import { ReservedSlot } from "../ui/ReservedSlot";
 import { ShoreMap } from "./ShoreMap";
 import { shoreViewFor } from "./shore";
 import { SkyWording } from "./SkyWording";
@@ -515,13 +516,38 @@ export async function DayPanel({ slug }: { slug: string }) {
         days={days}
         map={
           shore === null ? null : (
-            <ShoreMap
-              {...shore}
-              description={mapDescription(beach!.name, shore.markers.length)}
-              absence="We cannot place this beach on a map: every source we have for it is at the same point."
-              noCoast="The coastline this site traces is the open coast, and it does not reach this beach."
-              coastCredit={`Shore traced from CDIP's model lines, which run a few hundred metres offshore — so the water fades in rather than stopping at a shoreline.`}
-            />
+            <>
+              <ShoreMap
+                {...shore}
+                description={mapDescription(beach!.name, shore.markers.length)}
+                absence="We cannot place this beach on a map: every source we have for it is at the same point."
+                noCoast="The coastline this site traces is the open coast, and it does not reach this beach."
+                coastCredit={`Shore traced from CDIP's model lines, which run a few hundred metres offshore — so the water fades in rather than stopping at a shoreline.`}
+              />
+              {/*
+                The sighting layer from #121, reserved *on* the map rather than
+                instead of it. Until this slice the slot stood where a map would
+                go and said a map was coming; the map is here, so what is
+                reserved is the layer drawn on it, and the copy says that.
+
+                The three claims this copy has always had to make are unchanged.
+                iNaturalist records where people with phones went rather than
+                where animals are, so the slot promises a record of reports and
+                never a survey; and it says what the layer *will* show rather
+                than what was found, because no such report exists yet. Those
+                are asserted in this panel's tests now rather than the section's,
+                which mocks this component and would pass while the slot said
+                nothing at all. No issue number, per the standing rule.
+              */}
+              <div className="mt-4">
+                <ReservedSlot
+                  emoji="🐙"
+                  headline="Sightings will be drawn on this map."
+                  detail="Will show octopus, nudibranchs, sea hares and leopard sharks logged near this beach in the past week — reported by naturalists, not surveyed by us."
+                  density="row"
+                />
+              </div>
+            </>
           )
         }
       />

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -520,6 +520,7 @@ export async function DayPanel({ slug }: { slug: string }) {
               description={mapDescription(beach!.name, shore.markers.length)}
               absence="We cannot place this beach on a map: every source we have for it is at the same point."
               noCoast="The coastline this site traces is the open coast, and it does not reach this beach."
+              coastCredit={`Shore traced from CDIP's model lines, which run a few hundred metres offshore — so the water fades in rather than stopping at a shoreline.`}
             />
           )
         }

--- a/src/components/conditions/HourChart.tsx
+++ b/src/components/conditions/HourChart.tsx
@@ -465,7 +465,12 @@ export function HourChart({
     the cloud band, which is context for a frame that is not being drawn.
   */
   const shell = (body: React.ReactNode) => (
-    <div className="max-w-4xl overflow-hidden rounded-box border-[1.5px] border-ocean bg-white/60">
+    /*
+      `xl:max-w-none` because from that width the day row puts the map beside
+      this and the column is the constraint. The cap still does its job below
+      `xl`, where an uncapped chart on a full-width column drew 440px tall.
+    */
+    <div className="max-w-4xl overflow-hidden rounded-box border-[1.5px] border-ocean bg-white/60 xl:max-w-none">
       <div className="border-b-[1.5px] border-ocean bg-ocean px-4 py-2">
         {band}
       </div>

--- a/src/components/conditions/ShoreMap.test.tsx
+++ b/src/components/conditions/ShoreMap.test.tsx
@@ -20,24 +20,27 @@ const BOUNDS = {
 const MARKERS: ShoreMarker[] = [
   {
     kind: "mop-line",
-    name: "MOP line D0498",
+    source: "MOP line D0498",
+    network: "CDIP, Scripps Institution of Oceanography",
+    distanceKm: "0.3",
     lat: 32.862,
     lon: -117.261,
-    distance: "about 0.3 km from this beach",
   },
   {
     kind: "wave-buoy",
-    name: "Buoy Scripps Nearshore",
+    source: "Buoy Scripps Nearshore",
+    network: "NDBC",
+    distanceKm: "1.6",
     lat: 32.868,
     lon: -117.267,
-    distance: "about 1.6 km from this beach",
   },
   {
     kind: "tide-station",
-    name: "La Jolla (Scripps Institution Wharf)",
+    source: "La Jolla (Scripps Institution Wharf)",
+    network: "NOAA Tides & Currents",
+    distanceKm: null,
     lat: 32.867,
     lon: -117.257,
-    distance: "about 1.4 km from this beach",
   },
 ];
 
@@ -54,11 +57,19 @@ const PROPS = {
   noCoast: "The coastline this site traces does not reach this beach.",
 };
 
+/** The provenance lines beside the picture, in order. */
+function credits(container: HTMLElement): string[] {
+  return [...container.querySelectorAll("li p")].map(
+    (node) => node.textContent ?? "",
+  );
+}
+
 test("every marker names the source it stands for", () => {
-  render(<ShoreMap {...PROPS} />);
+  const { container } = render(<ShoreMap {...PROPS} />);
+  const lines = credits(container);
 
   for (const marker of MARKERS) {
-    expect(screen.getByText(marker.name)).toBeTruthy();
+    expect(lines.some((line) => line.startsWith(marker.source))).toBe(true);
   }
 });
 
@@ -66,14 +77,14 @@ test("a beach with no MOP line draws no MOP marker and does not silently omit it
   // 26 of the 51 committed beaches bind no MOP line. The marker cannot be
   // drawn, and a map that simply lacked it would read as a map of a beach that
   // has one somewhere off-frame.
-  render(
+  const { container } = render(
     <ShoreMap
       {...PROPS}
       markers={MARKERS.filter((marker) => marker.kind !== "mop-line")}
     />,
   );
 
-  expect(screen.queryByText("MOP line D0498")).toBeNull();
+  expect(credits(container).some((line) => line.includes("D0498"))).toBe(false);
   expect(screen.getByText(/no swell model/i)).toBeTruthy();
 });
 
@@ -81,10 +92,14 @@ test("a beach the traced coast does not reach keeps its markers and says so", ()
   // 23 of the 51 are in Mission Bay or San Diego Bay, 2.6 to 5.4 km from the
   // nearest MOP line. They still get the markers, which is what ADR-0010 asks
   // the map to draw; what they do not get is a shoreline invented for them.
-  render(<ShoreMap {...PROPS} coast={[]} />);
+  const { container } = render(<ShoreMap {...PROPS} coast={[]} />);
 
   expect(screen.getByText(PROPS.noCoast)).toBeTruthy();
-  expect(screen.getByText("Buoy Scripps Nearshore")).toBeTruthy();
+  expect(
+    credits(container).some((line) =>
+      line.startsWith("Buoy Scripps Nearshore"),
+    ),
+  ).toBe(true);
 });
 
 test("no box to draw is a sentence, never an empty frame", () => {
@@ -140,8 +155,13 @@ test("the map says nothing the caller did not give it", () => {
     decoration.remove();
   }
 
+  // Exactly what ProvenanceLine composes from the fields it was handed.
   const given = MARKERS.map(
-    (marker) => `${marker.name} · ${marker.distance}`,
+    (marker) =>
+      `${marker.source} · ${marker.network}` +
+      (marker.distanceKm
+        ? ` · about ${marker.distanceKm} km from this beach`
+        : ""),
   ).join("");
 
   expect((container.textContent ?? "").replace(/\s/g, "")).toBe(

--- a/src/components/conditions/ShoreMap.test.tsx
+++ b/src/components/conditions/ShoreMap.test.tsx
@@ -47,10 +47,9 @@ const MARKERS: ShoreMarker[] = [
 const PROPS = {
   coast: COAST,
   bounds: BOUNDS,
-  segment: [
-    { lat: 32.855, lon: -117.259 },
-    { lat: 32.884, lon: -117.253 },
-  ] as const,
+  // The middle two of the four, which is what a beach occupying part of the
+  // window looks like.
+  segment: COAST.slice(1, 3),
   markers: MARKERS,
   description: "A map of this beach and the four places its figures come from.",
   absence: "We cannot place this beach on a map.",
@@ -136,8 +135,11 @@ test("this beach's own stretch of shore is drawn apart from the rest", () => {
 test("markers differ in shape, not only in colour", () => {
   const { container } = render(<ShoreMap {...PROPS} />);
 
+  // The drawn shape rather than the SVG element: a diamond and a triangle are
+  // both <polygon>, so comparing tag names would call two different shapes the
+  // same and pass for the wrong reason.
   const shapes = [...container.querySelectorAll("[data-marker]")].map((node) =>
-    node.tagName.toLowerCase(),
+    node.getAttribute("data-shape"),
   );
 
   expect(shapes.length).toBe(MARKERS.length);

--- a/src/components/conditions/ShoreMap.test.tsx
+++ b/src/components/conditions/ShoreMap.test.tsx
@@ -54,6 +54,8 @@ const PROPS = {
   description: "A map of this beach and the four places its figures come from.",
   absence: "We cannot place this beach on a map.",
   noCoast: "The coastline this site traces does not reach this beach.",
+  coastCredit:
+    "Coast traced from CDIP's MOP lines, which run a few hundred metres offshore.",
 };
 
 /** The provenance lines beside the picture, in order. */
@@ -157,14 +159,17 @@ test("the map says nothing the caller did not give it", () => {
     decoration.remove();
   }
 
-  // Exactly what ProvenanceLine composes from the fields it was handed.
-  const given = MARKERS.map(
-    (marker) =>
-      `${marker.source} · ${marker.network}` +
-      (marker.distanceKm
-        ? ` · about ${marker.distanceKm} km from this beach`
-        : ""),
-  ).join("");
+  // The credit for the drawn shore, then exactly what ProvenanceLine composes
+  // from the fields each marker was handed. Nothing else.
+  const given =
+    PROPS.coastCredit +
+    MARKERS.map(
+      (marker) =>
+        `${marker.source} · ${marker.network}` +
+        (marker.distanceKm
+          ? ` · about ${marker.distanceKm} km from this beach`
+          : ""),
+    ).join("");
 
   expect((container.textContent ?? "").replace(/\s/g, "")).toBe(
     given.replace(/\s/g, ""),
@@ -196,4 +201,62 @@ test("the shaded side is the one the wave buoy is on", () => {
   // Off-frame to the west, the same way the buoy sits from the coast.
   expect(Math.max(...closing)).toBeLessThan(Math.min(...coastXs));
   expect(buoyX).toBeLessThan(Math.max(...coastXs));
+});
+
+test("the sea fades away from the line rather than ending at it", () => {
+  // The line is CDIP's model line, 117 to 930 m offshore, not the shoreline --
+  // at La Jolla the tide gauge and the pier are both over water and both fall
+  // on its landward side. A hard edge would claim a boundary the data does not
+  // have, so the wash is transparent where the line is and opaque out to sea.
+  const { container } = render(<ShoreMap {...PROPS} />);
+
+  const sea = container.querySelector("[data-sea]")!;
+  const gradient = container.querySelector("linearGradient");
+
+  expect(gradient).toBeTruthy();
+  expect(sea.getAttribute("fill")).toBe(
+    `url(#${gradient!.getAttribute("id")})`,
+  );
+
+  const stops = [...gradient!.querySelectorAll("stop")].map((stop) =>
+    Number(stop.getAttribute("stop-opacity")),
+  );
+  expect(stops[0]).toBe(0);
+  expect(stops[stops.length - 1]).toBeGreaterThan(0);
+});
+
+test("the fade is a real distance, so it shrinks as the frame widens", () => {
+  // The blur stands for the offset itself, so on a 20 km frame it is a few
+  // units and on a 4 km frame it is a sixth of the picture. A fade measured in
+  // frame units instead would blur a wide map by kilometres.
+  const near = render(<ShoreMap {...PROPS} />).container;
+  const wide = render(
+    <ShoreMap
+      {...PROPS}
+      bounds={{ south: 32.6, north: 33.0, west: -117.5, east: -117.1 }}
+    />,
+  ).container;
+
+  const spread = (root: HTMLElement): number => {
+    const g = root.querySelector("linearGradient")!;
+    return Math.hypot(
+      Number(g.getAttribute("x2")) - Number(g.getAttribute("x1")),
+      Number(g.getAttribute("y2")) - Number(g.getAttribute("y1")),
+    );
+  };
+
+  expect(spread(wide)).toBeLessThan(spread(near));
+});
+
+test("the drawn coast names what it was drawn from", () => {
+  // The markers are attributed one by one and the shape they sit on was not,
+  // which is the defect this branch's own design review raised against the day
+  // chart. A line drawn from a published dataset is a figure like any other.
+  const { container } = render(<ShoreMap {...PROPS} />);
+
+  expect(screen.getByText(PROPS.coastCredit)).toBeTruthy();
+
+  // Nothing to attribute when nothing is drawn.
+  const bare = render(<ShoreMap {...PROPS} coast={[]} />).container;
+  expect(bare.textContent).not.toContain(PROPS.coastCredit);
 });

--- a/src/components/conditions/ShoreMap.test.tsx
+++ b/src/components/conditions/ShoreMap.test.tsx
@@ -1,0 +1,177 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ShoreMap, type ShoreMarker } from "./ShoreMap";
+
+/** A short run of coast running due north, west-facing like the real one. */
+const COAST = [
+  { id: "D0500", lat: 32.85, lon: -117.26 },
+  { id: "D0501", lat: 32.86, lon: -117.26 },
+  { id: "D0502", lat: 32.87, lon: -117.259 },
+  { id: "D0503", lat: 32.88, lon: -117.258 },
+];
+
+const BOUNDS = {
+  south: 32.845,
+  north: 32.885,
+  west: -117.275,
+  east: -117.245,
+};
+
+const MARKERS: ShoreMarker[] = [
+  {
+    kind: "mop-line",
+    name: "MOP line D0498",
+    lat: 32.862,
+    lon: -117.261,
+    distance: "about 0.3 km from this beach",
+  },
+  {
+    kind: "wave-buoy",
+    name: "Buoy Scripps Nearshore",
+    lat: 32.868,
+    lon: -117.267,
+    distance: "about 1.6 km from this beach",
+  },
+  {
+    kind: "tide-station",
+    name: "La Jolla (Scripps Institution Wharf)",
+    lat: 32.867,
+    lon: -117.257,
+    distance: "about 1.4 km from this beach",
+  },
+];
+
+const PROPS = {
+  coast: COAST,
+  bounds: BOUNDS,
+  segment: [
+    { lat: 32.855, lon: -117.259 },
+    { lat: 32.884, lon: -117.253 },
+  ] as const,
+  markers: MARKERS,
+  description: "A map of this beach and the four places its figures come from.",
+  absence: "We cannot place this beach on a map.",
+  noCoast: "The coastline this site traces does not reach this beach.",
+};
+
+test("every marker names the source it stands for", () => {
+  render(<ShoreMap {...PROPS} />);
+
+  for (const marker of MARKERS) {
+    expect(screen.getByText(marker.name)).toBeTruthy();
+  }
+});
+
+test("a beach with no MOP line draws no MOP marker and does not silently omit it", () => {
+  // 26 of the 51 committed beaches bind no MOP line. The marker cannot be
+  // drawn, and a map that simply lacked it would read as a map of a beach that
+  // has one somewhere off-frame.
+  render(
+    <ShoreMap
+      {...PROPS}
+      markers={MARKERS.filter((marker) => marker.kind !== "mop-line")}
+    />,
+  );
+
+  expect(screen.queryByText("MOP line D0498")).toBeNull();
+  expect(screen.getByText(/no swell model/i)).toBeTruthy();
+});
+
+test("a beach the traced coast does not reach keeps its markers and says so", () => {
+  // 23 of the 51 are in Mission Bay or San Diego Bay, 2.6 to 5.4 km from the
+  // nearest MOP line. They still get the markers, which is what ADR-0010 asks
+  // the map to draw; what they do not get is a shoreline invented for them.
+  render(<ShoreMap {...PROPS} coast={[]} />);
+
+  expect(screen.getByText(PROPS.noCoast)).toBeTruthy();
+  expect(screen.getByText("Buoy Scripps Nearshore")).toBeTruthy();
+});
+
+test("no box to draw is a sentence, never an empty frame", () => {
+  // An empty frame on a page about the sea reads as open water.
+  render(<ShoreMap {...PROPS} bounds={null} />);
+
+  expect(screen.getByText(PROPS.absence)).toBeTruthy();
+  expect(document.querySelector("svg")).toBeNull();
+});
+
+test("the sea is shaded only where a coast says where it is", () => {
+  const { container: drawn } = render(<ShoreMap {...PROPS} />);
+  expect(drawn.querySelector("[data-sea]")).toBeTruthy();
+
+  const { container: bare } = render(<ShoreMap {...PROPS} coast={[]} />);
+  expect(bare.querySelector("[data-sea]")).toBeNull();
+});
+
+test("this beach's own stretch of shore is drawn apart from the rest", () => {
+  const { container } = render(<ShoreMap {...PROPS} />);
+
+  const segment = container.querySelector("[data-segment]");
+  const coast = container.querySelector("[data-coast]");
+
+  expect(segment).toBeTruthy();
+  expect(coast).toBeTruthy();
+  // Weight, not only colour: a reader who cannot separate the two hues still
+  // sees which part of the coast is the beach they chose.
+  expect(Number(segment!.getAttribute("stroke-width"))).toBeGreaterThan(
+    Number(coast!.getAttribute("stroke-width")),
+  );
+});
+
+test("markers differ in shape, not only in colour", () => {
+  const { container } = render(<ShoreMap {...PROPS} />);
+
+  const shapes = [...container.querySelectorAll("[data-marker]")].map((node) =>
+    node.tagName.toLowerCase(),
+  );
+
+  expect(shapes.length).toBe(MARKERS.length);
+  expect(new Set(shapes).size).toBe(MARKERS.length);
+});
+
+test("the map says nothing the caller did not give it", () => {
+  // ADR-0009's line, drawn rather than written: no depth, no hazard, no verdict
+  // about whether the water is safe. The only words are the names and distances
+  // handed in. Decoration is stripped first, because a glyph tying a name to
+  // its shape is not a claim about the sea.
+  const { container } = render(<ShoreMap {...PROPS} />);
+
+  for (const decoration of container.querySelectorAll('[aria-hidden="true"]')) {
+    decoration.remove();
+  }
+
+  const given = MARKERS.map(
+    (marker) => `${marker.name} · ${marker.distance}`,
+  ).join("");
+
+  expect((container.textContent ?? "").replace(/\s/g, "")).toBe(
+    given.replace(/\s/g, ""),
+  );
+});
+
+test("the whole picture has one spoken equivalent", () => {
+  render(<ShoreMap {...PROPS} />);
+
+  expect(screen.getByRole("img", { name: PROPS.description })).toBeTruthy();
+});
+
+test("the shaded side is the one the wave buoy is on", () => {
+  // The test the other sea assertion cannot make. A polygon closed on the wrong
+  // side draws the land as water and every existing assertion still passes:
+  // there is a [data-sea] path either way, and it is the same colour. The buoy
+  // is the one thing on this map known to be in the water.
+  const { container } = render(<ShoreMap {...PROPS} />);
+
+  const sea = container.querySelector("[data-sea]")!.getAttribute("d")!;
+  const buoyMark = container.querySelector('[data-marker="wave-buoy"]')!;
+  const buoyX = Number(buoyMark.getAttribute("points")!.split(",")[0]);
+
+  // The polygon closes on two points pushed off-frame to the seaward side.
+  const xs = [...sea.matchAll(/[ML](-?[\d.]+) /g)].map((m) => Number(m[1]));
+  const closing = xs.slice(-2);
+  const coastXs = xs.slice(0, -2);
+
+  // Off-frame to the west, the same way the buoy sits from the coast.
+  expect(Math.max(...closing)).toBeLessThan(Math.min(...coastXs));
+  expect(buoyX).toBeLessThan(Math.max(...coastXs));
+});

--- a/src/components/conditions/ShoreMap.tsx
+++ b/src/components/conditions/ShoreMap.tsx
@@ -42,7 +42,7 @@
  * adjective away from a warning.
  */
 
-import type { Bounds, ShorePoint } from "@/lib/coastline";
+import type { Bounds, Position, ShorePoint } from "@/lib/coastline";
 import { projectionFor } from "@/lib/coastline";
 import { ProvenanceLine } from "./ProvenanceLine";
 
@@ -78,14 +78,15 @@ export type ShoreMapProps = {
   /** The box the map covers, or null when there is nothing to frame. */
   bounds: Bounds | null;
   /**
-   * The run of `coast` this beach occupies, drawn heavier than the rest.
+   * Where this beach is, drawn heavier than anything around it.
    *
-   * A run and never the beach's two ends joined: `beaches.json` carries a
-   * bounding extent whose corners are not points on the MOP line, so a chord
-   * between them lands beside the shore at an angle to it and reads as a
-   * second, wrong coastline. `shore.ts` picks the run.
+   * A run of `coast` wherever a coast is drawn, because a chord between the two
+   * ends `beaches.json` carries lands beside the shore at an angle to it and
+   * reads as a second, wrong coastline. On the 23 beaches with no coast in
+   * frame it is those two ends after all, because nothing else on the picture
+   * says where the beach is. `shore.ts` makes that choice.
    */
-  segment: readonly ShorePoint[] | null;
+  segment: readonly Position[] | null;
   markers: readonly ShoreMarker[];
   /** The spoken equivalent of the whole picture. */
   description: string;
@@ -93,6 +94,16 @@ export type ShoreMapProps = {
   absence: string;
   /** What to say when the traced coast does not reach this beach. */
   noCoast: string;
+  /**
+   * What the drawn shore was traced from, said once under the picture.
+   *
+   * The markers are attributed one at a time and the shape they sit on was not,
+   * which is ADR-0010's rule applied to everything except the largest thing on
+   * the map. It matters more here than for an ordinary figure, because the line
+   * is CDIP's model line rather than a shoreline and a reader has no way to
+   * know that from looking.
+   */
+  coastCredit: string;
 };
 
 /**
@@ -170,7 +181,11 @@ const HALO = "stroke-cream";
 function seaPath(
   path: string,
   drawn: readonly { x: number; y: number }[],
-): string {
+): {
+  d: string;
+  from: { x: number; y: number };
+  unit: { x: number; y: number };
+} {
   const first = drawn[0];
   const last = drawn[drawn.length - 1];
 
@@ -178,8 +193,9 @@ function seaPath(
   const py = last.y - first.y;
   const length = Math.hypot(px, py) || 1;
 
+  const unit = { x: py / length, y: -px / length };
   const walk = { x: (px / length) * OFF_FRAME, y: (py / length) * OFF_FRAME };
-  const sea = { x: (py / length) * OFF_FRAME, y: (-px / length) * OFF_FRAME };
+  const sea = { x: unit.x * OFF_FRAME, y: unit.y * OFF_FRAME };
 
   const beyondEnd = { x: last.x + walk.x + sea.x, y: last.y + walk.y + sea.y };
   const beforeStart = {
@@ -187,11 +203,51 @@ function seaPath(
     y: first.y - walk.y + sea.y,
   };
 
-  return (
-    `${path} L${beyondEnd.x.toFixed(2)} ${beyondEnd.y.toFixed(2)}` +
-    ` L${beforeStart.x.toFixed(2)} ${beforeStart.y.toFixed(2)} Z`
-  );
+  return {
+    d:
+      `${path} L${beyondEnd.x.toFixed(2)} ${beyondEnd.y.toFixed(2)}` +
+      ` L${beforeStart.x.toFixed(2)} ${beforeStart.y.toFixed(2)} Z`,
+    from: drawn[Math.floor(drawn.length / 2)],
+    unit,
+  };
 }
+
+/**
+ * How far offshore the drawn line actually is, in metres.
+ *
+ * **The line is not the shoreline, and this number is the difference.** CDIP's
+ * MOP lines are computed at 10 m depth, and measured across the 25 beaches that
+ * bind one they stand 117 to 930 m out, median 644. At La Jolla the line is
+ * about 310 m seaward of the beach's own coordinate — which is why the Scripps
+ * tide gauge and the pier it is bolted to, both of them over water, fall on the
+ * landward side of it.
+ *
+ * A hard sea-and-land edge would claim a boundary the data does not have, and
+ * would claim it most loudly at the beach the page opens on. So the wash is
+ * transparent where the line is and reaches full strength this far out: the
+ * picture says the sea is that way, and declines to say the edge is here.
+ *
+ * The median rather than the maximum, because it is the typical offset rather
+ * than the worst one, and a blur sized by the worst case would swallow the
+ * tightest frames. Held as a real distance so it scales with the map: a few
+ * units on `mission-beach`'s 20 km frame, a sixth of the picture on La Jolla's
+ * 3.9 km one.
+ */
+const MODEL_LINE_OFFSET_M = 644;
+
+/** Metres per degree of latitude, from the mean earth radius `scripts/geo.mjs` uses. */
+const METRES_PER_DEGREE_LAT = (2 * Math.PI * 6371008.8) / 360;
+
+/**
+ * One id, because a page carries one map.
+ *
+ * A gradient is referenced by id, so two maps in one document would share this
+ * one — which is fine, since they would want the same fade, and wrong only if
+ * they ever wanted different ones. `useId` is not available here: this renders
+ * on the server, which is ADR-0025's requirement for the page's primary
+ * content.
+ */
+const SEA_FADE_ID = "shore-map-sea";
 
 export function ShoreMap({
   coast,
@@ -201,6 +257,7 @@ export function ShoreMap({
   description,
   absence,
   noCoast,
+  coastCredit,
 }: ShoreMapProps) {
   if (bounds === null) {
     return <p className="text-2xs text-fog italic">{absence}</p>;
@@ -218,6 +275,14 @@ export function ShoreMap({
     .join(" ");
 
   const sea = hasCoast ? seaPath(path, drawn) : null;
+
+  // Plot units per metre, from the projection itself rather than from a second
+  // copy of its arithmetic, so the fade cannot drift from the drawing.
+  const unitsPerMetre =
+    (project(bounds.south, bounds.west).y -
+      project(bounds.north, bounds.west).y) /
+    ((bounds.north - bounds.south) * METRES_PER_DEGREE_LAT);
+  const fade = MODEL_LINE_OFFSET_M * unitsPerMetre;
 
   const missing = MISSING_SOURCES.filter(
     ([kind]) => !markers.some((marker) => marker.kind === kind),
@@ -237,7 +302,32 @@ export function ShoreMap({
           a legend -- and it is a flat tint rather than a shaded one, because
           shading implies depth and depth here would be invented.
         */}
-        {sea !== null && <path d={sea} className="fill-ocean/12" data-sea="" />}
+        {sea !== null && (
+          <>
+            <defs>
+              <linearGradient
+                id={SEA_FADE_ID}
+                gradientUnits="userSpaceOnUse"
+                x1={sea.from.x}
+                y1={sea.from.y}
+                x2={sea.from.x + sea.unit.x * fade}
+                y2={sea.from.y + sea.unit.y * fade}
+              >
+                <stop
+                  offset="0"
+                  stopColor="var(--color-ocean)"
+                  stopOpacity={0}
+                />
+                <stop
+                  offset="1"
+                  stopColor="var(--color-ocean)"
+                  stopOpacity={0.14}
+                />
+              </linearGradient>
+            </defs>
+            <path d={sea.d} fill={`url(#${SEA_FADE_ID})`} data-sea="" />
+          </>
+        )}
 
         {hasCoast && (
           <path
@@ -280,7 +370,11 @@ export function ShoreMap({
         ))}
       </svg>
 
-      {!hasCoast && <p className="text-2xs text-fog mt-2 italic">{noCoast}</p>}
+      {hasCoast ? (
+        <p className="text-2xs text-fog mt-2 italic">{coastCredit}</p>
+      ) : (
+        <p className="text-2xs text-fog mt-2 italic">{noCoast}</p>
+      )}
 
       {/*
         The names live beside the picture rather than on it. A label per marker

--- a/src/components/conditions/ShoreMap.tsx
+++ b/src/components/conditions/ShoreMap.tsx
@@ -42,7 +42,7 @@
  * adjective away from a warning.
  */
 
-import type { Bounds, Position, ShorePoint } from "@/lib/coastline";
+import type { Bounds, ShorePoint } from "@/lib/coastline";
 import { projectionFor } from "@/lib/coastline";
 import { ProvenanceLine } from "./ProvenanceLine";
 
@@ -77,8 +77,15 @@ export type ShoreMapProps = {
   coast: readonly ShorePoint[];
   /** The box the map covers, or null when there is nothing to frame. */
   bounds: Bounds | null;
-  /** This beach's own two ends, drawn heavier than the coast around it. */
-  segment: readonly [Position, Position] | null;
+  /**
+   * The run of `coast` this beach occupies, drawn heavier than the rest.
+   *
+   * A run and never the beach's two ends joined: `beaches.json` carries a
+   * bounding extent whose corners are not points on the MOP line, so a chord
+   * between them lands beside the shore at an angle to it and reads as a
+   * second, wrong coastline. `shore.ts` picks the run.
+   */
+  segment: readonly ShorePoint[] | null;
   markers: readonly ShoreMarker[];
   /** The spoken equivalent of the whole picture. */
   description: string;
@@ -117,34 +124,73 @@ const OFF_FRAME = 2 * Math.hypot(WIDTH, HEIGHT);
  */
 const MARKS: Record<
   ShoreMarkerKind,
-  "rect" | "polygon" | "circle" | "ellipse"
+  "square" | "triangle" | "diamond" | "ring"
 > = {
-  "mop-line": "rect",
-  "wave-buoy": "polygon",
-  "tide-station": "circle",
-  "air-station": "ellipse",
+  "mop-line": "square",
+  "wave-buoy": "triangle",
+  "tide-station": "diamond",
+  "air-station": "ring",
 };
 
 /**
- * The seaward normal of a walked run, in plot coordinates.
+ * Every marker is outlined in the page's own ground.
  *
- * `sideOf` in `lib/coastline.ts` answers this geographically and the `sea-side`
- * gate row proves the answer is "left of the walk" for every beach that can be
- * asked. Converting that to plot coordinates is the one place the flip matters:
- * `projectionFor` puts north at the top, so y grows southward, and the
- * geographic left of a walk appears on the other hand on screen. Left of
- * geographic (dx, dy) is (-dy, dx); with y flipped, a plot direction (px, py)
- * has its seaward normal at (py, -px).
+ * Two of the four sources are frequently the same place — at La Jolla the tide
+ * gauge is bolted to the pier the air station is on, 200 m apart in a 3.9 km
+ * frame — and two filled shapes at one point drew a single black smudge. A
+ * halo in the ground colour separates them, so a reader sees two markers on top
+ * of each other rather than one shape they cannot name. It is also the honest
+ * picture: those stations really are in the same place.
+ */
+const HALO = "stroke-cream";
+
+/**
+ * The sea, as a polygon closed off the edge of the frame.
+ *
+ * **Which side is seaward.** `sideOf` in `lib/coastline.ts` answers that
+ * geographically and the `sea-side` gate row proves the answer is "left of the
+ * walk" for every beach that can be asked. Converting to plot coordinates is
+ * the one place the flip matters: `projectionFor` puts north at the top, so y
+ * grows southward and the geographic left of a walk appears on the other hand
+ * on screen. Left of geographic (dx, dy) is (-dy, dx); with y flipped, a plot
+ * direction (px, py) has its seaward normal at (py, -px).
+ *
+ * **The polygon also runs on past both ends, and that is not decoration.**
+ * Closing straight from the last point to seaward and back to the first leaves
+ * a wedge of frame unshaded wherever the coast is not perpendicular to that
+ * normal — a diagonal edge of missing sea in a corner, which reads as a drawing
+ * error because it is one. Extending along the walk as well as out to sea puts
+ * both closing corners outside the frame in both directions, so the whole
+ * seaward half is covered whatever angle the shore runs at.
  *
  * Taken from the run's two ends rather than segment by segment: the polygon
- * only has to close on the correct side of the frame, and a per-segment normal
+ * only has to close on the right side of the frame, and a per-segment normal
  * would fold on itself at a bend.
  */
-function seaward(from: { x: number; y: number }, to: { x: number; y: number }) {
-  const px = to.x - from.x;
-  const py = to.y - from.y;
+function seaPath(
+  path: string,
+  drawn: readonly { x: number; y: number }[],
+): string {
+  const first = drawn[0];
+  const last = drawn[drawn.length - 1];
+
+  const px = last.x - first.x;
+  const py = last.y - first.y;
   const length = Math.hypot(px, py) || 1;
-  return { x: (py / length) * OFF_FRAME, y: (-px / length) * OFF_FRAME };
+
+  const walk = { x: (px / length) * OFF_FRAME, y: (py / length) * OFF_FRAME };
+  const sea = { x: (py / length) * OFF_FRAME, y: (-px / length) * OFF_FRAME };
+
+  const beyondEnd = { x: last.x + walk.x + sea.x, y: last.y + walk.y + sea.y };
+  const beforeStart = {
+    x: first.x - walk.x + sea.x,
+    y: first.y - walk.y + sea.y,
+  };
+
+  return (
+    `${path} L${beyondEnd.x.toFixed(2)} ${beyondEnd.y.toFixed(2)}` +
+    ` L${beforeStart.x.toFixed(2)} ${beforeStart.y.toFixed(2)} Z`
+  );
 }
 
 export function ShoreMap({
@@ -171,14 +217,7 @@ export function ShoreMap({
     )
     .join(" ");
 
-  const off = hasCoast ? seaward(drawn[0], drawn[drawn.length - 1]) : null;
-  const last = drawn[drawn.length - 1];
-  const first = drawn[0];
-  const sea =
-    off === null
-      ? null
-      : `${path} L${(last.x + off.x).toFixed(2)} ${(last.y + off.y).toFixed(2)}` +
-        ` L${(first.x + off.x).toFixed(2)} ${(first.y + off.y).toFixed(2)} Z`;
+  const sea = hasCoast ? seaPath(path, drawn) : null;
 
   const missing = MISSING_SOURCES.filter(
     ([kind]) => !markers.some((marker) => marker.kind === kind),
@@ -218,13 +257,19 @@ export function ShoreMap({
           rather than only hue: the two are the same ocean, so a reader who sees
           no colour still sees which part of the shore they chose.
         */}
-        {segment !== null && (
+        {segment !== null && segment.length > 1 && (
           <path
-            d={`M${project(segment[0].lat, segment[0].lon).x.toFixed(2)} ${project(segment[0].lat, segment[0].lon).y.toFixed(2)} L${project(segment[1].lat, segment[1].lon).x.toFixed(2)} ${project(segment[1].lat, segment[1].lon).y.toFixed(2)}`}
+            d={segment
+              .map((point, index) => {
+                const at = project(point.lat, point.lon);
+                return `${index === 0 ? "M" : "L"}${at.x.toFixed(2)} ${at.y.toFixed(2)}`;
+              })
+              .join(" ")}
             fill="none"
             className="stroke-purple-deep"
             strokeWidth={3.5}
             strokeLinecap="round"
+            strokeLinejoin="round"
             vectorEffect="non-scaling-stroke"
             data-segment=""
           />
@@ -283,10 +328,10 @@ const MISSING_SOURCES: readonly (readonly [ShoreMarkerKind, string])[] = [
 
 /** Drawn beside each name, and hidden from assistive tech: the list says it. */
 const GLYPHS: Record<ShoreMarkerKind, string> = {
-  "mop-line": "▪",
-  "wave-buoy": "▴",
-  "tide-station": "●",
-  "air-station": "⬬",
+  "mop-line": "◼",
+  "wave-buoy": "▲",
+  "tide-station": "◆",
+  "air-station": "◯",
 };
 
 function Mark({
@@ -298,40 +343,45 @@ function Mark({
 }) {
   const at = project(marker.lat, marker.lon);
   const shape = MARKS[marker.kind];
-  const size = 2.6;
+  const size = 2.4;
+  const common = {
+    "data-marker": marker.kind,
+    "data-shape": shape,
+    vectorEffect: "non-scaling-stroke" as const,
+  };
 
-  if (shape === "rect") {
+  if (shape === "square") {
     return (
       <rect
         x={at.x - size / 2}
         y={at.y - size / 2}
         width={size}
         height={size}
-        className="fill-ink"
-        data-marker={marker.kind}
+        className={`fill-ink ${HALO}`}
+        strokeWidth={1.2}
+        {...common}
       />
     );
   }
 
-  if (shape === "polygon") {
+  if (shape === "triangle") {
     return (
       <polygon
-        points={`${at.x},${at.y - size} ${at.x - size},${at.y + size * 0.7} ${at.x + size},${at.y + size * 0.7}`}
-        className="fill-ink"
-        data-marker={marker.kind}
+        points={`${at.x},${at.y - size} ${at.x - size},${at.y + size * 0.72} ${at.x + size},${at.y + size * 0.72}`}
+        className={`fill-ink ${HALO}`}
+        strokeWidth={1.2}
+        {...common}
       />
     );
   }
 
-  if (shape === "ellipse") {
+  if (shape === "diamond") {
     return (
-      <ellipse
-        cx={at.x}
-        cy={at.y}
-        rx={size}
-        ry={size * 0.55}
-        className="fill-ink"
-        data-marker={marker.kind}
+      <polygon
+        points={`${at.x},${at.y - size} ${at.x + size},${at.y} ${at.x},${at.y + size} ${at.x - size},${at.y}`}
+        className={`fill-ink ${HALO}`}
+        strokeWidth={1.2}
+        {...common}
       />
     );
   }
@@ -340,12 +390,11 @@ function Mark({
     <circle
       cx={at.x}
       cy={at.y}
-      r={size * 0.75}
+      r={size * 0.85}
       fill="none"
       className="stroke-ink"
-      strokeWidth={1.4}
-      vectorEffect="non-scaling-stroke"
-      data-marker={marker.kind}
+      strokeWidth={1.6}
+      {...common}
     />
   );
 }

--- a/src/components/conditions/ShoreMap.tsx
+++ b/src/components/conditions/ShoreMap.tsx
@@ -1,0 +1,336 @@
+/**
+ * This beach's own stretch of coast, with the four places its figures come
+ * from plotted at their real distances.
+ *
+ * **ADR-0010's requirement drawn instead of written.** That decision ends on
+ * "no figure is ever shown without the reader being able to see where it came
+ * from", and the page has answered it in words ever since — a provenance line
+ * under each group, a distance in kilometres. A reader who wants to know
+ * whether the air temperature came from somewhere near the sand has been asked
+ * to hold "1.4 km" in their head and imagine it. This draws it.
+ *
+ * **So the frame is sized by the sources, not by the beach.** Mission Beach's
+ * map is 20 km tall because one of its stations is 9 km away, and the beach
+ * being a fifth of that frame is the message rather than a defect. A map
+ * comfortably framed on the sand would understate exactly the distance
+ * ADR-0010 exists to disclose.
+ *
+ * **A quarter of the county has no coast to draw, and gets the map anyway.**
+ * 23 of 51 beaches are in Mission Bay or San Diego Bay, between 2.6 and 5.4 km
+ * from the nearest MOP line, because `mop-lines.json` traces the open coast
+ * only. Widening their frames until the ocean appears was measured and
+ * rejected: `mission-bay-vacation-isle` needs roughly five times the margin to
+ * reach it, and what arrives is a shoreline 5 km away that is not this beach's
+ * shore. They keep the markers — which are the part ADR-0010 asked for and the
+ * part that works without a coastline — and the map says plainly that the
+ * traced coast does not reach them.
+ *
+ * **Presentational and pure**, like `DaySpark`. It takes a window, a box and a
+ * list of markers, and renders them; it resolves no station, reads no file and
+ * knows nothing about what a buoy is. The words are the caller's, which is this
+ * repo's rule about who owns the copy on this page.
+ *
+ * **Hand-rolled SVG**, per ADR-0025, and for the same three reasons: the
+ * runtime dependency budget is guarded, the largest thing drawn here is a few
+ * hundred points, and it has to render on the server.
+ *
+ * **The quiet register.** The brief puts the loud half of this site in the
+ * chrome and asks the data to be drawn like a chart in a field guide. So: thin
+ * strokes, one wash for the sea, no gridlines, no compass rose of our own, no
+ * depth, no hazard and no verdict about whether the water is safe. ADR-0009's
+ * line is easiest to cross with a picture, because a shaded sea is one
+ * adjective away from a warning.
+ */
+
+import type { Bounds, Position, ShorePoint } from "@/lib/coastline";
+import { projectionFor } from "@/lib/coastline";
+
+/** Which source a marker stands for. The list is closed on purpose. */
+export type ShoreMarkerKind =
+  "mop-line" | "wave-buoy" | "tide-station" | "air-station";
+
+/** One plotted source, named and measured by the caller. */
+export type ShoreMarker = {
+  kind: ShoreMarkerKind;
+  /** What this source is called, in the caller's own words. */
+  name: string;
+  lat: number;
+  lon: number;
+  /** How far off, already worded. `ProvenanceLine` owns that phrasing. */
+  distance: string;
+};
+
+export type ShoreMapProps = {
+  /** The windowed coast in walk order. Empty draws no shoreline and says so. */
+  coast: readonly ShorePoint[];
+  /** The box the map covers, or null when there is nothing to frame. */
+  bounds: Bounds | null;
+  /** This beach's own two ends, drawn heavier than the coast around it. */
+  segment: readonly [Position, Position] | null;
+  markers: readonly ShoreMarker[];
+  /** The spoken equivalent of the whole picture. */
+  description: string;
+  /** What to say instead of a map when there is no box at all. */
+  absence: string;
+  /** What to say when the traced coast does not reach this beach. */
+  noCoast: string;
+};
+
+/**
+ * The drawing space, in user units. Square-ish, because the brief asks for it
+ * and because the compass that lands on this in #173's second half is round.
+ *
+ * The projection letterboxes inside this rather than stretching to fill, so a
+ * tall thin window and a wide flat one both keep their shape.
+ */
+const WIDTH = 100;
+const HEIGHT = 100;
+
+/**
+ * Far enough that the sea polygon always leaves the frame.
+ *
+ * Twice the diagonal, so no window shape can leave a corner unshaded. The outer
+ * `<svg>` clips to its own viewport, so the overshoot costs nothing.
+ */
+const OFF_FRAME = 2 * Math.hypot(WIDTH, HEIGHT);
+
+/**
+ * A different shape per source, so colour is never the only thing telling two
+ * markers apart.
+ *
+ * The brief's accessibility rule, and the one a map breaks most easily: four
+ * dots in four hues is a legend waiting to happen, which is also an
+ * anti-reference. A reader who cannot separate the hues still sees a square, a
+ * triangle, a diamond and a ring.
+ */
+const MARKS: Record<
+  ShoreMarkerKind,
+  "rect" | "polygon" | "circle" | "ellipse"
+> = {
+  "mop-line": "rect",
+  "wave-buoy": "polygon",
+  "tide-station": "circle",
+  "air-station": "ellipse",
+};
+
+/**
+ * The seaward normal of a walked run, in plot coordinates.
+ *
+ * `sideOf` in `lib/coastline.ts` answers this geographically and the `sea-side`
+ * gate row proves the answer is "left of the walk" for every beach that can be
+ * asked. Converting that to plot coordinates is the one place the flip matters:
+ * `projectionFor` puts north at the top, so y grows southward, and the
+ * geographic left of a walk appears on the other hand on screen. Left of
+ * geographic (dx, dy) is (-dy, dx); with y flipped, a plot direction (px, py)
+ * has its seaward normal at (py, -px).
+ *
+ * Taken from the run's two ends rather than segment by segment: the polygon
+ * only has to close on the correct side of the frame, and a per-segment normal
+ * would fold on itself at a bend.
+ */
+function seaward(from: { x: number; y: number }, to: { x: number; y: number }) {
+  const px = to.x - from.x;
+  const py = to.y - from.y;
+  const length = Math.hypot(px, py) || 1;
+  return { x: (py / length) * OFF_FRAME, y: (-px / length) * OFF_FRAME };
+}
+
+export function ShoreMap({
+  coast,
+  bounds,
+  segment,
+  markers,
+  description,
+  absence,
+  noCoast,
+}: ShoreMapProps) {
+  if (bounds === null) {
+    return <p className="text-2xs text-fog italic">{absence}</p>;
+  }
+
+  const project = projectionFor(bounds, { width: WIDTH, height: HEIGHT });
+  const drawn = coast.map((point) => project(point.lat, point.lon));
+  const hasCoast = drawn.length > 1;
+
+  const path = drawn
+    .map(
+      (point, index) =>
+        `${index === 0 ? "M" : "L"}${point.x.toFixed(2)} ${point.y.toFixed(2)}`,
+    )
+    .join(" ");
+
+  const off = hasCoast ? seaward(drawn[0], drawn[drawn.length - 1]) : null;
+  const last = drawn[drawn.length - 1];
+  const first = drawn[0];
+  const sea =
+    off === null
+      ? null
+      : `${path} L${(last.x + off.x).toFixed(2)} ${(last.y + off.y).toFixed(2)}` +
+        ` L${(first.x + off.x).toFixed(2)} ${(first.y + off.y).toFixed(2)} Z`;
+
+  const missing = MISSING_SOURCES.filter(
+    ([kind]) => !markers.some((marker) => marker.kind === kind),
+  );
+
+  return (
+    <div>
+      <svg
+        role="img"
+        aria-label={description}
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        className="rounded-tile border-[1.5px] border-ocean block h-auto w-full bg-white/60"
+      >
+        {/*
+          One wash, no gradient and no depth. The sea is the only filled region
+          on this map, so a reader can tell water from land at a glance without
+          a legend -- and it is a flat tint rather than a shaded one, because
+          shading implies depth and depth here would be invented.
+        */}
+        {sea !== null && <path d={sea} className="fill-ocean/12" data-sea="" />}
+
+        {hasCoast && (
+          <path
+            d={path}
+            fill="none"
+            className="stroke-ocean"
+            strokeWidth={1.2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+            data-coast=""
+          />
+        )}
+
+        {/*
+          This beach's own stretch, heavier than the coast it sits on. Weight
+          rather than only hue: the two are the same ocean, so a reader who sees
+          no colour still sees which part of the shore they chose.
+        */}
+        {segment !== null && (
+          <path
+            d={`M${project(segment[0].lat, segment[0].lon).x.toFixed(2)} ${project(segment[0].lat, segment[0].lon).y.toFixed(2)} L${project(segment[1].lat, segment[1].lon).x.toFixed(2)} ${project(segment[1].lat, segment[1].lon).y.toFixed(2)}`}
+            fill="none"
+            className="stroke-purple-deep"
+            strokeWidth={3.5}
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+            data-segment=""
+          />
+        )}
+
+        {markers.map((marker) => (
+          <Mark key={marker.kind} marker={marker} project={project} />
+        ))}
+      </svg>
+
+      {!hasCoast && <p className="text-2xs text-fog mt-2 italic">{noCoast}</p>}
+
+      {/*
+        The names live beside the picture rather than on it. A label per marker
+        inside a 100-unit frame either overlaps its neighbour or shrinks under
+        the 10px floor ADR-0024 refused to go below, and both are worse than a
+        list. This is also what carries the marker names to a reader who is not
+        looking at the shapes.
+      */}
+      <ul className="mt-2 flex flex-col gap-1">
+        {markers.map((marker) => (
+          <li key={marker.kind} className="text-2xs text-fog leading-normal">
+            <span aria-hidden="true" className="mr-1.5 inline-block">
+              {GLYPHS[marker.kind]}
+            </span>
+            <span>{marker.name}</span>
+            {" · "}
+            {marker.distance}
+          </li>
+        ))}
+        {missing.map(([kind, sentence]) => (
+          <li key={kind} className="text-2xs text-fog leading-normal italic">
+            {sentence}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * What is said when a source is not bound, rather than leaving a gap.
+ *
+ * A map missing a marker reads as a map of a beach whose buoy is off-frame,
+ * which is a different and wrong claim. 26 of 51 beaches bind no MOP line and
+ * 36 bind no wave buoy, so this is the common case rather than the edge one.
+ * No issue numbers and no promises: what is absent is absent.
+ */
+const MISSING_SOURCES: readonly (readonly [ShoreMarkerKind, string])[] = [
+  ["mop-line", "No swell model is computed for this beach."],
+  ["wave-buoy", "No wave buoy is bound to this beach."],
+];
+
+/** Drawn beside each name, and hidden from assistive tech: the list says it. */
+const GLYPHS: Record<ShoreMarkerKind, string> = {
+  "mop-line": "▪",
+  "wave-buoy": "▴",
+  "tide-station": "●",
+  "air-station": "⬬",
+};
+
+function Mark({
+  marker,
+  project,
+}: {
+  marker: ShoreMarker;
+  project: (lat: number, lon: number) => { x: number; y: number };
+}) {
+  const at = project(marker.lat, marker.lon);
+  const shape = MARKS[marker.kind];
+  const size = 2.6;
+
+  if (shape === "rect") {
+    return (
+      <rect
+        x={at.x - size / 2}
+        y={at.y - size / 2}
+        width={size}
+        height={size}
+        className="fill-ink"
+        data-marker={marker.kind}
+      />
+    );
+  }
+
+  if (shape === "polygon") {
+    return (
+      <polygon
+        points={`${at.x},${at.y - size} ${at.x - size},${at.y + size * 0.7} ${at.x + size},${at.y + size * 0.7}`}
+        className="fill-ink"
+        data-marker={marker.kind}
+      />
+    );
+  }
+
+  if (shape === "ellipse") {
+    return (
+      <ellipse
+        cx={at.x}
+        cy={at.y}
+        rx={size}
+        ry={size * 0.55}
+        className="fill-ink"
+        data-marker={marker.kind}
+      />
+    );
+  }
+
+  return (
+    <circle
+      cx={at.x}
+      cy={at.y}
+      r={size * 0.75}
+      fill="none"
+      className="stroke-ink"
+      strokeWidth={1.4}
+      vectorEffect="non-scaling-stroke"
+      data-marker={marker.kind}
+    />
+  );
+}

--- a/src/components/conditions/ShoreMap.tsx
+++ b/src/components/conditions/ShoreMap.tsx
@@ -44,20 +44,32 @@
 
 import type { Bounds, Position, ShorePoint } from "@/lib/coastline";
 import { projectionFor } from "@/lib/coastline";
+import { ProvenanceLine } from "./ProvenanceLine";
 
 /** Which source a marker stands for. The list is closed on purpose. */
 export type ShoreMarkerKind =
   "mop-line" | "wave-buoy" | "tide-station" | "air-station";
 
-/** One plotted source, named and measured by the caller. */
+/**
+ * One plotted source, named and measured by the caller.
+ *
+ * The three text fields are `ProvenanceLine`'s own, passed through rather than
+ * reworded. That component is this repo's single owner of how "how far away" is
+ * said, and a map that spelled "about 1.4 km from this beach" itself would be
+ * a fifth place for that phrasing to drift — which is the whole reason it was
+ * made one component. The brief's inventory says as much: `ProvenanceLine`,
+ * reuse, unchanged, "used per needle, per series and per map marker".
+ */
 export type ShoreMarker = {
   kind: ShoreMarkerKind;
-  /** What this source is called, in the caller's own words. */
-  name: string;
+  /** What the figure names it, ready to print. Never a callsign turned into prose. */
+  source: string;
+  /** Who publishes it, or null where the binding genuinely does not know. */
+  network?: string | null;
+  /** Kilometres, already rounded by the caller's own threshold, or null. */
+  distanceKm?: string | null;
   lat: number;
   lon: number;
-  /** How far off, already worded. `ProvenanceLine` owns that phrasing. */
-  distance: string;
 };
 
 export type ShoreMapProps = {
@@ -234,13 +246,16 @@ export function ShoreMap({
       */}
       <ul className="mt-2 flex flex-col gap-1">
         {markers.map((marker) => (
-          <li key={marker.kind} className="text-2xs text-fog leading-normal">
-            <span aria-hidden="true" className="mr-1.5 inline-block">
+          <li key={marker.kind} className="flex items-baseline gap-1.5">
+            <span aria-hidden="true" className="text-2xs">
               {GLYPHS[marker.kind]}
             </span>
-            <span>{marker.name}</span>
-            {" · "}
-            {marker.distance}
+            <ProvenanceLine
+              source={marker.source}
+              network={marker.network ?? null}
+              distanceKm={marker.distanceKm ?? null}
+              surface="page"
+            />
           </li>
         ))}
         {missing.map(([kind, sentence]) => (

--- a/src/components/conditions/selectedDay.test.tsx
+++ b/src/components/conditions/selectedDay.test.tsx
@@ -104,7 +104,7 @@ function renderBoth() {
         days={DAYS}
         rows={[TIDE_ROW]}
       />
-      <ChosenDay days={VIEWS} />
+      <ChosenDay days={VIEWS} map={null} />
     </SelectedDayProvider>,
   );
 }
@@ -238,7 +238,7 @@ test("without a script the week is whole and offers no control", () => {
         days={DAYS}
         rows={[TIDE_ROW]}
       />
-      <ChosenDay days={VIEWS} />
+      <ChosenDay days={VIEWS} map={null} />
     </SelectedDayProvider>,
   );
 
@@ -263,7 +263,7 @@ test("a region outside the provider shows its first day rather than failing", ()
   // rendered without a provider is the state a reader without JavaScript is
   // already in, and turning that into an error would make a degraded page a
   // blank one.
-  const { container } = render(<ChosenDay days={VIEWS} />);
+  const { container } = render(<ChosenDay days={VIEWS} map={null} />);
 
   expect(drawnDay(container)).toBe(`Tide on ${DATES[0]}`);
 });

--- a/src/components/conditions/shore.test.ts
+++ b/src/components/conditions/shore.test.ts
@@ -1,0 +1,169 @@
+import { expect, test } from "vitest";
+import { allBeaches, beachBySlug } from "@/lib/beaches";
+import { shoreDistanceKm, shoreViewFor } from "./shore";
+
+/** The beach the page opens on, and the one with all four sources bound. */
+const LA_JOLLA = beachBySlug("la-jolla-shores-beach")!;
+
+test("all four sources are drawn, in the order the page introduces them", () => {
+  // Sea, shore, air -- the measured block's own order. Sorting by distance
+  // would reorder the list from beach to beach and stop it being learnable.
+  const view = shoreViewFor(LA_JOLLA);
+
+  expect(view.markers.map((marker) => marker.kind)).toEqual([
+    "mop-line",
+    "wave-buoy",
+    "tide-station",
+    "air-station",
+  ]);
+});
+
+test("every marker states its distance, including the near ones", () => {
+  // The cards withhold a distance under their thresholds, because beside a
+  // figure "0.3 km" adds nothing. Beside a picture of the distances it is the
+  // caption, and the MOP line at 0.3 km is the one this would drop.
+  const view = shoreViewFor(LA_JOLLA);
+
+  for (const marker of view.markers) {
+    expect(marker.distanceKm).not.toBeNull();
+  }
+  expect(
+    view.markers.find((marker) => marker.kind === "mop-line")?.distanceKm,
+  ).toBe("0.3");
+});
+
+test("the distances are the join's, not recomputed at request time", () => {
+  // beaches.json measured these once, offline, reproducibly. A second answer
+  // computed here could disagree with the one the provenance lines print.
+  const view = shoreViewFor(LA_JOLLA);
+  const air = view.markers.find((marker) => marker.kind === "air-station");
+
+  expect(LA_JOLLA.air_station_distance_m).toBe(1381);
+  expect(air?.distanceKm).toBe("1.4");
+});
+
+test("the frame holds every source, so nothing is drawn off the map", () => {
+  const view = shoreViewFor(LA_JOLLA);
+  const bounds = view.bounds!;
+
+  for (const marker of view.markers) {
+    expect(marker.lat).toBeGreaterThanOrEqual(bounds.south);
+    expect(marker.lat).toBeLessThanOrEqual(bounds.north);
+    expect(marker.lon).toBeGreaterThanOrEqual(bounds.west);
+    expect(marker.lon).toBeLessThanOrEqual(bounds.east);
+  }
+});
+
+test("a bay beach gets its markers and no coast", () => {
+  // 23 of 51. The traced coast is the open one, and Mission Bay is 2.6 to 5.4
+  // km from the nearest MOP line, so there is a map to draw but no shoreline
+  // on it.
+  const view = shoreViewFor(beachBySlug("mission-bay-sail-bay")!);
+
+  expect(view.coast).toEqual([]);
+  expect(view.markers.length).toBeGreaterThan(0);
+  expect(view.bounds).not.toBeNull();
+});
+
+test("a beach whose two ends are one point draws no segment", () => {
+  // mission-bay-vacation-isle carries an upper equal to its lower. A stroke
+  // from a point to itself is invisible and claims the beach has no length.
+  const view = shoreViewFor(beachBySlug("mission-bay-vacation-isle")!);
+
+  expect(view.segment).toBeNull();
+  // It still has a box, because its stations are somewhere else.
+  expect(view.bounds).not.toBeNull();
+});
+
+test("a beach with no MOP line carries no MOP marker", () => {
+  // 26 of 51 bind none. ShoreMap turns the gap into a sentence; this is the
+  // half that has to leave the gap rather than invent a position for it.
+  // childrens-pool is one, and it is an open-coast beach rather than a bay one
+  // -- no MOP line and no wave buoy is not the same fact as no coast in frame.
+  const view = shoreViewFor(beachBySlug("childrens-pool")!);
+
+  expect(view.markers.some((marker) => marker.kind === "mop-line")).toBe(false);
+});
+
+test("every committed beach assembles, and the county's split is pinned", () => {
+  // beaches.ts throws when a slug names a station no table holds, so running
+  // the whole inventory is the drift guard. The two counts are pinned because
+  // they are what ShoreMap's absence sentences are sized for: a data change
+  // that moved them should fail here rather than quietly change what half the
+  // county's map says.
+  const views = allBeaches().map((beach) => shoreViewFor(beach));
+
+  expect(views).toHaveLength(51);
+  expect(views.filter((view) => view.coast.length === 0)).toHaveLength(23);
+  expect(
+    views.filter((view) =>
+      view.markers.some((marker) => marker.kind === "mop-line"),
+    ),
+  ).toHaveLength(25);
+});
+
+test("a distance is worded the way the cards word it, on both sides of 10 km", () => {
+  // The committed inventory reaches 9.2 km, so the whole-kilometre half is one
+  // join away rather than in use. It is asserted here because the map has to
+  // agree with the measured block about how far away means, and agreeing only
+  // up to 10 km would be a second rule.
+  expect(shoreDistanceKm(325)).toBe("0.3");
+  expect(shoreDistanceKm(1381)).toBe("1.4");
+  expect(shoreDistanceKm(9160)).toBe("9.2");
+  expect(shoreDistanceKm(12400)).toBe("12");
+  expect(shoreDistanceKm(null)).toBeNull();
+});
+
+test("a beach whose every source is one point gets no box and no coast", () => {
+  // boundsAround returns null rather than a zero-span box, because a zero span
+  // divides by zero in the projection. No committed beach reaches this -- even
+  // vacation-isle's stations are somewhere else -- so it is built rather than
+  // found, and the map says so instead of drawing a coast at infinite
+  // magnification.
+  const isle = beachBySlug("mission-bay-vacation-isle")!;
+  const nowhere = {
+    ...isle,
+    mop_line: null,
+    wave_buoy: null,
+    tide_station: null,
+    air_station: null,
+  };
+
+  const view = shoreViewFor(nowhere);
+
+  expect(view.bounds).toBeNull();
+  expect(view.coast).toEqual([]);
+  expect(view.markers).toEqual([]);
+});
+
+test("this beach's stretch is a run of the drawn coast, not a chord across it", () => {
+  // beaches.json's segment is the beach's bounding extent, and its two ends are
+  // not points on the MOP polyline. A straight line between them floats off the
+  // coastline and reads as a second, wrong shore -- which is what it drew.
+  const view = shoreViewFor(LA_JOLLA);
+  const ids = view.coast.map((point) => point.id);
+
+  expect(view.segment).not.toBeNull();
+  expect(view.segment!.length).toBeGreaterThan(1);
+  for (const point of view.segment!) {
+    expect(ids).toContain(point.id);
+  }
+});
+
+test("the stretch is contiguous, and shorter than the coast around it", () => {
+  const view = shoreViewFor(LA_JOLLA);
+  const ids = view.coast.map((point) => point.id);
+  const first = ids.indexOf(view.segment![0].id);
+
+  expect(view.segment!.map((point) => point.id)).toEqual(
+    ids.slice(first, first + view.segment!.length),
+  );
+  expect(view.segment!.length).toBeLessThan(view.coast.length);
+});
+
+test("a beach with no coast in frame has no stretch to mark", () => {
+  const view = shoreViewFor(beachBySlug("mission-bay-sail-bay")!);
+
+  expect(view.coast).toEqual([]);
+  expect(view.segment).toBeNull();
+});

--- a/src/components/conditions/shore.test.ts
+++ b/src/components/conditions/shore.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "vitest";
 import { allBeaches, beachBySlug } from "@/lib/beaches";
+import type { ShorePoint } from "@/lib/coastline";
 import { shoreDistanceKm, shoreViewFor } from "./shore";
 
 /** The beach the page opens on, and the one with all four sources bound. */
@@ -142,10 +143,13 @@ test("this beach's stretch is a run of the drawn coast, not a chord across it", 
   // coastline and reads as a second, wrong shore -- which is what it drew.
   const view = shoreViewFor(LA_JOLLA);
   const ids = view.coast.map((point) => point.id);
+  // Where a coast is drawn the stretch is taken from it, so every point in it
+  // carries the line id that placed it.
+  const run = view.segment as readonly ShorePoint[];
 
-  expect(view.segment).not.toBeNull();
-  expect(view.segment!.length).toBeGreaterThan(1);
-  for (const point of view.segment!) {
+  expect(run).not.toBeNull();
+  expect(run.length).toBeGreaterThan(1);
+  for (const point of run) {
     expect(ids).toContain(point.id);
   }
 });
@@ -153,17 +157,34 @@ test("this beach's stretch is a run of the drawn coast, not a chord across it", 
 test("the stretch is contiguous, and shorter than the coast around it", () => {
   const view = shoreViewFor(LA_JOLLA);
   const ids = view.coast.map((point) => point.id);
-  const first = ids.indexOf(view.segment![0].id);
+  const run = view.segment as readonly ShorePoint[];
+  const first = ids.indexOf(run[0].id);
 
-  expect(view.segment!.map((point) => point.id)).toEqual(
-    ids.slice(first, first + view.segment!.length),
+  expect(run.map((point) => point.id)).toEqual(
+    ids.slice(first, first + run.length),
   );
-  expect(view.segment!.length).toBeLessThan(view.coast.length);
+  expect(run.length).toBeLessThan(view.coast.length);
 });
 
-test("a beach with no coast in frame has no stretch to mark", () => {
+test("a beach with no coast is still placed on its own map", () => {
+  // Without this the bay maps are two markers floating in an empty frame with
+  // nothing saying where the beach is, which is the one thing the picture has
+  // to show. The chord objection is about a stroke competing with a drawn
+  // shore; where no shore is drawn there is nothing to compete with, and the
+  // beach's own two ends are the best statement available.
   const view = shoreViewFor(beachBySlug("mission-bay-sail-bay")!);
+  const beach = beachBySlug("mission-bay-sail-bay")!;
 
   expect(view.coast).toEqual([]);
+  expect(view.segment).not.toBeNull();
+  expect(view.segment).toEqual([beach.segment.lower, beach.segment.upper]);
+});
+
+test("a beach with no coast and no extent has nothing to draw", () => {
+  // mission-bay-vacation-isle, whose upper equals its lower. One point is not a
+  // stretch of shore, and a stroke from a point to itself claims a beach with
+  // no length.
+  const view = shoreViewFor(beachBySlug("mission-bay-vacation-isle")!);
+
   expect(view.segment).toBeNull();
 });

--- a/src/components/conditions/shore.ts
+++ b/src/components/conditions/shore.ts
@@ -37,8 +37,13 @@ import { TIDE_NETWORK } from "./tideStation";
 export type ShoreView = {
   coast: readonly ShorePoint[];
   bounds: Bounds | null;
-  /** The run of `coast` this beach occupies, drawn heavier. Never a chord. */
-  segment: readonly ShorePoint[] | null;
+  /**
+   * Where this beach is, drawn heavier than anything around it.
+   *
+   * The run of `coast` it occupies where there is a coast, and its own two ends
+   * where there is not. See `beachStretch`.
+   */
+  segment: readonly Position[] | null;
   markers: readonly ShoreMarker[];
 };
 
@@ -73,9 +78,9 @@ export function shoreDistanceKm(metres: number | null): string | null {
 }
 
 /**
- * The stretch of drawn coast that is this beach, or null when there is none.
+ * Where this beach is on its own map, or null when it has no extent to draw.
  *
- * **A run of the polyline, never a chord between the segment's two ends.**
+ * **A run of the polyline, never a chord, wherever a coast is drawn.**
  * `beaches.json` carries the beach's bounding extent, and neither end is a
  * point on the MOP line: drawing a straight stroke between them puts a second,
  * heavier shore beside the real one at an angle to it, which is what it did the
@@ -86,11 +91,22 @@ export function shoreDistanceKm(metres: number | null): string | null {
  * two ends land on the same point, which is `mission-bay-vacation-isle`, whose
  * upper equals its lower.
  */
-function beachRun(
+function beachStretch(
   coast: readonly ShorePoint[],
   beach: Beach,
-): readonly ShorePoint[] | null {
-  if (coast.length < 2) return null;
+): readonly Position[] | null {
+  const { upper, lower } = beach.segment;
+  const hasExtent = upper.lat !== lower.lat || upper.lon !== lower.lon;
+
+  /*
+    No coast to mark a run of, so the beach's own two ends are drawn instead.
+    The objection to a chord is that it competes with a drawn shore at an angle
+    to it; where no shore is drawn there is nothing to compete with, and this is
+    the only thing that says where the beach is. Without it the 23 bay maps are
+    markers floating in an empty frame, which is the one question the picture
+    has to answer.
+  */
+  if (coast.length < 2) return hasExtent ? [lower, upper] : null;
 
   const nearest = (at: Position): number => {
     const lonScale = Math.cos((at.lat * Math.PI) / 180);
@@ -207,7 +223,7 @@ export function shoreViewFor(beach: Beach): ShoreView {
   return {
     coast,
     bounds,
-    segment: beachRun(coast, beach),
+    segment: beachStretch(coast, beach),
     markers,
   };
 }

--- a/src/components/conditions/shore.ts
+++ b/src/components/conditions/shore.ts
@@ -1,0 +1,213 @@
+/**
+ * What one beach's map is made of, assembled from the joins already committed.
+ *
+ * `ShoreMap` is presentational and pure — it takes a window, a box and a list
+ * of markers. This is the half that knows what a buoy is: it resolves the four
+ * sources through `beaches.ts`, words each one the way the rest of the page
+ * words it, and windows the county coast down to what this beach can see.
+ *
+ * The split is `series.ts`'s, one region over: the assembler reads, the
+ * component draws, and neither does the other's job.
+ *
+ * **Nothing here computes a distance.** Every figure comes off `beaches.json`,
+ * where the joins measured it once, offline, and `--check` can reproduce it.
+ * Recomputing at request time would be a second answer to a question already
+ * answered, and the two could disagree.
+ */
+
+import type { Beach } from "@/lib/beaches";
+import {
+  airStationFor,
+  mopLineFor,
+  tideStationFor,
+  waveBuoyFor,
+} from "@/lib/beaches";
+import type { Bounds, Position, ShorePoint } from "@/lib/coastline";
+import {
+  boundsAround,
+  coastline,
+  SHORE_WINDOW_MARGIN,
+  windowAround,
+} from "@/lib/coastline";
+import { MOP_NETWORK, mopLineSource } from "./mopLine";
+import type { ShoreMarker } from "./ShoreMap";
+import { TIDE_NETWORK } from "./tideStation";
+
+/** Everything `ShoreMap` needs, and nothing it has to look up for itself. */
+export type ShoreView = {
+  coast: readonly ShorePoint[];
+  bounds: Bounds | null;
+  /** The run of `coast` this beach occupies, drawn heavier. Never a chord. */
+  segment: readonly ShorePoint[] | null;
+  markers: readonly ShoreMarker[];
+};
+
+/**
+ * How far a source stands, for the map, in kilometres and already rounded.
+ *
+ * **Always stated, unlike on a card, and that is the difference the map makes.**
+ * `tideStationDistanceKm` withholds anything under 5 km and the sea card
+ * withholds a near buoy, both for the same good reason: beside a figure, "0.3
+ * km" adds nothing a reader came for. Beside a *picture of the distances* it is
+ * the caption. A marker drawn a third of the way across the frame with no
+ * number under it asks the reader to estimate the thing the map exists to say.
+ *
+ * The rounding is `MeasuredToday`'s, deliberately: one decimal under 10 km
+ * where the difference between 1.4 and 1.8 is a different walk, whole
+ * kilometres above it where a decimal would be false precision about a station
+ * in the next bay. Spelled here rather than imported because it is private to
+ * that component; lifting it into a shared module is a refactor of two files
+ * and belongs to its own slice.
+ *
+ * **The whole-kilometre half is unreachable through the committed inventory**,
+ * where the furthest source is 9.2 km, and it is kept and tested directly
+ * anyway. The rule is one statement about how a distance is worded, the cards
+ * already word it both ways, and a map that agreed with them only up to 10 km
+ * would be a second rule wearing the first one's clothes. Exported for that
+ * test, which is the only caller outside this file.
+ */
+export function shoreDistanceKm(metres: number | null): string | null {
+  if (metres === null) return null;
+  const km = metres / 1000;
+  return km < 10 ? km.toFixed(1) : km.toFixed(0);
+}
+
+/**
+ * The stretch of drawn coast that is this beach, or null when there is none.
+ *
+ * **A run of the polyline, never a chord between the segment's two ends.**
+ * `beaches.json` carries the beach's bounding extent, and neither end is a
+ * point on the MOP line: drawing a straight stroke between them puts a second,
+ * heavier shore beside the real one at an angle to it, which is what it did the
+ * first time. Marking the coast the beach actually occupies says the same thing
+ * and says it on the shape a reader is looking at.
+ *
+ * Null when the window holds no coast — 23 of 51 beaches — and null when the
+ * two ends land on the same point, which is `mission-bay-vacation-isle`, whose
+ * upper equals its lower.
+ */
+function beachRun(
+  coast: readonly ShorePoint[],
+  beach: Beach,
+): readonly ShorePoint[] | null {
+  if (coast.length < 2) return null;
+
+  const nearest = (at: Position): number => {
+    const lonScale = Math.cos((at.lat * Math.PI) / 180);
+    let best = Infinity;
+    let index = 0;
+    coast.forEach((point, at_) => {
+      const dx = (point.lon - at.lon) * lonScale;
+      const dy = point.lat - at.lat;
+      const distance = dx * dx + dy * dy;
+      if (distance < best) {
+        best = distance;
+        index = at_;
+      }
+    });
+    return index;
+  };
+
+  const from = nearest(beach.segment.lower);
+  const to = nearest(beach.segment.upper);
+  if (from === to) return null;
+
+  return coast.slice(Math.min(from, to), Math.max(from, to) + 1);
+}
+
+/**
+ * The four sources, in the order they are drawn and listed.
+ *
+ * Nearest-first is not the order: the list reads sea, then shore, then air,
+ * which is the order the page already introduces them in and the order the
+ * measured block puts them in. A list re-sorted by distance would change from
+ * beach to beach and stop being learnable.
+ *
+ * A source the join did not bind is absent from this list rather than present
+ * and empty. `ShoreMap` turns the absence into a sentence, because 26 of 51
+ * beaches bind no MOP line and 36 bind no wave buoy, and a map quietly short a
+ * marker reads as a map whose buoy is off-frame.
+ */
+function markersFor(beach: Beach): ShoreMarker[] {
+  const markers: ShoreMarker[] = [];
+
+  const mopLine = mopLineFor(beach);
+  if (mopLine !== null) {
+    markers.push({
+      kind: "mop-line",
+      source: mopLineSource(mopLine.id),
+      network: MOP_NETWORK,
+      distanceKm: shoreDistanceKm(beach.mop_line_distance_m),
+      lat: mopLine.lat,
+      lon: mopLine.lon,
+    });
+  }
+
+  const buoy = waveBuoyFor(beach);
+  if (buoy !== null) {
+    markers.push({
+      kind: "wave-buoy",
+      source: `Buoy ${buoy.name}`,
+      network: "NDBC",
+      distanceKm: shoreDistanceKm(beach.wave_buoy_distance_m),
+      lat: buoy.lat,
+      lon: buoy.lon,
+    });
+  }
+
+  const tide = tideStationFor(beach);
+  if (tide !== null) {
+    markers.push({
+      kind: "tide-station",
+      source: tide.name,
+      network: TIDE_NETWORK,
+      distanceKm: shoreDistanceKm(beach.tide_station_distance_m),
+      lat: tide.lat,
+      lon: tide.lon,
+    });
+  }
+
+  const air = airStationFor(beach);
+  if (air !== null) {
+    markers.push({
+      kind: "air-station",
+      // `display_name` and never `name`: the published one is a callsign for
+      // most of these, which is the distinction that field exists to make.
+      source: air.display_name,
+      // No network, and not a guess. An air station may be on the NWS or the
+      // NDBC network and the binding does not record which, so the air card has
+      // never named one either.
+      network: null,
+      distanceKm: shoreDistanceKm(beach.air_station_distance_m),
+      lat: air.lat,
+      lon: air.lon,
+    });
+  }
+
+  return markers;
+}
+
+/**
+ * One beach's map, ready to draw.
+ *
+ * The window is framed on the sources rather than on the sand, so a station 9
+ * km away puts itself in the picture at 9 km. That is what makes this ADR-0010
+ * drawn rather than written, and it is why `mission-beach` gets a 20 km frame
+ * in which its own beach is a fifth of the height.
+ */
+export function shoreViewFor(beach: Beach): ShoreView {
+  const markers = markersFor(beach);
+  const bounds = boundsAround(
+    [beach.segment.upper, beach.segment.lower, ...markers],
+    SHORE_WINDOW_MARGIN,
+  );
+
+  const coast = bounds === null ? [] : windowAround(coastline(), bounds);
+
+  return {
+    coast,
+    bounds,
+    segment: beachRun(coast, beach),
+    markers,
+  };
+}

--- a/src/lib/coastline.test.ts
+++ b/src/lib/coastline.test.ts
@@ -3,6 +3,7 @@ import {
   boundsAround,
   coastline,
   projectionFor,
+  sideOf,
   windowAround,
   withoutRepeats,
 } from "./coastline";
@@ -143,4 +144,54 @@ test("a box needs two distinct positions, and says so rather than collapsing", (
 
   expect(boundsAround([onePlace, onePlace], 0.1)).toBeNull();
   expect(boundsAround([], 0.1)).toBeNull();
+});
+
+test("west of a coast walked south to north is its seaward side", () => {
+  // The whole county coast faces west, and the file runs south to north, so
+  // "left of the walk" and "out to sea" are the same side. The map shades by
+  // this, so it is stated once here and checked against the committed buoys by
+  // the `sea-side` gate row rather than assumed.
+  const northward = [
+    { id: "D0001", lat: 32.0, lon: -117.0 },
+    { id: "D0002", lat: 32.1, lon: -117.0 },
+  ];
+
+  expect(sideOf(northward, { lat: 32.05, lon: -117.1 })).toBe("left");
+  expect(sideOf(northward, { lat: 32.05, lon: -116.9 })).toBe("right");
+});
+
+test("a run with no segment in it has no sides", () => {
+  // What a bay beach's window is: the traced coast does not reach it, so there
+  // is nothing to be on a side of. The map says so rather than shading a guess.
+  expect(sideOf([], { lat: 32.0, lon: -117.0 })).toBeNull();
+  expect(
+    sideOf([{ id: "D0001", lat: 32.0, lon: -117.0 }], {
+      lat: 32.0,
+      lon: -117.1,
+    }),
+  ).toBeNull();
+});
+
+test("a zero-length segment is stepped over rather than divided by", () => {
+  // withoutRepeats takes these out of the county coast, but sideOf is handed
+  // runs by callers and a repeat here would divide by zero and answer with a
+  // NaN that compares false both ways -- silently landward.
+  const withRepeat = [
+    { id: "D0001", lat: 32.0, lon: -117.0 },
+    { id: "D0002", lat: 32.0, lon: -117.0 },
+    { id: "D0003", lat: 32.1, lon: -117.0 },
+  ];
+
+  expect(sideOf(withRepeat, { lat: 32.05, lon: -117.1 })).toBe("left");
+});
+
+test("a position on the line itself is on neither side", () => {
+  // The MOP line a beach binds sits on this polyline, so this is the answer for
+  // the one marker that cannot be seaward or landward of the coast it traces.
+  const northward = [
+    { id: "D0001", lat: 32.0, lon: -117.0 },
+    { id: "D0002", lat: 32.1, lon: -117.0 },
+  ];
+
+  expect(sideOf(northward, { lat: 32.05, lon: -117.0 })).toBeNull();
 });

--- a/src/lib/coastline.test.ts
+++ b/src/lib/coastline.test.ts
@@ -1,0 +1,146 @@
+import { expect, test } from "vitest";
+import {
+  boundsAround,
+  coastline,
+  projectionFor,
+  windowAround,
+  withoutRepeats,
+} from "./coastline";
+
+test("the committed 1,210 MOP lines reduce to 1,087 distinct points", () => {
+  // Pinned against the real file rather than a fixture. 123 of the lines repeat
+  // their neighbour's coordinates exactly, and the count is here so a future
+  // data change fails loudly instead of silently changing the shape of the
+  // coast every consumer draws.
+  expect(coastline()).toHaveLength(1087);
+});
+
+test("a repeated coordinate is dropped rather than kept as a zero-length step", () => {
+  // The shape of the real defect, in miniature: D0002 sits exactly where D0001
+  // does. Keeping it would leave a segment with no length and therefore no
+  // direction, which is what corrupts a tangent or a side test downstream.
+  const kept = withoutRepeats([
+    { id: "D0001", lat: 32.5, lon: -117.1 },
+    { id: "D0002", lat: 32.5, lon: -117.1 },
+    { id: "D0003", lat: 32.6, lon: -117.1 },
+  ]);
+
+  expect(kept.map((point) => point.id)).toEqual(["D0001", "D0003"]);
+});
+
+test("the window keeps one point past each end so the coast reaches the frame", () => {
+  // Clipping to exactly what falls inside would draw a coastline that stops
+  // short of the edge with white on both sides of it, which reads as the land
+  // ending rather than as the map ending.
+  const points = [
+    { id: "D0001", lat: 32.0, lon: -117.0 },
+    { id: "D0002", lat: 32.1, lon: -117.0 },
+    { id: "D0003", lat: 32.2, lon: -117.0 },
+    { id: "D0004", lat: 32.3, lon: -117.0 },
+    { id: "D0005", lat: 32.4, lon: -117.0 },
+    { id: "D0006", lat: 32.5, lon: -117.0 },
+  ];
+
+  const kept = windowAround(points, {
+    south: 32.15,
+    north: 32.35,
+    west: -117.1,
+    east: -116.9,
+  });
+
+  expect(kept.map((point) => point.id)).toEqual([
+    "D0002",
+    "D0003",
+    "D0004",
+    "D0005",
+  ]);
+});
+
+test("a run that leaves the box and comes back stays one stroke", () => {
+  // The coast bends: 39 of the 1,209 real steps run north to south. A window
+  // that kept only what falls inside would cut a bend into two strokes with a
+  // gap where the land is.
+  const points = [
+    { id: "D0001", lat: 32.2, lon: -117.0 },
+    { id: "D0002", lat: 32.2, lon: -116.5 },
+    { id: "D0003", lat: 32.2, lon: -117.0 },
+  ];
+
+  const kept = windowAround(points, {
+    south: 32.1,
+    north: 32.3,
+    west: -117.1,
+    east: -116.9,
+  });
+
+  expect(kept.map((point) => point.id)).toEqual(["D0001", "D0002", "D0003"]);
+});
+
+test("a box the coast does not reach is empty, which a caller must say", () => {
+  // Not the same as a coast that is not there. The caller renders an absence,
+  // never a blank frame that reads as open water.
+  const kept = windowAround([{ id: "D0001", lat: 32.2, lon: -117.0 }], {
+    south: 33.0,
+    north: 33.1,
+    west: -117.1,
+    east: -116.9,
+  });
+
+  expect(kept).toEqual([]);
+});
+
+test("one mapping places the coast and every marker, centred and undistorted", () => {
+  // A marker plotted by different arithmetic from the coast beside it is a
+  // marker in the wrong place, so the projection is a value the map hands to
+  // everything it draws rather than a transform applied to the polyline.
+  const project = projectionFor(
+    { south: 32.0, north: 32.2, west: -117.2, east: -117.0 },
+    { width: 100, height: 100 },
+  );
+
+  const centre = project(32.1, -117.1);
+  expect(centre.x).toBeCloseTo(50, 6);
+  expect(centre.y).toBeCloseTo(50, 6);
+
+  // North is up: latitude falls as y grows.
+  expect(project(32.2, -117.1).y).toBeCloseTo(0, 6);
+  expect(project(32.0, -117.1).y).toBeCloseTo(100, 6);
+
+  // A degree of longitude covers cos(32.1 deg) = 0.8471 of a degree of latitude
+  // on the ground here, so a square box of degrees is letterboxed east to west
+  // rather than stretched to fill. Stretching it would bend the coast.
+  expect(project(32.1, -117.2).x).toBeCloseTo(7.6439, 3);
+  expect(project(32.1, -117.0).x).toBeCloseTo(92.3561, 3);
+});
+
+test("the box covers every source with an even margin on the ground", () => {
+  const bounds = boundsAround(
+    [
+      { lat: 32.0, lon: -117.2 },
+      { lat: 32.2, lon: -117.0 },
+    ],
+    0.1,
+  );
+
+  // A tenth of the larger span, added on each side.
+  expect(bounds).not.toBeNull();
+  expect(bounds!.south).toBeCloseTo(31.98, 10);
+  expect(bounds!.north).toBeCloseTo(32.22, 10);
+
+  // The same margin on the *ground* east to west, which takes more degrees of
+  // longitude than of latitude here. A margin measured in raw degrees would be
+  // 15 percent tighter east-west than north-south at this latitude.
+  const cos = Math.cos((32.1 * Math.PI) / 180);
+  expect(bounds!.west).toBeCloseTo(-117.2 - 0.02 / cos, 10);
+  expect(bounds!.east).toBeCloseTo(-117.0 + 0.02 / cos, 10);
+});
+
+test("a box needs two distinct positions, and says so rather than collapsing", () => {
+  // `mission-bay-vacation-isle` carries a segment whose upper equals its lower,
+  // so this is a real row rather than a hypothetical. A zero-span box divides by
+  // zero in the projection and draws a coast at infinite magnification.
+  const onePlace = { lat: 32.7737, lon: -117.2402 };
+
+  expect(boundsAround([onePlace, onePlace], 0.1)).toBeNull();
+  expect(boundsAround([], 0.1)).toBeNull();
+});

--- a/src/lib/coastline.ts
+++ b/src/lib/coastline.ts
@@ -308,3 +308,26 @@ export function sideOf(
   if (cross === 0) return null;
   return cross > 0 ? "left" : "right";
 }
+
+/**
+ * How much room a beach's map leaves around its sources, as a fraction of the
+ * larger span.
+ *
+ * Named here rather than at the call site because two things have to agree
+ * about it. `ShoreMap` frames the window it draws; the `sea-side` gate row
+ * checks which side of that window the water is on, and a wider frame reaches
+ * more coast and can change which segment is nearest a buoy. A checker run
+ * against a window the map does not draw would be checking a different claim.
+ *
+ * `scripts/sea-side.mjs` spells the number a second time, because it runs under
+ * plain node and cannot import this file; `sea-side.test.mjs` asserts the two
+ * are equal, so the pair cannot drift silently.
+ *
+ * 0.1 rather than more, measured. Raising it to reach the 23 beaches with no
+ * coast in frame costs the beaches that have one: at 0.1 La Jolla Shores fills
+ * 83 percent of its map's height, at 0.5 it fills 50 percent, and at 1.0 it
+ * fills 33 while Mission Beach's frame reaches 51 km. Half-fixing the bay
+ * beaches by shrinking every open-coast beach is the wrong trade, and the bay
+ * beaches are answered by saying so instead.
+ */
+export const SHORE_WINDOW_MARGIN = 0.1;

--- a/src/lib/coastline.ts
+++ b/src/lib/coastline.ts
@@ -235,3 +235,76 @@ export function withoutRepeats(
 
   return kept;
 }
+
+/** Which side of a walked polyline a position falls on, north being up. */
+export type Side = "left" | "right";
+
+/**
+ * The side of a run of coast a position falls on, or null when there is no run.
+ *
+ * **This is how the map knows which side to shade, and it is the one geometric
+ * claim on the page that is checked rather than assumed.** The county coast
+ * faces west and `mop-lines.json` runs south to north, so "left of the walk"
+ * and "out to sea" are the same side — and the `sea-side` gate row proves that
+ * against every committed wave buoy rather than leaving it to this comment.
+ *
+ * **Measured against the nearest segment, not the nearest point.** A vertex at
+ * a bend belongs to two segments pointing different ways, so picking by vertex
+ * picks an orientation by luck. The zero-length segments `withoutRepeats`
+ * removes are the same failure in its acute form: no length, no direction, and
+ * a side test that returns whatever the arithmetic produces.
+ *
+ * **The nearest segment must come from a window, not the whole county.** Walked
+ * end to end the file is not monotonic — it wraps Point Loma, and 39 of its
+ * 1,209 steps run north to south. Buoy 46232 sits 22.9 km off that peninsula
+ * and matches a segment on the wrap, where left is not seaward. Inside a
+ * beach's own window the question is well posed, which is the only place the
+ * map ever asks it.
+ *
+ * **Left here is geographic, not `x` and `y`.** `projectionFor` puts north at
+ * the top, so y grows southward and a caller drawing in plot coordinates sees
+ * this side on the other hand. Converting is the caller's job, once.
+ */
+export function sideOf(
+  points: readonly ShorePoint[],
+  at: Position,
+): Side | null {
+  const lonScale = Math.cos((at.lat * Math.PI) / 180);
+  const east = (lon: number): number => lon * lonScale;
+
+  let nearest = Infinity;
+  let cross = 0;
+
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const from = points[index];
+    const to = points[index + 1];
+
+    const dx = east(to.lon) - east(from.lon);
+    const dy = to.lat - from.lat;
+    const length = dx * dx + dy * dy;
+    // Looks removable and is not. Without it a repeated point divides by zero,
+    // and the NaN that follows is swallowed by `distance < nearest` being false
+    // for NaN -- so the answer is right today by accident of one comparison
+    // operator. Deleting this passes every test in this file; that is a blind
+    // spot in the tests rather than evidence the line is dead.
+    if (length === 0) continue;
+
+    const px = east(at.lon) - east(from.lon);
+    const py = at.lat - from.lat;
+
+    // Clamped, so a position past an end measures to the end rather than to the
+    // segment's infinite line, which would run off across the land.
+    const along = Math.min(1, Math.max(0, (px * dx + py * dy) / length));
+    const offX = px - along * dx;
+    const offY = py - along * dy;
+    const distance = offX * offX + offY * offY;
+
+    if (distance < nearest) {
+      nearest = distance;
+      cross = dx * py - dy * px;
+    }
+  }
+
+  if (cross === 0) return null;
+  return cross > 0 ? "left" : "right";
+}

--- a/src/lib/coastline.ts
+++ b/src/lib/coastline.ts
@@ -1,0 +1,237 @@
+/**
+ * The county coastline as a drawable polyline, from the MOP lines already
+ * committed.
+ *
+ * `mop-lines.json` holds 1,210 CDIP model lines at about 98 m spacing, keyed
+ * `D0001` upward and ordered south to north. `beaches.ts` reads that table one
+ * key at a time, to answer "which line does this beach bind". Nothing has ever
+ * read it as a *shape* before, and reading it as a shape is what this module is
+ * for.
+ *
+ * **The de-duplication is not housekeeping.** 123 of the 1,210 repeat their
+ * neighbour's coordinates exactly, so a polyline built straight from the file
+ * carries 123 zero-length segments. A zero-length segment has no direction, so
+ * every tangent is undefined there and every left-or-right test against it
+ * returns whatever the arithmetic happens to produce — which already gave one
+ * wrong answer while this work was being scoped. Removing them first is what
+ * makes the geometry below answerable at all.
+ *
+ * **Not `scripts/geo.mjs`.** That is build-side JavaScript for the joins that
+ * produced `beaches.json`, and it runs once, offline, against every beach. This
+ * is runtime TypeScript that runs per request against one.
+ */
+
+import mopLineTable from "@/data/mop-lines.json";
+import type { MopLine } from "./beaches";
+
+const MOP_LINES = mopLineTable.lines as Readonly<Record<string, MopLine>>;
+
+/** One point on the drawn coast, keeping the line id that placed it. */
+export interface ShorePoint {
+  /** The MOP line id this came from, so a marker can name what it marks. */
+  readonly id: string;
+  readonly lat: number;
+  readonly lon: number;
+}
+
+/**
+ * The whole county coast, walked south to north, with consecutive duplicates
+ * removed.
+ *
+ * The **first** of each run of repeats is the one kept. That choice is safe to
+ * make rather than merely convenient: no beach in `beaches.json` binds a line
+ * that this drops, so no marker loses the point it names. A later run that
+ * changed that would fail the pinned count in this module's test before it
+ * could fail silently on a page.
+ */
+export function coastline(): readonly ShorePoint[] {
+  return withoutRepeats(
+    Object.keys(MOP_LINES).map((id) => ({
+      id,
+      lat: MOP_LINES[id].lat,
+      lon: MOP_LINES[id].lon,
+    })),
+  );
+}
+
+/** A lat/lon box a map has to cover. */
+export interface Bounds {
+  readonly south: number;
+  readonly north: number;
+  readonly west: number;
+  readonly east: number;
+}
+
+/** Anything the map has to keep in frame: a segment end, a station, a buoy. */
+export interface Position {
+  readonly lat: number;
+  readonly lon: number;
+}
+
+/**
+ * The box that holds every position, with an even margin, or null when there is
+ * no box to draw.
+ *
+ * **The margin is a fraction of the larger span, in ground distance rather than
+ * in degrees.** Adding the same number of degrees to both axes would put 15
+ * percent less sea beside this coast than sky above it, because a degree of
+ * longitude is shorter here — so the fraction is converted through the same
+ * cosine `projectionFor` uses, and the two agree by construction.
+ *
+ * **Null when every position is the same place.** `mission-bay-vacation-isle`
+ * carries a segment whose upper equals its lower, so this is a committed row
+ * rather than a hypothetical: a zero-span box divides by zero in the projection
+ * and draws a coast at infinite magnification. The caller renders an absence
+ * and says why, which is what that beach is owed.
+ *
+ * No minimum span, because none is needed: measured across all 51 beaches with
+ * their four sources, the tightest box is `shoreline-park` at 1.8 km and the
+ * widest `mission-beach` at 17 km. A floor would be a constant standing in for
+ * a case the data does not contain.
+ */
+export function boundsAround(
+  positions: readonly Position[],
+  margin: number,
+): Bounds | null {
+  if (positions.length === 0) return null;
+
+  const lats = positions.map((position) => position.lat);
+  const lons = positions.map((position) => position.lon);
+  const south = Math.min(...lats);
+  const north = Math.max(...lats);
+  const west = Math.min(...lons);
+  const east = Math.max(...lons);
+
+  if (south === north && west === east) return null;
+
+  const lonScale = Math.cos((((south + north) / 2) * Math.PI) / 180);
+  const pad = margin * Math.max(north - south, (east - west) * lonScale);
+
+  return {
+    south: south - pad,
+    north: north + pad,
+    west: west - pad / lonScale,
+    east: east + pad / lonScale,
+  };
+}
+
+/** A point on the drawn plot, in the caller's own units. */
+export interface PlotPoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+/** The box a projection fits its bounds into. */
+export interface PlotSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+/** Places any position on the plot. See `projectionFor`. */
+export type Project = (lat: number, lon: number) => PlotPoint;
+
+/**
+ * One mapping from lat/lon onto a plot box, for everything the map draws.
+ *
+ * **A value rather than a transform over the polyline**, because the coast is
+ * not the only thing placed: the beach's own segment, the MOP line, the wave
+ * buoy, the tide station and the air station all go on the same picture, and a
+ * marker plotted by different arithmetic from the coast beside it is a marker
+ * in the wrong place. ADR-0010's requirement is that a reader can tell which
+ * station supplied which number; drawing them at their real distances only
+ * discharges it if the distances are real.
+ *
+ * **Equirectangular, corrected by cosine, and no more than that.** A degree of
+ * longitude covers cos(latitude) of a degree of latitude on the ground — 0.847
+ * at 32.1 degrees north — so plotting raw degrees would stretch this coast
+ * east to west by 18 percent and bend it. The correction is one multiplication.
+ * Anything more principled is a projection library, and ADR-0025 has already
+ * answered what this page spends a dependency on.
+ *
+ * **The fit letterboxes rather than stretches.** Whichever axis is the tighter
+ * fit sets the scale and the other is centred, so the shape is preserved and
+ * the whole box is reachable. Filling the frame instead would distort the coast
+ * differently on every beach.
+ */
+export function projectionFor(bounds: Bounds, size: PlotSize): Project {
+  const midLat = (bounds.south + bounds.north) / 2;
+  const lonScale = Math.cos((midLat * Math.PI) / 180);
+
+  const spanLat = bounds.north - bounds.south;
+  const spanLon = (bounds.east - bounds.west) * lonScale;
+
+  const scale = Math.min(size.width / spanLon, size.height / spanLat);
+  const padX = (size.width - spanLon * scale) / 2;
+  const padY = (size.height - spanLat * scale) / 2;
+
+  return (lat, lon) => ({
+    x: padX + (lon - bounds.west) * lonScale * scale,
+    // North is up, so latitude runs the opposite way to y.
+    y: padY + (bounds.north - lat) * scale,
+  });
+}
+
+/**
+ * The run of coastline that reaches a box, plus one point past each end.
+ *
+ * **The overhang is the point of the function.** Clipping to exactly what falls
+ * inside draws a coast that stops short of the frame with sea on both sides of
+ * its ends, which reads as the land ending rather than as the map ending. One
+ * point beyond means the stroke leaves the frame and the reader's eye continues
+ * it.
+ *
+ * Returns the points between the first and last that fall inside, so a run that
+ * dips out of the box and back in stays whole rather than becoming two strokes
+ * with a gap. Empty when the box reaches no point at all, which is a coast this
+ * file does not trace rather than a coast that is not there — a caller must say
+ * so rather than drawing nothing.
+ */
+export function windowAround(
+  points: readonly ShorePoint[],
+  bounds: Bounds,
+): readonly ShorePoint[] {
+  const inside = (point: ShorePoint): boolean =>
+    point.lat >= bounds.south &&
+    point.lat <= bounds.north &&
+    point.lon >= bounds.west &&
+    point.lon <= bounds.east;
+
+  const first = points.findIndex(inside);
+  if (first === -1) return [];
+
+  let last = first;
+  for (let index = points.length - 1; index > first; index -= 1) {
+    if (inside(points[index])) {
+      last = index;
+      break;
+    }
+  }
+
+  return points.slice(
+    Math.max(0, first - 1),
+    Math.min(points.length, last + 2),
+  );
+}
+
+/**
+ * The same run of points with every consecutive repeat dropped.
+ *
+ * Separate from `coastline` because it is the part with a rule in it, and a
+ * rule that can only be exercised through a 1,210-entry data file is a rule
+ * nobody can write a case for. Only *consecutive* repeats go: two points that
+ * coincide at opposite ends of the county are two real places, and collapsing
+ * them would join the coast to itself.
+ */
+export function withoutRepeats(
+  points: readonly ShorePoint[],
+): readonly ShorePoint[] {
+  const kept: ShorePoint[] = [];
+
+  for (const point of points) {
+    const last = kept[kept.length - 1];
+    if (last && last.lat === point.lat && last.lon === point.lon) continue;
+    kept.push(point);
+  }
+
+  return kept;
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -242,11 +242,28 @@ export default defineConfig({
       //
       // The figures below are these, not the ones in the block above, which
       // are kept because they are what the deletion on its own cost.
+      //
+      // 2026-08-30, #173's first half: the shore map, its assembler and the
+      // coastline geometry beneath them. All four rise, which is what a slice
+      // that adds only tested code does -- coastline.ts and shore.ts each
+      // finished fully covered, and the numerator grew faster than the
+      // denominator on every row.
+      //
+      //   statements 2368/2677 -> 2639/2959   88.45 -> 89.18
+      //   branches   1573/1779 -> 1696/1914   88.42 -> 88.61
+      //   functions   564/601  ->  606/644    93.84 -> 94.09
+      //   lines      2143/2434 -> 2388/2686   88.04 -> 88.90
+      //
+      // Two branches in this work are unreachable through the committed data
+      // and are covered by calling their functions directly rather than by
+      // widening the floor around them: `shoreDistanceKm` above 10 km, where
+      // the furthest source in the inventory is 9.2 km, and `boundsAround`
+      // returning null, which needs a beach whose every source is one point.
       thresholds: {
-        statements: 88.45,
-        branches: 88.42,
-        functions: 93.84,
-        lines: 88.04,
+        statements: 89.18,
+        branches: 88.61,
+        functions: 94.09,
+        lines: 88.9,
       },
     },
   },


### PR DESCRIPTION
Part of #173.

The map, end to end: the coastline geometry, a gate row proving which side is
the sea, `ShoreMap`, the sighting slot moving onto it, two ADRs, the two-column
row and the floor. **`Compass` is PR 3b** — see _The cut_ below.

Also opens with the `/design-review` `TASKS.md` scheduled for once PR 2 merged.

---

## What changed, by slice

**Review the day view against the brief it was built from.** One Must Fix — the
chart draws four series from three publishers and attributes none of them, while
ADR-0029's third clause states that "the chart's provenance names the cell" as
though it were built. Four Should Fixes. Two things checked and deliberately not
reported, including the sparklines not following the tab, which is a recorded
decision in the plan file (verified built: 0 of 14 paths changed). Contrast was
measured from painted pixels; both controls `cardText.ts` documents reproduced
exactly, 5.96:1 and 10.02:1.

**Read the MOP lines as a shape instead of a table.** `src/lib/coastline.ts` —
dedupe, window, project, side-of. 123 of the 1,210 lines repeat their
neighbour's coordinates, and the count is pinned at 1,087 so a data change fails
loudly. The projection is a value handed to everything drawn rather than a
transform over the polyline, because four markers go on the same picture.

**Check which side of the coast the sea is on.** New `sea-side` gate row, in
ADR-0021's shape: pure verdict, thin runner, unit tests against a fabricated
county with a buoy moved inland.

**Draw the beach and the places its figures come from.** `ShoreMap`, plus the
assembler beside it. Presentational and pure, hand-rolled SVG per ADR-0025.

**Let one component say how far away a source is.** My own miss in the commit
before it: `ShoreMap` took a pre-worded distance while its docstring said
`ProvenanceLine` owns that phrasing.

**Put the map beside the chart and close the ragged edge.** Two thirds and one
third at `xl`; stacked below, with the map's width capped rather than its height
because it is square.

**Stop the map claiming a shoreline it does not have.** See _The finding_ below.

**Reserve the sighting layer on the map instead of in its place.**

**Record what the map draws and what a reserved slot may stand for.** ADR-0030,
ADR-0031, and CONTEXT.md gains four terms.

**Move the floor and record what this half decided.**

---

## Three figures this work corrected

`TASKS.md` and the issue both assert the first two. Both now carry the
correction beside the sentence corrected.

**"All 13 wave buoys fall on the left of the polyline" fails at 12 of 13.** The
file is not monotonic — it wraps Point Loma, where 39 of its 1,209 steps run
north to south — so buoy 46232, 22.9 km off that peninsula, matches a segment on
the wrap and lands on the right. It is the *check* that is wrong: the map asks
inside one beach's window, where the coast runs one way, and there the rule holds
without exception. **And only 15 of 51 beaches bind a wave buoy at all**, so 15
is the number that can be asked.

**23 of 51 beaches have no coast in their window**, not the one the brief
anticipated — every Mission Bay and San Diego Bay beach, 2.6 to 5.4 km from the
nearest MOP line. Widening the frames to reach the ocean was measured and
rejected: at 0.5 margin `vacation-isle` finally reaches coast and La Jolla drops
from 83% to 50% of its own map, and what arrives is a shoreline 5 km away that is
not that beach's shore.

## The finding that changed the design

**The line the map draws is not the shoreline.** CDIP computes MOP lines at 10 m
depth: across the 25 beaches that bind one they stand 117 to 930 m out, median
644, and at La Jolla the line is ~310 m seaward of the beach's own coordinate.
So the Scripps tide gauge and the pier it is bolted to — both over water — drew
on the *landward* side of a hard sea-and-land edge, on the page the site opens
on.

ADR-0030 is the decision: the wash fades over the measured offset rather than
ending, the line names what it was traced from, and which side is seaward stays a
checked fact — the offset makes the boundary imprecise, not the question
meaningless.

## The cut

PR 3 had eight tasks against CLAUDE.md's guide of ~5 slices, and PR 2 had already
been cut mid-flight for the same reason. **3a is everything but the compass**;
it ends with a map a reader can see, so it is a complete path rather than a
layer. **3b is `Compass` alone**, adding needles to a map that exists.

Two consequences: the plan file is marked historical by 3b, and this says
`Part of #173` rather than `Closes` — the condition for `Closes` is not met, and
checking it rather than defaulting is what the last half got wrong in the other
direction.

## Three defects found by looking, not by a test

Each has a test now, and each test fails on the behaviour it names.

- The sea polygon closed straight to seaward and left an unshaded wedge in a
  corner wherever the shore was not perpendicular to that normal.
- The beach's own stretch was drawn as a chord between the two ends
  `beaches.json` carries — neither of which is on the MOP line — so it landed
  beside the shore at an angle and read as a second, wrong coastline.
- Two markers drew one black smudge where the tide gauge is bolted to the pier.

Nine of `ShoreMap`'s ten tests also pass with the sea shaded over the land. The
tenth checks the shaded side against the wave buoy, the only thing on the map
known to be in the water, and negating the normal fails that test and no other.

## Rendered-text diff

Run against `main`, per the rule the tide station's disappearance wrote, because
moving the sighting slot is a removal wearing a move's clothes. Two lines left
the page and both are deliberate: the old headline and its map emoji. The
`reported by naturalists, not surveyed by us` sentence appears on **neither**
side of the diff — it is identical on both, so #121's disclaimer survived
verbatim rather than being retyped into something that looks the same.

The three tests fixing that copy moved from `ConditionsSection.test.tsx` to
`DayPanel.test.tsx`, because that suite mocks the panel: left where they were,
all three passed whatever the slot said, including nothing. Deleting the slot now
fails all three; before the move it failed none.

---

## Gate output

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

The new row's own output:

```
sea-side: 15 of 15 beaches put their buoy left of their own coast
  36 bind no wave buoy
```

```
      Tests  1388 passed (1388)
Statements   : 89.18% ( 2639/2959 )
Branches     : 88.61% ( 1696/1914 )
Functions    : 94.09% ( 606/644 )
Lines        : 88.9% ( 2388/2686 )
```

All four rows rise, which is what a slice adding only tested code does.
`coastline.ts` and `shore.ts` each finished fully covered.

Measured on the built page at 1536×639: the map runs 1016 → 1488 and the content
column ends at 1488, so the day region reaches the same right edge as the week
above and the cards below. No horizontal overflow at 375, 768, 1024, 1280 or
1536.

---

## What I did not do

**No plan file for this branch.** `docs/plans/conditions-day-view.md` already
holds the decisions and gains a dated addendum here. A fourth copy would go stale
on its own — CLAUDE.md's own argument about `docs/plans/`.

**The design review's five findings are not fixed here.** None is #173's work
under one-issue-per-branch, and the map closes half the ragged edge on its own.
Filing them as issues when this merges was the agreed routing; the cost is stated
in the review — until finding 1 is worked, the page runs ADR-0029's permitted
duplication without the attribution clause that licenses it. You ruled on finding
2 (fade the chart fill toward the floor) and it is recorded there.

**No scale bar on the map.** Not asked for, and the distances are listed under
it. Worth a look at review.

**`roundedKm` and `shoreDistanceKm` are the same rule spelled twice** — one
decimal under 10 km, whole above. Lifting it into a shared module is a refactor
of two files and belongs to its own slice. Noticed, recorded in both docstrings
and in the plan addendum, not filed.

**The geometry is spelled twice** — `src/lib/coastline.ts` and
`scripts/sea-side.mjs` — because the gate row runs under plain node and cannot
import TypeScript. ADR-0021 already made that trade for `generated-date.mjs`. The
pin is not a sampled case: the whole committed file through both spellings, plus
every beach's side compared both ways, with the comparison count itself pinned so
a pin that stopped comparing would fail rather than pass.

**Screenshots are not in the repo.** They are pictures of a page 3b changes next,
and `.design/` is committed. The review carries its measurements instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
