### PR TITLE
The compass: two needles on the shore map, and one dial with two publishers

### DIFF
--- a/.design/conditions-day-view/TASKS.md
+++ b/.design/conditions-day-view/TASKS.md
@@ -294,6 +294,9 @@ nothing the chart touches. **`Compass` is not independent** — it needs the
 gridpoint wind direction that PR 2's first task adds, so it cannot start until
 that has merged. `ShoreMap` can be built and reviewed before it.
 
+**Both halves have shipped.** PR 3a on 2026-08-30 (#178, `Part of #173`) and
+PR 3b after it, which closes #173 and marks the plan historical.
+
 **Cut in two on 2026-08-30, at the compass**, the way PR 2 was cut the day
 before and for the same reason: eight tasks against CLAUDE.md's guide of about
 five slices. **PR 3a is everything except `Compass`** — the geometry, the
@@ -354,7 +357,7 @@ form the condition actually supports.
       that marker and says so rather than plotting nothing silently; each marker
       names its source; the map draws no judgement, no depth and no hazard.
 
-- [ ] **`Compass`.** Two needles on the map: wind from, and swell from, each with
+- [x] **`Compass`.** Two needles on the map: wind from, and swell from, each with
       a translucent arc for the range it swings through during daylight. A
       provenance line per needle, following `WeekGrid`'s resolution rather than
       `StatGroup`'s contract. _New component, rendered onto `ShoreMap`._
@@ -364,6 +367,23 @@ form the condition actually supports.
       arc widens with the day's spread; `mission-bay-vacation-isle`, whose segment
       has an upper equal to its lower, renders without a shore reference and says
       why rather than drawing a confident wrong dial.
+      **The bearings are spoken beside the picture rather than in an accessible
+      name**, and that is the same choice `ShoreMap` already made for its
+      markers: the map is one `role="img"`, so nothing drawn inside it reaches
+      the accessibility tree. The row under the map states both bearings in
+      words and in degrees, and the spread where it is wide.
+      **The needle is speed-weighted, and the measurement is why.** Two days of
+      seven in the committed run have a daylight spread past 170 degrees -- 200
+      on one -- so an unweighted mean lets a 0 mph pre-dawn bearing count as
+      much as a 12 mph afternoon one. The resultant is weighted; the arc stays
+      the full envelope, because that is the honesty a bare needle lacks.
+      **Neither needle carries an interpolated bearing.** Five hours in every
+      eight of the swell curve are drawn between CDIP's estimates, and halfway
+      between 350 and 10 is 0 where the height arithmetic says 180.
+      **Two needles on one radius drew as one**, on any day the wind and the
+      swell came from the same quarter -- an ordinary day at La Jolla, not an
+      edge case. Each has its own track now. Found by looking at the built page,
+      not by a test, and it has one now.
 
 - [x] **The sighting layer stays reserved.** `ReservedSlot` moves inside the map:
       the frame is real content now, and what is coming is the sightings drawn on
@@ -388,7 +408,7 @@ form the condition actually supports.
 
 ## Across all three
 
-- [ ] **Accessibility pass.** Per PR, not saved to the end. Text equivalents for
+- [x] **Accessibility pass.** Per PR, not saved to the end. Text equivalents for
       the chart and the compass; every new colour pair measured rather than
       assumed — series strokes clear 3:1 as graphical objects and any text on them
       clears 4.5:1; colour never the only channel separating two series, night from
@@ -396,15 +416,15 @@ form the condition actually supports.
       `md`; the site's `currentColor` focus ring inherited, never redefined;
       `prefers-reduced-motion` respected if any transition is added.
 
-- [ ] **Domain language.** CONTEXT.md gains the terms this work introduces and
+- [x] **Domain language.** CONTEXT.md gains the terms this work introduces and
       picks one word for each — the sparkline, the day panel, the dial, the shore
       map. The glossary is the thing kept current; a term used in three components
       under two names is the drift it exists to prevent.
       **Three of the four landed in PR 3a**, plus `hour chart`, which the list
-      above did not name and which had the same problem. The **dial** is the one
-      left and belongs with the compass in PR 3b.
+      above did not name and which had the same problem. **`Dial` landed with
+      the compass in PR 3b**, and the glossary is complete for this work.
 
-- [ ] **Plan file.** `docs/plans/conditions-day-view.md`, committed as its own
+- [x] **Plan file.** `docs/plans/conditions-day-view.md`, committed as its own
       first commit before PR 1's first slice. Required here rather than optional:
       this will not finish in one sitting, and it turns on choices someone will
       re-litigate — the compass's home, the fate of the cards, the cadence
@@ -434,3 +454,17 @@ onto a moved blocker is how a verified slice quietly stops being verified.
 
 **Noticing is not filing.** The duplicate-coordinate finding goes in the PR body
 for the coastline slice, not into the tracker as a separate row.
+
+**Two modules whose names differ only in case are one file on Windows.**
+`compass.ts` beside `Compass.tsx` resolved to each other, every test in the
+drawing's suite failed with an undefined component, and Linux CI would have
+passed the pair without noticing. The assembler is `needles.ts`, which is what
+`shore.ts` beside `ShoreMap.tsx` had already established.
+
+**Contrast on this map is measured from painted pixels**, by screenshotting the
+page and reading it back through a canvas. The CSS tree returns transparent for
+everything drawn here. The dial's four pairs, measured over the sea, which is
+the darker ground: wind needle 7.22:1, wind arc 3.60:1, swell needle 5.93:1,
+swell arc 3.64:1. The two arcs are set to the same measured contrast rather
+than the same opacity -- at one setting the purple read 2.77:1 where the ocean
+read 3.60:1.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -196,11 +196,13 @@ cloud as a band above, one of four series drawn at a time behind four tabs.
 _Avoid_: graph, the plot, day chart, timeline
 
 **Shore map**:
-The square picture beside the hour chart: this beach's stretch of coast, the
-sea washed in beside it, and the four sources its figures come from plotted at
-their real distances. The line it draws is CDIP's model line rather than a
-shoreline, so the wash fades rather than ending at it (ADR-0030). It reads no
-feed — every position on it is committed.
+The square picture beside the hour chart: this beach's own stretch of coast
+drawn heavier than the shore either side of it, and the open water washed in
+beside it. **It plots no stations, buoys or model lines** — it draws a place,
+not an inventory, and every source on the page is named in words under the
+group it belongs to (ADR-0033). The line it draws is CDIP's model line rather
+than a shoreline, which the sentence under it says. It reads no feed — every
+position on it is committed.
 _Avoid_: locator, mini map, station map, chart (that word is the plot's)
 
 **Dial**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -207,11 +207,13 @@ _Avoid_: locator, mini map, station map, chart (that word is the plot's)
 
 **Dial**:
 The compass drawn on the shore map: two needles standing out at the direction
-the wind and the swell come from and pointing in at the beach, each with a
-translucent arc for the range it swung through in daylight. It is read against
-the coast underneath it — a needle whose tail is over the shaded sea is onshore
-— which is why it sits on the map and not beside it. It carries two publishers
-on one drawing, one provenance line per needle (ADR-0032), and it is withheld
-on the 23 beaches the traced coast does not reach, where a bearing has nothing
-to be read against.
-_Avoid_: compass rose, wind rose, gauge, direction widget
+the wind and the swell come from and pointing in at the beach, each labelled at
+its tail and each with a translucent arc for the range it swung through in
+daylight. It is read against the coast underneath it — a needle whose tail is
+over the shaded sea is onshore — which is why it sits on the map and not beside
+it. **The labels are on the needles and there is no legend**: a word on the
+thing itself is what a legend is a substitute for, and a boxed legend is one of
+the brief's anti-references. It carries two publishers on one drawing, one
+provenance line per needle (ADR-0032), and it is withheld on the beaches the
+traced coast does not reach, where a bearing has nothing to be read against.
+_Avoid_: compass rose, wind rose, gauge, direction widget, legend

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -202,3 +202,14 @@ their real distances. The line it draws is CDIP's model line rather than a
 shoreline, so the wash fades rather than ending at it (ADR-0030). It reads no
 feed — every position on it is committed.
 _Avoid_: locator, mini map, station map, chart (that word is the plot's)
+
+**Dial**:
+The compass drawn on the shore map: two needles standing out at the direction
+the wind and the swell come from and pointing in at the beach, each with a
+translucent arc for the range it swung through in daylight. It is read against
+the coast underneath it — a needle whose tail is over the shaded sea is onshore
+— which is why it sits on the map and not beside it. It carries two publishers
+on one drawing, one provenance line per needle (ADR-0032), and it is withheld
+on the 23 beaches the traced coast does not reach, where a bearing has nothing
+to be read against.
+_Avoid_: compass rose, wind rose, gauge, direction widget

--- a/docs/adr/0032-one-dial-may-carry-two-provenances.md
+++ b/docs/adr/0032-one-dial-may-carry-two-provenances.md
@@ -1,0 +1,108 @@
+# 0032 — One dial may carry two provenances
+
+Date: 2026-08-30. Status: accepted. Extends ADR-0010's rule to a component that
+is not a `StatGroup`, and adds the `Dial` entry to `CONTEXT.md`, which is
+updated in the same pull request.
+
+## Context
+
+ADR-0010 settled how this site attributes a figure, and the rule it produced is
+narrow on purpose: **one `StatGroup` never spans two sources.** A group of
+figures carries one provenance line, and a reader who wants to know where a
+number came from reads the line under the group it is in. Two sources meant two
+groups.
+
+That rule has held because every consumer of it was a list of figures. The
+compass is not. It is one drawing, sixty units across, carrying two needles —
+where the wind comes from, and where the swell comes from — and those come from
+two publishers that share nothing: the National Weather Service's forecast cell
+for this beach, and CDIP's MOP model line a few hundred metres offshore.
+
+**Splitting it is available and is the wrong answer**, and the plan file already
+argued why before the component existed:
+
+> the insight is the _relationship_ — wind from the east is offshore at a
+> west-facing beach and onshore at an east-facing one — and two dials force the
+> reader to do angle arithmetic in their head.
+
+Two dials side by side would each satisfy ADR-0010 exactly and would destroy the
+thing the component is for. The whole design brief's third principle rests on
+the two needles being readable against each other and against one coastline.
+
+There is also precedent that the rule was already narrower than it read.
+`WeekGrid` holds NOAA's tides, CDIP's swell and this repo's own daylight
+arithmetic on one grid, and resolves it with a provenance line per **row**
+rather than by becoming three grids.
+
+## Decision
+
+**A component may carry more than one publisher when the reader's insight is
+the relationship between them, on condition that every figure it draws is
+attributed individually and adjacently.**
+
+For the compass that means, concretely:
+
+- **A provenance line per needle**, not per dial. The wind's names the grid
+  cell and the National Weather Service; the swell's names the MOP line and
+  CDIP. Both are `ProvenanceLine`, so the wording of "how far away" and "who
+  published it" stays owned by the one component that owns it everywhere else.
+- **Each line sits with its own reading.** The bearing in words and degrees is
+  printed immediately above the line that attributes it, so the pair reads as
+  one row. A block of two bearings followed by a block of two sources would
+  make the reader match them up, which is the work attribution exists to avoid.
+- **Beside the picture, not on it.** The map is one `role="img"`, so nothing
+  drawn inside it reaches the accessibility tree. The rows below are the dial's
+  text equivalent as well as its attribution, which is `ShoreMap`'s existing
+  rule for its markers rather than a new one.
+
+**ADR-0010 is unchanged for `StatGroup`.** This does not license a group of
+figures spanning two sources; it says that a _drawing_ whose subject is a
+relationship may, when each mark inside it is attributed.
+
+## The test this has to pass
+
+A rule that permits duplication is only worth having if it is checkable. The
+condition is: **for every mark the component draws, a reader can find that
+mark's publisher without leaving the component.** Two needles, two lines, in
+the same order. When a needle is withheld — 26 of 51 beaches bind no MOP line,
+and a cell can publish no wind direction — its line goes with it, so the block
+never names a source for something that is not drawn.
+
+## Alternatives considered
+
+**Two dials, one per source.** Satisfies ADR-0010 with nothing to decide.
+Rejected on the plan's own argument above: the insight is the angle between the
+two needles and the coast, and two dials make the reader compute it. It is the
+same failure the previous brief named when it said the tide time and the wave
+height "are three screens apart in reading order and never appear together."
+
+**One provenance line for the dial, naming both publishers.** Half the text and
+no rule to write. Rejected because it puts the matching back on the reader in a
+smaller space: "National Weather Service and CDIP" under two needles does not
+say which is which, and the moment one needle is withheld the line is wrong.
+
+**Attribute the needles in the map's own accessible description.** Tempting,
+since the dial is drawn inside the map's `<svg>`. Rejected because that
+description is built once for a picture that is the same on all seven days,
+where the needles change with the day a reader picks — so the attribution would
+have to become per-day, and with it the whole map.
+
+**Drop the compass and state the two bearings as figures in a card.** Would need
+no new rule at all. Rejected: `StatGroup` would then hold two sources anyway, or
+there would be two cards, and a bearing stated as a figure is the number the
+brief opens by saying means nothing on its own.
+
+## Consequences
+
+- **`Compass` is the second component to hold more than one publisher**, after
+  `WeekGrid`, and the two now answer it the same way. That is a pattern rather
+  than an exception, and the next component that needs it has somewhere to look.
+- **A needle and its provenance line are one unit.** Anything that withholds a
+  needle has to withhold its line, and the reverse. That is asserted rather than
+  documented: `ShoreMap` renders neither where the traced coast does not reach
+  the beach, and a beach with no MOP line draws one needle and one line.
+- **The duplication ADR-0029 permits now has a third instance on this page.**
+  The grid cell is named by the cloud row, by the sky wording and by the wind
+  needle. Each attributes its own figure and none covers another's, which is the
+  condition ADR-0029 sets — but three lines naming one publisher within one
+  screen is worth watching, and the day chart is about to add a fourth.

--- a/docs/adr/0033-the-map-draws-a-place-not-an-inventory.md
+++ b/docs/adr/0033-the-map-draws-a-place-not-an-inventory.md
@@ -1,0 +1,110 @@
+# 0033 — The map draws a place, not an inventory
+
+Date: 2026-08-30. Status: accepted. Supersedes the first clause of ADR-0030 and
+narrows what ADR-0010 asks a picture to do. ADR-0030's other two clauses stand.
+
+## Context
+
+`ShoreMap` shipped in #178 plotting the four places every figure on the page
+comes from — the MOP line, the wave buoy, the tide station, the air station —
+each at its real distance, with a different shape per source and a provenance
+line per shape. That was **ADR-0010 answered by drawing rather than by
+writing**: "no figure is ever shown without the reader being able to see where
+it came from", made literal.
+
+ADR-0030 then established that the drawn coastline is CDIP's model line rather
+than a shoreline — 117 to 930 m offshore, median 644 — and decided the sea wash
+must **fade** rather than end. Its reason was specific and was about the
+markers:
+
+> The Scripps tide gauge (9410230) and the Scripps Pier air station (LJAC1)
+> are at −117.2571 and −117.2570 — both on a pier, both over water, and both
+> **landward** of the drawn line. A map that shaded one side as sea and the
+> other as land put two instruments that are in the ocean onto the beach.
+
+**Reviewed on the built page, the drawn inventory was the wrong picture.** Four
+glyphs in four shapes over a coastline; two of them a few hundred metres apart
+wherever a tide gauge is bolted to the pier an air station stands on, so they
+overlapped and needed a halo to be told apart at all; and a frame stretched to
+hold whichever station happened to be furthest away — `pacific-beach` framed on
+one 7.4 km inland, `mission-beach` twenty kilometres tall with its own sand a
+fifth of the picture.
+
+And the fade, seen rather than reasoned about, was a **straight-edged gradient
+across a coastline that is not straight**: its iso-lines run along one normal
+taken from the drawn run's two endpoints, so the water's edge and the shore's
+edge visibly disagree.
+
+## Decision
+
+**The map draws where this beach is and which side of it the water is on. It
+plots no stations.**
+
+- **No markers.** ADR-0010 is satisfied by the words it always named: a
+  provenance line under every group, naming the station and its distance.
+  Those are unchanged and are on the page. What is dropped is the _second_,
+  drawn answer to the same question, which cost the picture its subject.
+- **The wash is one flat tint, and the water's edge is the drawn line.** With
+  no instruments on the map there is nothing to be placed on the wrong side of
+  that edge, which was the whole of ADR-0030's case for the fade. The residual
+  imprecision — the line is a few hundred metres out — is answered where
+  ADR-0030's second clause already answers it, in the sentence under the
+  picture, and that clause stands.
+- **The frame is sized by the beach and the line off it.** A frame sized by
+  things that are not drawn is a rule nobody can see from the page. The MOP
+  line stays in that arithmetic because it is _where the drawn coastline is_,
+  not an instrument standing somewhere: a window without it crops the shoreline
+  off the edge.
+
+## What was measured
+
+Framing on the beach alone leaves **14 of 51** beaches with a coast in view.
+Framing on the beach and its bound MOP line leaves **25**, against 28 under the
+old source-framed window — and the three lost were beaches whose frame had been
+stretched so wide it caught a coastline five kilometres away that was not
+theirs. `pacific-beach`, whose air station is 7,365 m off, now frames at about
+one kilometre.
+
+Contrast on the dial, read from painted pixels over the new solid wash: wind
+needle 6.03:1, wind arc 3.52:1, swell needle 5.23:1, swell arc 3.54:1, both
+needle labels 16.62:1. The floor is 3:1 for a graphical object and 4.5:1 for
+text.
+
+## Alternatives considered
+
+**Keep the markers and fix the glyphs.** The complaint began as "the icons look
+tacky and one is misaligned", which sounds like a drawing problem. Rejected:
+the misalignment is two instruments genuinely at one place, so no glyph fixes
+it, and the deeper cost is that a map of four station positions is not a map of
+a beach. The distances are better said than drawn — "about 1.4 km from this
+beach" is exact, and a dot 1.4 km away on a 4 km frame is an estimate the
+reader has to make.
+
+**Keep the fade and remove only the markers.** Would leave ADR-0030 untouched.
+Rejected because the fade's only stated justification was the markers, so
+keeping it would be keeping a mechanism whose reason had gone — and it was
+visibly wrong on its own terms, a straight gradient boundary across a bending
+shore.
+
+**Keep the frame sized by the sources.** No new arithmetic. Rejected: it would
+size every map by things no longer on it, which is exactly the invisible rule
+this repo refuses.
+
+## Consequences
+
+- **`ShoreMap` is much smaller**, and `shore.ts` no longer resolves a station,
+  words a source or rounds a distance. `shoreDistanceKm` goes with it, which
+  also retires the "same rule spelled twice" that the day view's plan recorded
+  against `MeasuredToday`'s `roundedKm`.
+- **The coverage floor fell**, under the second of the two legitimate reasons
+  `vitest.config.mts` records: well-covered code was deleted, so the surviving
+  denominator tilts toward the 0% entry plumbing. Nothing became untested.
+- **The `sea-side` gate's window is now wider than the one the map draws**, and
+  says so. That check needs the wave buoy in frame because the buoy is the only
+  ground truth for which side the water is on; asked inside the map's narrower
+  window it fails at 10 of 15. The property proven is about the polyline rather
+  than the frame, and the map's run is a contiguous sub-run of the checked one.
+- **ADR-0010's "drawn instead of written" reading is retired.** The requirement
+  was always about a reader being able to find a source, and words do that. A
+  future map that wants to show distance should say why drawing beats writing
+  for the specific question it is answering.

--- a/docs/plans/conditions-day-view.md
+++ b/docs/plans/conditions-day-view.md
@@ -1,6 +1,15 @@
 # The conditions day view
 
-Planned 2026-08-28. In flight: #171, #172, #173.
+> **Historical.** Planned 2026-08-28, shipped across PRs #174, #175, #176, #178
+> and #184, the last of them on 2026-08-30. It records what was intended then,
+> not what the code does now, and is not maintained. See
+> [`README.md`](README.md).
+>
+> Six decisions in it are still binding and live in `docs/adr/` instead:
+> ADR-0027 (what a plot may be asked, and what the compass may not do),
+> ADR-0028, ADR-0029, ADR-0030 (the map draws a model line, not a shore),
+> ADR-0031 and ADR-0032 (one dial may carry two provenances). The addenda below
+> are dated and stay as they are, including the three figures they correct.
 
 Design record: `.design/conditions-day-view/DESIGN_BRIEF.md` for the problem and
 the aesthetic direction, `TASKS.md` for the slices and their test seams. This

--- a/scripts/sea-side.mjs
+++ b/scripts/sea-side.mjs
@@ -140,7 +140,23 @@ export function sideOf(points, at) {
   return cross > 0 ? "left" : "right";
 }
 
-/** Everything one beach puts on its map, so the window is the one drawn. */
+/**
+ * A window wide enough for the question to have an answer.
+ *
+ * **This is deliberately wider than the window the map draws**, and it stopped
+ * being the same one when the map stopped plotting the four sources. The map is
+ * framed on the beach and the line off it now; this keeps the buoy in frame,
+ * because the buoy is the only ground truth there is for which side the water
+ * is on, and a window that excludes it leaves the side test matching a distant
+ * point against a short run of coast. Asked that way it fails at 10 of 15 --
+ * measured, not guessed.
+ *
+ * The property proven is about the polyline and not about the frame: walked
+ * south to north, this coast has the sea on its left. `boundsAround` grows with
+ * the points it is given, so the map's window is contained in this one and its
+ * run of coast is a contiguous sub-run of the run checked here. A sub-run walks
+ * the same way, which is what `ShoreMap`'s shading depends on.
+ */
 function positionsFor(beach, tables) {
   const positions = [beach.segment.upper, beach.segment.lower];
 

--- a/src/components/conditions/Compass.test.tsx
+++ b/src/components/conditions/Compass.test.tsx
@@ -234,3 +234,13 @@ test("the two arcs never share a track either", () => {
 
   expect(radius("wind")).not.toBe(radius("swell"));
 });
+
+test("a day with no bearings gets no sources block, not an empty list", () => {
+  // Reachable through `DayCompassSources`, which hands over whatever the day
+  // has. An empty `<ul>` under the map would be a list heading nothing, and
+  // the map's own marker names are already directly above it.
+  const { container } = render(<CompassSources needles={[]} />);
+
+  expect(container.querySelector("ul")).toBeNull();
+  expect(container.textContent).toBe("");
+});

--- a/src/components/conditions/Compass.test.tsx
+++ b/src/components/conditions/Compass.test.tsx
@@ -1,0 +1,128 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  Compass,
+  CompassSources,
+  DIAL_RADIUS,
+  type CompassNeedle,
+} from "./Compass";
+
+const WIND: CompassNeedle = {
+  kind: "wind",
+  label: "Wind",
+  fromDegT: 281,
+  spreadDeg: 40,
+  source: "this beach's own grid cell",
+  network: "National Weather Service, San Diego",
+  note: "a forecast, not a reading taken at the beach",
+};
+
+/** The dial draws around its own origin, so a bare `<svg>` is the whole rig. */
+function dial(needles: readonly CompassNeedle[]) {
+  const { container } = render(
+    <svg>
+      <Compass needles={needles} />
+    </svg>,
+  );
+  return container;
+}
+
+const num = (element: Element, name: string) =>
+  Number(element.getAttribute(name));
+
+test("the needle's tail stands in the direction the wind comes from", () => {
+  // Due east, on a map with north up: the tail is to the right of the beach
+  // and level with it. A sign flip anywhere in the bearing-to-plot conversion
+  // moves it to one of the other three sides, which is what this pins.
+  const container = dial([{ ...WIND, fromDegT: 90, spreadDeg: 0 }]);
+
+  const needle = container.querySelector('[data-needle="wind"]')!;
+  expect(num(needle, "x1")).toBeCloseTo(DIAL_RADIUS, 4);
+  expect(num(needle, "y1")).toBeCloseTo(0, 4);
+});
+
+test("north is up, not down", () => {
+  // The other half of the same conversion, and the one a y-down drawing space
+  // gets wrong: plot y grows southward, so due north is a negative y.
+  const container = dial([{ ...WIND, fromDegT: 0, spreadDeg: 0 }]);
+
+  const needle = container.querySelector('[data-needle="wind"]')!;
+  expect(num(needle, "x1")).toBeCloseTo(0, 4);
+  expect(num(needle, "y1")).toBeCloseTo(-DIAL_RADIUS, 4);
+});
+
+test("the needle points inward, at the beach it arrives at", () => {
+  // Which end carries the head is the whole reading. An arrow from the beach
+  // outward says the wind is going that way; this one says it comes from
+  // there, which is what every figure on this page means by a direction.
+  const container = dial([{ ...WIND, fromDegT: 90, spreadDeg: 0 }]);
+
+  const needle = container.querySelector('[data-needle="wind"]')!;
+  expect(Math.abs(num(needle, "x2"))).toBeLessThan(Math.abs(num(needle, "x1")));
+});
+
+test("the arc widens with the day's spread", () => {
+  const narrow = dial([{ ...WIND, fromDegT: 270, spreadDeg: 20 }]);
+  const wide = dial([{ ...WIND, fromDegT: 270, spreadDeg: 120 }]);
+
+  const ends = (container: Element) => {
+    const d = container.querySelector('[data-arc="wind"]')!.getAttribute("d")!;
+    const numbers = d.match(/-?\d+\.?\d*/g)!.map(Number);
+    // "M x0 y0 A r r 0 large sweep x1 y1" -- the first pair and the last.
+    return Math.hypot(
+      numbers[0] - numbers[numbers.length - 2],
+      numbers[1] - numbers[numbers.length - 1],
+    );
+  };
+
+  expect(ends(wide)).toBeGreaterThan(ends(narrow));
+});
+
+test("a day that never shifted gets no arc rather than a zero-length one", () => {
+  const container = dial([{ ...WIND, spreadDeg: 0 }]);
+
+  expect(container.querySelector('[data-arc="wind"]')).toBeNull();
+  expect(container.querySelector('[data-needle="wind"]')).not.toBeNull();
+});
+
+test("an arc wider than a half circle takes the long way round", () => {
+  // The SVG flag that says which of the two arcs between two points is meant.
+  // Without it a 200-degree swing draws as the 160-degree one it is not.
+  const container = dial([{ ...WIND, fromDegT: 214, spreadDeg: 200 }]);
+
+  const d = container.querySelector('[data-arc="wind"]')!.getAttribute("d")!;
+  expect(d).toMatch(/A [\d.]+ [\d.]+ 0 1 1 /);
+});
+
+test("nothing is drawn when there is no needle to draw", () => {
+  const container = dial([]);
+
+  expect(container.querySelector("[data-compass-dial]")).toBeNull();
+});
+
+test("the sources state the bearing in words and in degrees", () => {
+  render(<CompassSources needles={[WIND]} />);
+
+  expect(screen.getByText(/Wind, from the west, 281°/)).toBeDefined();
+});
+
+test("a wide swing is stated and a narrow one is not", () => {
+  const { unmount } = render(
+    <CompassSources needles={[{ ...WIND, spreadDeg: 120 }]} />,
+  );
+  expect(screen.getByText(/swinging through 120° in daylight/)).toBeDefined();
+  unmount();
+
+  render(<CompassSources needles={[{ ...WIND, spreadDeg: 30 }]} />);
+  expect(screen.queryByText(/swinging through/)).toBeNull();
+});
+
+test("each needle carries its own publisher", () => {
+  render(<CompassSources needles={[WIND]} />);
+
+  expect(
+    screen.getByText(
+      /this beach's own grid cell · National Weather Service, San Diego — a forecast, not a reading taken at the beach/,
+    ),
+  ).toBeDefined();
+});

--- a/src/components/conditions/Compass.test.tsx
+++ b/src/components/conditions/Compass.test.tsx
@@ -244,3 +244,53 @@ test("a day with no bearings gets no sources block, not an empty list", () => {
   expect(container.querySelector("ul")).toBeNull();
   expect(container.textContent).toBe("");
 });
+
+test("each needle is labelled on the dial, so it says what it is", () => {
+  // Reviewed on the built page, two arrows over a coastline did not say which
+  // was which and there is no legend on this map by design. The label is the
+  // page's own 10px register, set at the needle's tail where the eye starts.
+  const container = dial([
+    { ...WIND, kind: "wind", fromDegT: 90, spreadDeg: 0 },
+    { ...WIND, kind: "swell", label: "Swell", fromDegT: 270, spreadDeg: 0 },
+  ]);
+
+  // Keyed rather than ordered: the dial paints heaviest-first so the light
+  // shaft is never underneath, which puts the swell's markup ahead of the
+  // wind's. Nothing reads that order -- the `<svg>` is one `role="img"` -- so
+  // asserting it would pin a painting decision as if it were a reading one.
+  const textOf = (kind: string) =>
+    container.querySelector(`[data-needle-label="${kind}"]`)?.textContent;
+
+  expect(textOf("wind")).toBe("Wind");
+  expect(textOf("swell")).toBe("Swell");
+});
+
+test("a label sits at its own needle's tail, not at the other one's", () => {
+  const container = dial([
+    { ...WIND, kind: "wind", fromDegT: 90, spreadDeg: 0 },
+    { ...WIND, kind: "swell", label: "Swell", fromDegT: 270, spreadDeg: 0 },
+  ]);
+
+  const at = (kind: string) =>
+    Number(
+      container
+        .querySelector(`[data-needle-label="${kind}"]`)!
+        .getAttribute("x"),
+    );
+
+  // Wind comes from the east, swell from the west, so the labels are on
+  // opposite sides of the beach.
+  expect(at("wind")).toBeGreaterThan(0);
+  expect(at("swell")).toBeLessThan(0);
+});
+
+test("the label reads left to right whichever way the needle points", () => {
+  // A label rotated with its needle is upside down for half the compass. These
+  // are set horizontally and anchored away from the dial, so a bearing in the
+  // west does not push its own word across the picture.
+  const container = dial([{ ...WIND, kind: "wind", fromDegT: 270 }]);
+
+  const label = container.querySelector('[data-needle-label="wind"]')!;
+  expect(label.getAttribute("transform")).toBeNull();
+  expect(label.getAttribute("text-anchor")).toBe("end");
+});

--- a/src/components/conditions/Compass.test.tsx
+++ b/src/components/conditions/Compass.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import {
   Compass,
   CompassSources,
-  DIAL_RADIUS,
+  NEEDLE_TRACKS,
   type CompassNeedle,
 } from "./Compass";
 
@@ -37,7 +37,7 @@ test("the needle's tail stands in the direction the wind comes from", () => {
   const container = dial([{ ...WIND, fromDegT: 90, spreadDeg: 0 }]);
 
   const needle = container.querySelector('[data-needle="wind"]')!;
-  expect(num(needle, "x1")).toBeCloseTo(DIAL_RADIUS, 4);
+  expect(num(needle, "x1")).toBeCloseTo(NEEDLE_TRACKS.wind.tail, 4);
   expect(num(needle, "y1")).toBeCloseTo(0, 4);
 });
 
@@ -48,7 +48,7 @@ test("north is up, not down", () => {
 
   const needle = container.querySelector('[data-needle="wind"]')!;
   expect(num(needle, "x1")).toBeCloseTo(0, 4);
-  expect(num(needle, "y1")).toBeCloseTo(-DIAL_RADIUS, 4);
+  expect(num(needle, "y1")).toBeCloseTo(-NEEDLE_TRACKS.wind.tail, 4);
 });
 
 test("the needle points inward, at the beach it arrives at", () => {
@@ -125,4 +125,112 @@ test("each needle carries its own publisher", () => {
       /this beach's own grid cell · National Weather Service, San Diego — a forecast, not a reading taken at the beach/,
     ),
   ).toBeDefined();
+});
+
+test("the two needles differ in shape and in weight, not only in colour", () => {
+  // The brief's rule and the one a small graphic breaks most easily: the whole
+  // dial is a few dozen pixels, so a reader who cannot separate two hues would
+  // otherwise be left with two identical strokes.
+  const container = dial([
+    { ...WIND, kind: "wind", spreadDeg: 0 },
+    { ...WIND, kind: "swell", label: "Swell", fromDegT: 340, spreadDeg: 0 },
+  ]);
+
+  const windHead = container.querySelector('[data-needle-head="wind"]')!;
+  const swellHead = container.querySelector('[data-needle-head="swell"]')!;
+  const windShaft = container.querySelector('[data-needle="wind"]')!;
+  const swellShaft = container.querySelector('[data-needle="swell"]')!;
+
+  // Shape: an open chevron against a solid blade, which survives greyscale.
+  expect(windHead.tagName.toLowerCase()).toBe("polyline");
+  expect(swellHead.tagName.toLowerCase()).toBe("polygon");
+
+  // Weight: a different stroke, which survives greyscale too.
+  expect(num(windShaft, "stroke-width")).toBeLessThan(
+    num(swellShaft, "stroke-width"),
+  );
+});
+
+test("both needles are drawn when a day has both", () => {
+  const container = dial([
+    { ...WIND, kind: "wind" },
+    { ...WIND, kind: "swell", label: "Swell", fromDegT: 340 },
+  ]);
+
+  expect(container.querySelectorAll("[data-needle]")).toHaveLength(2);
+});
+
+test("the sources state both bearings, in words and in degrees", () => {
+  // The design brief's own example of what the dial's text equivalent says.
+  render(
+    <CompassSources
+      needles={[
+        { ...WIND, kind: "wind", fromDegT: 281, spreadDeg: 20 },
+        {
+          ...WIND,
+          kind: "swell",
+          label: "Swell",
+          fromDegT: 340,
+          spreadDeg: 20,
+          source: "MOP line D0498",
+          network: "CDIP, Scripps Institution of Oceanography",
+        },
+      ]}
+    />,
+  );
+
+  expect(screen.getByText(/Wind, from the west, 281°/)).toBeDefined();
+  expect(screen.getByText(/MOP line D0498 · CDIP/)).toBeDefined();
+
+  // 340 reads "north" and not "north-west", and this is where the eight-point
+  // rose costs something. The design brief's example name for this very
+  // bearing is "swell from the northwest, 340 degrees", which is a sixteen-
+  // point reading; `bearing.ts` records why the page has eight. The degrees
+  // are what carry the difference, and they are stated beside the word.
+  expect(screen.getByText(/Swell, from the north, 340°/)).toBeDefined();
+});
+
+test("two needles from the same bearing are still two needles", () => {
+  // Found by looking at the built page. With one radius for both, a day whose
+  // wind and swell came from the same quarter drew them exactly on top of each
+  // other -- the page said two things and showed one, and nothing failed. At
+  // La Jolla that is an ordinary day: the swell runs west to north-west and
+  // the afternoon wind west to south-west.
+  const container = dial([
+    { ...WIND, kind: "wind", fromDegT: 280, spreadDeg: 0 },
+    { ...WIND, kind: "swell", label: "Swell", fromDegT: 280, spreadDeg: 0 },
+  ]);
+
+  const wind = container.querySelector('[data-needle="wind"]')!;
+  const swell = container.querySelector('[data-needle="swell"]')!;
+
+  // Neither end coincides, so neither shaft is wholly hidden by the other.
+  expect(num(wind, "x1")).not.toBeCloseTo(num(swell, "x1"), 2);
+  expect(num(wind, "x2")).not.toBeCloseTo(num(swell, "x2"), 2);
+
+  // And the wind reaches past the swell at both ends, so its own stretches
+  // stay exposed however they are painted.
+  expect(Math.hypot(num(wind, "x1"), num(wind, "y1"))).toBeGreaterThan(
+    Math.hypot(num(swell, "x1"), num(swell, "y1")),
+  );
+  expect(Math.hypot(num(wind, "x2"), num(wind, "y2"))).toBeLessThan(
+    Math.hypot(num(swell, "x2"), num(swell, "y2")),
+  );
+});
+
+test("the two arcs never share a track either", () => {
+  const container = dial([
+    { ...WIND, kind: "wind", fromDegT: 280, spreadDeg: 60 },
+    { ...WIND, kind: "swell", label: "Swell", fromDegT: 280, spreadDeg: 60 },
+  ]);
+
+  const radius = (kind: string) =>
+    Number(
+      container
+        .querySelector(`[data-arc="${kind}"]`)!
+        .getAttribute("d")!
+        .match(/A (-?[\d.]+)/)![1],
+    );
+
+  expect(radius("wind")).not.toBe(radius("swell"));
 });

--- a/src/components/conditions/Compass.tsx
+++ b/src/components/conditions/Compass.tsx
@@ -59,20 +59,12 @@ export type CompassNeedle = {
 };
 
 /**
- * How far out the needle's tail stands, in the map's own plot units.
+ * The ring, in the map's own plot units.
  *
- * A quarter of the hundred-unit frame, so the dial reads as an instrument sat
- * on the beach rather than as a second picture covering the coast. Exported
- * because the tests check the tail lands on the bearing, and a test that
- * hard-coded the number would pass after somebody changed it here.
+ * Just under a third of the hundred-unit frame, so the dial reads as an
+ * instrument sat on the beach rather than a second picture covering the coast.
  */
-export const DIAL_RADIUS = 26;
-
-/** Where the head stops, short of the beach so the segment stays visible. */
-const HEAD_RADIUS = 7;
-
-/** The arc sits just outside the tails, where it crowds nothing. */
-const ARC_RADIUS = DIAL_RADIUS + 4;
+const RING_RADIUS = 30;
 
 /**
  * Plot coordinates for a bearing at a radius, with north up.
@@ -91,22 +83,81 @@ function at(degreesTrue: number, radius: number): { x: number; y: number } {
  *
  * The brief's rule, and the one a small graphic breaks most easily: the whole
  * dial is a few dozen pixels, and a reader who cannot separate two hues would
- * be left with two identical strokes. The wind is a thin line with an open
- * head; the swell is a heavier tapered blade. Colour reinforces the pair and
- * carries none of it.
+ * be left with two identical strokes.
+ *
+ * **Open against solid, and thin against heavy.** The wind is a light shaft
+ * under a hollow chevron, the swell a heavy one under a filled blade. Both
+ * differences survive greyscale, which is the test that matters: colour
+ * reinforces the pair and carries none of it. It also reads as what each is --
+ * air is the lighter mark and water the heavier one.
+ *
+ * **And each runs on its own track, which is not decoration.** Built with one
+ * radius for both, a day whose wind and swell came from the same quarter drew
+ * the two needles exactly on top of each other: the page said two things and
+ * showed one, and nothing failed. At La Jolla that is an ordinary day rather
+ * than an edge case -- the swell runs west to north-west and the afternoon
+ * wind west to south-west -- and it was found by looking at the picture.
+ *
+ * So the wind reaches from the ring almost to the sand and the swell occupies
+ * the middle of that span, leaving the wind's outer and inner stretches always
+ * exposed. The lengths differ as a consequence and carry no meaning: the two
+ * are a speed and a height, in different units, and nothing on this dial
+ * invites them to be compared as quantities.
  */
 const NEEDLES: Record<
   CompassNeedleKind,
-  { stroke: string; fill: string; width: number; head: number }
+  {
+    stroke: string;
+    fill: string;
+    /** Where the arc is drawn. Each kind has its own, so two never overlap. */
+    arc: number;
+    /**
+     * How solid the arc is, and the two are not the same number.
+     *
+     * **They are set to the same measured contrast, not to the same opacity**,
+     * because the two hues do not weigh the same. At 0.65 over the sea the
+     * ocean arc reads 3.60:1 from painted pixels and the purple one 2.77:1 --
+     * under the brief's 3:1 for a graphical object, on the same setting that
+     * cleared it for the other. Tuned by measurement, they land at 3.60 and
+     * 3.64.
+     */
+    arcOpacity: number;
+    /** Where the shaft starts, out at the bearing. */
+    tail: number;
+    /** Where it ends, pointing at the beach. */
+    head: number;
+    width: number;
+    /** Half the arrowhead's span across the shaft. */
+    barb: number;
+    solid: boolean;
+  }
 > = {
-  wind: { stroke: "stroke-ocean", fill: "fill-ocean", width: 1.4, head: 2.6 },
+  wind: {
+    stroke: "stroke-ocean",
+    fill: "fill-ocean",
+    arc: RING_RADIUS,
+    arcOpacity: 0.65,
+    tail: 28,
+    head: 3,
+    width: 1.4,
+    barb: 2.2,
+    solid: false,
+  },
   swell: {
     stroke: "stroke-purple-deep",
     fill: "fill-purple-deep",
+    arc: 24,
+    arcOpacity: 0.8,
+    tail: 22,
+    head: 8,
     width: 3,
-    head: 4,
+    barb: 3,
+    solid: true,
   },
 };
+
+/** The two needles' geometry, exported so tests read it rather than repeat it. */
+export const NEEDLE_TRACKS = NEEDLES;
 
 /**
  * The dial, drawn around whatever origin its parent translated it to.
@@ -125,7 +176,7 @@ export function Compass({ needles }: { needles: readonly CompassNeedle[] }) {
       <circle
         cx={0}
         cy={0}
-        r={ARC_RADIUS}
+        r={RING_RADIUS}
         fill="none"
         className="stroke-fog"
         strokeWidth={0.6}
@@ -133,32 +184,46 @@ export function Compass({ needles }: { needles: readonly CompassNeedle[] }) {
         vectorEffect="non-scaling-stroke"
       />
 
-      {needles.map((needle) => (
-        <Needle key={needle.kind} needle={needle} />
-      ))}
+      {/*
+        Heaviest first, so the light shaft is never the one underneath. The
+        list itself stays in reading order -- wind, then swell -- because that
+        is the order the sources below are read in, and drawing order is a
+        painting concern rather than a claim about which matters.
+      */}
+      {[...needles]
+        .sort((a, b) => NEEDLES[b.kind].width - NEEDLES[a.kind].width)
+        .map((needle) => (
+          <Needle key={needle.kind} needle={needle} />
+        ))}
     </g>
   );
 }
 
 function Needle({ needle }: { needle: CompassNeedle }) {
   const style = NEEDLES[needle.kind];
-  const tail = at(needle.fromDegT, DIAL_RADIUS);
-  const head = at(needle.fromDegT, HEAD_RADIUS);
+  const tail = at(needle.fromDegT, style.tail);
+  const head = at(needle.fromDegT, style.head);
+  const span = style.tail - style.head;
 
   /*
     The two barbs of the arrowhead, set back along the shaft and out to either
     side. Built from the same `at` conversion rather than from a rotation
     matrix, so there is one place in this file that knows which way north is.
   */
-  const barbBack = at(needle.fromDegT, HEAD_RADIUS + style.head * 1.6);
+  /*
+    The head is twice as long as it is wide across. Set back by less it draws
+    an obtuse blob rather than an arrow, which is what the swell's first
+    version did once its shaft was shortened to clear the wind's.
+  */
+  const barbBack = at(needle.fromDegT, style.head + style.barb * 2);
   const across = {
-    x: (tail.y - head.y) / DIAL_RADIUS,
-    y: (head.x - tail.x) / DIAL_RADIUS,
+    x: (tail.y - head.y) / span,
+    y: (head.x - tail.x) / span,
   };
   const barbs = [
-    `${(barbBack.x + across.x * style.head).toFixed(2)},${(barbBack.y + across.y * style.head).toFixed(2)}`,
+    `${(barbBack.x + across.x * style.barb).toFixed(2)},${(barbBack.y + across.y * style.barb).toFixed(2)}`,
     `${head.x.toFixed(2)},${head.y.toFixed(2)}`,
-    `${(barbBack.x - across.x * style.head).toFixed(2)},${(barbBack.y - across.y * style.head).toFixed(2)}`,
+    `${(barbBack.x - across.x * style.barb).toFixed(2)},${(barbBack.y - across.y * style.barb).toFixed(2)}`,
   ].join(" ");
 
   return (
@@ -177,11 +242,24 @@ function Needle({ needle }: { needle: CompassNeedle }) {
         data-needle={needle.kind}
       />
 
-      <polygon
-        points={barbs}
-        className={style.fill}
-        data-needle-head={needle.kind}
-      />
+      {style.solid ? (
+        <polygon
+          points={barbs}
+          className={style.fill}
+          data-needle-head={needle.kind}
+        />
+      ) : (
+        <polyline
+          points={barbs}
+          fill="none"
+          className={style.stroke}
+          strokeWidth={style.width}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+          data-needle-head={needle.kind}
+        />
+      )}
     </>
   );
 }
@@ -195,9 +273,10 @@ function Needle({ needle }: { needle: CompassNeedle }) {
  * two, and the arc says the same thing at the rim.
  */
 function Arc({ needle }: { needle: CompassNeedle }) {
+  const { arc: radius, arcOpacity, stroke } = NEEDLES[needle.kind];
   const half = needle.spreadDeg / 2;
-  const from = at(needle.fromDegT - half, ARC_RADIUS);
-  const to = at(needle.fromDegT + half, ARC_RADIUS);
+  const from = at(needle.fromDegT - half, radius);
+  const to = at(needle.fromDegT + half, radius);
 
   /*
     Which of the two arcs between the endpoints is meant. Without the flag a
@@ -213,12 +292,12 @@ function Arc({ needle }: { needle: CompassNeedle }) {
     <path
       d={
         `M${from.x.toFixed(2)} ${from.y.toFixed(2)} ` +
-        `A ${ARC_RADIUS} ${ARC_RADIUS} 0 ${largeArc} 1 ${to.x.toFixed(2)} ${to.y.toFixed(2)}`
+        `A ${radius} ${radius} 0 ${largeArc} 1 ${to.x.toFixed(2)} ${to.y.toFixed(2)}`
       }
       fill="none"
-      className={NEEDLES[needle.kind].stroke}
+      className={stroke}
       strokeWidth={4}
-      strokeOpacity={0.65}
+      strokeOpacity={arcOpacity}
       strokeLinecap="butt"
       vectorEffect="non-scaling-stroke"
       data-arc={needle.kind}

--- a/src/components/conditions/Compass.tsx
+++ b/src/components/conditions/Compass.tsx
@@ -137,10 +137,10 @@ const NEEDLES: Record<
     fill: "fill-ocean",
     arc: RING_RADIUS,
     arcOpacity: 0.65,
-    tail: 28,
+    tail: 26,
     head: 3,
-    width: 1.4,
-    barb: 2.2,
+    width: 1.3,
+    barb: 1.7,
     solid: false,
   },
   swell: {
@@ -148,10 +148,10 @@ const NEEDLES: Record<
     fill: "fill-purple-deep",
     arc: 24,
     arcOpacity: 0.8,
-    tail: 22,
+    tail: 21,
     head: 8,
-    width: 3,
-    barb: 3,
+    width: 2.4,
+    barb: 2.2,
     solid: true,
   },
 };
@@ -211,11 +211,14 @@ function Needle({ needle }: { needle: CompassNeedle }) {
     matrix, so there is one place in this file that knows which way north is.
   */
   /*
-    The head is twice as long as it is wide across. Set back by less it draws
-    an obtuse blob rather than an arrow, which is what the swell's first
-    version did once its shaft was shortened to clear the wind's.
+    The head is two and a half times as long as it is wide across.
+
+    Set back by less it draws an obtuse blob rather than an arrow, which is
+    what the swell's first version did once its shaft was shortened to clear
+    the wind's -- reviewed on the built page and called tacky, correctly. A
+    long, narrow head reads as a direction; a squat one reads as a shape.
   */
-  const barbBack = at(needle.fromDegT, style.head + style.barb * 2);
+  const barbBack = at(needle.fromDegT, style.head + style.barb * 2.5);
   const across = {
     x: (tail.y - head.y) / span,
     y: (head.x - tail.x) / span,
@@ -260,7 +263,71 @@ function Needle({ needle }: { needle: CompassNeedle }) {
           data-needle-head={needle.kind}
         />
       )}
+
+      <Label needle={needle} tail={tail} />
     </>
+  );
+}
+
+/**
+ * Where the needle's own word sits, out beyond its tail.
+ *
+ * **Two arrows over a coastline do not say which is which**, and this map has
+ * no legend by design — a boxed legend is one of the brief's anti-references,
+ * and the design review already named the cloud legend as the only element
+ * inside a frame that is chrome rather than data. A word at the tail is not a
+ * legend: it is the label on the thing itself, which is what a legend is a
+ * substitute for.
+ *
+ * **Horizontal, never rotated with its needle.** A label turned to follow a
+ * bearing is upside down for half the compass. It is anchored away from the
+ * dial instead — a needle out to the west puts its word further west — so the
+ * text runs outward and never crosses the picture.
+ *
+ * The size is in plot units rather than in the page's `text-2xs`, because a CSS
+ * pixel inside a hundred-unit viewBox is a hundredth of the map. 3.2 units is
+ * about 15px on the widest map this page draws and 10.5px on the narrowest, at
+ * 375 — which keeps it at ADR-0024's floor rather than under it.
+ */
+function Label({
+  needle,
+  tail,
+}: {
+  needle: CompassNeedle;
+  tail: { x: number; y: number };
+}) {
+  /*
+    Outside the arc, not just outside the tail. Set at the tail the word landed
+    on its own arc's track and the halo punched a hole through it -- visible on
+    the built page and picked up by the contrast probe, which kept sampling the
+    label's ink where it was looking for the band.
+  */
+  const out = at(needle.fromDegT, NEEDLES[needle.kind].arc + 4);
+  const eastward = tail.x >= 0;
+
+  return (
+    <text
+      x={Number(out.x.toFixed(2))}
+      y={Number(out.y.toFixed(2))}
+      textAnchor={eastward ? "start" : "end"}
+      dominantBaseline="middle"
+      fontSize={3.2}
+      className={`fill-ink stroke-cream uppercase ${
+        needle.kind === "wind" ? "font-bold" : "font-extrabold"
+      }`}
+      /*
+        A halo, not a badge. It exists so the word survives being drawn over
+        the coastline or the wash, and at 2.5 it read as a chip stuck on the
+        map -- which is the boxed legend this dial is meant not to have. 1.2 is
+        enough to separate the letters from what is behind them.
+      */
+      strokeWidth={1.2}
+      paintOrder="stroke"
+      strokeLinejoin="round"
+      data-needle-label={needle.kind}
+    >
+      {needle.label}
+    </text>
   );
 }
 

--- a/src/components/conditions/Compass.tsx
+++ b/src/components/conditions/Compass.tsx
@@ -1,0 +1,282 @@
+/**
+ * Where the wind and the swell come from, drawn on the beach they arrive at.
+ *
+ * **A bearing means nothing on its own, and that is why this is not a card.**
+ * 281 degrees is a number. Drawn on the shore map, over a coastline a reader
+ * can see, it becomes the thing they actually came for: whether the wind is
+ * coming off the land or off the water. The design brief's third principle is
+ * this component's whole justification -- "no dial floating beside a graph can
+ * say which" -- and it is why `ShoreMap` hosts this rather than the day panel.
+ *
+ * **The needles point inward, at the beach.** Every feed this page reads
+ * publishes the direction weather comes *from*, so the tail sits out at the
+ * bearing and the head arrives at the sand. An arrow drawn the other way is the
+ * same line saying the opposite thing, and a reader has no way to tell which
+ * convention a drawing chose. This one is checkable against the map underneath
+ * it: a needle whose tail is out over the shaded sea is onshore wind, which is
+ * the reading the whole component exists to make possible.
+ *
+ * **The arc is the honesty.** A bare needle on a day the wind swung through 200
+ * degrees would state a direction the day did not have. Measured across the
+ * committed run, two days of seven have a daylight spread past 170 degrees and
+ * four sit at 40 or less, so the two cases look completely different -- which is
+ * the point. `bearing.ts` computes the arc; this draws it.
+ *
+ * **Presentational and pure**, like `ShoreMap` and `DaySpark`. It takes needles
+ * and draws them; it reads no feed, resolves no station and words nothing. The
+ * sentences are the caller's.
+ *
+ * **The ring is chrome, and it is the one piece here that is.** The day view's
+ * review already named the cloud legend as the only element inside a frame that
+ * is not data, and this is a second. It earns it: an arc with nothing to be a
+ * portion of reads as a stray stroke rather than as a range, and the
+ * alternative -- labelled tick marks at the cardinals -- is the boxed legend
+ * the brief lists as an anti-reference. One faint circle is the smallest thing
+ * that makes the arc mean what it means.
+ */
+
+import { compassWords } from "./bearing";
+import { ProvenanceLine } from "./ProvenanceLine";
+
+/** Which source a needle stands for. The list is closed on purpose. */
+export type CompassNeedleKind = "wind" | "swell";
+
+/** One needle, worded and measured by the caller. */
+export type CompassNeedle = {
+  kind: CompassNeedleKind;
+  /** The needle's word, and the product's name: "Wind", "Swell". */
+  label: string;
+  /** Degrees true it comes *from*, weighted by how much there was. */
+  fromDegT: number;
+  /** The arc it swung through in daylight. Zero draws no arc. */
+  spreadDeg: number;
+  /** What the figure names its source, ready to print. */
+  source: string;
+  /** Who publishes it, or null where the binding does not know. */
+  network: string | null;
+  /** Why this source, when there is something to say. */
+  note: string | null;
+};
+
+/**
+ * How far out the needle's tail stands, in the map's own plot units.
+ *
+ * A quarter of the hundred-unit frame, so the dial reads as an instrument sat
+ * on the beach rather than as a second picture covering the coast. Exported
+ * because the tests check the tail lands on the bearing, and a test that
+ * hard-coded the number would pass after somebody changed it here.
+ */
+export const DIAL_RADIUS = 26;
+
+/** Where the head stops, short of the beach so the segment stays visible. */
+const HEAD_RADIUS = 7;
+
+/** The arc sits just outside the tails, where it crowds nothing. */
+const ARC_RADIUS = DIAL_RADIUS + 4;
+
+/**
+ * Plot coordinates for a bearing at a radius, with north up.
+ *
+ * The one conversion in this file and the one worth stating: bearings run
+ * clockwise from north, and plot y grows southward, so north is a *negative*
+ * y. Writing it the intuitive way puts every needle upside down.
+ */
+function at(degreesTrue: number, radius: number): { x: number; y: number } {
+  const radians = (degreesTrue * Math.PI) / 180;
+  return { x: radius * Math.sin(radians), y: -radius * Math.cos(radians) };
+}
+
+/**
+ * The two needles differ in shape and in weight, never in colour alone.
+ *
+ * The brief's rule, and the one a small graphic breaks most easily: the whole
+ * dial is a few dozen pixels, and a reader who cannot separate two hues would
+ * be left with two identical strokes. The wind is a thin line with an open
+ * head; the swell is a heavier tapered blade. Colour reinforces the pair and
+ * carries none of it.
+ */
+const NEEDLES: Record<
+  CompassNeedleKind,
+  { stroke: string; fill: string; width: number; head: number }
+> = {
+  wind: { stroke: "stroke-ocean", fill: "fill-ocean", width: 1.4, head: 2.6 },
+  swell: {
+    stroke: "stroke-purple-deep",
+    fill: "fill-purple-deep",
+    width: 3,
+    head: 4,
+  },
+};
+
+/**
+ * The dial, drawn around whatever origin its parent translated it to.
+ *
+ * `ShoreMap` puts that origin on the beach's own stretch of coast rather than
+ * at the middle of the frame, because the frame is sized by the sources: at
+ * `mission-beach` a station nine kilometres away puts the frame's centre out in
+ * the county somewhere, and a needle pointing at that would be pointing at
+ * nothing.
+ */
+export function Compass({ needles }: { needles: readonly CompassNeedle[] }) {
+  if (needles.length === 0) return null;
+
+  return (
+    <g data-compass-dial="">
+      <circle
+        cx={0}
+        cy={0}
+        r={ARC_RADIUS}
+        fill="none"
+        className="stroke-fog"
+        strokeWidth={0.6}
+        strokeOpacity={0.45}
+        vectorEffect="non-scaling-stroke"
+      />
+
+      {needles.map((needle) => (
+        <Needle key={needle.kind} needle={needle} />
+      ))}
+    </g>
+  );
+}
+
+function Needle({ needle }: { needle: CompassNeedle }) {
+  const style = NEEDLES[needle.kind];
+  const tail = at(needle.fromDegT, DIAL_RADIUS);
+  const head = at(needle.fromDegT, HEAD_RADIUS);
+
+  /*
+    The two barbs of the arrowhead, set back along the shaft and out to either
+    side. Built from the same `at` conversion rather than from a rotation
+    matrix, so there is one place in this file that knows which way north is.
+  */
+  const barbBack = at(needle.fromDegT, HEAD_RADIUS + style.head * 1.6);
+  const across = {
+    x: (tail.y - head.y) / DIAL_RADIUS,
+    y: (head.x - tail.x) / DIAL_RADIUS,
+  };
+  const barbs = [
+    `${(barbBack.x + across.x * style.head).toFixed(2)},${(barbBack.y + across.y * style.head).toFixed(2)}`,
+    `${head.x.toFixed(2)},${head.y.toFixed(2)}`,
+    `${(barbBack.x - across.x * style.head).toFixed(2)},${(barbBack.y - across.y * style.head).toFixed(2)}`,
+  ].join(" ");
+
+  return (
+    <>
+      {needle.spreadDeg > 0 && <Arc needle={needle} />}
+
+      <line
+        x1={Number(tail.x.toFixed(2))}
+        y1={Number(tail.y.toFixed(2))}
+        x2={Number(head.x.toFixed(2))}
+        y2={Number(head.y.toFixed(2))}
+        className={style.stroke}
+        strokeWidth={style.width}
+        strokeLinecap="round"
+        vectorEffect="non-scaling-stroke"
+        data-needle={needle.kind}
+      />
+
+      <polygon
+        points={barbs}
+        className={style.fill}
+        data-needle-head={needle.kind}
+      />
+    </>
+  );
+}
+
+/**
+ * The band the direction moved through while the sun was up.
+ *
+ * A stroked arc rather than a filled wedge from the centre. A wedge covering a
+ * fifth of the map on a settled day and half of it on an unsettled one would
+ * hide the coast underneath exactly when the reader most needs to compare the
+ * two, and the arc says the same thing at the rim.
+ */
+function Arc({ needle }: { needle: CompassNeedle }) {
+  const half = needle.spreadDeg / 2;
+  const from = at(needle.fromDegT - half, ARC_RADIUS);
+  const to = at(needle.fromDegT + half, ARC_RADIUS);
+
+  /*
+    Which of the two arcs between the endpoints is meant. Without the flag a
+    200-degree swing draws as the 160-degree one on the other side of the dial,
+    which is not merely wrong but the opposite claim.
+
+    The sweep flag is 1 because bearings increase clockwise and, in a space
+    where y grows downward, a positive sweep is clockwise on screen.
+  */
+  const largeArc = needle.spreadDeg > 180 ? 1 : 0;
+
+  return (
+    <path
+      d={
+        `M${from.x.toFixed(2)} ${from.y.toFixed(2)} ` +
+        `A ${ARC_RADIUS} ${ARC_RADIUS} 0 ${largeArc} 1 ${to.x.toFixed(2)} ${to.y.toFixed(2)}`
+      }
+      fill="none"
+      className={NEEDLES[needle.kind].stroke}
+      strokeWidth={4}
+      strokeOpacity={0.65}
+      strokeLinecap="butt"
+      vectorEffect="non-scaling-stroke"
+      data-arc={needle.kind}
+    />
+  );
+}
+
+/**
+ * Beyond this, the eight-point word for the needle stops covering its own arc.
+ *
+ * Not a threshold picked to suit the data: one compass point is exactly the
+ * width the words have, so a swing wider than one is a swing the words cannot
+ * describe and a reader is owed the number instead. It happens to separate the
+ * committed run cleanly -- four days at 40 or 50, two past 170 -- which is a
+ * check on the rule rather than the reason for it.
+ */
+const WIDE_SWING_DEG = 45;
+
+/**
+ * What the dial says, for a reader who is not looking at it.
+ *
+ * **Beside the picture rather than on it**, which is `ShoreMap`'s own rule for
+ * its markers and for the same two reasons: a label inside a hundred-unit frame
+ * either overlaps its neighbour or shrinks under the ten-pixel floor ADR-0024
+ * refused to go below, and the map is one `role="img"` whose contents are not
+ * in the accessibility tree at all. This block is the dial's text equivalent,
+ * so it states both bearings in words and in degrees.
+ *
+ * One provenance line per needle, which is `WeekGrid`'s resolution rather than
+ * `StatGroup`'s contract: one dial carrying two publishers is a deliberate
+ * break of one-group-one-source, answered by attributing each row.
+ */
+export function CompassSources({
+  needles,
+}: {
+  needles: readonly CompassNeedle[];
+}) {
+  if (needles.length === 0) return null;
+
+  return (
+    <ul className="mt-2 flex flex-col gap-1">
+      {needles.map((needle) => (
+        <li key={needle.kind}>
+          <p className="text-2xs text-ink leading-normal">
+            {needle.label}, from the {compassWords(needle.fromDegT)},{" "}
+            {Math.round(needle.fromDegT)}°
+            {needle.spreadDeg > WIDE_SWING_DEG
+              ? ` — swinging through ${Math.round(needle.spreadDeg)}° in daylight`
+              : ""}
+          </p>
+          <ProvenanceLine
+            source={needle.source}
+            network={needle.network}
+            note={needle.note}
+            surface="page"
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/conditions/DayCompass.test.tsx
+++ b/src/components/conditions/DayCompass.test.tsx
@@ -1,0 +1,65 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DayCompass, DayCompassSources, type CompassDay } from "./DayCompass";
+import { SelectedDayProvider } from "./selectedDay";
+import type { CompassNeedle } from "./Compass";
+
+function needle(fromDegT: number): CompassNeedle {
+  return {
+    kind: "wind",
+    label: "Wind",
+    fromDegT,
+    spreadDeg: 20,
+    source: "this beach's own grid cell",
+    network: "National Weather Service, San Diego",
+    note: null,
+  };
+}
+
+const DAYS: CompassDay[] = [
+  { localDate: "2026-08-17", needles: [needle(90)] },
+  { localDate: "2026-08-18", needles: [needle(270)] },
+];
+
+test("the dial opens on the first day, which is today", () => {
+  // The provider starts null and every consumer resolves it against its own
+  // first column, so the server render and the first client render agree by
+  // construction. A dial that read a clock could disagree with the heading.
+  render(
+    <SelectedDayProvider>
+      <DayCompassSources days={DAYS} />
+    </SelectedDayProvider>,
+  );
+
+  expect(screen.getByText(/from the east, 90°/)).toBeDefined();
+});
+
+test("a day the compass has nothing for draws no dial", () => {
+  const { container } = render(
+    <SelectedDayProvider>
+      <DayCompass days={[{ localDate: "2026-08-17", needles: [] }]} />
+    </SelectedDayProvider>,
+  );
+
+  expect(container.querySelector("[data-compass-dial]")).toBeNull();
+});
+
+test("a beach with no days at all draws nothing rather than throwing", () => {
+  const { container } = render(
+    <SelectedDayProvider>
+      <DayCompass days={[]} />
+      <DayCompassSources days={[]} />
+    </SelectedDayProvider>,
+  );
+
+  expect(container.textContent).toBe("");
+});
+
+test("the dial renders outside the provider, showing its first day", () => {
+  // The provider's default is the null state rather than a throw, so a region
+  // rendered outside it degrades to "the first day and no choice" -- which is
+  // exactly the state a reader with no JavaScript is in.
+  render(<DayCompassSources days={DAYS} />);
+
+  expect(screen.getByText(/from the east, 90°/)).toBeDefined();
+});

--- a/src/components/conditions/DayCompass.tsx
+++ b/src/components/conditions/DayCompass.tsx
@@ -1,0 +1,58 @@
+/**
+ * The dial for the day a reader chose, on a map that is the same on all seven.
+ *
+ * **The smallest client island that makes this work.** `DayPanel` builds the
+ * shore map once and hands it over as finished markup, because the beach, its
+ * coast and the four places its figures come from do not change when somebody
+ * picks Thursday. The needles do: each day has its own resultant bearing and
+ * its own arc. Seven copies of the map would carry the coast seven times --
+ * measured at La Jolla, four and a half kilobytes of coordinates a copy, and
+ * two hundred points at `del-mar-city-beach` -- to vary two numbers.
+ *
+ * So the map stays one server-rendered picture with a hole in it, and this
+ * fills the hole. Seven days of needles is a few dozen numbers.
+ *
+ * **Two components rather than one with a switch**, because the dial and its
+ * words go in two different places: the dial inside the map's own drawing
+ * space, where the projection puts it on the beach, and the words down in the
+ * list beside the picture, where `ShoreMap` already keeps the names of things
+ * it draws. Each is a line over one shared hook.
+ *
+ * Rendered outside the provider it shows the first day and offers no choice,
+ * which is `selectedDay.ts`'s deliberate default and the state a reader with a
+ * blocked script is in.
+ */
+
+"use client";
+
+import { Compass, CompassSources, type CompassNeedle } from "./Compass";
+import { resolveSelected, useSelectedDay } from "./selectedDay";
+
+/** One day's needles, keyed by the date the week grid chooses by. */
+export type CompassDay = {
+  /** `YYYY-MM-DD` in Pacific. */
+  localDate: string;
+  /** Empty on a day no feed gave a bearing for, which draws no dial. */
+  needles: readonly CompassNeedle[];
+};
+
+function useChosen(days: readonly CompassDay[]): CompassDay | undefined {
+  const { selected } = useSelectedDay();
+  const showing = resolveSelected(
+    selected,
+    days.map((day) => day.localDate),
+  );
+  return days.find((day) => day.localDate === showing) ?? days[0];
+}
+
+/** The dial itself, drawn into whatever origin `ShoreMap` translated it to. */
+export function DayCompass({ days }: { days: readonly CompassDay[] }) {
+  const day = useChosen(days);
+  return day === undefined ? null : <Compass needles={day.needles} />;
+}
+
+/** What the dial says, for a reader not looking at it. */
+export function DayCompassSources({ days }: { days: readonly CompassDay[] }) {
+  const day = useChosen(days);
+  return day === undefined ? null : <CompassSources needles={day.needles} />;
+}

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -140,6 +140,7 @@ function gridWeek(
   overrides: {
     windMph?: { kind: "absent"; reason: string };
     airTempF?: { kind: "absent"; reason: string };
+    windDirDegT?: { kind: "absent"; reason: string };
   } = {},
 ) {
   const hours = (localDate: string, base: number) => ({
@@ -147,6 +148,24 @@ function gridWeek(
     hours: Array.from({ length: 24 }, (_, hour) => ({
       atMs: localMidnightOf(localDate) + hour * HOUR,
       value: base + Math.floor(hour / 6) * 3,
+      published: hour % 6 === 0,
+    })),
+  });
+
+  /**
+   * One steady bearing all day, and a different one per day.
+   *
+   * Steady so the resultant is exactly the number written here and the
+   * assertion can be an equality rather than a range -- the circular mean has
+   * its own tests, and this one is about whether the wiring reaches the page.
+   * Different per day because a dial showing the wrong day is otherwise
+   * invisible, which is the failure the whole client island exists around.
+   */
+  const directions = (localDate: string) => ({
+    kind: "published" as const,
+    hours: Array.from({ length: 24 }, (_, hour) => ({
+      atMs: localMidnightOf(localDate) + hour * HOUR,
+      value: localDate === TODAY ? 180 : 270,
       published: hour % 6 === 0,
     })),
   });
@@ -162,6 +181,7 @@ function gridWeek(
         dateLabel: "Mon, Aug 17",
         isToday: localDate === TODAY,
         windMph: overrides.windMph ?? hours(localDate, 5),
+        windDirDegT: overrides.windDirDegT ?? directions(localDate),
         airTempF: overrides.airTempF ?? hours(localDate, 64),
       })),
     },
@@ -731,4 +751,67 @@ test("the slot says what the layer will show, not what was found", async () => {
     "Will show octopus, nudibranchs, sea hares and leopard sharks logged " +
       "near this beach in the past week",
   );
+});
+
+test("the map carries a dial for the day the reader chose", async () => {
+  // The map is one picture for the whole week and the needles are not, so the
+  // coast stays server-rendered and only the dial moves. Asserted through the
+  // words rather than through the drawing, because the words are what a reader
+  // not looking at the picture is given.
+  const dates = [TODAY, TOMORROW];
+  daylight(dates);
+  tideWeek(dates);
+  waveWeek(dates);
+  skyWeek(dates);
+  gridWeek(dates);
+  wordingWeek(
+    dates.map((localDate) => ({
+      localDate,
+      periodName: "Today",
+      words: "Patchy Fog",
+    })),
+  );
+
+  const { container } = render(
+    <SelectedDayProvider>
+      {await DayPanel({ slug: "la-jolla-shores-beach" })}
+    </SelectedDayProvider>,
+  );
+
+  expect(container.querySelector("[data-needle='wind']")).not.toBeNull();
+
+  // Scoped to the needle's own row. The sky wording names the same cell a few
+  // hundred pixels up, which is ADR-0029's permitted duplication and is why an
+  // unscoped query for that sentence finds two.
+  const row = screen.getByText(/^Wind, from the south, 180°/).closest("li")!;
+  expect(row.textContent).toContain(
+    "this beach's own grid cell · National Weather Service, San Diego",
+  );
+});
+
+test("a cell that publishes no wind direction draws no dial", async () => {
+  // The needle goes and the map stays: the four markers are what ADR-0010 asked
+  // for and they do not depend on a bearing.
+  const dates = [TODAY];
+  daylight(dates);
+  tideWeek(dates);
+  waveWeek(dates);
+  skyWeek(dates);
+  gridWeek(dates, {
+    windDirDegT: {
+      kind: "absent",
+      reason: "the cell declares windDirection and published no values",
+    },
+  });
+  wordingWeek([{ localDate: TODAY, periodName: "Today", words: "Patchy Fog" }]);
+
+  const { container } = render(
+    <SelectedDayProvider>
+      {await DayPanel({ slug: "la-jolla-shores-beach" })}
+    </SelectedDayProvider>,
+  );
+
+  expect(container.querySelector("[data-needle='wind']")).toBeNull();
+  expect(screen.queryByText(/Wind, from the/)).toBeNull();
+  expect(screen.getByText(/Buoy Scripps Nearshore/)).toBeDefined();
 });

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -794,8 +794,8 @@ test("the map carries a dial for the day the reader chose", async () => {
 });
 
 test("a cell that publishes no wind direction draws no dial", async () => {
-  // The needle goes and the map stays: the four markers are what ADR-0010 asked
-  // for and they do not depend on a bearing.
+  // The needle goes and the map stays. The picture is about where this beach
+  // is, which does not depend on a bearing.
   const dates = [TODAY];
   daylight(dates);
   tideWeek(dates);
@@ -817,7 +817,10 @@ test("a cell that publishes no wind direction draws no dial", async () => {
 
   expect(container.querySelector("[data-needle='wind']")).toBeNull();
   expect(screen.queryByText(/Wind, from the/)).toBeNull();
-  expect(screen.getByText(/Buoy Scripps Nearshore/)).toBeDefined();
+  // The map itself is unaffected: it draws a place, and a place does not stop
+  // existing because a forecast cell went quiet about the wind.
+  expect(container.querySelector("[data-coast]")).not.toBeNull();
+  expect(container.querySelector("[data-segment]")).not.toBeNull();
 });
 
 test("the dial carries a second needle for the swell, from its own publisher", async () => {

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -124,6 +124,10 @@ function waveWeek(dates: string[]) {
           atMs: localMidnightOf(localDate) + hour * HOUR,
           heightFt: 1.5 + Math.sin((hour / 24) * 2 * Math.PI) / 2,
           published: hour % 3 === 2,
+          // CDIP's own estimates carry a bearing; the hours drawn between them
+          // carry none, which is what the swell needle reads. Steady, so the
+          // resultant is exactly this and the assertion can be an equality.
+          directionDegT: hour % 3 === 2 ? 315 : null,
         })),
       })),
     },
@@ -814,4 +818,62 @@ test("a cell that publishes no wind direction draws no dial", async () => {
   expect(container.querySelector("[data-needle='wind']")).toBeNull();
   expect(screen.queryByText(/Wind, from the/)).toBeNull();
   expect(screen.getByText(/Buoy Scripps Nearshore/)).toBeDefined();
+});
+
+test("the dial carries a second needle for the swell, from its own publisher", async () => {
+  // One dial, two publishers -- `StatGroup`'s one-group-one-source contract
+  // broken on purpose and answered the way `WeekGrid` answers it, with a
+  // provenance line per row rather than by splitting the component.
+  const dates = [TODAY];
+  daylight(dates);
+  tideWeek(dates);
+  waveWeek(dates);
+  skyWeek(dates);
+  gridWeek(dates);
+  wordingWeek([{ localDate: TODAY, periodName: "Today", words: "Patchy Fog" }]);
+
+  const { container } = render(
+    <SelectedDayProvider>
+      {await DayPanel({ slug: "la-jolla-shores-beach" })}
+    </SelectedDayProvider>,
+  );
+
+  expect(container.querySelectorAll("[data-needle]")).toHaveLength(2);
+
+  const row = screen
+    .getByText(/^Swell, from the north-west, 315°/)
+    .closest("li")!;
+  expect(row.textContent).toContain("MOP line D0481");
+  expect(row.textContent).toContain(
+    "CDIP, Scripps Institution of Oceanography",
+  );
+});
+
+test("a beach with no swell model keeps its wind needle", async () => {
+  // 26 of 51 beaches bind no MOP line. The dial loses a needle and keeps the
+  // one it has, rather than the pair going down together.
+  const dates = [TODAY];
+  daylight(dates);
+  tideWeek(dates);
+  readWaveWeek.mockResolvedValue({
+    beachName: BINDING.beachName,
+    line: null,
+    state: {
+      kind: "no-line",
+      reason: "no MOP line is computed for this beach",
+    },
+  });
+  skyWeek(dates);
+  gridWeek(dates);
+  wordingWeek([{ localDate: TODAY, periodName: "Today", words: "Patchy Fog" }]);
+
+  const { container } = render(
+    <SelectedDayProvider>
+      {await DayPanel({ slug: "la-jolla-shores-beach" })}
+    </SelectedDayProvider>,
+  );
+
+  expect(container.querySelectorAll("[data-needle]")).toHaveLength(1);
+  expect(screen.getByText(/^Wind, from the south, 180°/)).toBeDefined();
+  expect(screen.queryByText(/^Swell, from/)).toBeNull();
 });

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -292,16 +292,16 @@ function cloudBandDescription(
 /**
  * The spoken equivalent of the whole map.
  *
- * Says what the picture is and how many sources are on it, and nothing about
- * what the shape of the coast means. A reader hearing this should learn the
- * same thing a reader seeing it does: that these figures come from places, and
- * roughly how many.
+ * Says what the picture is and nothing about what the shape of the coast
+ * means. A reader hearing this should learn the same thing a reader seeing it
+ * does: where this beach is on its own coast, and which side the water is on.
+ * The dial's own bearings are spoken separately, under the picture, because
+ * they change with the day and this does not.
  */
-function mapDescription(beachName: string, sources: number): string {
+function mapDescription(beachName: string): string {
   return (
-    `A map of ${beachName} and the ${sources} ` +
-    `${sources === 1 ? "place" : "places"} the figures on this page come from, ` +
-    `each drawn at its real distance from the beach.`
+    `A map of ${beachName}: its own stretch of coast drawn heavier than the ` +
+    `shore either side of it, and the open water shaded.`
   );
 }
 
@@ -507,10 +507,11 @@ export async function DayPanel({ slug }: { slug: string }) {
 
   /*
     The map is built once and handed over, outside the seven days, because it
-    is the same picture on all seven: this beach, its coast, and the four places
-    its figures come from. It is also the one thing in this region that reads no
-    feed -- `beaches.json` and `mop-lines.json` are committed -- so it cannot go
-    quiet and does not belong behind a Suspense boundary.
+    is the same picture on all seven: this beach, its own stretch of coast, and
+    the water beside it. Only the dial drawn on it changes with the day, and
+    that travels separately. It is also the one thing in this region that reads
+    no feed -- `beaches.json` and `mop-lines.json` are committed -- so it cannot
+    go quiet and does not belong behind a Suspense boundary.
 
     A beach the inventory does not hold is not this component's error to invent
     a map for: the route already answered that question before rendering, and
@@ -616,10 +617,10 @@ export async function DayPanel({ slug }: { slug: string }) {
             <>
               <ShoreMap
                 {...shore}
-                description={mapDescription(beach!.name, shore.markers.length)}
-                absence="We cannot place this beach on a map: every source we have for it is at the same point."
+                description={mapDescription(beach!.name)}
+                absence="We cannot place this beach on a map: the coordinates we hold for it are all one point."
                 noCoast="The coastline this site traces is the open coast, and it does not reach this beach."
-                coastCredit={`Shore traced from CDIP's model lines, which run a few hundred metres offshore — so the water fades in rather than stopping at a shoreline.`}
+                coastCredit={`Shore traced from CDIP's model lines, which are computed a few hundred metres offshore — so the water's edge is drawn further out than the sand.`}
                 compass={<DayCompass days={compassDays} />}
                 compassSources={<DayCompassSources days={compassDays} />}
               />

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -67,6 +67,14 @@ import type { HourSeries } from "./HourChart";
 import { MeasuredPanel } from "./MeasuredPanel";
 import { MeasuredToday } from "./MeasuredToday";
 import { ReservedSlot } from "../ui/ReservedSlot";
+import { DayCompass, DayCompassSources, type CompassDay } from "./DayCompass";
+import {
+  GRID_MODEL_NOTE,
+  GRID_NETWORK,
+  GRID_SOURCE,
+  gridCellCaveat,
+} from "./gridCell";
+import { gridWindReadings, needleFrom } from "./needles";
 import { ShoreMap } from "./ShoreMap";
 import { shoreViewFor } from "./shore";
 import { SkyWording } from "./SkyWording";
@@ -510,6 +518,65 @@ export async function DayPanel({ slug }: { slug: string }) {
   const beach = beachBySlug(slug);
   const shore = beach === null ? null : shoreViewFor(beach);
 
+  /*
+    Seven days of needles, built beside the seven days of series rather than
+    inside them.
+
+    The map is one picture for the whole week and the needles are not, so they
+    travel separately: `DayCompass` is the client island that picks the chosen
+    day's pair out of these, and the coast underneath stays a single
+    server-rendered drawing. Putting them inside `DayView` would mean seven
+    copies of the map to vary two numbers.
+
+    The window is this day's own daylight, which is the design brief's word for
+    it and is load-bearing rather than decorative: the committed run swings
+    across north in its first three hours, and a day measured end to end
+    reports an arc nobody could have stood in.
+  */
+  const cellNote = [
+    GRID_MODEL_NOTE,
+    gridCellCaveat(grid.cell?.elevationM ?? null),
+  ]
+    .filter((part): part is string => part !== null)
+    .join("; ");
+
+  const compassDays: CompassDay[] = daylight.days.map((day) => {
+    const gridDay =
+      grid.state.kind === "week"
+        ? grid.state.days.find((each) => each.localDate === day.localDate)
+        : undefined;
+
+    const wind =
+      gridDay === undefined
+        ? null
+        : needleFrom(
+            gridWindReadings(
+              gridDay.windDirDegT,
+              gridDay.windMph,
+              day.sunriseMs,
+              day.sunsetMs,
+            ),
+          );
+
+    return {
+      localDate: day.localDate,
+      needles:
+        wind === null
+          ? []
+          : [
+              {
+                kind: "wind" as const,
+                label: "Wind",
+                fromDegT: wind.fromDegT,
+                spreadDeg: wind.spreadDeg,
+                source: GRID_SOURCE,
+                network: GRID_NETWORK,
+                note: cellNote,
+              },
+            ],
+    };
+  });
+
   return (
     <section aria-labelledby="day-panel-heading">
       <ChosenDay
@@ -523,6 +590,8 @@ export async function DayPanel({ slug }: { slug: string }) {
                 absence="We cannot place this beach on a map: every source we have for it is at the same point."
                 noCoast="The coastline this site traces is the open coast, and it does not reach this beach."
                 coastCredit={`Shore traced from CDIP's model lines, which run a few hundred metres offshore — so the water fades in rather than stopping at a shoreline.`}
+                compass={<DayCompass days={compassDays} />}
+                compassSources={<DayCompassSources days={compassDays} />}
               />
               {/*
                 The sighting layer from #121, reserved *on* the map rather than

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -67,6 +67,7 @@ import type { HourSeries } from "./HourChart";
 import { MeasuredPanel } from "./MeasuredPanel";
 import { MeasuredToday } from "./MeasuredToday";
 import { ReservedSlot } from "../ui/ReservedSlot";
+import type { CompassNeedle } from "./Compass";
 import { DayCompass, DayCompassSources, type CompassDay } from "./DayCompass";
 import {
   GRID_MODEL_NOTE,
@@ -74,7 +75,8 @@ import {
   GRID_SOURCE,
   gridCellCaveat,
 } from "./gridCell";
-import { gridWindReadings, needleFrom } from "./needles";
+import { MOP_MODEL_NOTE, MOP_NETWORK, mopLineSource } from "./mopLine";
+import { gridWindReadings, needleFrom, swellReadings } from "./needles";
 import { ShoreMap } from "./ShoreMap";
 import { shoreViewFor } from "./shore";
 import { SkyWording } from "./SkyWording";
@@ -546,6 +548,11 @@ export async function DayPanel({ slug }: { slug: string }) {
         ? grid.state.days.find((each) => each.localDate === day.localDate)
         : undefined;
 
+    const swellDay =
+      waves.state.kind === "week"
+        ? waves.state.days.find((each) => each.localDate === day.localDate)
+        : undefined;
+
     const wind =
       gridDay === undefined
         ? null
@@ -558,23 +565,46 @@ export async function DayPanel({ slug }: { slug: string }) {
             ),
           );
 
-    return {
-      localDate: day.localDate,
-      needles:
-        wind === null
-          ? []
-          : [
-              {
-                kind: "wind" as const,
-                label: "Wind",
-                fromDegT: wind.fromDegT,
-                spreadDeg: wind.spreadDeg,
-                source: GRID_SOURCE,
-                network: GRID_NETWORK,
-                note: cellNote,
-              },
-            ],
-    };
+    const swell =
+      swellDay === undefined || waves.line === null
+        ? null
+        : needleFrom(
+            swellReadings(swellDay.hours, day.sunriseMs, day.sunsetMs),
+          );
+
+    const needles: CompassNeedle[] = [];
+
+    /*
+      Wind first, and the order is the reading order rather than an accident.
+      It is the one a reader can feel standing on the sand, it is the needle
+      that changes most between days, and it is the one whose relationship to
+      the coast decides whether the water is choppy or glassy.
+    */
+    if (wind !== null) {
+      needles.push({
+        kind: "wind",
+        label: "Wind",
+        fromDegT: wind.fromDegT,
+        spreadDeg: wind.spreadDeg,
+        source: GRID_SOURCE,
+        network: GRID_NETWORK,
+        note: cellNote,
+      });
+    }
+
+    if (swell !== null && waves.line !== null) {
+      needles.push({
+        kind: "swell",
+        label: "Swell",
+        fromDegT: swell.fromDegT,
+        spreadDeg: swell.spreadDeg,
+        source: mopLineSource(waves.line.id),
+        network: MOP_NETWORK,
+        note: MOP_MODEL_NOTE,
+      });
+    }
+
+    return { localDate: day.localDate, needles };
   });
 
   return (

--- a/src/components/conditions/MeasuredToday.tsx
+++ b/src/components/conditions/MeasuredToday.tsx
@@ -43,6 +43,7 @@
  */
 
 import type { AirView, WavesView } from "@/lib/conditions";
+import { compassWords } from "./bearing";
 import { CARD_PROSE, PAGE_MUTED } from "./cardText";
 import { DISCLOSURE_TARGET } from "./disclosure";
 import { ProvenanceLine } from "./ProvenanceLine";
@@ -247,28 +248,6 @@ function SeaCard({ beachName, buoy, state }: WavesView) {
  * written to stop.
  */
 const CALM_MPH = 1;
-
-const COMPASS = [
-  "north",
-  "north-east",
-  "east",
-  "south-east",
-  "south",
-  "south-west",
-  "west",
-  "north-west",
-] as const;
-
-/**
- * Plain words for a direction in degrees true.
- *
- * METAR publishes the direction the wind blows *from*, which is why the caller
- * says "from the". Naming it as the direction it blows towards would reverse
- * every reading on the page.
- */
-function compassWords(degreesTrue: number): string {
-  return COMPASS[Math.round(degreesTrue / 45) % 8];
-}
 
 /**
  * How far the station is, in kilometres, rounded.

--- a/src/components/conditions/ShoreMap.test.tsx
+++ b/src/components/conditions/ShoreMap.test.tsx
@@ -1,5 +1,6 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { projectionFor } from "@/lib/coastline";
 import { ShoreMap, type ShoreMarker } from "./ShoreMap";
 
 /** A short run of coast running due north, west-facing like the real one. */
@@ -259,4 +260,81 @@ test("the drawn coast names what it was drawn from", () => {
   // Nothing to attribute when nothing is drawn.
   const bare = render(<ShoreMap {...PROPS} coast={[]} />).container;
   expect(bare.textContent).not.toContain(PROPS.coastCredit);
+});
+
+test("the dial is anchored on the beach, not in the middle of the frame", () => {
+  // The frame is sized by the sources, so at `mission-beach` a station nine
+  // kilometres away puts the frame's centre out in the county. A dial there
+  // would draw needles arriving at open water rather than at the sand.
+  const { container } = render(
+    <ShoreMap {...PROPS} compass={<circle data-test-dial="" r={1} />} />,
+  );
+
+  const anchor = container.querySelector("svg [data-compass-anchor]")!;
+  const project = projectionFor(BOUNDS, { width: 100, height: 100 });
+  const middle = PROPS.segment[Math.floor(PROPS.segment.length / 2)];
+  const at = project(middle.lat, middle.lon);
+
+  expect(anchor.getAttribute("transform")).toBe(
+    `translate(${at.x.toFixed(2)} ${at.y.toFixed(2)})`,
+  );
+  expect(anchor.querySelector("[data-test-dial]")).not.toBeNull();
+});
+
+test("a beach the coast does not reach gets its markers and no dial", () => {
+  // Cole's rule, and the reason for it: a bearing is worth reading against a
+  // coastline and is a bare gauge without one -- which is the anti-reference
+  // the brief opens with. 23 of 51 beaches are in this state.
+  //
+  // The segment here is the beach's own two ends and NOT null, because that is
+  // what `shore.ts` draws on 22 of those 23: with no coast to mark a run of, a
+  // chord is the only thing that says where the beach is. Written with a null
+  // segment this test passes with the coast check deleted, which is what
+  // mutating it revealed -- it was asserting `mission-bay-vacation-isle`, the
+  // one beach of the 23 whose ends coincide, and nothing about the other 22.
+  const { container } = render(
+    <ShoreMap
+      {...PROPS}
+      coast={[]}
+      segment={[
+        { lat: 32.77, lon: -117.24 },
+        { lat: 32.78, lon: -117.235 },
+      ]}
+      compass={<circle data-test-dial="" r={1} />}
+      compassSources={<p>Wind, from the west, 281°</p>}
+    />,
+  );
+
+  expect(container.querySelector("[data-compass-anchor]")).toBeNull();
+  expect(container.querySelector("[data-test-dial]")).toBeNull();
+  expect(screen.queryByText("Wind, from the west, 281°")).toBeNull();
+  // The markers are the part that works without a coastline, and they stay.
+  expect(screen.getByText(/Buoy Scripps Nearshore/)).toBeTruthy();
+});
+
+test("a beach whose two ends are one point gets no dial either", () => {
+  // `mission-bay-vacation-isle`, whose segment upper equals its lower, so
+  // there is neither a coast nor a chord to stand a dial on.
+  const { container } = render(
+    <ShoreMap
+      {...PROPS}
+      coast={[]}
+      segment={null}
+      compass={<circle data-test-dial="" r={1} />}
+    />,
+  );
+
+  expect(container.querySelector("[data-compass-anchor]")).toBeNull();
+});
+
+test("the needles' sources are listed beside the picture with the markers'", () => {
+  render(
+    <ShoreMap
+      {...PROPS}
+      compass={<circle data-test-dial="" r={1} />}
+      compassSources={<p>Wind, from the west, 281°</p>}
+    />,
+  );
+
+  expect(screen.getByText("Wind, from the west, 281°")).toBeTruthy();
 });

--- a/src/components/conditions/ShoreMap.test.tsx
+++ b/src/components/conditions/ShoreMap.test.tsx
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { projectionFor } from "@/lib/coastline";
-import { ShoreMap, type ShoreMarker } from "./ShoreMap";
+import { ShoreMap } from "./ShoreMap";
 
 /** A short run of coast running due north, west-facing like the real one. */
 const COAST = [
@@ -18,91 +18,18 @@ const BOUNDS = {
   east: -117.245,
 };
 
-const MARKERS: ShoreMarker[] = [
-  {
-    kind: "mop-line",
-    source: "MOP line D0498",
-    network: "CDIP, Scripps Institution of Oceanography",
-    distanceKm: "0.3",
-    lat: 32.862,
-    lon: -117.261,
-  },
-  {
-    kind: "wave-buoy",
-    source: "Buoy Scripps Nearshore",
-    network: "NDBC",
-    distanceKm: "1.6",
-    lat: 32.868,
-    lon: -117.267,
-  },
-  {
-    kind: "tide-station",
-    source: "La Jolla (Scripps Institution Wharf)",
-    network: "NOAA Tides & Currents",
-    distanceKm: null,
-    lat: 32.867,
-    lon: -117.257,
-  },
-];
-
 const PROPS = {
   coast: COAST,
   bounds: BOUNDS,
   // The middle two of the four, which is what a beach occupying part of the
   // window looks like.
   segment: COAST.slice(1, 3),
-  markers: MARKERS,
-  description: "A map of this beach and the four places its figures come from.",
+  description: "A map of this beach and its own stretch of coast.",
   absence: "We cannot place this beach on a map.",
   noCoast: "The coastline this site traces does not reach this beach.",
   coastCredit:
-    "Coast traced from CDIP's MOP lines, which run a few hundred metres offshore.",
+    "Coast traced from CDIP's MOP lines, which are computed a few hundred metres offshore.",
 };
-
-/** The provenance lines beside the picture, in order. */
-function credits(container: HTMLElement): string[] {
-  return [...container.querySelectorAll("li p")].map(
-    (node) => node.textContent ?? "",
-  );
-}
-
-test("every marker names the source it stands for", () => {
-  const { container } = render(<ShoreMap {...PROPS} />);
-  const lines = credits(container);
-
-  for (const marker of MARKERS) {
-    expect(lines.some((line) => line.startsWith(marker.source))).toBe(true);
-  }
-});
-
-test("a beach with no MOP line draws no MOP marker and does not silently omit it", () => {
-  // 26 of the 51 committed beaches bind no MOP line. The marker cannot be
-  // drawn, and a map that simply lacked it would read as a map of a beach that
-  // has one somewhere off-frame.
-  const { container } = render(
-    <ShoreMap
-      {...PROPS}
-      markers={MARKERS.filter((marker) => marker.kind !== "mop-line")}
-    />,
-  );
-
-  expect(credits(container).some((line) => line.includes("D0498"))).toBe(false);
-  expect(screen.getByText(/no swell model/i)).toBeTruthy();
-});
-
-test("a beach the traced coast does not reach keeps its markers and says so", () => {
-  // 23 of the 51 are in Mission Bay or San Diego Bay, 2.6 to 5.4 km from the
-  // nearest MOP line. They still get the markers, which is what ADR-0010 asks
-  // the map to draw; what they do not get is a shoreline invented for them.
-  const { container } = render(<ShoreMap {...PROPS} coast={[]} />);
-
-  expect(screen.getByText(PROPS.noCoast)).toBeTruthy();
-  expect(
-    credits(container).some((line) =>
-      line.startsWith("Buoy Scripps Nearshore"),
-    ),
-  ).toBe(true);
-});
 
 test("no box to draw is a sentence, never an empty frame", () => {
   // An empty frame on a page about the sea reads as open water.
@@ -135,45 +62,25 @@ test("this beach's own stretch of shore is drawn apart from the rest", () => {
   );
 });
 
-test("markers differ in shape, not only in colour", () => {
+test("the map plots no stations, buoys or model lines", () => {
+  // It used to plot all four at their real distances, which is ADR-0010 drawn
+  // rather than written. The page still names every source in words under the
+  // group it belongs to, which is what that decision actually requires; the
+  // picture is about where this beach is and which way the water lies.
   const { container } = render(<ShoreMap {...PROPS} />);
 
-  // The drawn shape rather than the SVG element: a diamond and a triangle are
-  // both <polygon>, so comparing tag names would call two different shapes the
-  // same and pass for the wrong reason.
-  const shapes = [...container.querySelectorAll("[data-marker]")].map((node) =>
-    node.getAttribute("data-shape"),
-  );
-
-  expect(shapes.length).toBe(MARKERS.length);
-  expect(new Set(shapes).size).toBe(MARKERS.length);
+  expect(container.querySelectorAll("[data-marker]")).toHaveLength(0);
+  expect(container.querySelectorAll("circle, rect, polygon")).toHaveLength(0);
 });
 
 test("the map says nothing the caller did not give it", () => {
   // ADR-0009's line, drawn rather than written: no depth, no hazard, no verdict
-  // about whether the water is safe. The only words are the names and distances
-  // handed in. Decoration is stripped first, because a glyph tying a name to
-  // its shape is not a claim about the sea.
+  // about whether the water is safe. The credit for the drawn shore is the only
+  // text, because it is the only thing the caller handed in.
   const { container } = render(<ShoreMap {...PROPS} />);
 
-  for (const decoration of container.querySelectorAll('[aria-hidden="true"]')) {
-    decoration.remove();
-  }
-
-  // The credit for the drawn shore, then exactly what ProvenanceLine composes
-  // from the fields each marker was handed. Nothing else.
-  const given =
-    PROPS.coastCredit +
-    MARKERS.map(
-      (marker) =>
-        `${marker.source} · ${marker.network}` +
-        (marker.distanceKm
-          ? ` · about ${marker.distanceKm} km from this beach`
-          : ""),
-    ).join("");
-
   expect((container.textContent ?? "").replace(/\s/g, "")).toBe(
-    given.replace(/\s/g, ""),
+    PROPS.coastCredit.replace(/\s/g, ""),
   );
 });
 
@@ -183,76 +90,55 @@ test("the whole picture has one spoken equivalent", () => {
   expect(screen.getByRole("img", { name: PROPS.description })).toBeTruthy();
 });
 
-test("the shaded side is the one the wave buoy is on", () => {
+test("the shaded side is the seaward one", () => {
   // The test the other sea assertion cannot make. A polygon closed on the wrong
-  // side draws the land as water and every existing assertion still passes:
-  // there is a [data-sea] path either way, and it is the same colour. The buoy
-  // is the one thing on this map known to be in the water.
+  // side draws the land as water and every other assertion here still passes:
+  // there is a [data-sea] path either way, and it is the same colour.
+  //
+  // This fixture's coast runs south to north down a west-facing shore, so the
+  // water is to the west — smaller longitude, and therefore smaller x once
+  // projected. It used to be checked against the plotted wave buoy, which was
+  // the one thing on the map known to be in the water; the map plots no buoy
+  // now, so the fixture's own geometry carries it.
   const { container } = render(<ShoreMap {...PROPS} />);
 
   const sea = container.querySelector("[data-sea]")!.getAttribute("d")!;
-  const buoyMark = container.querySelector('[data-marker="wave-buoy"]')!;
-  const buoyX = Number(buoyMark.getAttribute("points")!.split(",")[0]);
+  const xs = [...sea.matchAll(/[ML](-?[\d.]+) /g)].map((m) => Number(m[1]));
 
   // The polygon closes on two points pushed off-frame to the seaward side.
-  const xs = [...sea.matchAll(/[ML](-?[\d.]+) /g)].map((m) => Number(m[1]));
   const closing = xs.slice(-2);
   const coastXs = xs.slice(0, -2);
 
-  // Off-frame to the west, the same way the buoy sits from the coast.
   expect(Math.max(...closing)).toBeLessThan(Math.min(...coastXs));
-  expect(buoyX).toBeLessThan(Math.max(...coastXs));
+
+  // And a point known to be out at sea falls west of every drawn coast point,
+  // which is the direction the closing corners went.
+  const project = projectionFor(BOUNDS, { width: 100, height: 100 });
+  const offshore = project(32.865, -117.272);
+  expect(offshore.x).toBeLessThan(Math.min(...coastXs));
 });
 
-test("the sea fades away from the line rather than ending at it", () => {
-  // The line is CDIP's model line, 117 to 930 m offshore, not the shoreline --
-  // at La Jolla the tide gauge and the pier are both over water and both fall
-  // on its landward side. A hard edge would claim a boundary the data does not
-  // have, so the wash is transparent where the line is and opaque out to sea.
+test("the water is one solid wash, not a gradient", () => {
+  // It used to fade from transparent at the line out to full strength 644 m
+  // seaward, because the line is CDIP's model line rather than a shoreline and
+  // a hard edge would claim a boundary the data does not have. The reason for
+  // that was the two instruments it drew onto the beach, and the map plots no
+  // instruments now. What the fade left behind was a straight-edged wash across
+  // a coastline that is not straight.
   const { container } = render(<ShoreMap {...PROPS} />);
 
   const sea = container.querySelector("[data-sea]")!;
-  const gradient = container.querySelector("linearGradient");
 
-  expect(gradient).toBeTruthy();
-  expect(sea.getAttribute("fill")).toBe(
-    `url(#${gradient!.getAttribute("id")})`,
-  );
-
-  const stops = [...gradient!.querySelectorAll("stop")].map((stop) =>
-    Number(stop.getAttribute("stop-opacity")),
-  );
-  expect(stops[0]).toBe(0);
-  expect(stops[stops.length - 1]).toBeGreaterThan(0);
-});
-
-test("the fade is a real distance, so it shrinks as the frame widens", () => {
-  // The blur stands for the offset itself, so on a 20 km frame it is a few
-  // units and on a 4 km frame it is a sixth of the picture. A fade measured in
-  // frame units instead would blur a wide map by kilometres.
-  const near = render(<ShoreMap {...PROPS} />).container;
-  const wide = render(
-    <ShoreMap
-      {...PROPS}
-      bounds={{ south: 32.6, north: 33.0, west: -117.5, east: -117.1 }}
-    />,
-  ).container;
-
-  const spread = (root: HTMLElement): number => {
-    const g = root.querySelector("linearGradient")!;
-    return Math.hypot(
-      Number(g.getAttribute("x2")) - Number(g.getAttribute("x1")),
-      Number(g.getAttribute("y2")) - Number(g.getAttribute("y1")),
-    );
-  };
-
-  expect(spread(wide)).toBeLessThan(spread(near));
+  expect(container.querySelector("linearGradient")).toBeNull();
+  expect(sea.getAttribute("fill")).toBeNull();
+  expect(sea.getAttribute("class")).toContain("fill-ocean");
+  expect(Number(sea.getAttribute("fill-opacity"))).toBeGreaterThan(0);
 });
 
 test("the drawn coast names what it was drawn from", () => {
-  // The markers are attributed one by one and the shape they sit on was not,
-  // which is the defect this branch's own design review raised against the day
-  // chart. A line drawn from a published dataset is a figure like any other.
+  // A line drawn from a published dataset is a figure like any other, and this
+  // matters more than for most: nothing about looking at a line down a coast
+  // says it is a model line computed offshore rather than the shore itself.
   const { container } = render(<ShoreMap {...PROPS} />);
 
   expect(screen.getByText(PROPS.coastCredit)).toBeTruthy();
@@ -260,12 +146,13 @@ test("the drawn coast names what it was drawn from", () => {
   // Nothing to attribute when nothing is drawn.
   const bare = render(<ShoreMap {...PROPS} coast={[]} />).container;
   expect(bare.textContent).not.toContain(PROPS.coastCredit);
+  expect(container).toBeTruthy();
 });
 
 test("the dial is anchored on the beach, not in the middle of the frame", () => {
-  // The frame is sized by the sources, so at `mission-beach` a station nine
-  // kilometres away puts the frame's centre out in the county. A dial there
-  // would draw needles arriving at open water rather than at the sand.
+  // The frame is sized by the beach and the line off it, so the middle of the
+  // frame is near the beach but is not the beach. A dial there would draw
+  // needles arriving at open water rather than at the sand.
   const { container } = render(
     <ShoreMap {...PROPS} compass={<circle data-test-dial="" r={1} />} />,
   );
@@ -281,7 +168,7 @@ test("the dial is anchored on the beach, not in the middle of the frame", () => 
   expect(anchor.querySelector("[data-test-dial]")).not.toBeNull();
 });
 
-test("a beach the coast does not reach gets its markers and no dial", () => {
+test("a beach the coast does not reach gets no dial", () => {
   // Cole's rule, and the reason for it: a bearing is worth reading against a
   // coastline and is a bare gauge without one -- which is the anti-reference
   // the brief opens with. 23 of 51 beaches are in this state.
@@ -290,8 +177,7 @@ test("a beach the coast does not reach gets its markers and no dial", () => {
   // what `shore.ts` draws on 22 of those 23: with no coast to mark a run of, a
   // chord is the only thing that says where the beach is. Written with a null
   // segment this test passes with the coast check deleted, which is what
-  // mutating it revealed -- it was asserting `mission-bay-vacation-isle`, the
-  // one beach of the 23 whose ends coincide, and nothing about the other 22.
+  // mutating it revealed.
   const { container } = render(
     <ShoreMap
       {...PROPS}
@@ -308,8 +194,9 @@ test("a beach the coast does not reach gets its markers and no dial", () => {
   expect(container.querySelector("[data-compass-anchor]")).toBeNull();
   expect(container.querySelector("[data-test-dial]")).toBeNull();
   expect(screen.queryByText("Wind, from the west, 281°")).toBeNull();
-  // The markers are the part that works without a coastline, and they stay.
-  expect(screen.getByText(/Buoy Scripps Nearshore/)).toBeTruthy();
+  // The beach is still placed, which is the one question the picture has to
+  // answer when there is no shoreline to draw.
+  expect(container.querySelector("[data-segment]")).not.toBeNull();
 });
 
 test("a beach whose two ends are one point gets no dial either", () => {
@@ -327,7 +214,7 @@ test("a beach whose two ends are one point gets no dial either", () => {
   expect(container.querySelector("[data-compass-anchor]")).toBeNull();
 });
 
-test("the needles' sources are listed beside the picture with the markers'", () => {
+test("the needles' sources are listed beneath the picture", () => {
   render(
     <ShoreMap
       {...PROPS}

--- a/src/components/conditions/ShoreMap.tsx
+++ b/src/components/conditions/ShoreMap.tsx
@@ -1,34 +1,35 @@
 /**
- * This beach's own stretch of coast, with the four places its figures come
- * from plotted at their real distances.
+ * This beach's own stretch of coast, and which side of it the water is on.
  *
- * **ADR-0010's requirement drawn instead of written.** That decision ends on
- * "no figure is ever shown without the reader being able to see where it came
- * from", and the page has answered it in words ever since — a provenance line
- * under each group, a distance in kilometres. A reader who wants to know
- * whether the air temperature came from somewhere near the sand has been asked
- * to hold "1.4 km" in their head and imagine it. This draws it.
+ * **A picture of a place, not a picture of an inventory.** It drew the four
+ * sources every figure on the page comes from, each at its real distance —
+ * ADR-0010 answered by drawing rather than by writing. Reviewed on the built
+ * page that was the wrong picture: four glyphs of four shapes, two of them
+ * overlapping wherever a tide gauge is bolted to the pier an air station
+ * stands on, and a frame stretched to hold a station nobody was asking about.
+ * ADR-0010 is satisfied by the words it always named — a provenance line under
+ * every group, naming the station and its distance — and those are unchanged.
  *
- * **So the frame is sized by the sources, not by the beach.** Mission Beach's
- * map is 20 km tall because one of its stations is 9 km away, and the beach
- * being a fifth of that frame is the message rather than a defect. A map
- * comfortably framed on the sand would understate exactly the distance
- * ADR-0010 exists to disclose.
+ * **So the frame is sized by the beach and the line off it.** Not by the
+ * county's instruments: a frame sized by things that are not drawn is a rule
+ * nobody can see from the page, and it left `pacific-beach` framed on a
+ * station 7.4 km inland. The bound MOP line stays in that arithmetic because
+ * it is where the drawn coastline *is*, 117 to 930 m out, so a window without
+ * it crops the shoreline off the edge.
  *
  * **A quarter of the county has no coast to draw, and gets the map anyway.**
  * 23 of 51 beaches are in Mission Bay or San Diego Bay, between 2.6 and 5.4 km
  * from the nearest MOP line, because `mop-lines.json` traces the open coast
  * only. Widening their frames until the ocean appears was measured and
- * rejected: `mission-bay-vacation-isle` needs roughly five times the margin to
- * reach it, and what arrives is a shoreline 5 km away that is not this beach's
- * shore. They keep the markers — which are the part ADR-0010 asked for and the
- * part that works without a coastline — and the map says plainly that the
- * traced coast does not reach them.
+ * rejected: what arrives is a shoreline 5 km away that is not this beach's
+ * shore. They get their own stretch drawn as a chord — the one thing that says
+ * where the beach is — and the map says plainly that the traced coast does not
+ * reach them.
  *
  * **Presentational and pure**, like `DaySpark`. It takes a window, a box and a
- * list of markers, and renders them; it resolves no station, reads no file and
- * knows nothing about what a buoy is. The words are the caller's, which is this
- * repo's rule about who owns the copy on this page.
+ * stretch, and renders them; it resolves no station and reads no file. The
+ * words are the caller's, which is this repo's rule about who owns the copy on
+ * this page.
  *
  * **Hand-rolled SVG**, per ADR-0025, and for the same three reasons: the
  * runtime dependency budget is guarded, the largest thing drawn here is a few
@@ -36,42 +37,14 @@
  *
  * **The quiet register.** The brief puts the loud half of this site in the
  * chrome and asks the data to be drawn like a chart in a field guide. So: thin
- * strokes, one wash for the sea, no gridlines, no compass rose of our own, no
- * depth, no hazard and no verdict about whether the water is safe. ADR-0009's
- * line is easiest to cross with a picture, because a shaded sea is one
- * adjective away from a warning.
+ * strokes, one flat wash for the sea, no gridlines, no depth, no hazard and no
+ * verdict about whether the water is safe. ADR-0009's line is easiest to cross
+ * with a picture, because a shaded sea is one adjective away from a warning.
  */
 
 import type { ReactNode } from "react";
 import type { Bounds, Position, ShorePoint } from "@/lib/coastline";
 import { projectionFor } from "@/lib/coastline";
-import { ProvenanceLine } from "./ProvenanceLine";
-
-/** Which source a marker stands for. The list is closed on purpose. */
-export type ShoreMarkerKind =
-  "mop-line" | "wave-buoy" | "tide-station" | "air-station";
-
-/**
- * One plotted source, named and measured by the caller.
- *
- * The three text fields are `ProvenanceLine`'s own, passed through rather than
- * reworded. That component is this repo's single owner of how "how far away" is
- * said, and a map that spelled "about 1.4 km from this beach" itself would be
- * a fifth place for that phrasing to drift — which is the whole reason it was
- * made one component. The brief's inventory says as much: `ProvenanceLine`,
- * reuse, unchanged, "used per needle, per series and per map marker".
- */
-export type ShoreMarker = {
-  kind: ShoreMarkerKind;
-  /** What the figure names it, ready to print. Never a callsign turned into prose. */
-  source: string;
-  /** Who publishes it, or null where the binding genuinely does not know. */
-  network?: string | null;
-  /** Kilometres, already rounded by the caller's own threshold, or null. */
-  distanceKm?: string | null;
-  lat: number;
-  lon: number;
-};
 
 export type ShoreMapProps = {
   /** The windowed coast in walk order. Empty draws no shoreline and says so. */
@@ -88,7 +61,6 @@ export type ShoreMapProps = {
    * says where the beach is. `shore.ts` makes that choice.
    */
   segment: readonly Position[] | null;
-  markers: readonly ShoreMarker[];
   /** The spoken equivalent of the whole picture. */
   description: string;
   /** What to say instead of a map when there is no box at all. */
@@ -98,11 +70,11 @@ export type ShoreMapProps = {
   /**
    * What the drawn shore was traced from, said once under the picture.
    *
-   * The markers are attributed one at a time and the shape they sit on was not,
-   * which is ADR-0010's rule applied to everything except the largest thing on
-   * the map. It matters more here than for an ordinary figure, because the line
-   * is CDIP's model line rather than a shoreline and a reader has no way to
-   * know that from looking.
+   * ADR-0010's rule applied to the largest thing on the map, which is now the
+   * only thing on it. It matters more here than for an ordinary figure: nothing
+   * about looking at a line down a coast says it is a model line computed a few
+   * hundred metres offshore rather than the shore itself, so these words are the
+   * only place a reader can learn it.
    */
   coastCredit: string;
   /**
@@ -122,13 +94,12 @@ export type ShoreMapProps = {
    */
   compass?: ReactNode;
   /**
-   * What the dial says, listed with the markers' own names below the picture.
+   * What the dial says, printed beneath the picture.
    *
-   * Two slots and not one, because these are the same split every marker on
-   * this map already has: a shape inside the frame, a name outside it. The
-   * `<svg>` is one `role="img"`, so nothing drawn inside it reaches the
-   * accessibility tree and this block is the dial's text equivalent rather than
-   * a caption on it.
+   * Two slots and not one, because the dial is drawn inside the frame and read
+   * outside it. The `<svg>` is one `role="img"`, so nothing drawn in it reaches
+   * the accessibility tree, and this block is the dial's text equivalent rather
+   * than a caption on it.
    *
    * **Both halves go together, and go together with the coast.** A dial drawn
    * with its sources missing is an unattributed figure; sources printed under a
@@ -155,37 +126,6 @@ const HEIGHT = 100;
  * `<svg>` clips to its own viewport, so the overshoot costs nothing.
  */
 const OFF_FRAME = 2 * Math.hypot(WIDTH, HEIGHT);
-
-/**
- * A different shape per source, so colour is never the only thing telling two
- * markers apart.
- *
- * The brief's accessibility rule, and the one a map breaks most easily: four
- * dots in four hues is a legend waiting to happen, which is also an
- * anti-reference. A reader who cannot separate the hues still sees a square, a
- * triangle, a diamond and a ring.
- */
-const MARKS: Record<
-  ShoreMarkerKind,
-  "square" | "triangle" | "diamond" | "ring"
-> = {
-  "mop-line": "square",
-  "wave-buoy": "triangle",
-  "tide-station": "diamond",
-  "air-station": "ring",
-};
-
-/**
- * Every marker is outlined in the page's own ground.
- *
- * Two of the four sources are frequently the same place — at La Jolla the tide
- * gauge is bolted to the pier the air station is on, 200 m apart in a 3.9 km
- * frame — and two filled shapes at one point drew a single black smudge. A
- * halo in the ground colour separates them, so a reader sees two markers on top
- * of each other rather than one shape they cannot name. It is also the honest
- * picture: those stations really are in the same place.
- */
-const HALO = "stroke-cream";
 
 /**
  * The sea, as a polygon closed off the edge of the frame.
@@ -244,48 +184,10 @@ function seaPath(
   };
 }
 
-/**
- * How far offshore the drawn line actually is, in metres.
- *
- * **The line is not the shoreline, and this number is the difference.** CDIP's
- * MOP lines are computed at 10 m depth, and measured across the 25 beaches that
- * bind one they stand 117 to 930 m out, median 644. At La Jolla the line is
- * about 310 m seaward of the beach's own coordinate — which is why the Scripps
- * tide gauge and the pier it is bolted to, both of them over water, fall on the
- * landward side of it.
- *
- * A hard sea-and-land edge would claim a boundary the data does not have, and
- * would claim it most loudly at the beach the page opens on. So the wash is
- * transparent where the line is and reaches full strength this far out: the
- * picture says the sea is that way, and declines to say the edge is here.
- *
- * The median rather than the maximum, because it is the typical offset rather
- * than the worst one, and a blur sized by the worst case would swallow the
- * tightest frames. Held as a real distance so it scales with the map: a few
- * units on `mission-beach`'s 20 km frame, a sixth of the picture on La Jolla's
- * 3.9 km one.
- */
-const MODEL_LINE_OFFSET_M = 644;
-
-/** Metres per degree of latitude, from the mean earth radius `scripts/geo.mjs` uses. */
-const METRES_PER_DEGREE_LAT = (2 * Math.PI * 6371008.8) / 360;
-
-/**
- * One id, because a page carries one map.
- *
- * A gradient is referenced by id, so two maps in one document would share this
- * one — which is fine, since they would want the same fade, and wrong only if
- * they ever wanted different ones. `useId` is not available here: this renders
- * on the server, which is ADR-0025's requirement for the page's primary
- * content.
- */
-const SEA_FADE_ID = "shore-map-sea";
-
 export function ShoreMap({
   coast,
   bounds,
   segment,
-  markers,
   description,
   absence,
   noCoast,
@@ -310,14 +212,6 @@ export function ShoreMap({
 
   const sea = hasCoast ? seaPath(path, drawn) : null;
 
-  // Plot units per metre, from the projection itself rather than from a second
-  // copy of its arithmetic, so the fade cannot drift from the drawing.
-  const unitsPerMetre =
-    (project(bounds.south, bounds.west).y -
-      project(bounds.north, bounds.west).y) /
-    ((bounds.north - bounds.south) * METRES_PER_DEGREE_LAT);
-  const fade = MODEL_LINE_OFFSET_M * unitsPerMetre;
-
   /*
     Where the dial stands: the middle of the beach's own drawn stretch.
 
@@ -336,10 +230,6 @@ export function ShoreMap({
           return project(middle.lat, middle.lon);
         })();
 
-  const missing = MISSING_SOURCES.filter(
-    ([kind]) => !markers.some((marker) => marker.kind === kind),
-  );
-
   return (
     <div>
       <svg
@@ -355,30 +245,12 @@ export function ShoreMap({
           shading implies depth and depth here would be invented.
         */}
         {sea !== null && (
-          <>
-            <defs>
-              <linearGradient
-                id={SEA_FADE_ID}
-                gradientUnits="userSpaceOnUse"
-                x1={sea.from.x}
-                y1={sea.from.y}
-                x2={sea.from.x + sea.unit.x * fade}
-                y2={sea.from.y + sea.unit.y * fade}
-              >
-                <stop
-                  offset="0"
-                  stopColor="var(--color-ocean)"
-                  stopOpacity={0}
-                />
-                <stop
-                  offset="1"
-                  stopColor="var(--color-ocean)"
-                  stopOpacity={0.14}
-                />
-              </linearGradient>
-            </defs>
-            <path d={sea.d} fill={`url(#${SEA_FADE_ID})`} data-sea="" />
-          </>
+          <path
+            d={sea.d}
+            className="fill-ocean"
+            fillOpacity={0.16}
+            data-sea=""
+          />
         )}
 
         {hasCoast && (
@@ -417,16 +289,7 @@ export function ShoreMap({
           />
         )}
 
-        {markers.map((marker) => (
-          <Mark key={marker.kind} marker={marker} project={project} />
-        ))}
-
-        {/*
-          Last, so the needles sit over the markers rather than under them. Two
-          of the four sources are often within a few hundred metres of the sand
-          -- at La Jolla the tide gauge and the air station share a pier -- so a
-          dial drawn first would have its shaft interrupted by them.
-        */}
+        {/* Last, so the dial sits over the coast rather than under it. */}
         {anchor !== null && (
           <g
             transform={`translate(${anchor.x.toFixed(2)} ${anchor.y.toFixed(2)})`}
@@ -443,121 +306,7 @@ export function ShoreMap({
         <p className="text-2xs text-fog mt-2 italic">{noCoast}</p>
       )}
 
-      {/*
-        The names live beside the picture rather than on it. A label per marker
-        inside a 100-unit frame either overlaps its neighbour or shrinks under
-        the 10px floor ADR-0024 refused to go below, and both are worse than a
-        list. This is also what carries the marker names to a reader who is not
-        looking at the shapes.
-      */}
-      <ul className="mt-2 flex flex-col gap-1">
-        {markers.map((marker) => (
-          <li key={marker.kind} className="flex items-baseline gap-1.5">
-            <span aria-hidden="true" className="text-2xs">
-              {GLYPHS[marker.kind]}
-            </span>
-            <ProvenanceLine
-              source={marker.source}
-              network={marker.network ?? null}
-              distanceKm={marker.distanceKm ?? null}
-              surface="page"
-            />
-          </li>
-        ))}
-        {missing.map(([kind, sentence]) => (
-          <li key={kind} className="text-2xs text-fog leading-normal italic">
-            {sentence}
-          </li>
-        ))}
-      </ul>
-
       {anchor !== null && compassSources}
     </div>
-  );
-}
-
-/**
- * What is said when a source is not bound, rather than leaving a gap.
- *
- * A map missing a marker reads as a map of a beach whose buoy is off-frame,
- * which is a different and wrong claim. 26 of 51 beaches bind no MOP line and
- * 36 bind no wave buoy, so this is the common case rather than the edge one.
- * No issue numbers and no promises: what is absent is absent.
- */
-const MISSING_SOURCES: readonly (readonly [ShoreMarkerKind, string])[] = [
-  ["mop-line", "No swell model is computed for this beach."],
-  ["wave-buoy", "No wave buoy is bound to this beach."],
-];
-
-/** Drawn beside each name, and hidden from assistive tech: the list says it. */
-const GLYPHS: Record<ShoreMarkerKind, string> = {
-  "mop-line": "◼",
-  "wave-buoy": "▲",
-  "tide-station": "◆",
-  "air-station": "◯",
-};
-
-function Mark({
-  marker,
-  project,
-}: {
-  marker: ShoreMarker;
-  project: (lat: number, lon: number) => { x: number; y: number };
-}) {
-  const at = project(marker.lat, marker.lon);
-  const shape = MARKS[marker.kind];
-  const size = 2.4;
-  const common = {
-    "data-marker": marker.kind,
-    "data-shape": shape,
-    vectorEffect: "non-scaling-stroke" as const,
-  };
-
-  if (shape === "square") {
-    return (
-      <rect
-        x={at.x - size / 2}
-        y={at.y - size / 2}
-        width={size}
-        height={size}
-        className={`fill-ink ${HALO}`}
-        strokeWidth={1.2}
-        {...common}
-      />
-    );
-  }
-
-  if (shape === "triangle") {
-    return (
-      <polygon
-        points={`${at.x},${at.y - size} ${at.x - size},${at.y + size * 0.72} ${at.x + size},${at.y + size * 0.72}`}
-        className={`fill-ink ${HALO}`}
-        strokeWidth={1.2}
-        {...common}
-      />
-    );
-  }
-
-  if (shape === "diamond") {
-    return (
-      <polygon
-        points={`${at.x},${at.y - size} ${at.x + size},${at.y} ${at.x},${at.y + size} ${at.x - size},${at.y}`}
-        className={`fill-ink ${HALO}`}
-        strokeWidth={1.2}
-        {...common}
-      />
-    );
-  }
-
-  return (
-    <circle
-      cx={at.x}
-      cy={at.y}
-      r={size * 0.85}
-      fill="none"
-      className="stroke-ink"
-      strokeWidth={1.6}
-      {...common}
-    />
   );
 }

--- a/src/components/conditions/ShoreMap.tsx
+++ b/src/components/conditions/ShoreMap.tsx
@@ -42,6 +42,7 @@
  * adjective away from a warning.
  */
 
+import type { ReactNode } from "react";
 import type { Bounds, Position, ShorePoint } from "@/lib/coastline";
 import { projectionFor } from "@/lib/coastline";
 import { ProvenanceLine } from "./ProvenanceLine";
@@ -104,6 +105,37 @@ export type ShoreMapProps = {
    * know that from looking.
    */
   coastCredit: string;
+  /**
+   * The dial, already rendered, placed in the map's own drawing space.
+   *
+   * A slot rather than data, because the needles change with the day a reader
+   * picks and this picture does not: the map is built once on the server and
+   * this is the one part of it that varies. `DayCompass` is what fills it.
+   *
+   * It is translated onto the beach's own stretch of coast rather than left at
+   * the frame's middle, because the frame is sized by the sources -- at
+   * `mission-beach` a station nine kilometres away puts the middle of the frame
+   * out in the county, and needles arriving there arrive at nothing.
+   *
+   * Withheld along with everything else when there is no coast to read a
+   * bearing against. See `compassSources`.
+   */
+  compass?: ReactNode;
+  /**
+   * What the dial says, listed with the markers' own names below the picture.
+   *
+   * Two slots and not one, because these are the same split every marker on
+   * this map already has: a shape inside the frame, a name outside it. The
+   * `<svg>` is one `role="img"`, so nothing drawn inside it reaches the
+   * accessibility tree and this block is the dial's text equivalent rather than
+   * a caption on it.
+   *
+   * **Both halves go together, and go together with the coast.** A dial drawn
+   * with its sources missing is an unattributed figure; sources printed under a
+   * map with no dial name a needle nobody can see. On the 23 beaches the traced
+   * coast does not reach, neither is rendered.
+   */
+  compassSources?: ReactNode;
 };
 
 /**
@@ -258,6 +290,8 @@ export function ShoreMap({
   absence,
   noCoast,
   coastCredit,
+  compass = null,
+  compassSources = null,
 }: ShoreMapProps) {
   if (bounds === null) {
     return <p className="text-2xs text-fog italic">{absence}</p>;
@@ -283,6 +317,24 @@ export function ShoreMap({
       project(bounds.north, bounds.west).y) /
     ((bounds.north - bounds.south) * METRES_PER_DEGREE_LAT);
   const fade = MODEL_LINE_OFFSET_M * unitsPerMetre;
+
+  /*
+    Where the dial stands: the middle of the beach's own drawn stretch.
+
+    Null wherever that stretch is not a run of the coast, which is exactly the
+    23 beaches the traced coastline does not reach. That is not an
+    implementation detail standing in for the rule -- a bearing read against no
+    shoreline is the bare gauge the brief's anti-references open with -- but the
+    two conditions are the same one, so the map cannot draw a dial it has
+    nothing to draw it against.
+  */
+  const anchor =
+    compass === null || !hasCoast || segment === null || segment.length < 2
+      ? null
+      : (() => {
+          const middle = segment[Math.floor(segment.length / 2)];
+          return project(middle.lat, middle.lon);
+        })();
 
   const missing = MISSING_SOURCES.filter(
     ([kind]) => !markers.some((marker) => marker.kind === kind),
@@ -368,6 +420,21 @@ export function ShoreMap({
         {markers.map((marker) => (
           <Mark key={marker.kind} marker={marker} project={project} />
         ))}
+
+        {/*
+          Last, so the needles sit over the markers rather than under them. Two
+          of the four sources are often within a few hundred metres of the sand
+          -- at La Jolla the tide gauge and the air station share a pier -- so a
+          dial drawn first would have its shaft interrupted by them.
+        */}
+        {anchor !== null && (
+          <g
+            transform={`translate(${anchor.x.toFixed(2)} ${anchor.y.toFixed(2)})`}
+            data-compass-anchor=""
+          >
+            {compass}
+          </g>
+        )}
       </svg>
 
       {hasCoast ? (
@@ -403,6 +470,8 @@ export function ShoreMap({
           </li>
         ))}
       </ul>
+
+      {anchor !== null && compassSources}
     </div>
   );
 }

--- a/src/components/conditions/bearing.test.ts
+++ b/src/components/conditions/bearing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { compassWords } from "./bearing";
+import { bearingSpread, compassWords, resultantBearing } from "./bearing";
 
 describe("compassWords", () => {
   it("names each of the eight points at its own bearing", () => {
@@ -25,5 +25,109 @@ describe("compassWords", () => {
     // rounding rule and the boundary is where an off-by-one shows up.
     expect(compassWords(22)).toBe("north");
     expect(compassWords(23)).toBe("north-east");
+  });
+});
+
+describe("resultantBearing", () => {
+  it("returns the one bearing it was given", () => {
+    expect(resultantBearing([{ degreesTrue: 281, weight: 9 }])).toBeCloseTo(
+      281,
+      6,
+    );
+  });
+
+  it("averages across north rather than through south", () => {
+    // The failure this exists to catch: (340 + 20) / 2 is 180, which is due
+    // south and the exact opposite of the answer.
+    const mean = resultantBearing([
+      { degreesTrue: 340, weight: 5 },
+      { degreesTrue: 20, weight: 5 },
+    ]);
+    expect(mean).toBeCloseTo(0, 6);
+  });
+
+  it("leans towards the hour that carried the most wind", () => {
+    // A 2 mph easterly and a 12 mph westerly are not a southerly average.
+    const mean = resultantBearing([
+      { degreesTrue: 90, weight: 2 },
+      { degreesTrue: 270, weight: 12 },
+    ]);
+    expect(mean).toBeCloseTo(270, 6);
+  });
+
+  it("ignores an hour with no wind in it", () => {
+    const withCalm = resultantBearing([
+      { degreesTrue: 270, weight: 8 },
+      { degreesTrue: 90, weight: 0 },
+    ]);
+    expect(withCalm).toBeCloseTo(270, 6);
+  });
+
+  it("has no answer when the hours cancel exactly", () => {
+    expect(
+      resultantBearing([
+        { degreesTrue: 90, weight: 5 },
+        { degreesTrue: 270, weight: 5 },
+      ]),
+    ).toBeNull();
+  });
+
+  it("has no answer when there is nothing to average", () => {
+    expect(resultantBearing([])).toBeNull();
+    expect(resultantBearing([{ degreesTrue: 90, weight: 0 }])).toBeNull();
+  });
+});
+
+describe("bearingSpread", () => {
+  it("is zero for one bearing", () => {
+    expect(bearingSpread([{ degreesTrue: 281, weight: 9 }])).toBe(0);
+  });
+
+  it("is zero when every hour blew from the same point", () => {
+    expect(
+      bearingSpread([
+        { degreesTrue: 210, weight: 4 },
+        { degreesTrue: 210, weight: 7 },
+        { degreesTrue: 210, weight: 2 },
+      ]),
+    ).toBe(0);
+  });
+
+  it("measures the short way round north, not the long way", () => {
+    // 350 and 10 are twenty degrees apart. Sorting and subtracting says 340.
+    expect(
+      bearingSpread([
+        { degreesTrue: 350, weight: 6 },
+        { degreesTrue: 10, weight: 6 },
+      ]),
+    ).toBeCloseTo(20, 6);
+  });
+
+  it("excludes the widest gap rather than the last step", () => {
+    // Three bearings clustered in the west with the whole eastern half empty.
+    expect(
+      bearingSpread([
+        { degreesTrue: 250, weight: 3 },
+        { degreesTrue: 270, weight: 3 },
+        { degreesTrue: 300, weight: 3 },
+      ]),
+    ).toBeCloseTo(50, 6);
+  });
+
+  it("ignores an hour with no wind in it", () => {
+    // A calm hour's published bearing is a number the instrument had to emit,
+    // not a direction anybody felt, and it must not widen the arc.
+    expect(
+      bearingSpread([
+        { degreesTrue: 270, weight: 8 },
+        { degreesTrue: 280, weight: 4 },
+        { degreesTrue: 90, weight: 0 },
+      ]),
+    ).toBeCloseTo(10, 6);
+  });
+
+  it("has no answer when there is nothing to measure", () => {
+    expect(bearingSpread([])).toBeNull();
+    expect(bearingSpread([{ degreesTrue: 90, weight: 0 }])).toBeNull();
   });
 });

--- a/src/components/conditions/bearing.test.ts
+++ b/src/components/conditions/bearing.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { compassWords } from "./bearing";
+
+describe("compassWords", () => {
+  it("names each of the eight points at its own bearing", () => {
+    expect(compassWords(0)).toBe("north");
+    expect(compassWords(45)).toBe("north-east");
+    expect(compassWords(90)).toBe("east");
+    expect(compassWords(135)).toBe("south-east");
+    expect(compassWords(180)).toBe("south");
+    expect(compassWords(225)).toBe("south-west");
+    expect(compassWords(270)).toBe("west");
+    expect(compassWords(315)).toBe("north-west");
+  });
+
+  it("wraps past the last point back to north rather than off the end", () => {
+    // 359 rounds to the ninth bucket, which is north again. Without the
+    // modulo this reads `undefined` and prints "from the undefined".
+    expect(compassWords(359)).toBe("north");
+    expect(compassWords(360)).toBe("north");
+  });
+
+  it("splits a bucket at its half-way bearing", () => {
+    // The boundary rather than the middle, because the middle passes under any
+    // rounding rule and the boundary is where an off-by-one shows up.
+    expect(compassWords(22)).toBe("north");
+    expect(compassWords(23)).toBe("north-east");
+  });
+});

--- a/src/components/conditions/bearing.ts
+++ b/src/components/conditions/bearing.ts
@@ -50,3 +50,116 @@ const COMPASS = [
 export function compassWords(degreesTrue: number): string {
   return COMPASS[Math.round(degreesTrue / 45) % 8];
 }
+
+/**
+ * One hour's direction, and how much of the thing there was to have one.
+ *
+ * **The weight is what stops a dead hour voting.** A gridpoint publishes a wind
+ * direction for every hour whether or not there is any wind, so a 0 mph
+ * pre-dawn bearing is a number the model had to emit rather than a direction
+ * anybody could have felt. Weighting by speed is the standard resultant-wind
+ * treatment and it is also the honest one here: the needle then points where
+ * the wind mostly came from rather than where the average of its labels lies.
+ *
+ * The caller says what the weight is -- miles per hour for the wind, feet of
+ * significant height for the swell -- because the two feeds measure different
+ * things and neither function needs to know which.
+ */
+export type WeightedBearing = {
+  /** Degrees true, the direction it comes *from*. */
+  degreesTrue: number;
+  /** How much there was. Zero or less takes the reading out of the answer. */
+  weight: number;
+};
+
+/**
+ * Below this, the readings have cancelled and there is no resultant to draw.
+ *
+ * Compared against the total weight rather than as an absolute, so it means the
+ * same thing for a 2 mph day and a 20 mph one. It is a floating-point guard,
+ * not a judgement about weak winds: two exactly opposed hours sum to about
+ * 1e-16 of their own weight, and every real day is many orders above it.
+ */
+const CANCELLED = 1e-9;
+
+/** Everything with something in it, which is what both answers are built from. */
+function carrying(
+  readings: readonly WeightedBearing[],
+): readonly WeightedBearing[] {
+  return readings.filter((reading) => reading.weight > 0);
+}
+
+/**
+ * Where these hours mostly came from, weighted by how much there was.
+ *
+ * **Vectors, not an average of the numbers**, and that is the whole of it:
+ * bearings are angles on a circle, so 340 and 20 average to 180 -- due south,
+ * the exact reverse of the answer -- under any arithmetic that treats them as
+ * quantities. Summing unit vectors and taking the angle back off the sum is the
+ * circular mean, and it wraps because the circle does.
+ *
+ * `null` when there is nothing to average, or when the hours cancel: a day that
+ * blew equally from the east and the west has no resultant direction, and
+ * drawing one would be inventing the answer the data declined to give.
+ */
+export function resultantBearing(
+  readings: readonly WeightedBearing[],
+): number | null {
+  const carried = carrying(readings);
+  if (carried.length === 0) return null;
+
+  let x = 0;
+  let y = 0;
+  let total = 0;
+  for (const { degreesTrue, weight } of carried) {
+    const radians = (degreesTrue * Math.PI) / 180;
+    x += weight * Math.cos(radians);
+    y += weight * Math.sin(radians);
+    total += weight;
+  }
+
+  if (Math.hypot(x, y) / total < CANCELLED) return null;
+
+  return ((Math.atan2(y, x) * 180) / Math.PI + 360) % 360;
+}
+
+/**
+ * The smallest arc that contains every one of these bearings.
+ *
+ * **Found by looking for the emptiest part of the circle**, not by sorting and
+ * subtracting: 350 and 10 are twenty degrees apart, and the difference of the
+ * sorted values says 340. The widest gap between neighbours is the part of the
+ * dial nothing blew from, so what is left over is the arc that holds them all.
+ *
+ * Unweighted, unlike the needle, because this is the envelope rather than the
+ * average -- an hour that happened is inside the range whether it was a strong
+ * hour or a weak one. It uses the same `weight > 0` filter for the same reason
+ * the needle does: a calm hour has no direction to be inside the range.
+ *
+ * `null` when there is nothing to measure, and 0 for a single bearing or for a
+ * day that never shifted.
+ */
+export function bearingSpread(
+  readings: readonly WeightedBearing[],
+): number | null {
+  const carried = carrying(readings);
+  if (carried.length === 0) return null;
+
+  const sorted = carried
+    .map(({ degreesTrue }) => ((degreesTrue % 360) + 360) % 360)
+    .sort((a, b) => a - b);
+
+  /*
+    The gap that closes the circle is measured on its own and without a modulo.
+    Taking it as `(first - last + 360) % 360` reads 0 when every bearing is the
+    same, which makes the widest gap 0 and the arc the whole dial -- a day that
+    never shifted reported as a day that blew from everywhere.
+  */
+  let widestGap = sorted[0] + 360 - sorted[sorted.length - 1];
+  for (let index = 0; index + 1 < sorted.length; index += 1) {
+    const gap = sorted[index + 1] - sorted[index];
+    if (gap > widestGap) widestGap = gap;
+  }
+
+  return 360 - widestGap;
+}

--- a/src/components/conditions/bearing.ts
+++ b/src/components/conditions/bearing.ts
@@ -1,0 +1,52 @@
+/**
+ * How this page says a direction.
+ *
+ * **One vocabulary, because two would be visible on one screen.** The measured
+ * air card has worded a bearing since it was written, and the compass on the
+ * shore map words two more a few hundred pixels away. A page that called 281
+ * degrees "west" beside a needle calling it "west-northwest" would be reporting
+ * a disagreement it does not have — which is the drift `CONTEXT.md`'s glossary
+ * exists to prevent, arriving through a helper rather than through a term.
+ *
+ * Lifted out of `MeasuredToday` unchanged when the compass needed it. Its own
+ * module rather than an export from that component, because a component
+ * exporting a helper makes the second caller depend on the first one's file.
+ */
+
+/**
+ * Eight points, not sixteen.
+ *
+ * The design brief's example accessible name reads "wind from the
+ * west-northwest, 281 degrees", which is a sixteen-point rose. This is eight,
+ * because eight is what the air card has always printed and the two sit on one
+ * page: adding the finer rose for the needles would either say "west" and
+ * "west-northwest" about the same wind in two places, or change the card's
+ * words as a side effect of building a compass.
+ *
+ * What the finer rose was for is the precision, and the degrees carry that
+ * already — every place these words are spoken states the bearing beside them.
+ */
+const COMPASS = [
+  "north",
+  "north-east",
+  "east",
+  "south-east",
+  "south",
+  "south-west",
+  "west",
+  "north-west",
+] as const;
+
+/**
+ * Plain words for a direction in degrees true.
+ *
+ * Every feed this page reads publishes the direction the wind or the swell
+ * comes *from*, which is why every caller says "from the". Naming it as the
+ * direction it travels towards would reverse every reading on the page.
+ *
+ * The modulo is not defensive: 359 rounds to the ninth bucket, and without it
+ * the page prints "from the undefined".
+ */
+export function compassWords(degreesTrue: number): string {
+  return COMPASS[Math.round(degreesTrue / 45) % 8];
+}

--- a/src/components/conditions/compass.test.ts
+++ b/src/components/conditions/compass.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import type { GridDaySeries } from "@/lib/conditions";
+import { gridWindReadings, needleFrom } from "./compass";
+
+/** 2026-08-17 in Pacific: sunrise 06:15, sunset 19:30, as epoch milliseconds. */
+const SUNRISE = Date.UTC(2026, 7, 17, 13, 15);
+const SUNSET = Date.UTC(2026, 7, 18, 2, 30);
+const hour = (utcHour: number) => Date.UTC(2026, 7, 17, utcHour, 0);
+
+function published(
+  hours: readonly { atMs: number; value: number }[],
+): GridDaySeries {
+  return {
+    kind: "published",
+    hours: hours.map((h) => ({ ...h, published: true })),
+  };
+}
+
+describe("gridWindReadings", () => {
+  it("pairs each direction with the speed published for the same instant", () => {
+    const readings = gridWindReadings(
+      published([{ atMs: hour(18), value: 281 }]),
+      published([{ atMs: hour(18), value: 9 }]),
+      SUNRISE,
+      SUNSET,
+    );
+
+    expect(readings).toEqual([{ degreesTrue: 281, weight: 9 }]);
+  });
+
+  it("pairs by instant and not by position", () => {
+    // The two series are gapless in the committed run, so joining by index
+    // happens to work today and would put the wrong speed on the wrong bearing
+    // the first time one of them is short.
+    const readings = gridWindReadings(
+      published([
+        { atMs: hour(18), value: 281 },
+        { atMs: hour(19), value: 20 },
+      ]),
+      published([{ atMs: hour(19), value: 12 }]),
+      SUNRISE,
+      SUNSET,
+    );
+
+    expect(readings).toEqual([{ degreesTrue: 20, weight: 12 }]);
+  });
+
+  it("keeps only the hours inside the daylight window", () => {
+    // The arc is the range the wind swings through during daylight, and the
+    // fixture's overnight hours swing across north: 340, 20, 150 in the first
+    // three. Including them would draw an arc nobody could have stood in.
+    const readings = gridWindReadings(
+      published([
+        { atMs: hour(9), value: 340 },
+        { atMs: hour(18), value: 281 },
+        { atMs: hour(23), value: 270 },
+      ]),
+      published([
+        { atMs: hour(9), value: 3 },
+        { atMs: hour(18), value: 9 },
+        { atMs: hour(23), value: 7 },
+      ]),
+      SUNRISE,
+      SUNSET,
+    );
+
+    expect(readings).toEqual([
+      { degreesTrue: 281, weight: 9 },
+      { degreesTrue: 270, weight: 7 },
+    ]);
+  });
+
+  it("drops an hour whose speed the cell did not publish", () => {
+    const readings = gridWindReadings(
+      published([
+        { atMs: hour(18), value: 281 },
+        { atMs: hour(19), value: 300 },
+      ]),
+      published([{ atMs: hour(18), value: 9 }]),
+      SUNRISE,
+      SUNSET,
+    );
+
+    expect(readings).toEqual([{ degreesTrue: 281, weight: 9 }]);
+  });
+
+  it("has nothing to read when the cell publishes no direction", () => {
+    expect(
+      gridWindReadings(
+        {
+          kind: "absent",
+          reason: "the cell declares windDirection and published none",
+        },
+        published([{ atMs: hour(18), value: 9 }]),
+        SUNRISE,
+        SUNSET,
+      ),
+    ).toEqual([]);
+  });
+
+  it("has nothing to read when the cell publishes no speed to weight by", () => {
+    expect(
+      gridWindReadings(
+        published([{ atMs: hour(18), value: 281 }]),
+        {
+          kind: "absent",
+          reason: "the cell declares windSpeed and published none",
+        },
+        SUNRISE,
+        SUNSET,
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("needleFrom", () => {
+  it("carries the resultant bearing and the arc it swung through", () => {
+    const needle = needleFrom([
+      { degreesTrue: 260, weight: 6 },
+      { degreesTrue: 280, weight: 6 },
+    ]);
+
+    expect(needle?.fromDegT).toBeCloseTo(270, 6);
+    expect(needle?.spreadDeg).toBeCloseTo(20, 6);
+  });
+
+  it("is withheld when there is nothing to draw", () => {
+    expect(needleFrom([])).toBeNull();
+  });
+
+  it("is withheld when the hours cancel and there is no direction to point", () => {
+    // A spread without a bearing is half an instrument: an arc with no needle
+    // in it says the wind had a range and declines to say where in it. Both or
+    // neither.
+    expect(
+      needleFrom([
+        { degreesTrue: 90, weight: 5 },
+        { degreesTrue: 270, weight: 5 },
+      ]),
+    ).toBeNull();
+  });
+});

--- a/src/components/conditions/compass.ts
+++ b/src/components/conditions/compass.ts
@@ -1,0 +1,86 @@
+/**
+ * What one day's needles are made of, assembled from the series the page
+ * already reads.
+ *
+ * The split is `shore.ts`'s, one instrument over: this half knows what a
+ * gridpoint hour is and turns a day of them into a bearing and an arc;
+ * `Compass` draws what it is handed and knows nothing about forecasts.
+ * `bearing.ts` under both of them owns the circular arithmetic and knows
+ * nothing about either.
+ *
+ * **Daylight, not the whole day**, which is the design brief's word and is
+ * doing real work rather than being a nicety. The committed gridpoint run
+ * swings across north in its first three hours -- 340, 20, 150 -- and a day
+ * measured end to end reports an arc no reader could have stood in. The plan's
+ * rule for the week's figures is the same one: what a reader can be there for.
+ */
+
+import type { GridDaySeries } from "@/lib/conditions";
+import { bearingSpread, resultantBearing } from "./bearing";
+import type { WeightedBearing } from "./bearing";
+
+/** One needle: where it came from, and how far it moved while doing so. */
+export type Needle = {
+  /** Degrees true it comes *from*, weighted by how much there was. */
+  fromDegT: number;
+  /** The arc containing every direction it blew from in daylight. */
+  spreadDeg: number;
+};
+
+/**
+ * One day of the cell's wind, as bearings weighted by the speed at that hour.
+ *
+ * **Joined on the instant, never on position.** Both series come gapless out of
+ * the same run today, so an index join would work and would put the wrong speed
+ * against the wrong bearing the first time one of them was short -- the same
+ * failure `readGridpointWeek` buckets by Pacific date to avoid rather than by
+ * counting hours.
+ *
+ * An hour missing from either series is not in the answer. There is no bearing
+ * to weight without a speed, and no speed to place without a bearing, and
+ * inventing either would be a drawn needle standing on one number.
+ */
+export function gridWindReadings(
+  directions: GridDaySeries,
+  speeds: GridDaySeries,
+  sunriseMs: number,
+  sunsetMs: number,
+): readonly WeightedBearing[] {
+  if (directions.kind !== "published" || speeds.kind !== "published") return [];
+
+  const speedAt = new Map(speeds.hours.map((hour) => [hour.atMs, hour.value]));
+
+  const readings: WeightedBearing[] = [];
+  for (const hour of directions.hours) {
+    if (hour.atMs < sunriseMs || hour.atMs >= sunsetMs) continue;
+    const speed = speedAt.get(hour.atMs);
+    if (speed === undefined) continue;
+    readings.push({ degreesTrue: hour.value, weight: speed });
+  }
+  return readings;
+}
+
+/**
+ * A day's readings as one needle, or nothing to draw.
+ *
+ * **Both numbers or neither.** An arc with no needle in it says the wind had a
+ * range and then declines to say where in that range it mostly sat, which is
+ * half an instrument and reads as a fault.
+ *
+ * One guard rather than two, and that is a finding rather than a style. Written
+ * as two sequential checks, whichever came second could never fire: a resultant
+ * implies a reading with something in it, which is exactly the condition a
+ * spread exists under. Mutating the second check left every test passing, which
+ * is how a branch that cannot be reached announces itself. This states the rule
+ * the needle actually has -- both numbers or neither -- without relying on an
+ * invariant proved in another module.
+ */
+export function needleFrom(
+  readings: readonly WeightedBearing[],
+): Needle | null {
+  const fromDegT = resultantBearing(readings);
+  const spreadDeg = bearingSpread(readings);
+  if (fromDegT === null || spreadDeg === null) return null;
+
+  return { fromDegT, spreadDeg };
+}

--- a/src/components/conditions/needles.test.ts
+++ b/src/components/conditions/needles.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { GridDaySeries } from "@/lib/conditions";
-import { gridWindReadings, needleFrom } from "./needles";
+import { gridWindReadings, needleFrom, swellReadings } from "./needles";
 
 /** 2026-08-17 in Pacific: sunrise 06:15, sunset 19:30, as epoch milliseconds. */
 const SUNRISE = Date.UTC(2026, 7, 17, 13, 15);
@@ -138,5 +138,53 @@ describe("needleFrom", () => {
         { degreesTrue: 270, weight: 5 },
       ]),
     ).toBeNull();
+  });
+});
+
+describe("swellReadings", () => {
+  const wave = (
+    atMs: number,
+    heightFt: number,
+    directionDegT: number | null,
+  ) => ({ atMs, heightFt, published: directionDegT !== null, directionDegT });
+
+  it("weights each of CDIP's bearings by the height that came with it", () => {
+    expect(
+      swellReadings(
+        [wave(hour(18), 3.2, 340), wave(hour(19), 1.5, 300)],
+        SUNRISE,
+        SUNSET,
+      ),
+    ).toEqual([
+      { degreesTrue: 340, weight: 3.2 },
+      { degreesTrue: 300, weight: 1.5 },
+    ]);
+  });
+
+  it("leaves out the hours this repo drew between CDIP's own", () => {
+    // Five hours in every eight of a swell curve are a line drawn between two
+    // estimates. They carry a height because a curve needs one and no bearing
+    // because a needle does not, and this is where that shows.
+    expect(
+      swellReadings(
+        [wave(hour(18), 3.2, 340), wave(hour(19), 2.8, null)],
+        SUNRISE,
+        SUNSET,
+      ),
+    ).toEqual([{ degreesTrue: 340, weight: 3.2 }]);
+  });
+
+  it("keeps only the hours inside the daylight window", () => {
+    expect(
+      swellReadings(
+        [wave(hour(9), 4, 200), wave(hour(18), 3.2, 340)],
+        SUNRISE,
+        SUNSET,
+      ),
+    ).toEqual([{ degreesTrue: 340, weight: 3.2 }]);
+  });
+
+  it("has nothing to read from a day with no estimates in daylight", () => {
+    expect(swellReadings([], SUNRISE, SUNSET)).toEqual([]);
   });
 });

--- a/src/components/conditions/needles.test.ts
+++ b/src/components/conditions/needles.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { GridDaySeries } from "@/lib/conditions";
-import { gridWindReadings, needleFrom } from "./compass";
+import { gridWindReadings, needleFrom } from "./needles";
 
 /** 2026-08-17 in Pacific: sunrise 06:15, sunset 19:30, as epoch milliseconds. */
 const SUNRISE = Date.UTC(2026, 7, 17, 13, 15);

--- a/src/components/conditions/needles.ts
+++ b/src/components/conditions/needles.ts
@@ -22,7 +22,7 @@
  * rule for the week's figures is the same one: what a reader can be there for.
  */
 
-import type { GridDaySeries } from "@/lib/conditions";
+import type { GridDaySeries, WaveHour } from "@/lib/conditions";
 import { bearingSpread, resultantBearing } from "./bearing";
 import type { WeightedBearing } from "./bearing";
 
@@ -63,6 +63,34 @@ export function gridWindReadings(
     const speed = speedAt.get(hour.atMs);
     if (speed === undefined) continue;
     readings.push({ degreesTrue: hour.value, weight: speed });
+  }
+  return readings;
+}
+
+/**
+ * One day of the swell, as bearings weighted by the height that came with them.
+ *
+ * **Only CDIP's own estimates**, which is the same distinction the swell curve
+ * draws with a mark and this reads off `directionDegT` being null. Five hours
+ * in every eight of that curve are a line this repo drew between two
+ * published points: they carry a height, because a polyline needs one at every
+ * hour, and no bearing, because halfway between 350 and 10 is not 180 and
+ * pretending otherwise would put a needle on a number nobody issued.
+ *
+ * Weighted by height for the same reason the wind is weighted by speed: a
+ * quarter-foot of leftover chop from the south should not pull the needle off
+ * the four-foot north-west swell a reader came to find.
+ */
+export function swellReadings(
+  hours: readonly WaveHour[],
+  sunriseMs: number,
+  sunsetMs: number,
+): readonly WeightedBearing[] {
+  const readings: WeightedBearing[] = [];
+  for (const hour of hours) {
+    if (hour.directionDegT === null) continue;
+    if (hour.atMs < sunriseMs || hour.atMs >= sunsetMs) continue;
+    readings.push({ degreesTrue: hour.directionDegT, weight: hour.heightFt });
   }
   return readings;
 }

--- a/src/components/conditions/needles.ts
+++ b/src/components/conditions/needles.ts
@@ -8,6 +8,13 @@
  * `bearing.ts` under both of them owns the circular arithmetic and knows
  * nothing about either.
  *
+ * **Named for the needles rather than for the compass**, which is `shore.ts`
+ * sitting beside `ShoreMap.tsx` under a different word rather than a different
+ * case. `compass.ts` beside `Compass.tsx` is one file on a case-insensitive
+ * filesystem: the imports resolved to each other on Windows, every test in the
+ * drawing's suite failed with an undefined component, and Linux CI would have
+ * passed the pair without noticing.
+ *
  * **Daylight, not the whole day**, which is the design brief's word and is
  * doing real work rather than being a nicety. The committed gridpoint run
  * swings across north in its first three hours -- 340, 20, 150 -- and a day

--- a/src/components/conditions/selectedDay.test.tsx
+++ b/src/components/conditions/selectedDay.test.tsx
@@ -12,6 +12,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { localMidnightOf } from "@/lib/pacific-time";
 import { ChosenDay, type DayView } from "./ChosenDay";
+import { DayCompassSources, type CompassDay } from "./DayCompass";
 import { SelectedDayProvider } from "./selectedDay";
 import { WeekGrid, type WeekDay, type WeekRow } from "./WeekGrid";
 import type { SparkPoint } from "./DaySpark";
@@ -95,7 +96,29 @@ function dayView(index: number): DayView {
 
 const VIEWS = DATES.map((_, index) => dayView(index));
 
-function renderBoth() {
+/**
+ * One needle per day, each from a different quarter.
+ *
+ * The dial travels beside the map rather than inside `DayView`, because the map
+ * is one picture for the whole week and the needles are not. That makes it a
+ * second consumer of the same choice, which is what this file exists to assert.
+ */
+const COMPASS_DAYS: CompassDay[] = DATES.map((localDate, index) => ({
+  localDate,
+  needles: [
+    {
+      kind: "wind",
+      label: "Wind",
+      fromDegT: [90, 180, 270][index],
+      spreadDeg: 20,
+      source: "this beach's own grid cell",
+      network: "National Weather Service, San Diego",
+      note: null,
+    },
+  ],
+}));
+
+function renderBoth(map: React.ReactNode = null) {
   return render(
     <SelectedDayProvider>
       <WeekGrid
@@ -104,7 +127,7 @@ function renderBoth() {
         days={DAYS}
         rows={[TIDE_ROW]}
       />
-      <ChosenDay days={VIEWS} map={null} />
+      <ChosenDay days={VIEWS} map={map} />
     </SelectedDayProvider>,
   );
 }
@@ -266,4 +289,25 @@ test("a region outside the provider shows its first day rather than failing", ()
   const { container } = render(<ChosenDay days={VIEWS} map={null} />);
 
   expect(drawnDay(container)).toBe(`Tide on ${DATES[0]}`);
+});
+
+test("the dial on the map follows the chosen day, and the map does not", () => {
+  // The second consumer of the one choice. The needles are per day and the
+  // coast is not, so the picture stays exactly where it was while the bearing
+  // under it changes -- which is the whole reason the compass is a client
+  // island inside a server-rendered map rather than seven copies of one.
+  const { container } = renderBoth(
+    <>
+      <p data-test-coast="">One coastline, drawn once</p>
+      <DayCompassSources days={COMPASS_DAYS} />
+    </>,
+  );
+
+  expect(screen.getByText(/from the east, 90°/)).toBeDefined();
+
+  fireEvent.click(container.querySelector(`[data-day-choice="${DATES[2]}"]`)!);
+
+  expect(screen.getByText(/from the west, 270°/)).toBeDefined();
+  expect(screen.queryByText(/from the east, 90°/)).toBeNull();
+  expect(screen.getByText("One coastline, drawn once")).toBeDefined();
 });

--- a/src/components/conditions/series.test.ts
+++ b/src/components/conditions/series.test.ts
@@ -44,10 +44,25 @@ test("the swell carries the read's own flag rather than a convenient constant", 
     daylight: null,
     allDay: null,
     hours: [
-      { atMs: START, heightFt: 2, published: true },
-      { atMs: START + HOUR, heightFt: 3, published: false },
-      { atMs: START + 2 * HOUR, heightFt: 4, published: false },
-      { atMs: START + 3 * HOUR, heightFt: 5, published: true },
+      { atMs: START, heightFt: 2, published: true, directionDegT: 340 },
+      {
+        atMs: START + HOUR,
+        heightFt: 3,
+        published: false,
+        directionDegT: null,
+      },
+      {
+        atMs: START + 2 * HOUR,
+        heightFt: 4,
+        published: false,
+        directionDegT: null,
+      },
+      {
+        atMs: START + 3 * HOUR,
+        heightFt: 5,
+        published: true,
+        directionDegT: 10,
+      },
     ],
   });
 

--- a/src/components/conditions/shore.test.ts
+++ b/src/components/conditions/shore.test.ts
@@ -1,190 +1,119 @@
 import { expect, test } from "vitest";
-import { allBeaches, beachBySlug } from "@/lib/beaches";
+import { allBeaches, beachBySlug, mopLineFor } from "@/lib/beaches";
 import type { ShorePoint } from "@/lib/coastline";
-import { shoreDistanceKm, shoreViewFor } from "./shore";
+import { shoreViewFor } from "./shore";
 
 /** The beach the page opens on, and the one with all four sources bound. */
 const LA_JOLLA = beachBySlug("la-jolla-shores-beach")!;
 
-test("all four sources are drawn, in the order the page introduces them", () => {
-  // Sea, shore, air -- the measured block's own order. Sorting by distance
-  // would reorder the list from beach to beach and stop it being learnable.
-  const view = shoreViewFor(LA_JOLLA);
-
-  expect(view.markers.map((marker) => marker.kind)).toEqual([
-    "mop-line",
-    "wave-buoy",
-    "tide-station",
-    "air-station",
-  ]);
-});
-
-test("every marker states its distance, including the near ones", () => {
-  // The cards withhold a distance under their thresholds, because beside a
-  // figure "0.3 km" adds nothing. Beside a picture of the distances it is the
-  // caption, and the MOP line at 0.3 km is the one this would drop.
-  const view = shoreViewFor(LA_JOLLA);
-
-  for (const marker of view.markers) {
-    expect(marker.distanceKm).not.toBeNull();
-  }
-  expect(
-    view.markers.find((marker) => marker.kind === "mop-line")?.distanceKm,
-  ).toBe("0.3");
-});
-
-test("the distances are the join's, not recomputed at request time", () => {
-  // beaches.json measured these once, offline, reproducibly. A second answer
-  // computed here could disagree with the one the provenance lines print.
-  const view = shoreViewFor(LA_JOLLA);
-  const air = view.markers.find((marker) => marker.kind === "air-station");
-
-  expect(LA_JOLLA.air_station_distance_m).toBe(1381);
-  expect(air?.distanceKm).toBe("1.4");
-});
-
-test("the frame holds every source, so nothing is drawn off the map", () => {
+test("the frame holds the beach and the line its coast is drawn from", () => {
+  // The map plots no stations, so nothing else belongs in the arithmetic that
+  // sizes it. The MOP line stays because it is where the drawn coastline *is*,
+  // 117 to 930 m off the sand -- a window without it is a map of a beach with
+  // its shoreline cropped off the edge.
   const view = shoreViewFor(LA_JOLLA);
   const bounds = view.bounds!;
+  const line = mopLineFor(LA_JOLLA)!;
 
-  for (const marker of view.markers) {
-    expect(marker.lat).toBeGreaterThanOrEqual(bounds.south);
-    expect(marker.lat).toBeLessThanOrEqual(bounds.north);
-    expect(marker.lon).toBeGreaterThanOrEqual(bounds.west);
-    expect(marker.lon).toBeLessThanOrEqual(bounds.east);
+  for (const at of [LA_JOLLA.segment.upper, LA_JOLLA.segment.lower, line]) {
+    expect(at.lat).toBeGreaterThanOrEqual(bounds.south);
+    expect(at.lat).toBeLessThanOrEqual(bounds.north);
+    expect(at.lon).toBeGreaterThanOrEqual(bounds.west);
+    expect(at.lon).toBeLessThanOrEqual(bounds.east);
   }
 });
 
-test("a bay beach gets its markers and no coast", () => {
-  // 23 of 51. The traced coast is the open one, and Mission Bay is 2.6 to 5.4
-  // km from the nearest MOP line, so there is a map to draw but no shoreline
-  // on it.
-  const view = shoreViewFor(beachBySlug("mission-bay-sail-bay")!);
+test("a station seven kilometres away no longer decides the frame", () => {
+  // The frames used to be sized by the four sources, so a distant station put
+  // itself in the picture at its real distance and left the beach a fraction
+  // of its own map -- for a reason nothing drawn on it gave, now that none of
+  // them is drawn. `pacific-beach` binds the furthest air station in the
+  // inventory and frames at about a kilometre.
+  const beach = beachBySlug("pacific-beach")!;
+  const bounds = shoreViewFor(beach).bounds!;
 
-  expect(view.coast).toEqual([]);
-  expect(view.markers.length).toBeGreaterThan(0);
+  const kmPerDegree = 111.32;
+  const heightKm = (bounds.north - bounds.south) * kmPerDegree;
+
+  expect(beach.air_station_distance_m).toBe(7365);
+  expect(heightKm).toBeLessThan(2);
+});
+
+test("a bay beach gets a map and no coast", () => {
+  // The traced coast is the open one, and Mission Bay is 2.6 to 5.4 km from
+  // the nearest MOP line, so there is a frame to draw but no shoreline in it.
+  const bay = beachBySlug("mission-bay-de-anza-cove")!;
+  const view = shoreViewFor(bay);
+
   expect(view.bounds).not.toBeNull();
+  expect(view.coast).toHaveLength(0);
 });
 
 test("a beach whose two ends are one point draws no segment", () => {
-  // mission-bay-vacation-isle carries an upper equal to its lower. A stroke
-  // from a point to itself is invisible and claims the beach has no length.
-  const view = shoreViewFor(beachBySlug("mission-bay-vacation-isle")!);
+  const isle = beachBySlug("mission-bay-vacation-isle")!;
+  const view = shoreViewFor(isle);
 
+  expect(isle.segment.upper).toEqual(isle.segment.lower);
   expect(view.segment).toBeNull();
-  // It still has a box, because its stations are somewhere else.
-  expect(view.bounds).not.toBeNull();
-});
-
-test("a beach with no MOP line carries no MOP marker", () => {
-  // 26 of 51 bind none. ShoreMap turns the gap into a sentence; this is the
-  // half that has to leave the gap rather than invent a position for it.
-  // childrens-pool is one, and it is an open-coast beach rather than a bay one
-  // -- no MOP line and no wave buoy is not the same fact as no coast in frame.
-  const view = shoreViewFor(beachBySlug("childrens-pool")!);
-
-  expect(view.markers.some((marker) => marker.kind === "mop-line")).toBe(false);
 });
 
 test("every committed beach assembles, and the county's split is pinned", () => {
-  // beaches.ts throws when a slug names a station no table holds, so running
-  // the whole inventory is the drift guard. The two counts are pinned because
-  // they are what ShoreMap's absence sentences are sized for: a data change
-  // that moved them should fail here rather than quietly change what half the
-  // county's map says.
-  const views = allBeaches().map((beach) => shoreViewFor(beach));
+  // The figures move when the joins move, which is the point of pinning them:
+  // a data change that halves the beaches with a coast should fail here rather
+  // than quietly ship half the maps without one.
+  const views = allBeaches().map(shoreViewFor);
 
   expect(views).toHaveLength(51);
-  expect(views.filter((view) => view.coast.length === 0)).toHaveLength(23);
-  expect(
-    views.filter((view) =>
-      view.markers.some((marker) => marker.kind === "mop-line"),
-    ),
-  ).toHaveLength(25);
+  expect(views.filter((view) => view.coast.length > 1)).toHaveLength(25);
+  expect(views.filter((view) => view.bounds === null)).toHaveLength(1);
 });
 
-test("a distance is worded the way the cards word it, on both sides of 10 km", () => {
-  // The committed inventory reaches 9.2 km, so the whole-kilometre half is one
-  // join away rather than in use. It is asserted here because the map has to
-  // agree with the measured block about how far away means, and agreeing only
-  // up to 10 km would be a second rule.
-  expect(shoreDistanceKm(325)).toBe("0.3");
-  expect(shoreDistanceKm(1381)).toBe("1.4");
-  expect(shoreDistanceKm(9160)).toBe("9.2");
-  expect(shoreDistanceKm(12400)).toBe("12");
-  expect(shoreDistanceKm(null)).toBeNull();
+test("a beach with no coast is still placed on its own map", () => {
+  // The chord between the beach's own two ends, which is the only thing that
+  // says where it is when no shoreline is drawn.
+  const bay = beachBySlug("mission-bay-de-anza-cove")!;
+  const view = shoreViewFor(bay);
+
+  expect(view.coast).toHaveLength(0);
+  expect(view.segment).toEqual([bay.segment.lower, bay.segment.upper]);
 });
 
-test("a beach whose every source is one point gets no box and no coast", () => {
-  // boundsAround returns null rather than a zero-span box, because a zero span
-  // divides by zero in the projection. No committed beach reaches this -- even
-  // vacation-isle's stations are somewhere else -- so it is built rather than
-  // found, and the map says so instead of drawing a coast at infinite
-  // magnification.
+test("a beach with no coast and no extent has nothing to draw", () => {
   const isle = beachBySlug("mission-bay-vacation-isle")!;
-  const nowhere = {
-    ...isle,
-    mop_line: null,
-    wave_buoy: null,
-    tide_station: null,
-    air_station: null,
-  };
-
-  const view = shoreViewFor(nowhere);
+  const view = shoreViewFor(isle);
 
   expect(view.bounds).toBeNull();
-  expect(view.coast).toEqual([]);
-  expect(view.markers).toEqual([]);
+  expect(view.coast).toHaveLength(0);
+  expect(view.segment).toBeNull();
 });
 
 test("this beach's stretch is a run of the drawn coast, not a chord across it", () => {
-  // beaches.json's segment is the beach's bounding extent, and its two ends are
-  // not points on the MOP polyline. A straight line between them floats off the
-  // coastline and reads as a second, wrong shore -- which is what it drew.
+  // Drawn between the two ends `beaches.json` carries -- neither of which is a
+  // point on the MOP line -- the stroke lands beside the shore at an angle and
+  // reads as a second, wrong coastline.
   const view = shoreViewFor(LA_JOLLA);
-  const ids = view.coast.map((point) => point.id);
-  // Where a coast is drawn the stretch is taken from it, so every point in it
-  // carries the line id that placed it.
-  const run = view.segment as readonly ShorePoint[];
+  const coast = view.coast as readonly ShorePoint[];
+  const segment = view.segment!;
 
-  expect(run).not.toBeNull();
-  expect(run.length).toBeGreaterThan(1);
-  for (const point of run) {
-    expect(ids).toContain(point.id);
+  expect(segment.length).toBeGreaterThan(2);
+  for (const point of segment) {
+    expect(
+      coast.some((at) => at.lat === point.lat && at.lon === point.lon),
+    ).toBe(true);
   }
 });
 
 test("the stretch is contiguous, and shorter than the coast around it", () => {
   const view = shoreViewFor(LA_JOLLA);
-  const ids = view.coast.map((point) => point.id);
-  const run = view.segment as readonly ShorePoint[];
-  const first = ids.indexOf(run[0].id);
+  const coast = view.coast as readonly ShorePoint[];
+  const segment = view.segment!;
 
-  expect(run.map((point) => point.id)).toEqual(
-    ids.slice(first, first + run.length),
+  const first = coast.findIndex(
+    (at) => at.lat === segment[0].lat && at.lon === segment[0].lon,
   );
-  expect(run.length).toBeLessThan(view.coast.length);
-});
-
-test("a beach with no coast is still placed on its own map", () => {
-  // Without this the bay maps are two markers floating in an empty frame with
-  // nothing saying where the beach is, which is the one thing the picture has
-  // to show. The chord objection is about a stroke competing with a drawn
-  // shore; where no shore is drawn there is nothing to compete with, and the
-  // beach's own two ends are the best statement available.
-  const view = shoreViewFor(beachBySlug("mission-bay-sail-bay")!);
-  const beach = beachBySlug("mission-bay-sail-bay")!;
-
-  expect(view.coast).toEqual([]);
-  expect(view.segment).not.toBeNull();
-  expect(view.segment).toEqual([beach.segment.lower, beach.segment.upper]);
-});
-
-test("a beach with no coast and no extent has nothing to draw", () => {
-  // mission-bay-vacation-isle, whose upper equals its lower. One point is not a
-  // stretch of shore, and a stroke from a point to itself claims a beach with
-  // no length.
-  const view = shoreViewFor(beachBySlug("mission-bay-vacation-isle")!);
-
-  expect(view.segment).toBeNull();
+  segment.forEach((point, step) => {
+    expect(coast[first + step].lat).toBe(point.lat);
+    expect(coast[first + step].lon).toBe(point.lon);
+  });
+  expect(segment.length).toBeLessThan(coast.length);
 });

--- a/src/components/conditions/shore.ts
+++ b/src/components/conditions/shore.ts
@@ -1,27 +1,23 @@
 /**
  * What one beach's map is made of, assembled from the joins already committed.
  *
- * `ShoreMap` is presentational and pure — it takes a window, a box and a list
- * of markers. This is the half that knows what a buoy is: it resolves the four
- * sources through `beaches.ts`, words each one the way the rest of the page
- * words it, and windows the county coast down to what this beach can see.
+ * `ShoreMap` is presentational and pure — it takes a window, a box and this
+ * beach's own stretch. This is the half that knows what a beach is: it windows
+ * the county coast down to what this beach can see, and finds the run of it the
+ * beach occupies.
  *
  * The split is `series.ts`'s, one region over: the assembler reads, the
  * component draws, and neither does the other's job.
  *
- * **Nothing here computes a distance.** Every figure comes off `beaches.json`,
- * where the joins measured it once, offline, and `--check` can reproduce it.
- * Recomputing at request time would be a second answer to a question already
- * answered, and the two could disagree.
+ * **Nothing here computes a distance, because nothing here states one.** The
+ * map used to plot the four sources at their real distances and caption each
+ * with a figure off `beaches.json`. It does not any more — the page names every
+ * source in words, under the group it belongs to, which is what ADR-0010 asks
+ * for and always was.
  */
 
 import type { Beach } from "@/lib/beaches";
-import {
-  airStationFor,
-  mopLineFor,
-  tideStationFor,
-  waveBuoyFor,
-} from "@/lib/beaches";
+import { mopLineFor } from "@/lib/beaches";
 import type { Bounds, Position, ShorePoint } from "@/lib/coastline";
 import {
   boundsAround,
@@ -29,9 +25,6 @@ import {
   SHORE_WINDOW_MARGIN,
   windowAround,
 } from "@/lib/coastline";
-import { MOP_NETWORK, mopLineSource } from "./mopLine";
-import type { ShoreMarker } from "./ShoreMap";
-import { TIDE_NETWORK } from "./tideStation";
 
 /** Everything `ShoreMap` needs, and nothing it has to look up for itself. */
 export type ShoreView = {
@@ -44,38 +37,7 @@ export type ShoreView = {
    * where there is not. See `beachStretch`.
    */
   segment: readonly Position[] | null;
-  markers: readonly ShoreMarker[];
 };
-
-/**
- * How far a source stands, for the map, in kilometres and already rounded.
- *
- * **Always stated, unlike on a card, and that is the difference the map makes.**
- * `tideStationDistanceKm` withholds anything under 5 km and the sea card
- * withholds a near buoy, both for the same good reason: beside a figure, "0.3
- * km" adds nothing a reader came for. Beside a *picture of the distances* it is
- * the caption. A marker drawn a third of the way across the frame with no
- * number under it asks the reader to estimate the thing the map exists to say.
- *
- * The rounding is `MeasuredToday`'s, deliberately: one decimal under 10 km
- * where the difference between 1.4 and 1.8 is a different walk, whole
- * kilometres above it where a decimal would be false precision about a station
- * in the next bay. Spelled here rather than imported because it is private to
- * that component; lifting it into a shared module is a refactor of two files
- * and belongs to its own slice.
- *
- * **The whole-kilometre half is unreachable through the committed inventory**,
- * where the furthest source is 9.2 km, and it is kept and tested directly
- * anyway. The rule is one statement about how a distance is worded, the cards
- * already word it both ways, and a map that agreed with them only up to 10 km
- * would be a second rule wearing the first one's clothes. Exported for that
- * test, which is the only caller outside this file.
- */
-export function shoreDistanceKm(metres: number | null): string | null {
-  if (metres === null) return null;
-  const km = metres / 1000;
-  return km < 10 ? km.toFixed(1) : km.toFixed(0);
-}
 
 /**
  * Where this beach is on its own map, or null when it has no extent to draw.
@@ -87,9 +49,9 @@ export function shoreDistanceKm(metres: number | null): string | null {
  * first time. Marking the coast the beach actually occupies says the same thing
  * and says it on the shape a reader is looking at.
  *
- * Null when the window holds no coast — 23 of 51 beaches — and null when the
- * two ends land on the same point, which is `mission-bay-vacation-isle`, whose
- * upper equals its lower.
+ * Null when the window holds no coast, and null when the two ends land on the
+ * same point, which is `mission-bay-vacation-isle`, whose upper equals its
+ * lower.
  */
 function beachStretch(
   coast: readonly ShorePoint[],
@@ -102,9 +64,8 @@ function beachStretch(
     No coast to mark a run of, so the beach's own two ends are drawn instead.
     The objection to a chord is that it competes with a drawn shore at an angle
     to it; where no shore is drawn there is nothing to compete with, and this is
-    the only thing that says where the beach is. Without it the 23 bay maps are
-    markers floating in an empty frame, which is the one question the picture
-    has to answer.
+    the only thing that says where the beach is. Without it the bay maps are an
+    empty frame, which is the one question the picture has to answer.
   */
   if (coast.length < 2) return hasExtent ? [lower, upper] : null;
 
@@ -132,98 +93,38 @@ function beachStretch(
 }
 
 /**
- * The four sources, in the order they are drawn and listed.
- *
- * Nearest-first is not the order: the list reads sea, then shore, then air,
- * which is the order the page already introduces them in and the order the
- * measured block puts them in. A list re-sorted by distance would change from
- * beach to beach and stop being learnable.
- *
- * A source the join did not bind is absent from this list rather than present
- * and empty. `ShoreMap` turns the absence into a sentence, because 26 of 51
- * beaches bind no MOP line and 36 bind no wave buoy, and a map quietly short a
- * marker reads as a map whose buoy is off-frame.
- */
-function markersFor(beach: Beach): ShoreMarker[] {
-  const markers: ShoreMarker[] = [];
-
-  const mopLine = mopLineFor(beach);
-  if (mopLine !== null) {
-    markers.push({
-      kind: "mop-line",
-      source: mopLineSource(mopLine.id),
-      network: MOP_NETWORK,
-      distanceKm: shoreDistanceKm(beach.mop_line_distance_m),
-      lat: mopLine.lat,
-      lon: mopLine.lon,
-    });
-  }
-
-  const buoy = waveBuoyFor(beach);
-  if (buoy !== null) {
-    markers.push({
-      kind: "wave-buoy",
-      source: `Buoy ${buoy.name}`,
-      network: "NDBC",
-      distanceKm: shoreDistanceKm(beach.wave_buoy_distance_m),
-      lat: buoy.lat,
-      lon: buoy.lon,
-    });
-  }
-
-  const tide = tideStationFor(beach);
-  if (tide !== null) {
-    markers.push({
-      kind: "tide-station",
-      source: tide.name,
-      network: TIDE_NETWORK,
-      distanceKm: shoreDistanceKm(beach.tide_station_distance_m),
-      lat: tide.lat,
-      lon: tide.lon,
-    });
-  }
-
-  const air = airStationFor(beach);
-  if (air !== null) {
-    markers.push({
-      kind: "air-station",
-      // `display_name` and never `name`: the published one is a callsign for
-      // most of these, which is the distinction that field exists to make.
-      source: air.display_name,
-      // No network, and not a guess. An air station may be on the NWS or the
-      // NDBC network and the binding does not record which, so the air card has
-      // never named one either.
-      network: null,
-      distanceKm: shoreDistanceKm(beach.air_station_distance_m),
-      lat: air.lat,
-      lon: air.lon,
-    });
-  }
-
-  return markers;
-}
-
-/**
  * One beach's map, ready to draw.
  *
- * The window is framed on the sources rather than on the sand, so a station 9
- * km away puts itself in the picture at 9 km. That is what makes this ADR-0010
- * drawn rather than written, and it is why `mission-beach` gets a 20 km frame
- * in which its own beach is a fifth of the height.
+ * **Framed on the beach and the line off it, not on the county's instruments.**
+ * The frame used to be sized by the four sources, so that a station nine
+ * kilometres inland put itself in the picture at nine kilometres — ADR-0010
+ * drawn rather than written. The sources are not drawn any more, and a frame
+ * sized by things a reader cannot see is the kind of invisible rule this repo
+ * refuses: `mission-beach`'s map was twenty kilometres tall with its own sand
+ * occupying a fifth of it, for a reason nothing on the picture gave.
+ *
+ * The bound MOP line stays in the frame's arithmetic while being absent from
+ * its drawing, and that is not the same mistake. It is not an instrument
+ * standing somewhere: it is where the drawn coastline *is*, sitting 117 to 930
+ * metres off the sand, so a window that excluded it would be a map of a beach
+ * with the shoreline cropped off the edge. Measured across the inventory,
+ * framing on the beach alone leaves 14 of 51 beaches with a coast in view;
+ * framing on the beach and its line leaves 26, and the median frame falls from
+ * 4.0 km to 3.1 km.
  */
 export function shoreViewFor(beach: Beach): ShoreView {
-  const markers = markersFor(beach);
+  const line = mopLineFor(beach);
+
   const bounds = boundsAround(
-    [beach.segment.upper, beach.segment.lower, ...markers],
+    [
+      beach.segment.upper,
+      beach.segment.lower,
+      ...(line === null ? [] : [{ lat: line.lat, lon: line.lon }]),
+    ],
     SHORE_WINDOW_MARGIN,
   );
 
   const coast = bounds === null ? [] : windowAround(coastline(), bounds);
 
-  return {
-    coast,
-    bounds,
-    segment: beachStretch(coast, beach),
-    markers,
-  };
+  return { coast, bounds, segment: beachStretch(coast, beach) };
 }

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -1430,10 +1430,11 @@ test("an hour the forecast did not reach is absent rather than zero", async () =
  * readGridpointWeek
  * ========================================================================= */
 
-/** The cell answering with a wind and a temperature series, or an absence. */
+/** The cell answering with a wind, a direction and a temperature, or an absence. */
 function gridSeriesOk(
   windMph: unknown,
   airTempF: unknown = { kind: "published", hours: [] },
+  windDirDegT: unknown = { kind: "published", hours: [] },
 ) {
   fetchGridForecast.mockResolvedValue({
     kind: "ok",
@@ -1444,7 +1445,7 @@ function gridSeriesOk(
       windMph,
       airTempF,
       gustMph: { kind: "published", hours: [] },
-      windDirDegT: { kind: "published", hours: [] },
+      windDirDegT,
       apparentTempF: { kind: "published", hours: [] },
     },
     url: "https://example.invalid",
@@ -1551,6 +1552,64 @@ test("all seven days are returned even when the run reaches none of them", async
 
   if (view.state.kind !== "week") throw new Error("expected a week");
   expect(view.state.days).toHaveLength(7);
+});
+
+test("the cell's wind direction is bucketed by Pacific day like its speed is", async () => {
+  // The compass reads a day of directions, so a run bucketed by position
+  // rather than by date would draw Tuesday's needle on Monday's map.
+  gridSeriesOk(
+    { kind: "published", hours: [] },
+    { kind: "published", hours: [] },
+    {
+      kind: "published",
+      hours: [
+        { atMs: hourUtc(18, 0), value: 281, published: true },
+        { atMs: hourUtc(19, 0), value: 340, published: true },
+      ],
+    },
+  );
+
+  const view = await readGridpointWeek(BEACH, NOON_PACIFIC_20260817);
+
+  if (view.state.kind !== "week") throw new Error("expected a week");
+  const [today, tomorrow] = view.state.days;
+  expect(today.windDirDegT).toEqual({
+    kind: "published",
+    hours: [{ atMs: hourUtc(18, 0), value: 281, published: true }],
+  });
+  expect(tomorrow.windDirDegT).toEqual({
+    kind: "published",
+    hours: [{ atMs: hourUtc(19, 0), value: 340, published: true }],
+  });
+});
+
+test("a cell that publishes no wind direction still publishes its speed", async () => {
+  // The same asymmetry the other two series have, and the one that matters for
+  // the compass: a needle with no bearing is withheld, and the wind tab keeps
+  // its curve. Collapsing the two would take a drawn chart off the page over a
+  // needle nobody asked for.
+  gridSeriesOk(
+    {
+      kind: "published",
+      hours: [{ atMs: hourUtc(18, 0), value: 8, published: true }],
+    },
+    { kind: "published", hours: [] },
+    {
+      kind: "absent",
+      reason:
+        "SGX/54,21: the National Weather Service declares windDirection and published no values.",
+    },
+  );
+
+  const view = await readGridpointWeek(BEACH, NOON_PACIFIC_20260817);
+
+  if (view.state.kind !== "week") throw new Error("expected a week");
+  expect(view.state.days[0].windDirDegT).toEqual({
+    kind: "absent",
+    reason:
+      "SGX/54,21: the National Weather Service declares windDirection and published no values.",
+  });
+  expect(view.state.days[0].windMph.kind).toBe("published");
 });
 
 test("a beach with no forecast cell is a permanent fact, not an outage", async () => {

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -673,13 +673,21 @@ test("an unknown slug is a coding error, not a quiet feed", async () => {
 
 /** Three-hourly rows for one Pacific day, in metres-converted feet. */
 function mopRows(
-  entries: { atMs: number; heightFt: number; periodS: number }[],
+  entries: {
+    atMs: number;
+    heightFt: number;
+    periodS: number;
+    directionDegT?: number;
+  }[],
 ) {
   fetchMopForecast.mockResolvedValue({
     kind: "ok",
     forecast: {
       lineId: "D0498",
-      rows: entries.map((entry) => ({ ...entry, directionDegT: 270 })),
+      rows: entries.map((entry) => ({
+        directionDegT: 270,
+        ...entry,
+      })),
       flaggedOut: 0,
     },
     url: "https://example.invalid",
@@ -909,10 +917,51 @@ test("the day carries every hour of it, drawn between CDIP's own estimates", asy
 
   if (view.state.kind !== "week") throw new Error("expected a week");
   expect(view.state.days[0].hours).toEqual([
-    { atMs: pacificHour(0, 2), heightFt: 2, published: true },
-    { atMs: pacificHour(0, 3), heightFt: 3, published: false },
-    { atMs: pacificHour(0, 4), heightFt: 4, published: false },
-    { atMs: pacificHour(0, 5), heightFt: 5, published: true },
+    {
+      atMs: pacificHour(0, 2),
+      heightFt: 2,
+      published: true,
+      directionDegT: 270,
+    },
+    {
+      atMs: pacificHour(0, 3),
+      heightFt: 3,
+      published: false,
+      directionDegT: null,
+    },
+    {
+      atMs: pacificHour(0, 4),
+      heightFt: 4,
+      published: false,
+      directionDegT: null,
+    },
+    {
+      atMs: pacificHour(0, 5),
+      heightFt: 5,
+      published: true,
+      directionDegT: 270,
+    },
+  ]);
+});
+
+test("only CDIP's own estimates carry a direction, never the hours between", async () => {
+  // A bearing cannot be interpolated the way a height can: halfway between 350
+  // and 10 is 0, and the arithmetic that gets a height right says 180 -- due
+  // south, the reverse of both. So the drawn hours carry a height and no
+  // direction, which is the same distinction `published` already makes.
+  mopRows([
+    { atMs: pacificHour(0, 2), heightFt: 2, periodS: 14, directionDegT: 350 },
+    { atMs: pacificHour(0, 5), heightFt: 5, periodS: 14, directionDegT: 10 },
+  ]);
+
+  const view = await readWaveWeek(BEACH, NOON_PACIFIC_20260817);
+
+  if (view.state.kind !== "week") throw new Error("expected a week");
+  expect(view.state.days[0].hours.map((hour) => hour.directionDegT)).toEqual([
+    350,
+    null,
+    null,
+    10,
   ]);
 });
 
@@ -931,9 +980,24 @@ test("the hours before the grid's first estimate come from the day before", asyn
   if (view.state.kind !== "week") throw new Error("expected a week");
   const today = view.state.days.find((day) => day.localDate === "2026-08-17");
   expect(today?.hours).toEqual([
-    { atMs: pacificHour(0, 0), heightFt: 2, published: false },
-    { atMs: pacificHour(0, 1), heightFt: 3, published: false },
-    { atMs: pacificHour(0, 2), heightFt: 4, published: true },
+    {
+      atMs: pacificHour(0, 0),
+      heightFt: 2,
+      published: false,
+      directionDegT: null,
+    },
+    {
+      atMs: pacificHour(0, 1),
+      heightFt: 3,
+      published: false,
+      directionDegT: null,
+    },
+    {
+      atMs: pacificHour(0, 2),
+      heightFt: 4,
+      published: true,
+      directionDegT: 270,
+    },
   ]);
 });
 
@@ -951,8 +1015,18 @@ test("a gap wider than the grid is left empty rather than drawn across", async (
 
   if (view.state.kind !== "week") throw new Error("expected a week");
   expect(view.state.days[0].hours).toEqual([
-    { atMs: pacificHour(0, 2), heightFt: 2, published: true },
-    { atMs: pacificHour(0, 11), heightFt: 8, published: true },
+    {
+      atMs: pacificHour(0, 2),
+      heightFt: 2,
+      published: true,
+      directionDegT: 270,
+    },
+    {
+      atMs: pacificHour(0, 11),
+      heightFt: 8,
+      published: true,
+      directionDegT: 270,
+    },
   ]);
 });
 

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -1472,10 +1472,25 @@ export type GridDaySeries =
   | { kind: "published"; hours: readonly GridpointHour[] }
   | { kind: "absent"; reason: string };
 
-/** One day of the cell's wind and air temperature. */
+/** One day of the cell's wind, its direction, and air temperature. */
 export interface GridpointWeekDay extends WeekDayFrame {
   /** Wind speed in miles per hour. */
   windMph: GridDaySeries;
+  /**
+   * Wind direction in degrees true, the direction it blows *from*.
+   *
+   * **Hours rather than a bearing for the day**, because how a day of
+   * directions becomes one is a presentation decision and this is the read.
+   * The compass weights them by speed and takes the circular mean over the
+   * daylight window; a different consumer could want the whole day, or the
+   * envelope, or nothing. Carrying the hours keeps every one of those a change
+   * to a component rather than a change to what is read.
+   *
+   * Its own series and not a field on `windMph`'s hours, which is the shape the
+   * parser publishes and the shape the absences need: a cell can declare a
+   * speed and no direction, and the two owe different sentences.
+   */
+  windDirDegT: GridDaySeries;
   /** Air temperature in Fahrenheit. */
   airTempF: GridDaySeries;
 }
@@ -1590,6 +1605,7 @@ export async function readGridpointWeek(
   }
 
   const windByDate = gridHoursByDate(result.forecast.windMph);
+  const dirByDate = gridHoursByDate(result.forecast.windDirDegT);
   const tempByDate = gridHoursByDate(result.forecast.airTempF);
 
   const days = weekOfDays(nowMs).map((frame) => ({
@@ -1597,6 +1613,11 @@ export async function readGridpointWeek(
     windMph: gridDaySeries(
       result.forecast.windMph,
       windByDate,
+      frame.localDate,
+    ),
+    windDirDegT: gridDaySeries(
+      result.forecast.windDirDegT,
+      dirByDate,
       frame.localDate,
     ),
     airTempF: gridDaySeries(

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -921,6 +921,20 @@ export interface WaveHour {
   heightFt: number;
   /** True when CDIP issued an estimate for this instant. */
   published: boolean;
+  /**
+   * Peak direction in degrees true, and `null` on every drawn hour.
+   *
+   * **A bearing is not interpolable the way a height is**, and the arithmetic
+   * that gets a height right gets a direction exactly backwards: halfway
+   * between 350 and 10 is 0, and averaging them as numbers says 180 -- due
+   * south, the reverse of both. Circular interpolation would answer that, and
+   * would be this repo drawing a figure between two the model published, which
+   * is the thing `published` exists to keep visible.
+   *
+   * So the hours between CDIP's estimates carry a height, because a curve needs
+   * one, and no direction, because a needle does not.
+   */
+  directionDegT: number | null;
 }
 
 /**
@@ -1045,7 +1059,12 @@ function hourlyWaveHeights(rows: readonly MopWaveRow[]): WaveHour[] {
   const hours: WaveHour[] = [];
 
   rows.forEach((row, index) => {
-    hours.push({ atMs: row.atMs, heightFt: row.heightFt, published: true });
+    hours.push({
+      atMs: row.atMs,
+      heightFt: row.heightFt,
+      published: true,
+      directionDegT: row.directionDegT,
+    });
 
     const next = rows[index + 1];
     if (next === undefined) return;
@@ -1059,6 +1078,7 @@ function hourlyWaveHeights(rows: readonly MopWaveRow[]): WaveHour[] {
         atMs,
         heightFt: row.heightFt + (next.heightFt - row.heightFt) * through,
         published: false,
+        directionDegT: null,
       });
     }
   });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -271,11 +271,25 @@ export default defineConfig({
       // 97.53%, and its uncovered statement is the body of
       // `WORDS.swell.outage` -- the sentence for a CDIP outage, which no test
       // in that suite provokes.
+      // LOWERED 2026-08-30 under REASON 2, when the map stopped plotting the
+      // four sources. Nothing became untested: `markersFor` and
+      // `shoreDistanceKm` in `shore.ts`, and `Mark`, `MARKS`, `GLYPHS` and
+      // `MISSING_SOURCES` in `ShoreMap.tsx`, were all fully covered and are
+      // deleted along with the tests that covered them. The surviving
+      // denominator is weighted further toward the 0% entry plumbing that has
+      // always dragged these figures down in plain sight.
+      //
+      // Every file this branch touched is still at 100% on all four metrics
+      // except two, and both are unchanged from the rise above: `ShoreMap` at
+      // 96.77% branches, whose one uncovered branch is the `|| 1`
+      // divide-by-zero guard for a drawn run whose ends project to one point,
+      // and `DayPanel` at 97.53% statements, whose uncovered statement is the
+      // sentence for a CDIP outage that suite does not provoke.
       thresholds: {
-        statements: 89.58,
-        branches: 88.99,
-        functions: 94.34,
-        lines: 89.29,
+        statements: 89.43,
+        branches: 88.92,
+        functions: 94.27,
+        lines: 89.13,
       },
     },
   },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -259,11 +259,23 @@ export default defineConfig({
       // widening the floor around them: `shoreDistanceKm` above 10 km, where
       // the furthest source in the inventory is 9.2 km, and `boundsAround`
       // returning null, which needs a beach whose every source is one point.
+      // RAISED 2026-08-30, the compass. All four rose, and every file this
+      // half added -- bearing.ts, needles.ts, Compass.tsx, DayCompass.tsx --
+      // finished at 100% on all four metrics, so none of them appears in the
+      // report's table at all.
+      //
+      // The two files it modified are named rather than absorbed. `ShoreMap`
+      // is 100% statements and 97.56% branches; the one uncovered branch is
+      // the `|| 1` in `Math.hypot(px, py) || 1`, the divide-by-zero guard for
+      // a drawn run whose two ends project to the same point. `DayPanel` is
+      // 97.53%, and its uncovered statement is the body of
+      // `WORDS.swell.outage` -- the sentence for a CDIP outage, which no test
+      // in that suite provokes.
       thresholds: {
-        statements: 89.18,
-        branches: 88.61,
-        functions: 94.09,
-        lines: 88.9,
+        statements: 89.58,
+        branches: 88.99,
+        functions: 94.34,
+        lines: 89.29,
       },
     },
   },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -286,10 +286,12 @@ export default defineConfig({
       // and `DayPanel` at 97.53% statements, whose uncovered statement is the
       // sentence for a CDIP outage that suite does not provoke.
       thresholds: {
-        statements: 89.43,
-        branches: 88.92,
-        functions: 94.27,
-        lines: 89.13,
+        // Back up a hundredth of a point each when the needles gained their
+        // labels, which are covered like everything else in `Compass.tsx`.
+        statements: 89.44,
+        branches: 88.94,
+        functions: 94.28,
+        lines: 89.14,
       },
     },
   },


### PR DESCRIPTION
Closes #173.

The second half of the day view's spatial region: the compass — and, after
review, a cleanup of the map it sits on.

## Changed after review (2026-08-30)

Four things came back from looking at the built page, and two more fell out of
them. The map now draws a place rather than an inventory, which is
[ADR-0033](docs/adr/0033-the-map-draws-a-place-not-an-inventory.md).

- **The map plots no stations, buoys or model lines.** They were ADR-0010
  answered by drawing rather than by writing, and reviewed on the page that was
  a picture of four station positions rather than a picture of a beach — with
  two glyphs overlapping wherever a tide gauge is bolted to the pier an air
  station stands on, which no glyph fixes because the instruments really are at
  one place. Every source is still named in words under the group it belongs to,
  which is what ADR-0010 requires and always did.
- **The water is one flat wash.** ADR-0030 argued for a fade with one specific
  reason — a hard edge drew the Scripps gauge and pier, both over water, onto the
  beach — and removing the markers removes it. What the fade left behind was
  wrong on its own terms: its iso-lines run along a single normal taken from the
  drawn run's two endpoints, so it drew a straight-edged boundary across a shore
  that bends.
- **The frame is re-decided, because it had to be.** It was sized by the four
  sources, and a frame sized by things that are not drawn is a rule nobody can
  see from the page — `pacific-beach` was framed on a station 7,365 m inland and
  now frames at about a kilometre. Measured: framing on the beach alone leaves
  14 of 51 beaches with a coast in view, framing on the beach and its bound MOP
  line leaves 25, against 28 before. The three lost had frames stretched wide
  enough to catch a coastline five kilometres away that was not theirs.
- **Each needle is labelled at its tail, and both are slimmer.** Two arrows over
  a coastline did not say which was which, and there is no legend by design. The
  labels are horizontal rather than rotated with their needle — a label that
  follows a bearing is upside down for half the compass — and the heads are two
  and a half times as long as they are wide, which is the difference between an
  arrow and a blob.

Two more the cleanup had to answer:

- **The `sea-side` gate's window is now wider than the map's**, and says so
  rather than still claiming they are the same. That check needs the wave buoy
  in frame because the buoy is the only ground truth for which side the water is
  on; asked inside the map's narrower window it fails at 10 of 15, measured. The
  property proven is about the polyline, and the map's run is a contiguous
  sub-run of the checked one.
- **The test that catches the sea shaded over the land used the plotted buoy as
  its anchor**, and there is no buoy now. It reads the fixture's own geometry
  instead and still fails when the seaward normal is flipped.

The coverage floor moved down under the second of the two reasons
`vitest.config.mts` records — well-covered code was deleted, nothing became
untested — and then back up a hundredth when the labels landed.

Everything below describes the compass as originally built and stands except
where this section corrects it.

---

The second half of the day view's spatial region: the compass. #178 drew the
coast and the four places this beach's figures come from; this puts two needles
on it — where the wind comes from, and where the swell comes from — which is the
brief's third principle, that direction belongs to place.

**A bearing on its own is a number.** 281 degrees says nothing. Over a drawn
coastline it becomes the thing a reader came for: whether the wind is coming off
the land or off the water. At La Jolla today the wind reads 233 degrees and the
shaft crosses the shaded sea, so it is onshore — read off the picture, with no
normal computed and no arithmetic done in anybody's head.

## The slices

Eight, one commit each, gates green at every one.

1. **Give one module the words for a bearing** — `compassWords` out of
   `MeasuredToday` into `bearing.ts`, unchanged. Pure refactor.
2. **Read a day's hours as one bearing and an arc** — the circular arithmetic.
3. **Carry the cell's wind direction into the week** — `windDirDegT` through
   `conditions.ts`, parsed since the cell was first read and never asked for.
4. **Turn a day of hours into one needle** — `needles.ts`, the assembler.
5. **Draw the wind's needle on the map it arrives at** — `Compass`, the client
   island that follows the chosen day, `ShoreMap`'s two slots, the wiring.
6. **Give the swell its own needle on the same dial** — MOP direction through,
   the second needle, one dial with two publishers.
7. **Record what one dial may carry, and name it** — ADR-0032, `Dial` in
   CONTEXT.md.
8. **Move the floor and tick what this half built.**

Eight is past CLAUDE.md's guide of about five, and the split was put to Cole
before any of it was written: one PR against two, wind needle then swell needle.
One PR was chosen, because the two needles share the module, the component and
the ADR — and a split would have shipped "one dial may carry two provenances"
one PR before there were two.

## Two decisions taken on measurement, before writing code

**The needle is weighted by how much wind there was.** Measured across the
committed gridpoint run, the daylight spread per day is 200°, 170°, 60°, 40°,
40°, 40° — two days in seven where the wind had no settled direction at all. An
unweighted mean lets a 0 mph pre-dawn bearing count as much as a 12 mph
afternoon one, and on those two days points at a number the day did not have.
The resultant is speed-weighted; the arc stays the full envelope, because that
is the honesty a bare needle lacks; and the words state the swing where it is
wider than one compass point.

**The week view carries the hours, not a pre-aggregated bearing.** That keeps
every alternative above a change to a component rather than a change to what is
read.

## Five things the build found, none of which was in a plan

**Two modules whose names differ only in case are one file on Windows.**
`compass.ts` beside `Compass.tsx` resolved to each other: every test in the
drawing's suite failed with an undefined component. **Linux CI would have passed
the pair without noticing.** The assembler is `needles.ts` now, which is what
`shore.ts` beside `ShoreMap.tsx` had already established.

**Two needles on one radius drew as one.** On any day the wind and the swell
come from the same quarter, the second needle covered the first exactly — the
page said two things and showed one, and nothing failed. At La Jolla that is an
ordinary day rather than an edge case: the swell runs west to north-west and the
afternoon wind west to south-west. Each runs on its own track now, and there is a
regression test that fails when they share one. **Found by looking at the built
page, not by a test.**

**A bearing is not interpolable the way a height is.** Five hours in every eight
of the swell curve are a line this repo drew between two of CDIP's estimates.
Halfway between 350 and 10 is 0, and the arithmetic that gets a height right
says 180 — due south, the reverse of both. `directionDegT` is `null` on every
drawn hour, so the needle reads only what CDIP issued.

**The two arcs needed different opacities to reach the same contrast.** At 0.65
the ocean arc reads 3.60:1 over the sea from painted pixels and the purple one
2.77:1 — under the brief's 3:1 for a graphical object, on the setting that
cleared it for the other hue. They are set to the same measured contrast rather
than the same number.

**One guard in `needleFrom` could never fire.** Written as two sequential checks,
whichever ran second was unreachable — a resultant implies a reading implies a
spread. The mutation that deleted it left every test passing, which is how that
announces itself. It is one condition now.

## Accessibility, measured rather than assumed

Contrast read from painted pixels — screenshot the page, hand the PNG back to
the browser, read it through a canvas. The CSS tree returns transparent for
everything drawn on this map. Sampled over the sea, which is the darker ground:

| Pair         | Ratio        | Floor |
| ------------ | ------------ | ----- |
| Wind needle  | **6.03:1**   | 3:1   |
| Wind arc     | **3.52:1**   | 3:1   |
| Swell needle | **5.23:1**   | 3:1   |
| Swell arc    | **3.54:1**   | 3:1   |
| Needle label | **16.62:1**  | 4.5:1 |
| Ring         | 1.40:1       | —     |

Re-measured after the review, because the ground beneath them changed from a
fading gradient to a solid wash. The needles read 7.22 and 5.93 over the old
one.

The ring stays at 1.40:1 and is named rather than quietly excluded: it is the
dial's frame in the same sense the plot has a border, the arc's meaning is also
carried in words below it, and raising it puts a second loud circle on a quiet
map. Say so if that reads wrong and it is a one-line change.

- **Colour is never the only channel.** The wind is a thin shaft under a hollow
  chevron, the swell a heavy one under a filled blade — open against solid, thin
  against heavy, both surviving greyscale.
- **The bearings are spoken beside the picture**, not in an accessible name. The
  map is one `role="img"`, so nothing drawn inside it reaches the accessibility
  tree; the rows below state both bearings in words and degrees, and the swing
  where it is wide. That is `ShoreMap`'s own rule for its markers.
- **No new controls**, so no touch targets and no focus ring to inherit. No
  transitions, so `prefers-reduced-motion` is not engaged.
- **No horizontal overflow** at 375, 768, 1280 or 1536. The dial is 195px wide
  at 375 and both needles stay distinguishable there.

## What I did not do, and why

**The eight-point rose costs something, and it is recorded in a test rather than
hidden.** 340 degrees reads "north", where the brief's example name for that
exact bearing is "swell from the northwest, 340 degrees" — a sixteen-point
reading. `compassWords` has printed eight points on the air card since it was
written, a few hundred pixels away on the same page, and two vocabularies for one
bearing is worse than a coarser one when the degrees are stated beside the word.
Moving to sixteen would change the card's copy too, which is a different branch.
**One line to reverse if you want the finer rose.**

**The grid cell is now named three times on one screen** — the cloud row, the sky
wording and the wind needle. Each attributes its own figure and none covers
another's, which is the condition ADR-0029 sets, so this is permitted rather than
broken. It is recorded in ADR-0032's consequences because #179 will make it four.
Not filed separately: noticing is not filing.

**The 23 beaches with no coast get markers and no dial**, per the decision taken
before #178 merged. The rule rests on there being no coast and not on there being
no segment — `shore.ts` draws a two-point chord on 22 of those 23 — and the first
version of its test asserted the wrong one, passing with the coast check deleted.
Mutation is what said so.

## Verification

Every slice was mutated to prove its tests can fail: dropping the speed
weighting, reporting the gap instead of its complement, letting calm hours vote,
forgetting the closing gap, joining the two series by position, dropping the
daylight window, pointing north down, swapping sin and cos, pointing the needle
outward, always taking the short arc, anchoring the dial at the frame's centre,
letting a coastless beach have a dial, putting both needles back on one track,
attributing the swell to the grid cell, and making the dial always show the first
day. Each fails between one and five tests. The one that did not fail anything is
in the list above.

Coverage rose on all four metrics — 89.18→89.58 statements, 88.61→88.99
branches, 94.09→94.34 functions, 88.9→89.29 lines. `bearing.ts`, `needles.ts`,
`Compass.tsx` and `DayCompass.tsx` each finished at 100% on all four.

`npm run gate`, at the tip of this branch:

```
… format
… lint
… typecheck
… adr-numbers
… sea-side
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
