### PR TITLE
Name the day the chart's figures belong to

### DIFF
--- a/src/components/conditions/ChosenDay.tsx
+++ b/src/components/conditions/ChosenDay.tsx
@@ -44,6 +44,15 @@ export type DayView = {
   localDate: string;
   /** This day's name in the heading: "Today", "Thu, Aug 27". */
   dayName: string;
+  /**
+   * The same day inside a sentence: "today", "on Thu, Aug 27".
+   *
+   * A second form rather than `dayName` lowercased, because lowercasing a date
+   * gives "thu, aug 27" — and a third form of one fact is what three positions
+   * genuinely want. `DayPanel` composes all of them in one place, next to the
+   * `when` its absence sentences take.
+   */
+  chartWhen: string;
   /** Local midnight this day begins on, and the next. The plot's two edges. */
   startMs: number;
   endMs: number;
@@ -142,6 +151,7 @@ export function ChosenDay({
             series={day.series}
             sunriseMs={day.sunriseMs}
             sunsetMs={day.sunsetMs}
+            when={day.chartWhen}
             cloud={day.cloud}
             cloudDescription={day.cloudDescription}
             nowMs={day.nowMs}

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -398,9 +398,27 @@ export async function DayPanel({ slug }: { slug: string }) {
     days in the same order and the two cannot disagree about which is Tuesday.
   */
   const days: DayView[] = daylight.days.map((day) => {
-    // "today" inside a sentence, `Thu, Aug 27` on the other six. The grid's own
-    // label, so the heading and the cell a reader just chose agree.
+    /*
+      Three forms of one day, because three positions want three.
+
+      `when` goes where a noun or a preposition already precedes it -- "for
+      today", "Tide Thu, Aug 27, hour by hour" -- and is the form every absence
+      sentence and every spoken description takes. `dayName` heads the region,
+      where it is capitalised. `chartWhen` closes the chart's summary line,
+      which ends on the day rather than continuing past it: "high 5.3 ft today"
+      needs no preposition and "high 5.3 ft Thu, Aug 27" reads as "5.3 ft Thu"
+      and then a stray "Aug 27", because the comma inside the label collides
+      with the sentence.
+
+      All three are composed here, in one expression each, rather than derived
+      from one another downstream. `dayName` is not `when` capitalised and
+      `chartWhen` is not `dayName` lowercased: lowercasing a date gives "thu,
+      aug 27". A component deriving one from another would be inventing a
+      calendar rule at a call site, which is the drift `ProvenanceLine`'s
+      docstring records for a different fact.
+    */
     const when = day.isToday ? "today" : day.dayLabel;
+    const chartWhen = day.isToday ? "today" : `on ${day.dayLabel}`;
 
     const tideDay =
       hourly.state.kind === "week"
@@ -526,6 +544,7 @@ export async function DayPanel({ slug }: { slug: string }) {
       localDate: day.localDate,
       // "Today" at the head of a heading, the grid's own label otherwise.
       dayName: day.isToday ? "Today" : day.dayLabel,
+      chartWhen,
       /*
         The frame comes from the calendar, not from a feed.
 

--- a/src/components/conditions/HourChart.test.tsx
+++ b/src/components/conditions/HourChart.test.tsx
@@ -89,6 +89,11 @@ const PROPS = {
   endMs: END,
   sunriseMs: SUNRISE,
   sunsetMs: SUNSET,
+  // The chart is handed the day already worded, so "today" here is a fixture
+  // value and not a fact this component knows. `selectedDay.test.tsx` is where
+  // the word is checked against the heading, which is the only place the two
+  // can be compared.
+  when: "today",
   series: [TIDE],
 };
 

--- a/src/components/conditions/HourChart.tsx
+++ b/src/components/conditions/HourChart.tsx
@@ -176,6 +176,34 @@ export type HourChartProps = {
   /** Sunset; everything after it is shaded as night. */
   sunsetMs: number;
   /**
+   * Which day these figures belong to, ready to print inside a sentence:
+   * `"today"`, or `"on Thu, Aug 27"`.
+   *
+   * **The summary line said "today" on all seven days until this existed**, four
+   * lines under a heading naming the day — and it mis-stated a figure and not
+   * only a date, since Wednesday's range called today's attributes Wednesday's
+   * tide to a reader standing in Monday. `DayPanel`'s `WORDS` records the rule
+   * it broke: every sentence names the day, because the region is no longer
+   * always today.
+   *
+   * **Required, and never defaulted to `"today"`.** A default is exactly how
+   * the word got here — true when it was written, false the moment the week
+   * became the selector — and it would go on being true for whichever caller
+   * forgets next.
+   *
+   * **Worded by the caller, which is the opposite of what `ProvenanceLine`
+   * concluded and right for a different reason.** That component takes a number
+   * and writes the sentence, because four call sites had drifted into four
+   * wordings of one fact. Here the fact is a calendar's and this component's
+   * whole argument is that it draws a frame and knows nothing about calendars:
+   * it cannot tell a relative word from a date without being told, so a clause
+   * built here would need a conditional on the literal string `"today"`. The
+   * closer precedent is this component's own: `description`, `absence` and
+   * `cloudDescription` are three caller-worded day-named strings it already
+   * prints, and this is the fourth.
+   */
+  when: string;
+  /**
    * Cloud cover per forecast hour, 0 to 100, drawn along the top of the plot.
    *
    * A layer rather than a series of its own: it is the condition the selected
@@ -378,6 +406,7 @@ export function HourChart({
   series,
   sunriseMs,
   sunsetMs,
+  when,
   cloud = [],
   cloudDescription = "Cloud cover through the day.",
   nowMs = null,
@@ -1128,7 +1157,7 @@ export function HourChart({
 
         <p className="text-2xs leading-relaxed mt-3 text-fog">
           Low {lowValue.toFixed(1)} {unitLabel}, high {highValue.toFixed(1)}{" "}
-          {unitLabel} today. Night is shaded; cloud is the band above.
+          {unitLabel} {when}. Night is shaded; cloud is the band above.
         </p>
 
         {/*

--- a/src/components/conditions/selectedDay.test.tsx
+++ b/src/components/conditions/selectedDay.test.tsx
@@ -177,6 +177,57 @@ test("choosing a day in the week redraws the panel below", () => {
   expect(screen.queryByText(`Measured on ${DATES[0]}`)).toBeNull();
 });
 
+/**
+ * The sentence under the plot, which is the axis in words.
+ *
+ * Found by its own opening rather than by a test hook, because what is being
+ * asserted is the sentence a reader gets. A `data-` attribute would let the
+ * markup move and the words stay wrong.
+ */
+function summary(container: HTMLElement): string {
+  return (
+    [...container.querySelectorAll("p")].find((each) =>
+      each.textContent?.startsWith("Low "),
+    )?.textContent ?? ""
+  );
+}
+
+/** The heading's own name for the day, without the phrase that follows it. */
+function headingDay(container: HTMLElement): string {
+  return (
+    container
+      .querySelector("#day-panel-heading")
+      ?.textContent?.replace(", hour by hour", "") ?? ""
+  );
+}
+
+test("the summary names the day the heading names, not today", () => {
+  // The rule `WORDS` records: "Every sentence names the day, because the region
+  // is no longer always today." Every absence sentence in the region takes a
+  // `when` for this reason and so does the measured block; this one does not,
+  // so the page names the day correctly twice and falsely once inside about
+  // sixty pixels. It mis-states a figure and not only a date -- Wednesday's
+  // range called today's attributes Wednesday's tide to a reader standing in
+  // Monday.
+  const { container } = renderBoth();
+
+  fireEvent.click(container.querySelector(`[data-day-choice="${DATES[2]}"]`)!);
+
+  expect(headingDay(container)).toBe("Wed, Aug 19");
+  expect(summary(container)).toContain("Wed, Aug 19");
+  expect(summary(container)).not.toContain("today");
+});
+
+test("and it still says today on today, rather than a date for every day", () => {
+  // The other direction, because the cheap fix for the above is to print the
+  // label unconditionally -- which would put "Mon, Aug 17" under a heading
+  // reading "Today" and lose the one day the word is true of.
+  const { container } = renderBoth();
+
+  expect(headingDay(container)).toBe("Today");
+  expect(summary(container)).toContain("today");
+});
+
 test("switching costs no request, because every day was already here", () => {
   // The whole week ships from the first render. Nothing fetches on a click,
   // and the way to assert that without mocking the network is that the markup

--- a/src/components/conditions/selectedDay.test.tsx
+++ b/src/components/conditions/selectedDay.test.tsx
@@ -65,6 +65,10 @@ function dayView(index: number): DayView {
   return {
     localDate,
     dayName: isToday ? "Today" : DAYS[index].dayLabel,
+    // The heading's form and the sentence's form, composed the way `DayPanel`
+    // composes them. A fixture deriving one from the other would prove the two
+    // agree here and nothing about whether they agree on the page.
+    chartWhen: isToday ? "today" : `on ${DAYS[index].dayLabel}`,
     startMs: localMidnightOf(localDate),
     endMs: localMidnightOf(localDate) + 24 * HOUR,
     sunriseMs: localMidnightOf(localDate) + 6 * HOUR,


### PR DESCRIPTION
Closes #177

The summary line under the plot ended with "today" on all seven days, four lines
under a heading naming the day. It mis-stated a figure and not only a date:
`Low 0.8 ft, high 5.4 ft` is Thursday's range, and calling it today's attributes
Thursday's tide to a reader standing in Monday.

## The decision

#177 offered two shapes and routed the choice to a human. **Chosen: `HourChart`
takes a `when`**, rather than moving the sentence up to `DayPanel`.

The deciding fact, which was not in the issue: the summary line is the axis in
words — its own docstring says so — and `lowValue`/`highValue` feed both it and
the `data-axis="low"`/`"high"` labels from one computation. Moving the sentence
to `DayPanel` would have put the two figures a sighted reader compares directly
into two components. That drift is not hypothetical: `DayPanel`'s spoken
descriptions already compute their own range, and `gridDescription` rounds to
`.toFixed(0)` where the axis uses `.toFixed(1)` — so the Wind tab already says
*"from 5 to 8 mph"* to a screen reader and *"Low 5.0 mph, high 8.0 mph"* on
screen. Keeping the sentence beside the axis is what stops a second copy of that.

The issue's objection to this shape — that it puts a calendar vocabulary into a
component that draws frames — turned out to be weaker than it reads.
`HourChart` is already handed three day-named strings composed upstream
(`description`, `absence`, `cloudDescription`), so a fourth follows the
component's own pattern rather than inventing one.

## What changed

One slice, two commits.

**`c7e3246` — the regression test, as MUST FAIL.** In `selectedDay.test.tsx`,
because the assertion is that the sentence names *the same day the heading
names* — a claim no component test can make, since `HourChart` is handed no day
name to compare against. That is also why nothing caught this. A second test
guards the other direction: the cheap fix is to print the label
unconditionally, which would put "Mon, Aug 17" under a heading reading "Today".

**`0ca8232` — the fix.** `HourChart` gains a required `when`; `DayView` gains
`chartWhen`; `ChosenDay` passes it through beside `cloudDescription` and `nowMs`.

Two things worth naming:

- **Required, never defaulted to `"today"`.** A default is exactly how the word
  got here — true when the region was always today, false the moment #175 made
  the week the selector. Making it required turned the omission into a typecheck
  failure at every place a chart is built.
- **A third form of the day in `DayPanel`, not a reuse of the two it had.**
  `when` goes where a noun or preposition precedes it (`for today`, `Tide Thu,
  Aug 27, hour by hour`); `dayName` heads the region capitalised; `chartWhen`
  *closes* a sentence, and there the comma inside the label collides with it —
  `high 5.3 ft Thu, Aug 27` reads as "5.3 ft Thu" and then a stray "Aug 27". So
  it carries the preposition. None is derived from another: lowercasing
  `dayName` gives "thu, aug 27".

## Verification

`npm run gate`, at `0ca8232`, from a cleared `.next/`:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… sea-side
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

The MUST FAIL commit failed with the bug quoted verbatim:

```
AssertionError: expected 'Low 20.0 ft, high 22.3 ft today. Nigh…' to contain 'Wed, Aug 19'
Received: "Low 20.0 ft, high 22.3 ft today. Night is shaded; cloud is the band above."
```

### Read off the built page

| day chosen | heading                    | summary                                                       |
| ---------- | -------------------------- | ------------------------------------------------------------- |
| today      | `Today, hour by hour`      | `Low 1.0 ft, high 5.4 ft today. Night is shaded; …`            |
| a later day | `Thu, Sep 3, hour by hour` | `Low 0.8 ft, high 5.4 ft on Thu, Sep 3. Night is shaded; …`    |

The figures differ between the two, so it is the right day's *range* and not
only the right day's name. The cloud band's own accessible name follows the same
day (`Cloud cover through Thu, Sep 3, …`), which it already did.

## Noticed, not filed

**The Wind and Temp tabs disagree with themselves by a rounding.** `DayPanel`'s
`gridDescription` prints `from 5 to 8 mph` to a screen reader while the axis and
this summary print `5.0` and `8.0`. It is the drift that decided the seam above,
it predates this branch, and fixing it means choosing which rounding is right
for a forecast in whole units — a wording call rather than a bug with an obvious
patch. Left alone here; worth a look when someone is next in `DayPanel`'s
description builders.

## Not done, and why

- **No plan file, no ADR.** The rule this restores is already recorded in
  `WORDS`'s own docstring, and nothing new is decided.
- **The spoken `description` strings are untouched.** They already name the day
  correctly; only the visible sentence did not.
