### PR TITLE
Name the publisher under the day chart's plot

### DIFF
--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -958,6 +958,50 @@ test("the wind and the air temperature name the cell, on both their tabs", async
   expect(provenance(container)).toContain("Air temperature");
 });
 
+test("a beach with no tide station credits nobody rather than reaching through", async () => {
+  // `station` is null exactly in this state, and the four sources are composed
+  // once for the week -- before any tab knows whether it has a curve to
+  // attribute. An implementation that reached through the null would throw here
+  // instead of rendering the absence the reader is owed.
+  readHourlyTide.mockResolvedValue({
+    beachName: BINDING.beachName,
+    station: null,
+    state: {
+      kind: "no-station",
+      reason: "no station within 40 km of this beach publishes predictions",
+    },
+  });
+
+  const { container } = render(
+    await DayPanel({ slug: "la-jolla-shores-beach" }),
+  );
+
+  expect(screen.getByText(/no station within 40 km/)).toBeDefined();
+  expect(container.querySelector("[data-series-provenance]")).toBeNull();
+});
+
+test("a beach with no forecast cell leaves wind and temperature uncredited", async () => {
+  // The same for the third source. There is no curve on either tab to
+  // attribute, and no cell to name if there were.
+  readGridpointWeek.mockResolvedValue({
+    beachName: BINDING.beachName,
+    cell: null,
+    state: {
+      kind: "no-cell",
+      reason: "the forecast grid does not reach this beach",
+    },
+  });
+
+  const { container } = render(
+    await DayPanel({ slug: "la-jolla-shores-beach" }),
+  );
+
+  fireEvent.click(container.querySelector('[data-series-tab="wind"]')!);
+
+  expect(screen.getByText(/the forecast grid does not reach/)).toBeDefined();
+  expect(container.querySelector("[data-series-provenance]")).toBeNull();
+});
+
 test("the attribution survives choosing an hour", async () => {
   // ADR-0027 lets a plot be asked a question only additively: an interaction
   // may reveal what the page did not carry, and may never put something drawn

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -880,3 +880,93 @@ test("a beach with no swell model keeps its wind needle", async () => {
   expect(screen.getByText(/^Wind, from the south, 180°/)).toBeDefined();
   expect(screen.queryByText(/^Swell, from/)).toBeNull();
 });
+
+/* =========================================================================
+ * Who published the curve
+ * ========================================================================= */
+
+/**
+ * The chart's own attribution, scoped so that the sky wording's line above the
+ * plot is never read in its place.
+ *
+ * Reading the wrong line is not a hypothetical here: the nearest provenance
+ * above this chart names the grid cell, and the whole of finding 1 is that a
+ * reader takes it for the plot's. An unscoped `getByText` would make the same
+ * mistake the reader does, and pass.
+ */
+function provenance(container: HTMLElement): string {
+  return container.querySelector("[data-series-provenance]")?.textContent ?? "";
+}
+
+test("the tide curve names NOAA, not the grid cell above it", async () => {
+  // The line a reader would otherwise take for this plot's belongs to
+  // `SkyWording` and names the National Weather Service's cell. The tide is
+  // NOAA's, and the two are a few pixels apart.
+  const { container } = render(
+    await DayPanel({ slug: "la-jolla-shores-beach" }),
+  );
+
+  expect(provenance(container)).toContain(
+    "La Jolla (Scripps Institution Wharf)",
+  );
+  expect(provenance(container)).toContain("NOAA Tides & Currents");
+  expect(provenance(container)).not.toContain("this beach's own grid cell");
+});
+
+test("the swell curve names CDIP's model, which is not the buoy below it", async () => {
+  // ADR-0029 permits a modelled height beside a measured one on condition that
+  // each is attributed. The sea card 40px under this curve leads with the
+  // buoy's measurement, so an unattributed curve leaves the only named source
+  // on the screen belonging to the figure that is not drawn.
+  const { container } = render(
+    await DayPanel({ slug: "la-jolla-shores-beach" }),
+  );
+
+  fireEvent.click(container.querySelector('[data-series-tab="swell"]')!);
+
+  expect(provenance(container)).toContain("MOP line D0481");
+  expect(provenance(container)).toContain(
+    "CDIP, Scripps Institution of Oceanography",
+  );
+  expect(provenance(container)).toContain(
+    "a model of the swell at 10 m depth, not a measurement",
+  );
+  expect(provenance(container)).not.toContain("NOAA");
+});
+
+test("the wind and the air temperature name the cell, on both their tabs", async () => {
+  // Neither is attributed anywhere on this page. The only wind provenance it
+  // carries is the air card's Scripps Pier, which is the station these curves
+  // did not come from -- ADR-0029's whole subject.
+  const { container } = render(
+    await DayPanel({ slug: "la-jolla-shores-beach" }),
+  );
+
+  fireEvent.click(container.querySelector('[data-series-tab="wind"]')!);
+  expect(provenance(container)).toContain("this beach's own grid cell");
+  expect(provenance(container)).toContain(
+    "National Weather Service, San Diego",
+  );
+  expect(provenance(container)).toContain(
+    "a forecast, not a reading taken at the beach",
+  );
+
+  fireEvent.click(container.querySelector('[data-series-tab="temperature"]')!);
+  expect(provenance(container)).toContain("this beach's own grid cell");
+  // "Temp" is a tab shortened to fit four across a phone. Everywhere a reader
+  // is not paying for the width, this page says the word in full.
+  expect(provenance(container)).toContain("Air temperature");
+});
+
+test("the attribution survives choosing an hour", async () => {
+  // ADR-0027 lets a plot be asked a question only additively: an interaction
+  // may reveal what the page did not carry, and may never put something drawn
+  // or written behind a gesture.
+  const { container } = render(
+    await DayPanel({ slug: "la-jolla-shores-beach" }),
+  );
+
+  fireEvent.click(container.querySelector('[data-hour-column="9"]')!);
+
+  expect(provenance(container)).toContain("NOAA Tides & Currents");
+});

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -75,12 +75,23 @@ import {
   GRID_SOURCE,
   gridCellCaveat,
 } from "./gridCell";
-import { MOP_MODEL_NOTE, MOP_NETWORK, mopLineSource } from "./mopLine";
+import {
+  MOP_MODEL_NOTE,
+  MOP_NETWORK,
+  mopLineDistanceKm,
+  mopLineSource,
+} from "./mopLine";
 import { gridWindReadings, needleFrom, swellReadings } from "./needles";
+import type { ProvenanceFacts } from "./ProvenanceLine";
 import { ShoreMap } from "./ShoreMap";
 import { shoreViewFor } from "./shore";
 import { SkyWording } from "./SkyWording";
 import { gridPoints, swellPoints, tidePoints } from "./series";
+import {
+  TIDE_NETWORK,
+  tideStationDistanceKm,
+  tideStationNote,
+} from "./tideStation";
 
 /**
  * What each tab says when its own feed is the thing that is missing.
@@ -316,6 +327,66 @@ export async function DayPanel({ slug }: { slug: string }) {
   ]);
 
   /*
+    Who published each curve, composed once for the week rather than per day.
+
+    A tide station, a model line and a forecast cell are bound to the beach and
+    never to the day: all seven days of a tab carry the same publisher, so
+    building these inside the loop would be seven copies of one fact. Every word
+    comes from `tideStation.ts`, `mopLine.ts` and `gridCell.ts` -- three modules
+    that exist because two call sites wording one fact is how `ProvenanceLine`
+    came to print one station two ways on one card.
+
+    `null` where the beach binds no such source, which is the same condition
+    under which that tab has no curve to attribute: each of the three fields is
+    null exactly when its own read's state is `no-station`, `no-line` or
+    `no-cell`, and none of those states reaches a plot.
+  */
+  const cellNote = [
+    GRID_MODEL_NOTE,
+    gridCellCaveat(grid.cell?.elevationM ?? null),
+  ]
+    .filter((part): part is string => part !== null)
+    .join("; ");
+
+  const station = hourly.station;
+  const tideProvenance: ProvenanceFacts | null =
+    station === null
+      ? null
+      : {
+          label: "Tide",
+          source: station.name,
+          network: TIDE_NETWORK,
+          distanceKm: tideStationDistanceKm(station.distanceM),
+          note: tideStationNote(station.distanceM, station.water),
+        };
+
+  const swellProvenance: ProvenanceFacts | null =
+    waves.line === null
+      ? null
+      : {
+          label: "Swell",
+          source: mopLineSource(waves.line.id),
+          network: MOP_NETWORK,
+          distanceKm: mopLineDistanceKm(waves.line.distanceM),
+          note: MOP_MODEL_NOTE,
+        };
+
+  /*
+    One cell and two tabs, so two lines rather than one shared: the label is
+    what says which curve is being attributed, and it is the only field of the
+    two that differs.
+
+    No distance, which is the omission `WeekPanel`'s cloud row already makes. A
+    cell is a 2.5 km square of map with the beach somewhere inside it, so "about
+    n km from this beach" would be a figure about nothing -- unlike a station or
+    a model line, which stand at a point.
+  */
+  const cellProvenance = (label: string): ProvenanceFacts | null =>
+    grid.cell === null
+      ? null
+      : { label, source: GRID_SOURCE, network: GRID_NETWORK, note: cellNote };
+
+  /*
     The seven days come from the daylight read, which is the same choice
     `WeekPanel` makes one region up: it is computed from the beach's own
     coordinates rather than fetched, so it cannot fail and costs no request.
@@ -376,6 +447,7 @@ export async function DayPanel({ slug }: { slug: string }) {
                 day.sunsetLabel,
               ),
         absence: absenceFor(hourly, WORDS.tide, when),
+        provenance: tideProvenance,
       },
       {
         key: "swell",
@@ -392,6 +464,7 @@ export async function DayPanel({ slug }: { slug: string }) {
                 day.sunsetLabel,
               ),
         absence: absenceFor(waves, WORDS.swell, when),
+        provenance: swellProvenance,
       },
       {
         key: "wind",
@@ -408,6 +481,7 @@ export async function DayPanel({ slug }: { slug: string }) {
           WORDS.wind.outOfReach(when),
         ),
         absence: gridAbsenceFor(grid, gridDay?.windMph, WORDS.wind, when),
+        provenance: cellProvenance("Wind"),
       },
       {
         /*
@@ -441,6 +515,10 @@ export async function DayPanel({ slug }: { slug: string }) {
           WORDS.temperature,
           when,
         ),
+        // The word the tab drops, put back. Same rule as the spoken
+        // description and the sentence under the plot: "Temp" buys width on a
+        // 375px tab bar, and nothing else on this page pays for it.
+        provenance: cellProvenance("Air temperature"),
       },
     ];
 
@@ -536,13 +614,6 @@ export async function DayPanel({ slug }: { slug: string }) {
     across north in its first three hours, and a day measured end to end
     reports an arc nobody could have stood in.
   */
-  const cellNote = [
-    GRID_MODEL_NOTE,
-    gridCellCaveat(grid.cell?.elevationM ?? null),
-  ]
-    .filter((part): part is string => part !== null)
-    .join("; ");
-
   const compassDays: CompassDay[] = daylight.days.map((day) => {
     const gridDay =
       grid.state.kind === "week"

--- a/src/components/conditions/HourChart.test.tsx
+++ b/src/components/conditions/HourChart.test.tsx
@@ -33,6 +33,27 @@ const OVERNIGHT_DIP = hourly([
   2.4, 3.1, 3.9, 4.5, 4.8, 4.6, 4.1, 3.5,
 ]);
 
+/**
+ * Each tab's source, written out rather than imported from `tideStation.ts` and
+ * `mopLine.ts`.
+ *
+ * This component looks nothing up: it prints what the caller composed. A
+ * fixture sharing the constants could not tell a chart printing its caller's
+ * words from one that had gone and found its own.
+ */
+const TIDE_SOURCE = {
+  label: "Tide",
+  source: "La Jolla (Scripps Institution Wharf)",
+  network: "NOAA Tides & Currents",
+};
+
+const SWELL_SOURCE = {
+  label: "Swell",
+  source: "MOP line D0481",
+  network: "CDIP, Scripps Institution of Oceanography",
+  note: "a model of the swell at 10 m depth, not a measurement",
+};
+
 /** The tab this chart opens on, and the one every test here drives unless it says otherwise. */
 const TIDE = {
   key: "tide",
@@ -41,6 +62,7 @@ const TIDE = {
   points: OVERNIGHT_DIP as readonly SparkPoint[],
   description: "Tide through Monday, 0.2 to 4.8 feet",
   absence: "No hourly prediction for this day.",
+  provenance: TIDE_SOURCE,
 };
 
 /**
@@ -59,6 +81,7 @@ const SWELL = {
   })) as readonly SparkPoint[],
   description: "Swell through Monday, three-hourly",
   absence: "No swell forecast reaches this day.",
+  provenance: SWELL_SOURCE,
 };
 
 const PROPS = {
@@ -898,6 +921,73 @@ describe("the tabs", () => {
     expect(markup).not.toContain("data-series-tab");
     expect(markup).not.toContain('role="tabpanel"');
     expect(markup).toContain("data-curve");
+  });
+});
+
+describe("who published the curve", () => {
+  const TABBED = { ...PROPS, series: [TIDE, SWELL] };
+
+  /** The chart's own attribution, and nothing else on the page that looks like one. */
+  function line(container: HTMLElement): HTMLElement | null {
+    return container.querySelector("[data-series-provenance] p");
+  }
+
+  test("the line names the tab that is selected, not the tab that opened", () => {
+    // Four tabs and three publishers, so one line for the chart would be wrong
+    // on at least two of them. This is the whole of finding 1 in the day view's
+    // design review.
+    const { container } = render(<HourChart {...TABBED} />);
+
+    expect(line(container)?.textContent).toContain("NOAA Tides & Currents");
+
+    fireEvent.click(container.querySelector('[data-series-tab="swell"]')!);
+
+    expect(line(container)?.textContent).toContain("MOP line D0481");
+    expect(line(container)?.textContent).not.toContain("NOAA");
+  });
+
+  test("a series with no source prints no line rather than an empty one", () => {
+    // 26 of 51 beaches bind no MOP line, and a beach with no tide station or no
+    // forecast cell has nothing to name either. A `ProvenanceLine` with an
+    // empty source would be a credit to nobody dressed as a credit.
+    const { container } = render(
+      <HourChart {...PROPS} series={[{ ...TIDE, provenance: null }]} />,
+    );
+
+    expect(container.querySelector("[data-curve]")).not.toBeNull();
+    expect(line(container)).toBeNull();
+  });
+
+  test("a quiet tab prints no attribution, because its absence names the publisher", () => {
+    // What is attributed is the curve. There is none here, and the sentence in
+    // its place already says which publisher went quiet -- that is what
+    // `DayPanel`'s per-product wording exists for.
+    const { container } = render(
+      <HourChart {...PROPS} series={[{ ...TIDE, points: [] }]} />,
+    );
+
+    expect(screen.getByText(TIDE.absence)).toBeDefined();
+    expect(line(container)).toBeNull();
+  });
+
+  test("the line is legible on the chart's own ground, not a card's", () => {
+    // `ProvenanceLine` defaults to the reading card's colour -- white at 55%,
+    // which paints 1.03:1 on cream and shipped that way from two call sites.
+    // This chart's shell is `bg-white/60`, lighter still.
+    const { container } = render(<HourChart {...TABBED} />);
+
+    expect(line(container)?.getAttribute("class")).toContain("text-fog");
+    expect(line(container)?.getAttribute("class")).not.toContain("text-white");
+  });
+
+  test("the attribution survives choosing an hour", () => {
+    // ADR-0027's additive condition: an interaction may reveal what the page
+    // did not carry and may never put something written behind a gesture.
+    const { container } = render(<HourChart {...TABBED} />);
+
+    fireEvent.click(container.querySelector('[data-hour-column="9"]')!);
+
+    expect(line(container)?.textContent).toContain("NOAA Tides & Currents");
   });
 });
 

--- a/src/components/conditions/HourChart.tsx
+++ b/src/components/conditions/HourChart.tsx
@@ -104,6 +104,7 @@ import { useId, useState } from "react";
 import { nightBands } from "./dayFrame";
 import { useHydrated } from "./hydrated";
 import type { SparkPoint } from "./DaySpark";
+import { ProvenanceLine, type ProvenanceFacts } from "./ProvenanceLine";
 import { TOUCH_TARGET } from "../ui/touchTarget";
 
 /**
@@ -135,6 +136,25 @@ export type HourSeries = {
    * wind series is a fact about one forecast run.
    */
   absence: string;
+  /**
+   * Who published this curve, printed beneath the plot when there is one.
+   *
+   * **Per series, because the four tabs are three publishers.** The tide is
+   * NOAA's, the swell is CDIP's model and the wind and the air temperature are
+   * the National Weather Service's cell — so one line for the chart would be
+   * wrong on at least two tabs, and the nearest line above the plot already is:
+   * it names the cell, and a reader who takes it for the plot's source is
+   * misinformed whenever the tide or the swell is drawn. ADR-0029 licenses the
+   * modelled swell sitting a few pixels above the buoy's measured height
+   * *on condition that each is attributed*, which is this field.
+   *
+   * **Required and nullable rather than optional.** `null` is a real state and
+   * not an omission: 26 of 51 beaches bind no MOP line, and a beach with no
+   * tide station or no forecast cell has nothing to name either. Making the
+   * field required is what stops the fifth series being composed without one,
+   * which is exactly how these four came to be drawn by nobody.
+   */
+  provenance: ProvenanceFacts | null;
 };
 
 export type HourChartProps = {
@@ -377,7 +397,7 @@ export function HourChart({
   // prop's docstring: picking the first one with data would be a rule a reader
   // could not see.
   const active = series[mounted ? tab : 0] ?? series[0];
-  const { points, unitLabel, description, absence } = active;
+  const { points, unitLabel, description, absence, provenance } = active;
 
   const onTabKeyDown = (event: React.KeyboardEvent) => {
     const moves: Record<string, number> = { ArrowLeft: -1, ArrowRight: 1 };
@@ -1030,6 +1050,40 @@ export function HourChart({
           Low {lowValue.toFixed(1)} {unitLabel}, high {highValue.toFixed(1)}{" "}
           {unitLabel} today. Night is shaded; cloud is the band above.
         </p>
+
+        {/*
+          Who published the curve, and it changes with the tab.
+
+          **Last, and beneath the summary, because it is the most subordinate
+          thing here** -- the same place `WeekGrid` puts its three. It is also
+          the reading order the fault needs: a reader arriving at the plot from
+          above has just passed a line naming the forecast cell, and this is the
+          first thing after the plot that says whose the plot actually is.
+
+          **Labelled, though the tab bar is four inches away and says the same
+          word.** Two sources are inside this frame -- the curve and the cloud
+          band above it, which is the National Weather Service's sky whatever
+          tab is selected -- so an unlabelled "MOP line D0481 · CDIP" under the
+          whole thing would credit CDIP with the weather. `WeekGrid` labels its
+          lines for exactly this reason and records it. The label is the series'
+          own word in full rather than the tab's: "Temp" is a tab shortened to
+          fit four across a 375px screen, and this line is not paying for that
+          width.
+
+          **`surface="page"`, and it is not a preference.** The chart's shell is
+          `bg-white/60`; the default paints `CARD_MUTED`, white at 55%, which on
+          this ground is the colour of the ground. `ProvenanceLine`'s own
+          docstring records two callers that shipped exactly that at 1.03:1.
+
+          Only where there is a plot. A quiet tab prints its `absence` instead,
+          and every one of those sentences already names the publisher that went
+          quiet -- which is what `WORDS` in `DayPanel` exists to do.
+        */}
+        {provenance !== null && (
+          <div className="mt-2" data-series-provenance>
+            <ProvenanceLine {...provenance} surface="page" />
+          </div>
+        )}
       </div>
     </>,
   );

--- a/src/components/conditions/ProvenanceLine.tsx
+++ b/src/components/conditions/ProvenanceLine.tsx
@@ -83,6 +83,20 @@ type ProvenanceLineProps = {
   surface?: "card" | "page";
 };
 
+/**
+ * Everything this line says about a source, less the ground it is printed on.
+ *
+ * **Two things a caller knows and one it does not.** Which station answered,
+ * who publishes it and how far away it stands are facts about the data, and
+ * travel with it: `HourSeries` carries a set of these per tab, composed where
+ * the read is. Which surface it lands on is a fact about the markup and is
+ * known only at the call site, so it stays out of here -- a series that carried
+ * its own `surface` would be a data structure with an opinion about where it
+ * would be rendered, and the whole reason this prop exists is that the last
+ * component to guess that got it wrong at 1.03:1.
+ */
+export type ProvenanceFacts = Omit<ProvenanceLineProps, "surface">;
+
 export function ProvenanceLine({
   source,
   network = null,

--- a/src/components/conditions/cardText.test.ts
+++ b/src/components/conditions/cardText.test.ts
@@ -99,3 +99,26 @@ test("the page's muted role clears the floor on the page", () => {
 test("the card's muted role is unreadable on the page, which is why two exist", () => {
   expect(contrast(painted(CARD_MUTED, CREAM), CREAM)).toBeLessThan(1.1);
 });
+
+/**
+ * The day chart's tile, which is a third ground and not the page's own.
+ *
+ * `HourChart`'s shell is `bg-white/60` over the page, so the provenance line
+ * beneath its plot is printed on cream lightened rather than on cream. It is
+ * the *lighter* of the two, which makes `CARD_MUTED` worse here than the 1.03:1
+ * it shipped at on cream and `PAGE_MUTED` slightly better -- but "slightly
+ * better than a figure measured somewhere else" is the reasoning that produced
+ * the invisible line in the first place, so this ground is computed rather than
+ * argued from the one next to it.
+ */
+const CHART = over(WHITE, 0.6, CREAM);
+
+test("the page's muted role clears the floor on the day chart's tile", () => {
+  expect(contrast(painted(PAGE_MUTED, CHART), CHART)).toBeGreaterThanOrEqual(
+    FLOOR,
+  );
+});
+
+test("the card's muted role would be invisible on the day chart's tile too", () => {
+  expect(contrast(painted(CARD_MUTED, CHART), CHART)).toBeLessThan(1.1);
+});

--- a/src/components/conditions/selectedDay.test.tsx
+++ b/src/components/conditions/selectedDay.test.tsx
@@ -79,6 +79,9 @@ function dayView(index: number): DayView {
         points: points(localDate, index * 10),
         description: `Tide on ${localDate}`,
         absence: "No tide series.",
+        // This file is about which day is shown, not about who published it.
+        // Null keeps the fixture to the one fact under test.
+        provenance: null,
       },
       {
         key: "swell",
@@ -87,6 +90,7 @@ function dayView(index: number): DayView {
         points: points(localDate, index * 10 + 100),
         description: `Swell on ${localDate}`,
         absence: "No swell series.",
+        provenance: null,
       },
     ],
     wording: <p>Words for {localDate}</p>,


### PR DESCRIPTION
Closes #179

The day chart drew four curves from three publishers and credited none of them.
The nearest provenance above the plot is `SkyWording`'s and names the National
Weather Service's grid cell, so a reader who took it for the plot's source was
misinformed whenever the tide or the swell was drawn; on the swell tab the
nearest line *below* named the NDBC buoy, whose measured 3.0 ft is not the
modelled height above it. ADR-0029's third clause — "the chart's provenance
names the cell while the card's names the station" — is what licenses that
forecast-beside-measurement pair, and it described a page that did not exist.

## What changed

One slice, two commits.

**`f0603a9` — the regression test, as MUST FAIL.** Four assertions in
`DayPanel.test.tsx` reading the rendered text per tab rather than asserting a
component is present, which is the technique #176 used to catch the tide station
going unnamed. Scoped to the chart's own element: an unscoped `getByText` would
find `SkyWording`'s line — the very line finding 1 says a reader mistakes for
the plot's — and pass. **This commit is red by construction**; the gate is green
from the second commit onward. That is the shape `404fc1c` → `47c5d6e` used.

**`a2c2089` — the fix.** `HourSeries` gains a `provenance` field, `DayPanel`
fills it from `tideStation.ts`, `mopLine.ts` and `gridCell.ts` (none changed),
and `HourChart` renders one `ProvenanceLine` under the plot for whichever tab is
selected.

Three decisions worth naming:

- **The seam is `HourSeries`, not `series.ts`.** The review's _Fix:_ clause said
  "`series.ts` already assembles per-series metadata"; it assembles per-series
  *points* and carries no metadata at all. #179 caught that and this follows the
  issue.
- **`provenance` is required and nullable, not optional.** A beach with no tide
  station, no MOP line or no forecast cell has nothing to name, and 26 of 51
  bind no line — but an optional field is how four curves came to be drawn by
  nobody, so every construction site now has to say which it is.
- **`surface="page"`.** The chart's shell is `bg-white/60`; the default paints
  `CARD_MUTED` white-at-55% onto it, which is the 1.03:1 failure recorded in
  `ProvenanceLine`'s own docstring.

## Verification

`npm run gate`, at `a2c2089`:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… sea-side
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

Coverage, from the same suite — the branch floor is 88.94% and the two absence
tests are what keep it there, since the new null branches would otherwise have
dropped it to 88.88%:

```
 Test Files  93 passed (93)
      Tests  1456 passed (1456)

Statements   : 89.46% ( 2717/3037 )
Branches     : 89.04% ( 1763/1980 )
Functions    : 94.29% ( 628/666 )
Lines        : 89.16% ( 2452/2750 )
```

### Contrast, measured from painted pixels

The issue asks for painted pixels and not the CSS tree, because the CSS-tree
walk scores white-on-cream as passing. Rendered at 1536×639, screenshotted per
element, decoded, and read as *ground = the modal pixel, ink = whichever extreme
is further from it in luminance*. The two documented controls were measured in
the same run and reproduce exactly, which is what says the method works:

| line                             | ground             | ink                | ratio      |
| -------------------------------- | ------------------ | ------------------ | ---------- |
| chart provenance — Tide          | `rgb(253,252,251)` | `rgb(107,95,125)`  | **5.76:1** |
| chart provenance — Swell         | `rgb(253,252,251)` | `rgb(107,95,125)`  | **5.76:1** |
| chart provenance — Wind          | `rgb(253,252,251)` | `rgb(107,95,125)`  | **5.76:1** |
| chart provenance — Air temp      | `rgb(253,252,251)` | `rgb(107,95,125)`  | **5.76:1** |
| _control:_ `ReadingCard` line    | `rgb(26,26,46)`    | `rgb(152,152,161)` | 5.96:1     |
| _control:_ `ReadingCard` prose   | `rgb(26,26,46)`    | `rgb(198,198,203)` | 10.02:1    |

`rgb(253,252,251)` is `bg-white/60` over `--color-cream` and `rgb(107,95,125)`
is `--color-fog`, so the paint agrees with the arithmetic to the byte.
`cardText.test.ts` now computes that ground rather than arguing from the one
next to it — including the inverse assertion that `CARD_MUTED` would be
invisible on it too, which is the thing that could quietly come back.

### What it says on the page

Read off the built page at La Jolla Shores, verbatim:

```
Tide   La Jolla (Scripps Institution Wharf) · NOAA Tides & Currents
Swell  MOP line D0498 · CDIP, Scripps Institution of Oceanography ·
       about 0.3 km from this beach — a model of the swell at 10 m depth,
       not a measurement
Wind   this beach's own grid cell · National Weather Service, San Diego —
       a forecast, not a reading taken at the beach
Air temperature  (the same as Wind)
```

## Not done, and why

- **No plan file.** The work finished in one sitting and turned on no choice
  between approaches. The issue and this body are the durable record.
- **No ADR.** Nothing is decided here that ADR-0029 did not already decide; this
  is the condition it attached, arriving late.
- **`docs/plans/conditions-day-view.md` is untouched**, per its own historical
  note: it is a dated record now, not amended.
- **Findings 2–5 of the review are untouched.** #179 is finding 1.

## Noticed, not filed

**The swell attribution now appears twice on one screen at `xl`.** Where the map
sits beside the chart, the compass's own sources block repeats "MOP line D0498 ·
CDIP, Scripps Institution of Oceanography — a model of the swell at 10 m depth,
not a measurement" about 160px from the chart's copy of the same sentence, and
the same for the grid cell. Both are correct under ADR-0010 — the curve and the
needle are two graphics and each names its own source, which is exactly what
ADR-0032 settled for the dial — and removing either would leave a graphic
unattributed. But it is redundant to look at, and it is only visible at the one
breakpoint where the two sit side by side. Worth a design eye rather than a
tracker row.

**The cloud band is still unattributed as a graphic.** It is the National
Weather Service's sky drawn inside a frame that now credits NOAA or CDIP on two
of four tabs. Labelling the line is what keeps that from being a miscredit —
`WeekGrid`'s own reason for labelling — and `cloudDescription` already names the
band's publisher to a screen reader. A visible second line for the band is a
design decision, not this fix.
