### PR TITLE
Let the week's reserved band size to what it holds

### DIFF
--- a/src/components/conditions/WeekGrid.test.tsx
+++ b/src/components/conditions/WeekGrid.test.tsx
@@ -226,6 +226,18 @@ test("the reserved band steps at the same width the days do", () => {
   expect(band?.className).not.toContain("sm:grid-cols-3");
 });
 
+test("a band holding one slot is not laid out for three", () => {
+  // At 1536 the three-column band renders a 472px dashed box with 968px empty
+  // to its right, directly under a full-width seven-column grid. The layout is
+  // still correct for the case it was written for -- three products, side by
+  // side -- and wrong for the case it is in, and nothing failed because a grid
+  // with one child is a valid grid.
+  renderGrid({ reserved: RESERVED });
+
+  expect(RESERVED).toHaveLength(1);
+  expect(reservedSlot()?.parentElement?.className).not.toContain("grid-cols-3");
+});
+
 /**
  * ADR-0014, asserted where both ranks render inside one component. "The week
  * ahead" is a region and "Tue, Aug 18" is a day inside it, and the two were

--- a/src/components/conditions/WeekGrid.test.tsx
+++ b/src/components/conditions/WeekGrid.test.tsx
@@ -47,6 +47,31 @@ const RESERVED = [
   },
 ];
 
+/**
+ * The band at the width it was laid out for.
+ *
+ * Three across is a rule about three, and asserting it needs three to assert it
+ * against. The one-slot `RESERVED` above is what the page actually hands over
+ * today, and the two fixtures are the two halves of the same claim: the band
+ * takes the shape of what it holds.
+ *
+ * The first headline is shared with `RESERVED` so one helper finds the band in
+ * both.
+ */
+const RESERVED_THREE = [
+  RESERVED[0],
+  {
+    emoji: "🌡️",
+    headline: "A water temperature is coming.",
+    detail: "The buoy reports one, and the page does not carry it yet.",
+  },
+  {
+    emoji: "🏖️",
+    headline: "A surf zone forecast is coming.",
+    detail: "Rip current risk, issued for this stretch of coast.",
+  },
+];
+
 function renderGrid(overrides: Partial<Parameters<typeof WeekGrid>[0]> = {}) {
   return render(
     <WeekGrid
@@ -215,7 +240,11 @@ test("the reserved band says it belongs to the week above it", () => {
 });
 
 test("the reserved band steps at the same width the days do", () => {
-  renderGrid({ reserved: RESERVED });
+  // Three slots, because three across is what this asserts. It was written
+  // when `RESERVED` held three and kept passing when the array shrank to one,
+  // at which point it was asserting a three-column grid around a single box --
+  // the defect, pinned as if it were the contract.
+  renderGrid({ reserved: RESERVED_THREE });
 
   // `lg` is where the days above first go wider than two. Three slots side by
   // side from 640px gave roughly 26 characters over five ragged lines at 768,

--- a/src/components/conditions/WeekGrid.tsx
+++ b/src/components/conditions/WeekGrid.tsx
@@ -673,8 +673,27 @@ export function WeekGrid({
             narrow and the slots said it was wide, in adjacent bands of the
             same section. Three across beside four days is close enough that
             neither band contradicts the other.
+
+            **And it is a rule about three, so it is asked for only when there
+            are three.** The band held three when that was written and holds
+            one now, which rendered a 472px dashed box in a 1440px band with
+            968px empty beside it, under a full-width seven-column grid. A grid
+            with one child is a valid grid, so nothing failed.
+
+            The threshold is three rather than two. At two slots a three-column
+            grid leaves one column empty -- the same fault, a third smaller --
+            where two full-width rows say exactly what is there. That also
+            keeps this to one literal class: a count interpolated into
+            `lg:grid-cols-${n}` compiles to nothing under ADR-0006's opt-in
+            source detection and would fail only at a width no test runs at.
+
+            Padding `reserved` to three would be the other way to make the
+            container match, and it would be a lie: two more dashed boxes
+            announcing nothing are worse than the empty ground they fill.
           */}
-          <div className="grid gap-3 lg:grid-cols-3">
+          <div
+            className={`grid gap-3 ${reserved.length > 2 ? "lg:grid-cols-3" : ""}`}
+          >
             {reserved.map((slot) => (
               <ReservedSlot key={slot.headline} {...slot} density="row" />
             ))}


### PR DESCRIPTION
Closes #182

The week's reserved band was `grid gap-3 lg:grid-cols-3` and `WeekPanel` hands
it exactly one slot, so at 1536 it rendered a 472px dashed box in a 1440px band
with 968px empty beside it, directly under a full-width seven-column grid. The
layout is still correct for the case it was written for and wrong for the case
it is in.

## What changed

One slice, two commits.

**`b8f131f` — the regression test, as MUST FAIL.** With one slot, the band is
not laid out for three.

**`ed9c961` — the fix.** `lg:grid-cols-3` is asked for only when there are
three. The comment above it is kept and amended: three across at `lg` is still
the right rule *for three*, and what was missing was saying so.

Two decisions worth naming:

- **The threshold is three, not the two the issue suggested.** At two slots a
  three-column grid leaves one column empty — the same fault, a third smaller —
  where two full-width rows say exactly what is there. It also keeps this to one
  literal class name: a count interpolated into `lg:grid-cols-${n}` compiles to
  nothing under ADR-0006's opt-in source detection and would fail only at a
  width no test runs at.
- **`reserved` is not padded to three.** The band holding one thing is the true
  state, and two dashed boxes announcing nothing are worse than the ground they
  would fill.

## There was already an assertion, pointed the wrong way

`WeekGrid.test.tsx`'s "the reserved band steps at the same width the days do"
checked that `lg:grid-cols-3` **is** present — against the one-slot fixture. It
was written when `RESERVED` held three and went on passing when the array shrank
to one, at which point it was asserting a three-column grid around a single box:
the defect pinned as if it were the contract.

It is not deleted. It is right about what it was written to assert — `lg` is
where the days above first go wider than two — and it now has a three-slot
fixture to assert it against. The two fixtures are the two halves of one claim:
the band takes the shape of what it holds.

## Verification

`npm run gate`, at `ed9c961`, from a cleared `.next/`:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… sea-side
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

**The mutation check the issue asked for.** Inverting the condition
(`> 2` → `<= 2`) fails both assertions, and the two it fails are the two halves:

```
× the reserved band steps at the same width the days do
× a band holding one slot is not laid out for three
Tests  2 failed | 39 passed (41)
```

Reverted; the tree at `ed9c961` is the real implementation.

**Measured on the built page at 1536**, with the fix and then against `main`:

| block                | before                  | after                    |
| -------------------- | ----------------------- | ------------------------ |
| week grid            | x=48 w=1440 right=1488  | unchanged                |
| **week reserved slot** | **x=48 w=472 right=520** | **x=48 w=1440 right=1488** |
| chart tile           | x=48 w=944 right=992    | unchanged                |
| "How to read…"       | x=48 w=1440 right=1488  | unchanged                |

The slot's right edge now lands at 1488 with everything else in the column.

## Two figures in the issue's table are stale

The review measured at `main` @ `16780b3` and three PRs have landed in this
region since, so I re-derived rather than quoted. The 472px box reproduces
exactly. Two other rows do not:

- **Chart card: the issue says 896 wide / right edge 944; it measures 944 / 992.**
- **Sighting slot: the issue says 1440 wide / right edge 1488; it measures 472
  wide at x=1016, right edge 1488.** That is not a defect — #178 put the map
  beside the chart, and the sighting slot sits inside the map's third of the
  row, so it is full-width *for its column* and its right edge already lines up.

Neither changes this fix. Both matter if anyone reasons further from that
table's ragged-edge argument.

## Not done, and why

- **No plan file, no ADR.** One condition; nothing decided that outlives it.
- **The ragged right edge is not otherwise pursued.** The issue calls this
  "the other half" of a question whose first half #173's map closed. With the
  band at 1440 the only block not ending at 1488 is the chart tile, which ends
  at 992 because the map occupies the rest of that row — a reservation that was
  filled, not an edge left ragged.
