### PR TITLE
Fade the chart's fill toward the floor

### DIFF
--- a/src/components/conditions/HourChart.test.tsx
+++ b/src/components/conditions/HourChart.test.tsx
@@ -461,6 +461,89 @@ describe("published points", () => {
   });
 });
 
+describe("the fill under the curve", () => {
+  /** The `url(#…)` the area points at, or null when it points at nothing. */
+  function fillRef(container: HTMLElement): string | null {
+    const fill = container.querySelector("[data-area]")?.getAttribute("fill");
+    return fill?.match(/^url\(#(.+)\)$/)?.[1] ?? null;
+  }
+
+  /**
+   * The gradient an area actually resolves to, found by id rather than by
+   * being the only one in the document.
+   *
+   * A reference to an id nothing defines paints nothing at all, which looks
+   * exactly like a fade that works and is the trap `ShoreMap` fell into -- nine
+   * of its ten tests passed with the sea shaded over the land. So the id is
+   * followed rather than assumed to land somewhere.
+   */
+  function gradientFor(container: HTMLElement): Element | null {
+    const id = fillRef(container);
+    if (id === null) return null;
+    return (
+      [...container.querySelectorAll("linearGradient")].find(
+        (each) => each.getAttribute("id") === id,
+      ) ?? null
+    );
+  }
+
+  test("the area is filled with a gradient, not a flat colour", () => {
+    // A flat fill closed to the foot of the frame asserts a quantity the axis
+    // has explicitly disclaimed: the range is this day's own, so the foot is
+    // 74.0 °F on the temperature tab and the fill draws a 3 °F day as a
+    // mountain.
+    const { container } = render(<HourChart {...PROPS} />);
+
+    const area = container.querySelector("[data-area]");
+    expect(area).not.toBeNull();
+    expect(fillRef(container)).not.toBeNull();
+    expect(area?.getAttribute("class")).not.toContain("fill-ocean");
+  });
+
+  test("the gradient it points at is really in the document", () => {
+    const { container } = render(<HourChart {...PROPS} />);
+
+    expect(gradientFor(container)).not.toBeNull();
+  });
+
+  test("the gradient ends fully transparent, so the frame's foot is bare", () => {
+    // The hard edge at the foot is the part that reads as a quantity. Anything
+    // above zero there is still a baseline being asserted.
+    const { container } = render(<HourChart {...PROPS} />);
+
+    const stops = [...(gradientFor(container)?.querySelectorAll("stop") ?? [])];
+    expect(stops.length).toBeGreaterThanOrEqual(2);
+    expect(Number(stops[stops.length - 1].getAttribute("stop-opacity"))).toBe(
+      0,
+    );
+    // And it is a fade rather than a fill that is transparent throughout: the
+    // body the fill was added for has to survive the fix for the foot.
+    expect(Number(stops[0].getAttribute("stop-opacity"))).toBeGreaterThan(0);
+  });
+
+  test("two charts on one page do not share a gradient", () => {
+    // Duplicate SVG ids resolve to whichever the document sees first, so a
+    // literal id would silently bind every chart on the page to one gradient.
+    const { container } = render(
+      <>
+        <HourChart {...PROPS} />
+        <HourChart {...PROPS} />
+      </>,
+    );
+
+    const ids = [...container.querySelectorAll("linearGradient")].map((each) =>
+      each.getAttribute("id"),
+    );
+
+    // Both halves, because `expect(first).not.toBeNull()` is satisfied by the
+    // `undefined` a chart that rendered no gradient at all would give, and two
+    // of those compare equal -- a test that fails for the wrong reason today
+    // and passes for the wrong reason tomorrow.
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+  });
+});
+
 describe("when there is no series", () => {
   test("an unavailable series renders its reason, not an empty frame", () => {
     // A curve is a stronger claim than a figure: a flat line at zero says the

--- a/src/components/conditions/HourChart.test.tsx
+++ b/src/components/conditions/HourChart.test.tsx
@@ -497,7 +497,9 @@ describe("the fill under the curve", () => {
     const area = container.querySelector("[data-area]");
     expect(area).not.toBeNull();
     expect(fillRef(container)).not.toBeNull();
-    expect(area?.getAttribute("class")).not.toContain("fill-ocean");
+    // `?? ""` because the fixed version carries no class at all, and
+    // `not.toContain` on null throws rather than passing.
+    expect(area?.getAttribute("class") ?? "").not.toContain("fill-ocean");
   });
 
   test("the gradient it points at is really in the document", () => {

--- a/src/components/conditions/HourChart.tsx
+++ b/src/components/conditions/HourChart.tsx
@@ -238,6 +238,27 @@ const CLOUD_H = 14;
 const PAD = 8;
 
 /**
+ * The fill's strength where the curve is, fading to nothing at the frame's foot.
+ *
+ * **Higher than the 12% the flat fill used, and that is arithmetic rather than
+ * taste.** A gradient from 12% to transparent averages about 6% across the
+ * shape, which is half the ink the flat fill had — so fixing the foot by fading
+ * would have quietly undone the thing the fill was added for, and left the plot
+ * reading as the empty field with a thread across it that the review objected
+ * to. 24% at the curve averages about the same 12% the shape carried before,
+ * so the body is preserved and only the hard edge along the bottom goes.
+ *
+ * The bottom stop is zero and not "nearly zero". Anything above it is still an
+ * edge along the frame's foot, and the edge is the part that reads as a
+ * quantity. Ruled 2026-08-29 in the day view's design review, finding 2, which
+ * also records the two alternatives that were rejected: dropping the fill where
+ * the floor is not near zero, which would have made four tabs look like two
+ * chart styles, and labelling the floor as a floor, which answers a problem of
+ * form with words.
+ */
+const AREA_TOP_OPACITY = 0.24;
+
+/**
  * The plot frame's shape on a phone, where its own is too flat to read.
  *
  * **One aspect ratio cannot serve both ends of this range, and that is a
@@ -550,6 +571,9 @@ export function HourChart({
     )
     .join(" ");
 
+  /** What the publisher issued, which is what gets a mark. See `MARKS_FIT_NARROW`. */
+  const publishedPoints = points.filter((point) => point.published);
+
   /**
    * The same curve, closed to the foot of the frame.
    *
@@ -558,20 +582,40 @@ export function HourChart({
    * objected to. A fill gives the series body and makes the shape legible at a
    * glance rather than only on inspection.
    *
-   * It is the row's own colour at a low opacity, which is what keeps it clear of
-   * ADR-0009: `weekTone.ts` records that what makes colour a verdict is
-   * *differential* colour, a green day beside a red one. Every hour of every day
-   * takes the same ocean whatever the tide is doing, so this asserts nothing
-   * about the water.
+   * It is the row's own colour, which is what keeps it clear of ADR-0009:
+   * `weekTone.ts` records that what makes colour a verdict is *differential*
+   * colour, a green day beside a red one. Every hour of every day takes the
+   * same ocean whatever the tide is doing, so this asserts nothing about the
+   * water.
+   *
+   * **What it is painted with, though, is not the colour it started as, and
+   * that is the fix for a second reading it was making anyway.** Flat at 12%
+   * and closed to `HEIGHT`, the shape had a hard edge along the bottom of the
+   * frame — and the frame's bottom is `lowValue`, not zero. On the temperature
+   * tab, where a day runs 74.0 to 77.0 °F, that drew three degrees as a
+   * mountain. The docstring above and the range's own both argued well and
+   * neither addressed the other: one is why the scale floats, the other is why
+   * there is a fill, and together they assert a baseline the axis disclaims.
+   *
+   * The gradient is the whole of the answer. See `AREA_TOP_OPACITY`.
    */
-  /** What the publisher issued, which is what gets a mark. See `MARKS_FIT_NARROW`. */
-  const publishedPoints = points.filter((point) => point.published);
-
   const areaPath =
     points.length < 2
       ? null
       : `${path} L${x(points[points.length - 1].atMs).toFixed(2)} ${HEIGHT} ` +
         `L${x(points[0].atMs).toFixed(2)} ${HEIGHT} Z`;
+
+  /**
+   * The gradient's own id, per rendered chart.
+   *
+   * From the same `useId` the tabs take theirs from rather than a second call:
+   * one instance, one identity. A literal would be a duplicate SVG id the
+   * moment two charts are on a page — and duplicates resolve to whichever the
+   * document sees first, so every chart would silently paint through the first
+   * one's gradient. React 19 emits `_R_0_`-shaped ids, which need no escaping
+   * inside `url(#…)`.
+   */
+  const areaFillId = `${tabIds}area`;
 
   /** The now line, only when this day is today and the instant is inside it. */
   const nowX =
@@ -800,6 +844,43 @@ export function HourChart({
               className="block h-auto w-full max-sm:h-full"
             >
               {/*
+                The fill's fade, running the frame's height rather than the
+                shape's own box.
+
+                `gradientUnits="userSpaceOnUse"` so the stops are pinned to the
+                frame: y=0 is the top of the plot and y=HEIGHT is its foot,
+                whatever the area's bounding box happens to be on this tab. The
+                default maps 0..1 onto the shape instead, which would move the
+                fade with the data and is the kind of coupling this plot spent
+                three revisions removing from the cloud layer.
+
+                `currentColor` rather than a colour, and `text-ocean` rather
+                than `var(--color-ocean)`: a stop takes no Tailwind fill
+                utility, and every colour in this repo is named by a class so
+                that ADR-0006's scanner can see it. The class is a literal
+                string in `src/`, which is what makes the `stylesheet` gate's
+                reading hold.
+              */}
+              <defs>
+                <linearGradient
+                  id={areaFillId}
+                  className="text-ocean"
+                  gradientUnits="userSpaceOnUse"
+                  x1={0}
+                  y1={0}
+                  x2={0}
+                  y2={HEIGHT}
+                >
+                  <stop
+                    offset="0"
+                    stopColor="currentColor"
+                    stopOpacity={AREA_TOP_OPACITY}
+                  />
+                  <stop offset="1" stopColor="currentColor" stopOpacity={0} />
+                </linearGradient>
+              </defs>
+
+              {/*
               Night, full height, the ground the whole day is drawn on. It is
               the only shading inside this frame: cloud has its own band above,
               so nothing here has to be told apart from anything else by shade.
@@ -819,8 +900,7 @@ export function HourChart({
               {areaPath !== null && (
                 <path
                   d={areaPath}
-                  className="fill-ocean"
-                  fillOpacity={0.12}
+                  fill={`url(#${areaFillId})`}
                   stroke="none"
                   data-area
                 />


### PR DESCRIPTION
Closes #180

**This one needs a look before it merges.** #180 is labelled `needs-human`
because the property at stake — that the fill reads as weight and not as a
quantity — is not something a gate can assert. Screenshots are below; the
numbers say the edge is gone, but whether it now reads right is yours.

The plot scales each series to its own day's min and max, then filled from the
curve to the foot of the frame. The foot is `lowValue`, not zero, so the shape
had a hard edge along a baseline the axis explicitly disclaims — worst on Temp,
where a day running 72.0–75.0 °F drew as a mountain. Two docstrings argued the
two halves of that (why the scale floats, why there is a fill) and neither
addressed the other.

## What changed

One slice, two commits.

**`8cb9177` — the regression test, as MUST FAIL.** Nothing asserted anything
about `data-area` before this, which is why the suite was green. Four
assertions: the fill is a gradient reference, that reference lands on a gradient
that exists, its last stop is fully transparent, and two charts on a page do not
share an id.

**`98b53bc` — the fix.** A `<linearGradient>` down the frame, ocean at the top
and transparent at the bottom, replacing `fill-ocean` at `fillOpacity={0.12}`.

Three decisions inside it:

- **The top stop is 24%, not the 12% the flat fill used.** A fade from 12% to
  nothing averages about 6% across the shape — half the ink — which would have
  fixed the foot by undoing the reason the fill exists, leaving the "empty field
  with a thread across it" the review objected to. 24% at the curve averages
  about the 12% the shape carried before.
- **`gradientUnits="userSpaceOnUse"`,** so the stops pin to the frame rather
  than to the shape's bounding box. The default would move the fade with the
  data, which is the coupling the cloud layer took three revisions to remove.
- **`currentColor` with `text-ocean` on the gradient,** not a hex and not
  `var(--color-ocean)`. A stop takes no Tailwind fill utility, no component in
  this repo references a theme variable directly, and the class has to be a
  literal in `src/` for ADR-0006's scanner. Built from a cleared `.next/`.

The id comes from the `useId` the tabs already use. React 19 emits `_R_…_`-shaped
ids — checked with `renderToStaticMarkup` rather than assumed — so nothing needs
escaping inside `url(#…)`.

## Verification

`npm run gate`, at `98b53bc`, from a cleared `.next/`:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… sea-side
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

### The mutation check the issue asked for

"Prove this one can fail before trusting it" — nine of `ShoreMap`'s ten tests
passed with the sea shaded over the land. Two mutations, run against the real
suite:

| mutation                                            | result                                                                                                        |
| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
| `fill={url(#…)}` → `className="fill-ocean" fillOpacity={0.12}` | **3 failed** — gradient reference, reference resolves, last stop transparent |
| `areaFillId` → a literal string                     | **1 failed** — two charts on one page do not share a gradient                                                  |

All four assertions are killable, and by the mutation each is actually about.
Both mutations were reverted; the tree at `98b53bc` is the real implementation.

### Painted pixels, off the built page

The `[data-area]` fill resolves on all four tabs (`url(#_R_naatpesnelb_area)` in
the hydrated DOM), and one column of the rasterised plot at mid-morning — where
the ground is the plain frame, not a night band — fades to the tile's own colour
at the foot:

| tab  | y=55%              | y=75%              | y=90%              | y=99%              |
| ---- | ------------------ | ------------------ | ------------------ | ------------------ |
| Tide | `rgb(228,233,239)` | `rgb(239,241,244)` | `rgb(248,248,248)` | `rgb(252,251,250)` |
| Swell | `rgb(228,233,239)` | `rgb(239,241,244)` | `rgb(248,248,248)` | `rgb(252,251,250)` |
| Wind | `rgb(228,233,239)` | `rgb(239,241,244)` | `rgb(248,248,248)` | `rgb(252,251,250)` |
| Temp | `rgb(253,252,251)` | `rgb(239,241,244)` | `rgb(248,248,248)` | `rgb(252,251,250)` |

The tile's own ground is `rgb(253,252,251)`, so at the frame's foot the fill is
within one count per channel of painting nothing. The 55% and 75% rows are the
positive control and they matter: a gradient reference that resolves to nothing
paints nothing *anywhere*, which would pass the foot check for exactly the wrong
reason. Temp reads bare at 55% because its curve is below that height at the
sampled hour.

### Unchanged furniture

Not re-asserted here — the existing tests already run on every render and are
the net: night bands (`data-night` count of 2), published-point marks (`circle`
counts of 24 and 8), the summary line, and the cloud band's separation from the
plot. ADR-0027's additive condition is intact; nothing moved behind a gesture.

## What it looks like

Temp tab, 1536×639, the case that made this visible — before and after are in
the review thread below. The mass moves under the curve and the bottom of the
frame goes bare, so the 3 °F day stops drawing as a mountain. The Tide tab is
the honest case (its floor is near zero) and it still reads as an area chart
with body, which is the thing the 24% top stop was chosen to protect.

## Not done, and why

- **No plan file.** One sitting, and the approach was already ruled in the
  review; the issue and this body are the durable record.
- **No ADR.** The decision and its two rejected alternatives are recorded in
  finding 2 of the design review, which the constant's docstring cites. Nothing
  new is decided here. If you want the rule — "a fill on a floating baseline
  fades to the floor" — binding on plots that do not exist yet, that is an ADR
  worth its own commit, and I did not assume it.
- **The per-day range is untouched.** It is the other half of the pair and
  keeping it is what the ruling assumed.
