### PR TITLE
The map's weather leaves the coast for a corner readout

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -205,15 +205,17 @@ than a shoreline, which the sentence under it says. It reads no feed — every
 position on it is committed.
 _Avoid_: locator, mini map, station map, chart (that word is the plot's)
 
-**Dial**:
-The compass drawn on the shore map: two needles standing out at the direction
-the wind and the swell come from and pointing in at the beach, each labelled at
-its tail and each with a translucent arc for the range it swung through in
-daylight. It is read against the coast underneath it — a needle whose tail is
-over the shaded sea is onshore — which is why it sits on the map and not beside
-it. **The labels are on the needles and there is no legend**: a word on the
-thing itself is what a legend is a substitute for, and a boxed legend is one of
-the brief's anti-references. It carries two publishers on one drawing, one
-provenance line per needle (ADR-0032), and it is withheld on the beaches the
-traced coast does not reach, where a bearing has nothing to be read against.
-_Avoid_: compass rose, wind rose, gauge, direction widget, legend
+**Readout**:
+The wind and swell block laid over a corner of the shore map: one row per
+source, each an arrow pointing the way the weather travels with a faint wedge
+behind it for the range that direction swung through in daylight, beside the
+word for the direction and its degrees. It is read against the coast in the same
+frame — an arrow crossing the shaded sea onto the land is onshore — which is why
+it is on the map and not beside it. **It lies over the picture rather than being
+drawn inside it** (ADR-0034): it is in the accessibility tree, so each row is
+its own spoken equivalent, and it covers nothing the map draws because the
+corner it stands in is measured per beach rather than fixed. It carries two
+publishers on one instrument, one provenance line per row (ADR-0032), and it is
+withheld on the beaches the traced coast does not reach, where a bearing has
+nothing to be read against.
+_Avoid_: dial, badge, compass rose, wind rose, gauge, direction widget, legend

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -215,7 +215,9 @@ it is on the map and not beside it. **It lies over the picture rather than being
 drawn inside it** (ADR-0034): it is in the accessibility tree, so each row is
 its own spoken equivalent, and it covers nothing the map draws because the
 corner it stands in is measured per beach rather than fixed. It carries two
-publishers on one instrument, one provenance line per row (ADR-0032), and it is
-withheld on the beaches the traced coast does not reach, where a bearing has
-nothing to be read against.
+publishers on one instrument, one provenance line per row (ADR-0032). **It is
+drawn on all 51 beaches**, including the 23 the traced coast does not reach:
+withholding it there left nearly half the inventory with no wind figure
+anywhere on the picture, and the objection it was withheld under was about a
+needle over an empty frame rather than about a labelled block.
 _Avoid_: dial, badge, compass rose, wind rose, gauge, direction widget, legend

--- a/docs/adr/0034-the-weather-leaves-the-map-for-a-corner-readout.md
+++ b/docs/adr/0034-the-weather-leaves-the-map-for-a-corner-readout.md
@@ -52,6 +52,15 @@ picture rather than as a drawing inside it.**
   with the unabbreviated sentence as its label, which is how `DaylightWeek` and
   `Placeholder` already name a thing whose visible content is not its name. The
   sentence under the map keeps attribution and stops restating bearings.
+- **It is drawn on all 51 beaches**, including the 23 in Mission Bay and San
+  Diego Bay that the traced coast does not reach. The dial was withheld there
+  on the rule that "a bearing read against no shoreline is the bare gauge the
+  brief's anti-references open with". That objection was about a needle drawn
+  over an empty frame; a labelled block carrying a word for the direction, its
+  degrees, a magnitude with units and a publisher beneath is not that thing.
+  The cost of withholding it was that nearly half the inventory printed no wind
+  figure anywhere on the picture — the same figure the week grid above states
+  for every one of those beaches.
 
 **The bearing is still read against the coast, which is what the reversed
 decision was protecting.** The block is inside the same square frame as the
@@ -150,5 +159,10 @@ the half of that pair a parent planning a beach day actually reads.
 - **The readout's width has a hard ceiling of 50 drawing units**, and a later
   slice adding a field to a row will meet it. The height does not; spend that
   instead.
-- **The 23 beaches with no traced coast still get nothing**, unchanged by this
-  decision. That is the next slice, not this one.
+- **The 23 beaches with no traced coast gain a wind row**, where they had
+  neither a bearing nor a provenance line before. They gain no swell row, and
+  that is right rather than incidental: they bind no MOP line, so there is no
+  swell estimate for them to be given.
+- **The map's own absence sentence is unchanged.** A beach with no traced coast
+  still says so under the picture, and now says it beneath a readout rather
+  than beneath nothing.

--- a/docs/adr/0034-the-weather-leaves-the-map-for-a-corner-readout.md
+++ b/docs/adr/0034-the-weather-leaves-the-map-for-a-corner-readout.md
@@ -1,0 +1,154 @@
+# 0034 — The weather leaves the map for a corner readout
+
+Date: 2026-08-31. Status: accepted. Reverses the decision in
+`docs/plans/conditions-day-view.md` that "the compass sits on the map, because a
+bearing is meaningless without a coast", and replaces the `Dial` entry in
+`CONTEXT.md` with `Readout`, updated in the same pull request. ADR-0032's rule —
+one instrument may carry two provenances — stands unchanged; its subject is now
+this block. ADR-0033, ADR-0024 and ADR-0010 are untouched.
+
+## Context
+
+The compass shipped in #184 as a dial drawn inside the shore map's own drawing
+space: a ring at `RING_RADIUS = 30` in a 100-unit frame — 60 units across, with
+labels out at 34 — translated onto the beach's own stretch of coast rather than
+the frame's middle.
+
+**Reviewed on the built page, the instrument was covering its own subject.** The
+coastline the needles exist to be read against was underneath them, and on some
+beaches the dial overflowed the frame. That is the whole of issue #192.
+
+Two further things were true of the map and were not visible until it was looked
+at properly. `anchor === null` withheld the dial **and its provenance** wherever
+no coast is traced, so 23 of 51 beaches — Mission Bay and San Diego Bay — printed
+no wind bearing and no wind figure anywhere on the picture. And the sentence
+under the map restated the dial's bearings, because the `<svg>` is one
+`role="img"` and nothing drawn inside it reaches the accessibility tree.
+
+**The decision being reversed is binding and lives only in a plan file**, which
+stops being maintained the moment it merges. That is why this is an ADR: without
+one, the reversal would be an undocumented contradiction of a document that
+still reads as current.
+
+## Decision
+
+**The wind and the swell are read in a corner of the map, as HTML laid over the
+picture rather than as a drawing inside it.**
+
+- **One row per source**: an arrow pointing the way the weather travels, a faint
+  wedge behind it for the range the direction swung through in daylight, the
+  word for that direction, and its degrees.
+- **The ring goes and the arc becomes a wedge**, which is one change rather than
+  two. The ring's only stated justification was that "an arc with nothing to be a
+  portion of reads as a stray stroke rather than as a range". At corner size that
+  arc cannot be judged — a 40° arc and a 50° arc on a 9px ring are the same
+  picture — so the thing it justified goes with it. The wedge was rejected once,
+  because "a wedge covering a fifth of the map on a settled day and half of it on
+  an unsettled one would hide the coast underneath"; in a corner block there is
+  no coast underneath, so that reason has expired.
+- **The corner is measured per beach, not fixed.** See below: a fixed corner
+  cannot be kept off the picture on this inventory.
+- **The block is the text equivalent of itself.** Each row is one `role="img"`
+  with the unabbreviated sentence as its label, which is how `DaylightWeek` and
+  `Placeholder` already name a thing whose visible content is not its name. The
+  sentence under the map keeps attribution and stops restating bearings.
+
+**The bearing is still read against the coast, which is what the reversed
+decision was protecting.** The block is inside the same square frame as the
+shoreline, north-up, a few centimetres from it; an arrow whose tail is out over
+the shaded sea is onshore wind, exactly as before. What changed is that the
+reader can now see the coast they are reading it against.
+
+## What was measured
+
+**Placement.** Every beach walked through `shoreViewFor` and projected, as the
+widest readout each placement rule survives on its worst beach. The three
+figures do not move at any block height from 12 units to 40:
+
+| placement                        | widest readout | worst beach                    |
+| -------------------------------- | -------------- | ------------------------------ |
+| fixed top-left                   | 8.3 units      | `childrens-pool`               |
+| top, side flipping left/right    | 19.0 units     | `la-jolla-cove`                |
+| the roomiest of the four corners | 50.5 units     | `mission-bay-visitor-s-center` |
+
+8.3 units is about 27px on the 327px map a 375px viewport draws. At a realistic
+46 × 14 a fixed top-left block sits on the beach's own stretch on **21 of the 47
+beaches that draw one**, including the default beach. The cause is structural:
+where no coast is traced, `beachStretch` draws the beach's own two ends, so the
+segment is a chord between the frame's margin corners and always blocks one
+diagonal pair — `childrens-pool` reads 8 units clear at the top-left, 8 at the
+bottom-right and 92 at each of the others.
+
+An adaptive corner clears the beach's stretch **and the whole windowed
+coastline** on every beach in the inventory. `corner.test.ts` asserts it.
+
+**Width is the entire constraint and height is free.** The 50.5-unit ceiling is
+identical for a band 14 units deep and one 40 deep, because what blocks a corner
+is a stroke crossing it diagonally rather than one grazing its edge.
+
+**What the rows cost, at `text-2xs`.** `SWELL south-west 270°` is 147.6px. The
+block's box leaves 151.5px inside a 327px map and 124px inside the 272px map a
+320px viewport draws — and ADR-0004 commits this site to 320 CSS px. So the row
+**wraps**, which is ADR-0004's own resolution of the same squeeze: content that
+no longer fits grows its container rather than being clipped, because a taller
+block is a visible degradation and a line running off the picture is an
+invisible one. Measured on the built page at `ocean-beach`, which prints the
+widest row the inventory holds: one line at 1536 and 375, two at 320, and the
+ink inside the reserved box at all three.
+
+## Alternatives considered
+
+**Fixed top-left, as the plan wrote it.** Rejected by the measurement above: it
+is not a corner the block can stand in. The plan's stated reason for preferring
+it — a control that moves between Del Mar and Coronado is a control a reader has
+to find again — is real, and is the price this decision pays. Its other reason,
+that an adaptive corner "becomes untestable in the useful direction", is wrong:
+the property is exactly as assertable either way, and it is the fixed rule that
+cannot be verified, because it is false.
+
+**Reserving a band inside the frame**, projecting the whole picture into the
+lower 86 units so a fixed top-left is empty by construction. Keeps the corner
+fixed and makes the check trivial. Rejected: it costs about 14% of the drawn
+picture's height on every lat-dominant beach, on a map whose entire complaint
+was that the picture was being taken away from the reader.
+
+**The block above the map rather than on it.** No overlay, no collision, no
+contrast question. Rejected: it costs vertical height in a column already
+stacking a map, a coast credit, provenance rows and the sightings slot, reviewed
+in a 555px-tall stop — and it puts the bearing outside the frame that gives it
+meaning.
+
+**A translucent panel behind the block.** Legible over anything. Rejected: a
+bordered panel floating on a map is the boxed legend the brief lists as an
+anti-reference, and the dial already rejected exactly this once, where a label
+halo at `strokeWidth` 2.5 "read as a chip stuck on the map".
+
+**Keeping the dial and shrinking it.** The smallest change. Rejected: a ring at
+half the radius puts the labels inside the picture rather than outside it, the
+arc becomes unjudgeable at any radius that fits, and none of it is in the
+accessibility tree — so the duplicated sentence under the map would have to
+stay.
+
+**Dropping the direction word and keeping only the degrees**, which is what
+makes a row fit on one line at 320px. Rejected: `bearing.ts` exists because a
+bearing in degrees is not a direction most readers can picture, and the word is
+the half of that pair a parent planning a beach day actually reads.
+
+## Consequences
+
+- **`Compass` renders HTML and no longer knows where it is.** Which corner is
+  safe is a question about the coastline underneath, so `ShoreMap` projects,
+  asks `corner.ts`, and positions the block. `NEEDLE_TRACKS` and the two needle
+  radii go: two arrows in two labelled rows cannot overlap, so the separate
+  tracks that stopped them coinciding have nothing left to do.
+- **`ShoreMap`'s `compass` slot is now `readout`**, and its contract changed with
+  its name: it was a group translated into plot units and it is now HTML
+  positioned against the map's box.
+- **`corner.ts` is a new pure module and a new seam.** It takes projected points
+  and a box and answers with a corner, so the inventory-wide check calls it
+  directly rather than rendering 51 maps.
+- **The readout's width has a hard ceiling of 50 drawing units**, and a later
+  slice adding a field to a row will meet it. The height does not; spend that
+  instead.
+- **The 23 beaches with no traced coast still get nothing**, unchanged by this
+  decision. That is the next slice, not this one.

--- a/docs/plans/map-weather-readout.md
+++ b/docs/plans/map-weather-readout.md
@@ -361,3 +361,66 @@ against hour parameters rather than twice.
    in `ShoreMap`, the geometry module, the swell crest layer at true projected
    wavelength, and the reduced-motion freeze.
 8. The wind layer, unclipped, over the frame, reusing the geometry module.
+
+## Addendum — 2026-08-31: the corner is chosen per beach, because a fixed one has nowhere to stand
+
+**The seam found this before slice 2 started, which is what it was agreed
+for.** The decision above — "Fixed top-left on all 51 beaches, not a corner
+chosen per beach" — was to be held by a test walking every beach through
+`shoreViewFor`, projecting, and failing if the badge's box covers the drawn
+segment. Run first rather than last, that test says the fixed top-left cannot
+pass it.
+
+Measured across the inventory, as the widest badge each placement rule survives
+on its worst beach. The three figures are stable at every badge height between
+12 and 20 plot units:
+
+| placement                  | widest badge it survives | worst beach                    |
+| -------------------------- | ------------------------ | ------------------------------ |
+| fixed top-left             | **8.3 units**            | `childrens-pool`               |
+| top, side flips left/right | **19.0 units**           | `la-jolla-cove`                |
+| any of the four corners    | **50.5 units**           | `mission-bay-visitor-s-center` |
+
+8.3 units is about 27px on the 328px map a phone draws, against the 150–165px
+two rows of four fields need. At a realistic 46 × 14 the fixed top-left badge
+sits on the beach's own stretch on **21 of the 47 beaches that draw one**,
+including `la-jolla-shores-beach`, which is the default beach.
+
+**The cause is structural rather than unlucky, which is why no smaller badge
+escapes it.** On the 23 bay beaches the segment is a chord between the frame's
+own margin corners — `beachStretch` draws the beach's two ends where there is no
+coast to mark a run of — so it crosses the frame corner to corner and always
+blocks one diagonal pair. `childrens-pool` reads `tl=8, br=8, tr=92, bl=92`, and
+the pattern repeats down the bay list. A fixed corner is a coin toss taken 51
+times.
+
+**So the corner is chosen per beach.** The rejected alternative is adopted, and
+the reason it was rejected splits in two:
+
+- **"The same control jumps corners between beaches" stands**, and is the price.
+  It is paid against a badge that otherwise covers the subject of the picture on
+  nearly half the inventory. A reader sees one beach at a time, and the choice is
+  computed from committed data, so a given beach's corner never moves between
+  visits.
+- **"It becomes untestable in the useful direction — you can assert it moved,
+  not that it landed somewhere good" is wrong**, and is the half worth recording.
+  The property is exactly as assertable as the fixed version's: the box of the
+  corner this beach chose holds no drawn point. It is the _fixed_ rule that
+  cannot be verified, because it is false.
+
+**The assertion is also widened while it is being written.** The plan asked only
+that the badge clear the drawn segment. Measured, an adaptive corner clears the
+segment **and the whole windowed coastline** at 50 × 14 on every beach — 0 of 47
+with no corner available — so the test asserts both. The coast is the larger
+half of what the map exists to show, and there was no reason but arithmetic to
+leave it out; the arithmetic turned out not to charge for it.
+
+**What this costs the badge is a budget rather than a redesign.** 50 plot units
+is about 165px on the narrowest map, so the two rows have to stay compact. That
+is a constraint the fixed rule never surfaced because it failed long before
+reaching one.
+
+Everything else in this plan is unchanged. The ADR in slice 2 records the corner
+choice alongside the dial leaving the map, because both are the same decision
+seen from two sides: the readout stops covering the picture, and where it stands
+is what makes that true.

--- a/docs/plans/map-weather-readout.md
+++ b/docs/plans/map-weather-readout.md
@@ -1,0 +1,363 @@
+# The map's weather: a corner readout, and water and air that move
+
+Planned 2026-08-31. In flight.
+
+> Supersedes, in `docs/plans/conditions-day-view.md`, the decision that "the
+> compass sits on the map" and its rejection of needles that follow a scrubbed
+> hour. Narrows ADR-0027's clause "the compass may not follow the selected
+> hour". Each reversal is argued below and each gets its own ADR, because a
+> plan file stops being maintained when it merges and an ADR does not.
+
+## The problem, from the reader's side
+
+The shore map draws this beach's coast and which side of it the water is on, and
+a dial with two needles is drawn on top of it. The dial's ring is 30 units in a
+100-unit frame — 60 units across, plus labels at radius 34 — and it is anchored
+on the beach's own stretch of coast rather than the frame's middle. So it covers
+the thing the map exists to show, and on some beaches it overflows the edge.
+
+Reviewed on the built page: it is visually distracting, and the coastline the
+needles are meant to be read against is underneath them.
+
+Two further things are true of the map and were not visible until this was
+looked at properly.
+
+**Nearly half the inventory has no weather on the map at all.** `anchor` is
+`null` wherever no coast is traced, and that withholds the dial _and_ its
+provenance. 23 of 51 beaches — Mission Bay and San Diego Bay — therefore print
+no wind bearing and no wind figure anywhere on the picture.
+
+**The map states the day while the chart beside it states an hour.** ADR-0027
+built hour selection into `HourChart` and explicitly declined to let the compass
+follow it. Read again with the redesign in hand, that decision turns out to rest
+on an assumption the redesign removes.
+
+## The solution
+
+**A minimal readout in the map's top-left corner, and a picture that moves.**
+
+```
+↗ WIND    WNW 281°   12 mph
+↗ SWELL   W 270°     3.4 ft · 14s
+```
+
+Two rows, tabular figures, laid over the map as HTML rather than drawn in plot
+units. Arrows stay geographically true — north-up, pointing the way the weather
+travels — so the onshore/offshore reading survives being moved: the map is
+north-up and the coast is in the same frame. Behind each arrow, a faint wedge
+spanning the day's daylight swing.
+
+Under it, two animated layers. Swell crests perpendicular to the swell bearing,
+travelling shoreward along it, clipped to the sea so they vanish under the
+shoreline. Wind streams over the whole frame, above everything, crossing the
+water's edge onto the land.
+
+And the block follows the hour the chart is showing, falling back to the day's
+figures when nothing is selected.
+
+## Decisions
+
+### The readout
+
+**The arrows keep true bearings, and the animation is not a substitute for
+them.** The alternative — a corner readout whose arrows are decorative icons,
+with the moving field carrying direction — was rejected because the field is
+gated off under `prefers-reduced-motion`. A map with no directional information
+for a reader who turned motion off is worse than the map that exists today.
+
+**The block is an HTML overlay in a `relative` wrapper**, not SVG in plot units.
+Three reasons. Plot-unit type is already at ADR-0024's 10px floor — 3.2 units is
+10.5px on the 328px map a phone draws — and this block carries four fields per
+row where today's label carries one word. The `<svg>` is one `role="img"`, so
+nothing drawn inside it reaches the accessibility tree; an overlay is in the
+tree, which is what genuinely retires `CompassSources`' bearing sentence rather
+than duplicating it. And an overlay costs zero vertical height, in a column
+already stacking map, coast credit, provenance rows and the sightings slot,
+reviewed in a 555px-tall stop.
+
+**Fixed top-left on all 51 beaches**, not a corner chosen per beach. A control
+that moves as a reader goes from Del Mar to Coronado is a control they have to
+find again. Safety is asserted rather than eyeballed: a test walks every beach
+through `shoreViewFor`, projects, and fails if the badge's box covers the drawn
+segment.
+
+**The ring goes, and the spread becomes a wedge.** The ring is the map's only
+piece of chrome and its stated justification is that "an arc with nothing to be
+a portion of reads as a stray stroke rather than as a range". At corner size the
+arc it justifies can no longer be judged — a 40° arc and a 50° arc on a 9px ring
+are the same picture — so both go and a filled cone takes over. The cone reads
+at 16px, and a 190° day drawing a blob is correct: that day had no direction.
+
+The wedge was rejected once, and its reason has expired. "A wedge covering a
+fifth of the map on a settled day and half of it on an unsettled one would hide
+the coast underneath." In a corner badge there is no coast underneath.
+
+**The figures are ones the page already holds.** Swell reuses `WaveReading` —
+the three-hour step that carried the largest daylight height, with its own
+period — so the map and the week grid cannot print different numbers for
+Thursday, and thickness and spacing describe one estimate rather than two
+unrelated averages. Wind has no such figure and takes the peak daylight hour,
+mirroring that rule so both rows can be worded once: each figure is the largest
+thing the daylight window holds, and each arrow is the direction that window
+mostly delivered.
+
+**`CompassSources` drops to bare provenance lines**, and the step's timestamp
+moves into them: "CDIP MOP D0606, 709 m — estimate for 2 PM". One place says the
+numbers, one place says where they came from. It also keeps the badge at
+~190px of the 328px map rather than ~240px.
+
+**The block renders on all 51 beaches.** The objection it was withheld under — "a
+bearing read against no shoreline is the bare gauge the brief's anti-references
+open with" — was about a needle drawn over an empty frame. A labelled readout
+with units and a provenance line is not that.
+
+### Following the hour
+
+**The block tracks `HourChart`'s selection, and the wedge does not.** The wedge
+stays the day's daylight swing; the arrow is this hour inside it. That pairing is
+the whole argument for why ADR-0027's clause can be narrowed — see below — and
+it is a better instrument than either half: a reader sees the hour _and_ what the
+day did around it.
+
+`selectedMs` is `useState` local to `HourChart` today and lifts into a context
+mirroring `selectedDay.ts`, including that module's deliberate default: outside
+the provider the chart keeps its own state and offers no choice.
+
+**Not `aria-live`.** `HourChart`'s readout already is. Two live regions firing on
+one arrow-press means a keyboard reader hears the change twice.
+
+**The swell steps on CDIP's grid; the wind glides.** `WaveHour.directionDegT` is
+`null` on five hours in eight by deliberate policy — "halfway between 350 and 10
+is 0, and averaging them as numbers says 180 — due south, the reverse of both".
+So the swell row holds the last published estimate and its provenance names the
+step's time, while the wind moves every hour. Two feeds visibly running at
+different cadences is a true fact about them, and the chart already marks
+published points, so it explains itself. `periodS` joins `WaveHour` as
+`null`-on-interpolated, mirroring `directionDegT`.
+
+### The animation
+
+**The governing rule: the animation restates, it never states.** Every fact a
+layer carries is in the corner block at full contrast. This is the decision that
+lets a page this careful about provenance carry an animated layer at all, and it
+binds in both directions — the field may sit as faint as looks right, _and_ it
+may never show anything the block does not say.
+
+Five things fall out of it rather than needing to be arranged: the layers are
+decorative reinforcement and exempt from the 3:1 graphical-object floor that the
+arcs were measured against; `prefers-reduced-motion` loses nothing, so freezing
+them is honest; the block is already the accessible equivalent; no animated
+channel owes a provenance line under ADR-0010; and a beach with no MOP line has
+no swell row and therefore no crests, automatically.
+
+**Spatial quantities are drawn true. Temporal ones cannot be.** Crest spacing is
+the real deep-water wavelength, `L ≈ 1.56 × T²` metres, converted through the
+map's own scale: a 14s swell is ~306 m, about 7.7 plot units on a typical 3.5 km
+frame, so ~13 crests cross the picture. A 20s groundswell draws 6 and an 8s
+windswell draws 40, and the difference is a fact rather than a constant someone
+chose. Speed cannot be true — 10 mph across a 4 km frame is fifteen minutes to
+cross — so it is an admitted mapping carrying nothing. Thickness cannot be true
+either, since wave height is vertical and this is a plan view; it is a
+comparative restatement of a figure printed in the corner.
+
+Deep-water is an approximation at the MOP line's 10 m depth. It is stated, not
+assumed.
+
+**Wind is unclipped and swell is clipped, and that asymmetry is the legend.**
+One layer stops at the water's edge and one does not, which tells a reader which
+substance is which without a boxed legend. It is also the strongest statement of
+the thing the whole map is for: a stream entering over the sea wash and
+continuing onto the land is visibly onshore wind.
+
+**One translating `<g>` per layer**, holding a doubled tile that loops after
+exactly one wavelength — the `animate-strip` trick already in this repo. One
+compositor-friendly transform per layer rather than N animated elements, and
+freezing it under reduced motion leaves a valid frame rather than a half-drawn
+one. Parameters arrive as CSS custom properties so scrubbing the hour does not
+remount and restart the animation.
+
+**`ShoreMap` emits the clip and two empty slots; the client island fills them.**
+That is the pattern the `compass` slot already uses, and it exists for a measured
+reason: seven copies of the map to vary two numbers is 4.5 KB of coordinates a
+copy at La Jolla and 200 points at `del-mar-city-beach`.
+
+## Test seams
+
+Agreed before starting, each at the highest point it will sit.
+
+- **`shoreViewFor`** — already pure, already the seam. The badge-collision check
+  walks all 51 beaches through it and projects, rather than asserting anything
+  about one beach that happened to look right.
+- **A pure geometry module** turning `(bearing, heightFt, periodS,
+metresPerUnit)` into `{crestAngle, strokeWidth, spacing, duration, travel}`,
+  exported the way `NEEDLE_TRACKS` is so tests read it rather than repeat it.
+  Named so it cannot collide case-only with its component: `Compass.tsx` and
+  `compass.ts` are one file on Windows, and Linux CI would pass the pair.
+- **The governing rule as a rendered invariant** — the set of animated layers on
+  a day is a subset of the rows in the corner block. This is the ADR held by the
+  gate rather than by prose, which is this repo's stated preference.
+- **The `stylesheet` gate** for the keyframes and the `motion-reduce` utility.
+  Tailwind's source detection is opt-in here (ADR-0006), so a class in the built
+  CSS is evidence a component uses it.
+- **`selectedDay.ts`'s existing shape** for the hour context, so the two
+  selections work the same way and have the same out-of-provider default.
+
+## Out of scope
+
+- **CDFW MarineBIOS Shoreline Types [ds3115].** It traces the real shoreline for
+  the whole county including both bays, and would let the animation reach the 23
+  beaches this plan leaves it off. It is separate work and larger than it looks:
+  `seaPath` closes the sea polygon from one normal taken from the drawn run's
+  two endpoints, which assumes a monotone open run — around a bay the first and
+  last points land near each other, the length collapses toward zero, and the
+  wash floods an arbitrary half of the frame. So it is a rewrite of the sea wash
+  (ADR-0033) and the `sea-side` gate row, not a data swap. It is additive rather
+  than a replacement: `mop-lines.json` stays, because it carries the wave
+  forecast and not just a line. Open `TODO(verify)`: its licence and required
+  attribution, its download format and endpoint, its file size against the
+  115 KB `mop-lines.json` precedent, and whether its line direction is
+  consistent enough for `sideOf` to be asked.
+- **Shoreline type as content.** That dataset separates Rocky Shores, Tidal
+  Flats, Coastal Marsh and Beaches. The sightings slot on this very map promises
+  "octopus, nudibranchs, sea hares and leopard sharks", which live on rocky shore
+  and tidal flat rather than on sand. That is a larger idea than this plan and is
+  noted, not started.
+- **A third, measured needle on today.** Still rejected, on the reason
+  `conditions-day-view.md` gives.
+- **A verdict of any kind.** ADR-0009's line is easiest to cross with a picture,
+  and a moving one more so. Nothing here says whether the water is good.
+
+## Interaction with #191
+
+Issue #191 reports the wind figure stated at two precisions across five places —
+`11.5 mph` in four and `12 mph` in the fifth. The corner block adds a sixth
+statement of that figure. It must adopt the same precision rule, or #191 lands
+first.
+
+## Considered and rejected
+
+**A pure readout, with the animation carrying direction.** Cheapest corner
+design. Rejected: the field is gated off under `prefers-reduced-motion`, so the
+map would say nothing directional to a reader who turned motion off — and
+directional is the one thing the map is for.
+
+**Holding both layers to the 3:1 non-text contrast floor**, as the arcs are.
+Maximally defensible on accessibility grounds and directly contrary to the
+request for something that does not distract. Rejected once "restates, never
+states" made the exemption principled rather than convenient: the information is
+available elsewhere at full contrast, which is the condition the floor exists
+under.
+
+**Clamping crest spacing to a legible band.** Guarantees the picture always
+reads. Rejected: it is "don't fix a symptom with a constant" with two constants
+instead of one, and it lies silently at both ends of the range. If 40 crests read
+as noise on an 8s day, the answer is to change what is drawn per crest — thinner,
+fainter — not to misreport the wavelength. This is a look-at-the-page decision
+and belongs to the review of the third slice.
+
+**Fixed spacing, with period nowhere.** Keeps the corner rows to three fields.
+Rejected: the difference between a 20s groundswell and 8s wind chop is the most
+interesting thing in the swell data, it is free to draw correctly, and hiding it
+costs a magic number in the geometry module.
+
+**Interpolating the swell's period and height between CDIP's points** so the
+field glides rather than steps. Rejected: it draws two figures between points the
+model published, which is precisely what the `published` flag exists to keep
+visible.
+
+**Only the wind following the hour.** Smallest change, no `WaveHour` field, no
+stale timestamps. Rejected: two rows obeying different rules with nothing saying
+so, and a reader scrubbing sees one arrow move and one not, and reads the still
+one as broken.
+
+**A resultant vector magnitude for the wind**, which is the physically correct
+partner of a resultant bearing. Rejected on the case that matters: a genuinely
+windy day that swung 190° has a resultant near zero, so the map would print
+"1 mph" to somebody standing in it.
+
+**An adaptive corner**, chosen per beach to avoid the coast. Cannot collide, by
+construction. Rejected: the same control jumps corners between beaches, and it
+becomes untestable in the useful direction — you can assert it moved, not that it
+landed somewhere good.
+
+**A translucent panel behind the badge.** Legible over anything. Rejected: a
+bordered panel floating on a map is the boxed legend the brief lists as an
+anti-reference, and `Compass` already rejected exactly this once at
+`strokeWidth` 2.5, where the label halo "read as a chip stuck on the map".
+
+**The block above the map rather than on it.** No overlay wrapper, no collision,
+no contrast question. Rejected: it costs vertical height in a column already
+stacking four blocks and reviewed at 555px, and it is not what was asked for.
+
+**Wind fading over land** rather than crossing it at full strength. Rejected:
+that is close to the straight-edged gradient across a curved coastline ADR-0033
+removed for visibly disagreeing with the shore's own edge.
+
+**A visual-regression gate.** Catches what unit tests cannot, including whether
+the thing is distracting. Rejected: a dependency this repo guards, a display the
+gate table would have to declare skipped by default, and animation makes the
+screenshot nondeterministic unless it is frozen first.
+
+**One PR for all of it.** Rejected on CLAUDE.md's own guide — the work touches
+`ShoreMap`, `Compass`, `DayCompass`, `DayPanel`, `HourChart` (1,199 lines) and
+its test file (1,135), `ChosenDay`, `conditions.ts`, two new modules and three
+ADRs. Split at the two dependency boundaries below.
+
+## The reversals, and why each survives
+
+**"The compass sits on the map, because a bearing is meaningless without a
+coast."** It still is, and the block is still in the same frame as the coast,
+north-up, a few centimetres from it. What moves is that the picture is no longer
+covered by the instrument reading it. The animated field then restores the
+geographic reading more directly than an arrow ever did — a stream crossing the
+water's edge onto the sand _is_ onshore wind, with no angle arithmetic asked of
+anybody.
+
+**ADR-0027: "The compass may not follow the selected hour."** Its surviving
+argument is that "a needle whose meaning changes depending on what was last
+clicked is a different instrument from one showing the day's dominant
+direction". That assumed one instrument. The block carries two facts: the wedge
+is the day's swing and means the same thing on all seven days, and the arrow is
+this hour read against it. The day-dominant reading the clause protects is not
+removed — it becomes the thing the hour is measured against.
+
+ADR-0027's four conditions still bind and are met. Selection is by click, tap or
+key and never by hover. The change is additive: the day figure is present before
+anything is touched, and nothing drawn or written goes behind a gesture. No new
+control is added, so the 44px floor is inherited rather than re-owed. And the
+readout forms no judgement, which is ADR-0009's line.
+
+**That an animated layer may exist here at all** is new rather than a reversal,
+and is the third ADR.
+
+## Slices, in order
+
+Three PRs, split at the two real dependency boundaries. Each is demonstrable on
+the built page on its own, and each needs a human look, because whether a thing
+reads correctly to a person is not something a gate can assert.
+
+**PR 1 — the readout (#192).**
+
+1. This plan file, as its own first commit.
+2. ADR: the dial leaves the map for a corner readout. Then the corner block
+   replaces the dial — arrow, wedge, label, bearing — with the ring, `anchor`
+   and the needle-track geometry removed.
+3. Magnitudes join the rows; the step's timestamp moves to the provenance line;
+   `CompassSources` drops to bare provenance.
+4. The block extends to all 51 beaches. The 23 bay beaches gain a wind figure.
+
+**PR 2 — it follows the hour (#193).** Blocked on #192.
+
+5. ADR narrowing ADR-0027's clause. `selectedMs` lifts into a context; the block
+   follows the selected hour and falls back to the day's figures; the wedge does
+   not move.
+6. `periodS` joins `WaveHour` as `null`-on-interpolated; the swell steps on
+   CDIP's grid and its provenance names the step.
+
+**PR 3 — the field (#194).** Blocked on #193, so the layers are built once
+against hour parameters rather than twice.
+
+7. ADR: the animation restates, it never states. Then the clip and the two slots
+   in `ShoreMap`, the geometry module, the swell crest layer at true projected
+   wavelength, and the reduced-motion freeze.
+8. The wind layer, unclipped, over the frame, reusing the geometry module.

--- a/src/components/conditions/Compass.test.tsx
+++ b/src/components/conditions/Compass.test.tsx
@@ -13,9 +13,13 @@ const WIND: CompassNeedle = {
   label: "Wind",
   fromDegT: 281,
   spreadDeg: 40,
-  source: "this beach's own grid cell",
-  network: "National Weather Service, San Diego",
-  note: "a forecast, not a reading taken at the beach",
+  figure: "11.5 mph",
+  provenance: {
+    label: "Biggest wind in daylight",
+    source: "this beach's own grid cell",
+    network: "National Weather Service, San Diego",
+    note: "a forecast, not a reading taken at the beach",
+  },
 };
 
 function readout(needles: readonly CompassNeedle[]) {
@@ -117,12 +121,39 @@ test("nothing is rendered when there is no needle to render", () => {
   expect(container.querySelector("[data-readout]")).toBeNull();
 });
 
-test("the row states its word, the direction and the degrees", () => {
+test("the row states its word, the direction, the degrees and how much", () => {
   const container = readout([WIND]);
 
   expect(
     container.querySelector('[data-readout-label="wind"]')!.textContent,
   ).toBe("Wind");
+  expect(
+    container.querySelector('[data-readout-bearing="wind"]')!.textContent,
+  ).toBe("west 281°");
+  expect(
+    container.querySelector('[data-readout-figure="wind"]')!.textContent,
+  ).toBe("11.5 mph");
+});
+
+test("the figure is printed exactly as the caller worded it", () => {
+  // The rounding is a decision made upstream and has to survive verbatim: the
+  // swell's comes from `swellFigure`, so the week grid and this readout cannot
+  // print different numbers for one day, and the wind's carries the precision
+  // rule #191 is about.
+  const container = readout([
+    { ...WIND, kind: "swell", label: "Swell", figure: "3.4 ft · 14 s" },
+  ]);
+
+  expect(
+    container.querySelector('[data-readout-figure="swell"]')!.textContent,
+  ).toBe("3.4 ft · 14 s");
+});
+
+test("a source with a direction and no magnitude still says the direction", () => {
+  // A ragged forecast rather than a fault, so the row says what it knows.
+  const container = readout([{ ...WIND, figure: null }]);
+
+  expect(container.querySelector('[data-readout-figure="wind"]')).toBeNull();
   expect(
     container.querySelector('[data-readout-bearing="wind"]')!.textContent,
   ).toBe("west 281°");
@@ -136,7 +167,11 @@ test("the row's accessible name is the sentence the visible row abbreviates", ()
   // concatenate with its neighbours rather than read as a phrase.
   render(<Compass needles={[WIND]} />);
 
-  expect(screen.getByRole("img", { name: "Wind, from the west, 281°" }));
+  expect(
+    screen.getByRole("img", {
+      name: "Wind, from the west, 281°, at its biggest 11.5 mph",
+    }),
+  );
 });
 
 test("a wide swing is spoken and a narrow one is not", () => {
@@ -145,9 +180,16 @@ test("a wide swing is spoken and a narrow one is not", () => {
   // number. The wedge shows it either way; the sentence states it only when
   // the word alone would mislead.
   expect(needleSentence({ ...WIND, spreadDeg: 120 })).toBe(
-    "Wind, from the west, 281°, swinging through 120° in daylight",
+    "Wind, from the west, 281°, swinging through 120° in daylight, " +
+      "at its biggest 11.5 mph",
   );
   expect(needleSentence({ ...WIND, spreadDeg: 30 })).toBe(
+    "Wind, from the west, 281°, at its biggest 11.5 mph",
+  );
+});
+
+test("a row with no magnitude is spoken without one", () => {
+  expect(needleSentence({ ...WIND, spreadDeg: 30, figure: null })).toBe(
     "Wind, from the west, 281°",
   );
 });
@@ -215,25 +257,49 @@ test("the rows read in the order the sources beneath them do", () => {
   expect(kinds).toEqual(["wind", "swell"]);
 });
 
-test("the sources state the bearing in words and in degrees", () => {
-  render(<CompassSources needles={[WIND]} />);
+test("the sources say where the figures came from, not what they are", () => {
+  // The readout is HTML and is in the accessibility tree, so it is its own
+  // spoken equivalent. This block used to restate both bearings underneath it,
+  // which was a second statement of a figure the page already made.
+  const { container } = render(<CompassSources needles={[WIND]} />);
 
-  expect(screen.getByText(/Wind, from the west, 281°/)).toBeDefined();
+  expect(container.textContent).not.toContain("from the west");
+  expect(container.textContent).not.toContain("281°");
+  expect(screen.getByText(/this beach's own grid cell/)).toBeDefined();
 });
 
-test("the sources state a wide swing and pass over a narrow one", () => {
-  // The same rule the row's own sentence keeps, stated in the same words. It is
-  // in two places for this slice only: the sources block loses its bearing
-  // sentence in the next one, when the magnitudes arrive and it drops to bare
-  // provenance.
-  const { unmount } = render(
-    <CompassSources needles={[{ ...WIND, spreadDeg: 120 }]} />,
+test("each line says which of the two rows it attributes", () => {
+  // Two provenance lines under one picture have to say which is which, now
+  // that neither restates its own bearing.
+  render(
+    <CompassSources
+      needles={[
+        WIND,
+        {
+          ...WIND,
+          kind: "swell",
+          label: "Swell",
+          provenance: {
+            ...WIND.provenance,
+            label: "Biggest swell in daylight",
+          },
+        },
+      ]}
+    />,
   );
-  expect(screen.getByText(/swinging through 120° in daylight/)).toBeDefined();
-  unmount();
 
-  render(<CompassSources needles={[{ ...WIND, spreadDeg: 30 }]} />);
-  expect(screen.queryByText(/swinging through/)).toBeNull();
+  expect(screen.getByText("Biggest wind in daylight")).toBeDefined();
+  expect(screen.getByText("Biggest swell in daylight")).toBeDefined();
+});
+
+test("the superlative is stated rather than left to be inferred", () => {
+  // `WaveWeek`'s rule and its reason: a single figure under the bare word
+  // invites a reader to take it for the day's typical swell, which is the one
+  // thing it is not. The readout has no room for the word, so the attribution
+  // line beneath the picture carries it.
+  render(<CompassSources needles={[WIND]} />);
+
+  expect(screen.getByText("Biggest wind in daylight")).toBeDefined();
 });
 
 test("each needle carries its own publisher", () => {
@@ -246,34 +312,37 @@ test("each needle carries its own publisher", () => {
   ).toBeDefined();
 });
 
-test("the sources state both bearings, in words and in degrees", () => {
-  // The design brief's own example of what the map's text equivalent says.
+test("two publishers are attributed separately under one instrument", () => {
+  // ADR-0032: one instrument carrying two publishers is a deliberate break of
+  // `StatGroup`'s one-group-one-source contract, answered by a line per row
+  // rather than by splitting the instrument.
   render(
     <CompassSources
       needles={[
-        { ...WIND, kind: "wind", fromDegT: 281, spreadDeg: 20 },
+        WIND,
         {
           ...WIND,
           kind: "swell",
           label: "Swell",
-          fromDegT: 340,
-          spreadDeg: 20,
-          source: "MOP line D0498",
-          network: "CDIP, Scripps Institution of Oceanography",
+          provenance: {
+            label: "Biggest swell in daylight",
+            source: "MOP line D0498",
+            network: "CDIP, Scripps Institution of Oceanography",
+            distanceKm: "0.7",
+          },
         },
       ]}
     />,
   );
 
-  expect(screen.getByText(/Wind, from the west, 281°/)).toBeDefined();
-  expect(screen.getByText(/MOP line D0498 · CDIP/)).toBeDefined();
-
-  // 340 reads "north" and not "north-west", and this is where the eight-point
-  // rose costs something. The design brief's example name for this very
-  // bearing is "swell from the northwest, 340 degrees", which is a sixteen-
-  // point reading; `bearing.ts` records why the page has eight. The degrees
-  // are what carry the difference, and they are stated beside the word.
-  expect(screen.getByText(/Swell, from the north, 340°/)).toBeDefined();
+  expect(
+    screen.getByText(/this beach's own grid cell · National Weather Service/),
+  ).toBeDefined();
+  expect(
+    screen.getByText(
+      /MOP line D0498 · CDIP, Scripps Institution of Oceanography · about 0.7 km from this beach/,
+    ),
+  ).toBeDefined();
 });
 
 test("a day with no bearings gets no sources block, not an empty list", () => {

--- a/src/components/conditions/Compass.test.tsx
+++ b/src/components/conditions/Compass.test.tsx
@@ -3,7 +3,8 @@ import { render, screen } from "@testing-library/react";
 import {
   Compass,
   CompassSources,
-  NEEDLE_TRACKS,
+  NEEDLE_GLYPHS,
+  needleSentence,
   type CompassNeedle,
 } from "./Compass";
 
@@ -17,87 +18,201 @@ const WIND: CompassNeedle = {
   note: "a forecast, not a reading taken at the beach",
 };
 
-/** The dial draws around its own origin, so a bare `<svg>` is the whole rig. */
-function dial(needles: readonly CompassNeedle[]) {
-  const { container } = render(
-    <svg>
-      <Compass needles={needles} />
-    </svg>,
-  );
+function readout(needles: readonly CompassNeedle[]) {
+  const { container } = render(<Compass needles={needles} />);
   return container;
 }
 
 const num = (element: Element, name: string) =>
   Number(element.getAttribute(name));
 
-test("the needle's tail stands in the direction the wind comes from", () => {
-  // Due east, on a map with north up: the tail is to the right of the beach
+test("the arrow's tail stands in the direction the wind comes from", () => {
+  // Due east, on a glyph with north up: the tail is to the right of the middle
   // and level with it. A sign flip anywhere in the bearing-to-plot conversion
   // moves it to one of the other three sides, which is what this pins.
-  const container = dial([{ ...WIND, fromDegT: 90, spreadDeg: 0 }]);
+  const container = readout([{ ...WIND, fromDegT: 90, spreadDeg: 0 }]);
 
-  const needle = container.querySelector('[data-needle="wind"]')!;
-  expect(num(needle, "x1")).toBeCloseTo(NEEDLE_TRACKS.wind.tail, 4);
-  expect(num(needle, "y1")).toBeCloseTo(0, 4);
+  const arrow = container.querySelector('[data-arrow="wind"]')!;
+  expect(num(arrow, "x1")).toBeCloseTo(8, 4);
+  expect(num(arrow, "y1")).toBeCloseTo(0, 4);
 });
 
 test("north is up, not down", () => {
   // The other half of the same conversion, and the one a y-down drawing space
   // gets wrong: plot y grows southward, so due north is a negative y.
-  const container = dial([{ ...WIND, fromDegT: 0, spreadDeg: 0 }]);
+  const container = readout([{ ...WIND, fromDegT: 0, spreadDeg: 0 }]);
 
-  const needle = container.querySelector('[data-needle="wind"]')!;
-  expect(num(needle, "x1")).toBeCloseTo(0, 4);
-  expect(num(needle, "y1")).toBeCloseTo(-NEEDLE_TRACKS.wind.tail, 4);
+  const arrow = container.querySelector('[data-arrow="wind"]')!;
+  expect(num(arrow, "x1")).toBeCloseTo(0, 4);
+  expect(num(arrow, "y1")).toBeCloseTo(-8, 4);
 });
 
-test("the needle points inward, at the beach it arrives at", () => {
-  // Which end carries the head is the whole reading. An arrow from the beach
-  // outward says the wind is going that way; this one says it comes from
-  // there, which is what every figure on this page means by a direction.
-  const container = dial([{ ...WIND, fromDegT: 90, spreadDeg: 0 }]);
+test("the arrow points the way the weather travels", () => {
+  // Which end carries the head is the whole reading. Every feed this page reads
+  // publishes the direction weather comes *from*, so an easterly wind is drawn
+  // travelling west: tail in the east, head in the west.
+  const container = readout([{ ...WIND, fromDegT: 90, spreadDeg: 0 }]);
 
-  const needle = container.querySelector('[data-needle="wind"]')!;
-  expect(Math.abs(num(needle, "x2"))).toBeLessThan(Math.abs(num(needle, "x1")));
+  const arrow = container.querySelector('[data-arrow="wind"]')!;
+  expect(num(arrow, "x1")).toBeGreaterThan(0);
+  expect(num(arrow, "x2")).toBeLessThan(0);
+
+  // And the head is at the far side rather than in the middle, so the arrow
+  // reads as a direction on its own without a beach under it to arrive at.
+  const head = container.querySelector('[data-arrow-head="wind"]')!;
+  expect(head.getAttribute("points")).toContain("-8.00,0.00");
 });
 
-test("the arc widens with the day's spread", () => {
-  const narrow = dial([{ ...WIND, fromDegT: 270, spreadDeg: 20 }]);
-  const wide = dial([{ ...WIND, fromDegT: 270, spreadDeg: 120 }]);
+test("the wedge widens with the day's spread", () => {
+  const narrow = readout([{ ...WIND, fromDegT: 270, spreadDeg: 20 }]);
+  const wide = readout([{ ...WIND, fromDegT: 270, spreadDeg: 120 }]);
 
   const ends = (container: Element) => {
-    const d = container.querySelector('[data-arc="wind"]')!.getAttribute("d")!;
+    const d = container
+      .querySelector('[data-wedge="wind"]')!
+      .getAttribute("d")!;
     const numbers = d.match(/-?\d+\.?\d*/g)!.map(Number);
-    // "M x0 y0 A r r 0 large sweep x1 y1" -- the first pair and the last.
+    // "M0 0 L x0 y0 A r r 0 large sweep x1 y1 Z" -- the first drawn pair after
+    // the origin, and the last.
     return Math.hypot(
-      numbers[0] - numbers[numbers.length - 2],
-      numbers[1] - numbers[numbers.length - 1],
+      numbers[2] - numbers[numbers.length - 2],
+      numbers[3] - numbers[numbers.length - 1],
     );
   };
 
   expect(ends(wide)).toBeGreaterThan(ends(narrow));
 });
 
-test("a day that never shifted gets no arc rather than a zero-length one", () => {
-  const container = dial([{ ...WIND, spreadDeg: 0 }]);
+test("the wedge is a cone from the middle, not a ring around it", () => {
+  // The ring went with the dial. Its only stated justification was giving the
+  // arc something to be a portion of, and at 16px that arc can no longer be
+  // judged -- so what is left has to be readable as a filled shape.
+  const container = readout([{ ...WIND, fromDegT: 270, spreadDeg: 60 }]);
 
-  expect(container.querySelector('[data-arc="wind"]')).toBeNull();
-  expect(container.querySelector('[data-needle="wind"]')).not.toBeNull();
+  const wedge = container.querySelector('[data-wedge="wind"]')!;
+  expect(wedge.getAttribute("d")).toMatch(/^M0 0 L/);
+  expect(wedge.getAttribute("d")).toMatch(/Z$/);
+  expect(container.querySelector("circle")).toBeNull();
 });
 
-test("an arc wider than a half circle takes the long way round", () => {
+test("a day that never shifted gets no wedge rather than a zero-width one", () => {
+  const container = readout([{ ...WIND, spreadDeg: 0 }]);
+
+  expect(container.querySelector('[data-wedge="wind"]')).toBeNull();
+  expect(container.querySelector('[data-arrow="wind"]')).not.toBeNull();
+});
+
+test("a spread wider than a half circle takes the long way round", () => {
   // The SVG flag that says which of the two arcs between two points is meant.
   // Without it a 200-degree swing draws as the 160-degree one it is not.
-  const container = dial([{ ...WIND, fromDegT: 214, spreadDeg: 200 }]);
+  const container = readout([{ ...WIND, fromDegT: 214, spreadDeg: 200 }]);
 
-  const d = container.querySelector('[data-arc="wind"]')!.getAttribute("d")!;
+  const d = container.querySelector('[data-wedge="wind"]')!.getAttribute("d")!;
   expect(d).toMatch(/A [\d.]+ [\d.]+ 0 1 1 /);
 });
 
-test("nothing is drawn when there is no needle to draw", () => {
-  const container = dial([]);
+test("nothing is rendered when there is no needle to render", () => {
+  const container = readout([]);
 
-  expect(container.querySelector("[data-compass-dial]")).toBeNull();
+  expect(container.querySelector("[data-readout]")).toBeNull();
+});
+
+test("the row states its word, the direction and the degrees", () => {
+  const container = readout([WIND]);
+
+  expect(
+    container.querySelector('[data-readout-label="wind"]')!.textContent,
+  ).toBe("Wind");
+  expect(
+    container.querySelector('[data-readout-bearing="wind"]')!.textContent,
+  ).toBe("west 281°");
+});
+
+test("the row's accessible name is the sentence the visible row abbreviates", () => {
+  // `role="img"` with a label is how `DaylightWeek` and `Placeholder` name a
+  // thing whose visible content is not its name. This repo does not use
+  // `sr-only`, and `ReadingCard` records why: the accessible-name algorithm
+  // joins inline text nodes with no separator, so a hidden connective would
+  // concatenate with its neighbours rather than read as a phrase.
+  render(<Compass needles={[WIND]} />);
+
+  expect(screen.getByRole("img", { name: "Wind, from the west, 281°" }));
+});
+
+test("a wide swing is spoken and a narrow one is not", () => {
+  // One compass point is exactly the width the words have, so a swing wider
+  // than one is a swing the word cannot describe and a reader is owed the
+  // number. The wedge shows it either way; the sentence states it only when
+  // the word alone would mislead.
+  expect(needleSentence({ ...WIND, spreadDeg: 120 })).toBe(
+    "Wind, from the west, 281°, swinging through 120° in daylight",
+  );
+  expect(needleSentence({ ...WIND, spreadDeg: 30 })).toBe(
+    "Wind, from the west, 281°",
+  );
+});
+
+test("the glyph itself is not in the accessibility tree twice", () => {
+  // The row is one `role="img"` with a sentence on it; the drawing inside it is
+  // the same fact drawn, so it is hidden rather than named again.
+  const container = readout([WIND]);
+
+  expect(
+    container
+      .querySelector('[data-readout-glyph="wind"]')!
+      .getAttribute("aria-hidden"),
+  ).toBe("true");
+});
+
+test("the two rows differ in shape and in weight, not only in colour", () => {
+  // The brief's rule and the one a small graphic breaks most easily: a 16px
+  // glyph is the size at which two hues are the weakest way to tell two marks
+  // apart, and these two are read as a pair, one above the other.
+  const container = readout([
+    { ...WIND, kind: "wind", spreadDeg: 0 },
+    { ...WIND, kind: "swell", label: "Swell", fromDegT: 340, spreadDeg: 0 },
+  ]);
+
+  const windHead = container.querySelector('[data-arrow-head="wind"]')!;
+  const swellHead = container.querySelector('[data-arrow-head="swell"]')!;
+
+  // Shape: an open chevron against a solid blade, which survives greyscale.
+  expect(windHead.tagName.toLowerCase()).toBe("polyline");
+  expect(swellHead.tagName.toLowerCase()).toBe("polygon");
+
+  // Weight: a different stroke, which survives greyscale too.
+  expect(NEEDLE_GLYPHS.wind.width).toBeLessThan(NEEDLE_GLYPHS.swell.width);
+  expect(
+    num(container.querySelector('[data-arrow="wind"]')!, "stroke-width"),
+  ).toBeLessThan(
+    num(container.querySelector('[data-arrow="swell"]')!, "stroke-width"),
+  );
+});
+
+test("both rows are rendered when a day has both", () => {
+  const container = readout([
+    { ...WIND, kind: "wind" },
+    { ...WIND, kind: "swell", label: "Swell", fromDegT: 340 },
+  ]);
+
+  expect(container.querySelectorAll("[data-readout-row]")).toHaveLength(2);
+});
+
+test("the rows read in the order the sources beneath them do", () => {
+  // Wind first: it is the one a reader can feel standing on the sand, the one
+  // that changes most between days, and the one whose relationship to the coast
+  // decides whether the water is choppy or glassy. The dial painted
+  // heaviest-first and nothing read that order; two rows in a column are read
+  // in the order they are written, so the order is now a reading decision.
+  const container = readout([
+    { ...WIND, kind: "wind" },
+    { ...WIND, kind: "swell", label: "Swell", fromDegT: 340 },
+  ]);
+
+  const kinds = [...container.querySelectorAll("[data-readout-row]")].map(
+    (row) => row.getAttribute("data-readout-row"),
+  );
+  expect(kinds).toEqual(["wind", "swell"]);
 });
 
 test("the sources state the bearing in words and in degrees", () => {
@@ -106,7 +221,11 @@ test("the sources state the bearing in words and in degrees", () => {
   expect(screen.getByText(/Wind, from the west, 281°/)).toBeDefined();
 });
 
-test("a wide swing is stated and a narrow one is not", () => {
+test("the sources state a wide swing and pass over a narrow one", () => {
+  // The same rule the row's own sentence keeps, stated in the same words. It is
+  // in two places for this slice only: the sources block loses its bearing
+  // sentence in the next one, when the magnitudes arrive and it drops to bare
+  // provenance.
   const { unmount } = render(
     <CompassSources needles={[{ ...WIND, spreadDeg: 120 }]} />,
   );
@@ -127,41 +246,8 @@ test("each needle carries its own publisher", () => {
   ).toBeDefined();
 });
 
-test("the two needles differ in shape and in weight, not only in colour", () => {
-  // The brief's rule and the one a small graphic breaks most easily: the whole
-  // dial is a few dozen pixels, so a reader who cannot separate two hues would
-  // otherwise be left with two identical strokes.
-  const container = dial([
-    { ...WIND, kind: "wind", spreadDeg: 0 },
-    { ...WIND, kind: "swell", label: "Swell", fromDegT: 340, spreadDeg: 0 },
-  ]);
-
-  const windHead = container.querySelector('[data-needle-head="wind"]')!;
-  const swellHead = container.querySelector('[data-needle-head="swell"]')!;
-  const windShaft = container.querySelector('[data-needle="wind"]')!;
-  const swellShaft = container.querySelector('[data-needle="swell"]')!;
-
-  // Shape: an open chevron against a solid blade, which survives greyscale.
-  expect(windHead.tagName.toLowerCase()).toBe("polyline");
-  expect(swellHead.tagName.toLowerCase()).toBe("polygon");
-
-  // Weight: a different stroke, which survives greyscale too.
-  expect(num(windShaft, "stroke-width")).toBeLessThan(
-    num(swellShaft, "stroke-width"),
-  );
-});
-
-test("both needles are drawn when a day has both", () => {
-  const container = dial([
-    { ...WIND, kind: "wind" },
-    { ...WIND, kind: "swell", label: "Swell", fromDegT: 340 },
-  ]);
-
-  expect(container.querySelectorAll("[data-needle]")).toHaveLength(2);
-});
-
 test("the sources state both bearings, in words and in degrees", () => {
-  // The design brief's own example of what the dial's text equivalent says.
+  // The design brief's own example of what the map's text equivalent says.
   render(
     <CompassSources
       needles={[
@@ -190,107 +276,11 @@ test("the sources state both bearings, in words and in degrees", () => {
   expect(screen.getByText(/Swell, from the north, 340°/)).toBeDefined();
 });
 
-test("two needles from the same bearing are still two needles", () => {
-  // Found by looking at the built page. With one radius for both, a day whose
-  // wind and swell came from the same quarter drew them exactly on top of each
-  // other -- the page said two things and showed one, and nothing failed. At
-  // La Jolla that is an ordinary day: the swell runs west to north-west and
-  // the afternoon wind west to south-west.
-  const container = dial([
-    { ...WIND, kind: "wind", fromDegT: 280, spreadDeg: 0 },
-    { ...WIND, kind: "swell", label: "Swell", fromDegT: 280, spreadDeg: 0 },
-  ]);
-
-  const wind = container.querySelector('[data-needle="wind"]')!;
-  const swell = container.querySelector('[data-needle="swell"]')!;
-
-  // Neither end coincides, so neither shaft is wholly hidden by the other.
-  expect(num(wind, "x1")).not.toBeCloseTo(num(swell, "x1"), 2);
-  expect(num(wind, "x2")).not.toBeCloseTo(num(swell, "x2"), 2);
-
-  // And the wind reaches past the swell at both ends, so its own stretches
-  // stay exposed however they are painted.
-  expect(Math.hypot(num(wind, "x1"), num(wind, "y1"))).toBeGreaterThan(
-    Math.hypot(num(swell, "x1"), num(swell, "y1")),
-  );
-  expect(Math.hypot(num(wind, "x2"), num(wind, "y2"))).toBeLessThan(
-    Math.hypot(num(swell, "x2"), num(swell, "y2")),
-  );
-});
-
-test("the two arcs never share a track either", () => {
-  const container = dial([
-    { ...WIND, kind: "wind", fromDegT: 280, spreadDeg: 60 },
-    { ...WIND, kind: "swell", label: "Swell", fromDegT: 280, spreadDeg: 60 },
-  ]);
-
-  const radius = (kind: string) =>
-    Number(
-      container
-        .querySelector(`[data-arc="${kind}"]`)!
-        .getAttribute("d")!
-        .match(/A (-?[\d.]+)/)![1],
-    );
-
-  expect(radius("wind")).not.toBe(radius("swell"));
-});
-
 test("a day with no bearings gets no sources block, not an empty list", () => {
   // Reachable through `DayCompassSources`, which hands over whatever the day
-  // has. An empty `<ul>` under the map would be a list heading nothing, and
-  // the map's own marker names are already directly above it.
+  // has. An empty `<ul>` under the map would be a list heading nothing.
   const { container } = render(<CompassSources needles={[]} />);
 
   expect(container.querySelector("ul")).toBeNull();
   expect(container.textContent).toBe("");
-});
-
-test("each needle is labelled on the dial, so it says what it is", () => {
-  // Reviewed on the built page, two arrows over a coastline did not say which
-  // was which and there is no legend on this map by design. The label is the
-  // page's own 10px register, set at the needle's tail where the eye starts.
-  const container = dial([
-    { ...WIND, kind: "wind", fromDegT: 90, spreadDeg: 0 },
-    { ...WIND, kind: "swell", label: "Swell", fromDegT: 270, spreadDeg: 0 },
-  ]);
-
-  // Keyed rather than ordered: the dial paints heaviest-first so the light
-  // shaft is never underneath, which puts the swell's markup ahead of the
-  // wind's. Nothing reads that order -- the `<svg>` is one `role="img"` -- so
-  // asserting it would pin a painting decision as if it were a reading one.
-  const textOf = (kind: string) =>
-    container.querySelector(`[data-needle-label="${kind}"]`)?.textContent;
-
-  expect(textOf("wind")).toBe("Wind");
-  expect(textOf("swell")).toBe("Swell");
-});
-
-test("a label sits at its own needle's tail, not at the other one's", () => {
-  const container = dial([
-    { ...WIND, kind: "wind", fromDegT: 90, spreadDeg: 0 },
-    { ...WIND, kind: "swell", label: "Swell", fromDegT: 270, spreadDeg: 0 },
-  ]);
-
-  const at = (kind: string) =>
-    Number(
-      container
-        .querySelector(`[data-needle-label="${kind}"]`)!
-        .getAttribute("x"),
-    );
-
-  // Wind comes from the east, swell from the west, so the labels are on
-  // opposite sides of the beach.
-  expect(at("wind")).toBeGreaterThan(0);
-  expect(at("swell")).toBeLessThan(0);
-});
-
-test("the label reads left to right whichever way the needle points", () => {
-  // A label rotated with its needle is upside down for half the compass. These
-  // are set horizontally and anchored away from the dial, so a bearing in the
-  // west does not push its own word across the picture.
-  const container = dial([{ ...WIND, kind: "wind", fromDegT: 270 }]);
-
-  const label = container.querySelector('[data-needle-label="wind"]')!;
-  expect(label.getAttribute("transform")).toBeNull();
-  expect(label.getAttribute("text-anchor")).toBe("end");
 });

--- a/src/components/conditions/Compass.tsx
+++ b/src/components/conditions/Compass.tsx
@@ -56,7 +56,7 @@
  */
 
 import { compassWords } from "./bearing";
-import { ProvenanceLine } from "./ProvenanceLine";
+import { ProvenanceLine, type ProvenanceFacts } from "./ProvenanceLine";
 
 /** Which source a needle stands for. The list is closed on purpose. */
 export type CompassNeedleKind = "wind" | "swell";
@@ -70,12 +70,32 @@ export type CompassNeedle = {
   fromDegT: number;
   /** The arc it swung through in daylight. Zero draws no wedge. */
   spreadDeg: number;
-  /** What the figure names its source, ready to print. */
-  source: string;
-  /** Who publishes it, or null where the binding does not know. */
-  network: string | null;
-  /** Why this source, when there is something to say. */
-  note: string | null;
+  /**
+   * How much of it there was, worded and rounded by the caller: "11.5 mph",
+   * "3.4 ft · 14 s".
+   *
+   * **A string rather than a number, because the rounding is a decision made
+   * elsewhere and has to survive verbatim.** The swell's is `swellFigure`, so
+   * the week grid and this readout cannot print different numbers for Thursday;
+   * the wind's carries the precision issue #191 is about, and a component that
+   * re-rounded either would be a second opinion about a figure the page holds
+   * once. `ProvenanceLine.distanceKm` is a string for the same reason.
+   *
+   * `null` where the source gave a direction and no magnitude, which is a
+   * ragged forecast rather than a fault. The row then says what it knows.
+   */
+  figure: string | null;
+  /**
+   * Where this row's figures came from, ready for `ProvenanceLine`.
+   *
+   * The whole record rather than its three most-used fields, because the label
+   * and the distance are load-bearing here: the label is what says which of two
+   * lines is the wind, now that neither restates its bearing, and it is where
+   * the superlative goes — `WaveWeek` records why "Swell" over a single figure
+   * invites a reader to take it for the day's typical swell, "which is the one
+   * thing it is not".
+   */
+  provenance: ProvenanceFacts;
 };
 
 /**
@@ -196,9 +216,11 @@ export function needleSentence(needle: CompassNeedle): string {
     needle.spreadDeg > WIDE_SWING_DEG
       ? `, swinging through ${Math.round(needle.spreadDeg)}° in daylight`
       : "";
+  const figure =
+    needle.figure === null ? "" : `, at its biggest ${needle.figure}`;
   return (
     `${needle.label}, from the ${compassWords(needle.fromDegT)}, ` +
-    `${Math.round(needle.fromDegT)}°${swing}`
+    `${Math.round(needle.fromDegT)}°${swing}${figure}`
   );
 }
 
@@ -248,7 +270,12 @@ function Row({ needle }: { needle: CompassNeedle }) {
       </span>{" "}
       <span className="whitespace-nowrap" data-readout-bearing={needle.kind}>
         {compassWords(needle.fromDegT)} {Math.round(needle.fromDegT)}°
-      </span>
+      </span>{" "}
+      {needle.figure !== null && (
+        <span className="whitespace-nowrap" data-readout-figure={needle.kind}>
+          {needle.figure}
+        </span>
+      )}
     </p>
   );
 }
@@ -378,17 +405,27 @@ function Wedge({ needle }: { needle: CompassNeedle }) {
 }
 
 /**
- * Where each figure came from, printed beneath the picture.
+ * Where each row's figures came from, printed beneath the picture.
  *
- * **Beside the picture rather than on it**, which is `ShoreMap`'s own rule and
- * has outlived the reason it was written for. It said this block was the dial's
- * text equivalent, because the `<svg>` is one `role="img"` and nothing drawn
- * inside it reaches the accessibility tree. The readout is HTML and is in that
- * tree, so it is its own equivalent; what is left here is attribution.
+ * **Attribution and nothing else, which is what the readout being HTML buys.**
+ * This block used to restate both bearings in words and degrees, because the
+ * `<svg>` is one `role="img"` and nothing drawn inside it reaches the
+ * accessibility tree, so the dial needed a text equivalent and this was it. The
+ * readout is in that tree and is its own equivalent, so the sentence was a
+ * second statement of a figure the page already made — and one place saying the
+ * numbers and one saying where they came from is the arrangement that leaves.
+ *
+ * **The label is doing the work the sentence used to.** Two provenance lines
+ * under one picture have to say which is which, and that is what
+ * `ProvenanceLine.label` is for. It also carries the superlative, which
+ * `WaveWeek` records is not optional: a single figure under the bare word
+ * "Swell" invites a reader to take it for the day's typical swell, "which is
+ * the one thing it is not". Both are the caller's words.
  *
  * One provenance line per needle, which is `WeekGrid`'s resolution rather than
  * `StatGroup`'s contract: one instrument carrying two publishers is a
- * deliberate break of one-group-one-source, answered by attributing each row.
+ * deliberate break of one-group-one-source, answered by attributing each row
+ * (ADR-0032).
  */
 export function CompassSources({
   needles,
@@ -401,19 +438,7 @@ export function CompassSources({
     <ul className="mt-2 flex flex-col gap-1">
       {needles.map((needle) => (
         <li key={needle.kind}>
-          <p className="text-2xs text-ink leading-normal">
-            {needle.label}, from the {compassWords(needle.fromDegT)},{" "}
-            {Math.round(needle.fromDegT)}°
-            {needle.spreadDeg > WIDE_SWING_DEG
-              ? ` — swinging through ${Math.round(needle.spreadDeg)}° in daylight`
-              : ""}
-          </p>
-          <ProvenanceLine
-            source={needle.source}
-            network={needle.network}
-            note={needle.note}
-            surface="page"
-          />
+          <ProvenanceLine {...needle.provenance} surface="page" />
         </li>
       ))}
     </ul>

--- a/src/components/conditions/Compass.tsx
+++ b/src/components/conditions/Compass.tsx
@@ -1,38 +1,58 @@
 /**
- * Where the wind and the swell come from, drawn on the beach they arrive at.
+ * Where the wind and the swell come from, read in the corner of the map they
+ * arrive at.
  *
- * **A bearing means nothing on its own, and that is why this is not a card.**
- * 281 degrees is a number. Drawn on the shore map, over a coastline a reader
- * can see, it becomes the thing they actually came for: whether the wind is
- * coming off the land or off the water. The design brief's third principle is
- * this component's whole justification -- "no dial floating beside a graph can
- * say which" -- and it is why `ShoreMap` hosts this rather than the day panel.
+ * **A bearing means nothing on its own, and that has not changed.** 281 degrees
+ * is a number; read in the same frame as a coastline a reader can see, it
+ * becomes the thing they came for — whether the wind is coming off the land or
+ * off the water. The design brief's third principle is still this component's
+ * justification, and it is still why `ShoreMap` hosts this rather than the day
+ * panel.
  *
- * **The needles point inward, at the beach.** Every feed this page reads
- * publishes the direction weather comes *from*, so the tail sits out at the
- * bearing and the head arrives at the sand. An arrow drawn the other way is the
- * same line saying the opposite thing, and a reader has no way to tell which
- * convention a drawing chose. This one is checkable against the map underneath
- * it: a needle whose tail is out over the shaded sea is onshore wind, which is
- * the reading the whole component exists to make possible.
+ * **What changed is that the instrument stopped covering the picture.** This
+ * was a dial: a ring 30 units across a 100-unit frame, two needles and two
+ * labels, anchored on the beach's own stretch of coast — so the coastline the
+ * needles were to be read against was underneath them, and on some beaches the
+ * dial overflowed the edge. Reviewed on the built page it was distracting, and
+ * it was covering its own subject. See ADR-0034.
  *
- * **The arc is the honesty.** A bare needle on a day the wind swung through 200
- * degrees would state a direction the day did not have. Measured across the
- * committed run, two days of seven have a daylight spread past 170 degrees and
- * four sit at 40 or less, so the two cases look completely different -- which is
- * the point. `bearing.ts` computes the arc; this draws it.
+ * **The arrows still carry true bearings, and that is deliberate rather than
+ * inherited.** The alternative considered was a corner block whose arrows are
+ * decorative, with an animated field carrying direction instead. That field is
+ * gated off under `prefers-reduced-motion`, so the map would say nothing
+ * directional at all to a reader who turned motion off — and directional is the
+ * one thing this map is for.
+ *
+ * **The arrow points the way the weather travels.** Every feed this page reads
+ * publishes the direction weather comes *from*, so the tail sits at that
+ * bearing and the head is opposite it. Drawn the other way it is the same line
+ * saying the reverse, and a reader has no way to tell which convention a
+ * drawing chose. This one is checkable against the map beside it: an arrow
+ * whose tail is out over the shaded sea is onshore wind, which is the reading
+ * the whole component exists to make possible.
+ *
+ * **The ring went and the arc became a wedge**, which is one change rather than
+ * two. The ring's only stated justification was that "an arc with nothing to be
+ * a portion of reads as a stray stroke rather than as a range" — so at corner
+ * size, where a 40° arc and a 50° arc on a 9px ring are the same picture, the
+ * arc it justified can no longer be judged and both go. A filled cone reads at
+ * 16px, and a 190° day drawing a near-blob is correct: that day had no
+ * direction. The wedge was rejected once, on the grounds that "a wedge covering
+ * a fifth of the map on a settled day and half of it on an unsettled one would
+ * hide the coast underneath". In a corner readout there is no coast underneath.
+ *
+ * **HTML, not SVG in plot units.** Plot-unit type was already at ADR-0024's
+ * 10px floor — 3.2 units is 10.5px on the 328px map a phone draws — and these
+ * rows carry four fields where the old label carried one word. The `<svg>` is
+ * one `role="img"`, so nothing drawn inside it reaches the accessibility tree
+ * at all; this block is in the tree, which is what makes it the text equivalent
+ * rather than a picture needing one. And it costs no vertical height, in a
+ * column already stacking a map, a coast credit, provenance rows and the
+ * sightings slot, reviewed in a 555px-tall stop.
  *
  * **Presentational and pure**, like `ShoreMap` and `DaySpark`. It takes needles
- * and draws them; it reads no feed, resolves no station and words nothing. The
- * sentences are the caller's.
- *
- * **The ring is chrome, and it is the one piece here that is.** The day view's
- * review already named the cloud legend as the only element inside a frame that
- * is not data, and this is a second. It earns it: an arc with nothing to be a
- * portion of reads as a stray stroke rather than as a range, and the
- * alternative -- labelled tick marks at the cardinals -- is the boxed legend
- * the brief lists as an anti-reference. One faint circle is the smallest thing
- * that makes the arc mean what it means.
+ * and renders them; it reads no feed, resolves no station and words nothing
+ * that is not arithmetic on what it was handed. The sentences are the caller's.
  */
 
 import { compassWords } from "./bearing";
@@ -48,7 +68,7 @@ export type CompassNeedle = {
   label: string;
   /** Degrees true it comes *from*, weighted by how much there was. */
   fromDegT: number;
-  /** The arc it swung through in daylight. Zero draws no arc. */
+  /** The arc it swung through in daylight. Zero draws no wedge. */
   spreadDeg: number;
   /** What the figure names its source, ready to print. */
   source: string;
@@ -59,19 +79,35 @@ export type CompassNeedle = {
 };
 
 /**
- * The ring, in the map's own plot units.
+ * The glyph's own drawing space, in its own units.
  *
- * Just under a third of the hundred-unit frame, so the dial reads as an
- * instrument sat on the beach rather than a second picture covering the coast.
+ * Its own frame rather than the map's: this is 16 CSS pixels of picture inside
+ * a row of text, so it is sized like an icon and knows nothing about the
+ * hundred-unit frame the coastline is drawn in. `ARM` leaves a margin inside
+ * the box for the arrowhead's barbs, which reach across the shaft.
  */
-const RING_RADIUS = 30;
+const GLYPH_UNITS = 20;
+const ARM = 8;
+
+/**
+ * The wedge reaches past the arrow's tail, and that is what makes a settled day
+ * readable.
+ *
+ * Drawn at the arrow's own radius, a 30-degree spread is a sliver lying under
+ * the shaft and is invisible at 16px -- looked at on the built page, the swell
+ * row appeared to have no wedge at all rather than a narrow one. Reaching 1.5
+ * units further out leaves a rim of it showing whatever the shaft covers, so
+ * the difference between a settled day and an unsettled one is a difference in
+ * the picture rather than between a picture and nothing.
+ */
+const WEDGE_RADIUS = 9.5;
 
 /**
  * Plot coordinates for a bearing at a radius, with north up.
  *
  * The one conversion in this file and the one worth stating: bearings run
  * clockwise from north, and plot y grows southward, so north is a *negative*
- * y. Writing it the intuitive way puts every needle upside down.
+ * y. Writing it the intuitive way puts every arrow upside down.
  */
 function at(degreesTrue: number, radius: number): { x: number; y: number } {
   const radians = (degreesTrue * Math.PI) / 180;
@@ -79,53 +115,33 @@ function at(degreesTrue: number, radius: number): { x: number; y: number } {
 }
 
 /**
- * The two needles differ in shape and in weight, never in colour alone.
+ * The two rows differ in shape and in weight, never in colour alone.
  *
- * The brief's rule, and the one a small graphic breaks most easily: the whole
- * dial is a few dozen pixels, and a reader who cannot separate two hues would
- * be left with two identical strokes.
+ * The brief's rule, kept even though each arrow now sits beside its own word
+ * and could lean on that. A 16px glyph is exactly the size at which two hues
+ * are the weakest thing to tell two marks apart, and the pair is read as a pair
+ * — one above the other — so a reader who cannot separate the colours would
+ * otherwise be comparing two identical arrows.
  *
  * **Open against solid, and thin against heavy.** The wind is a light shaft
  * under a hollow chevron, the swell a heavy one under a filled blade. Both
- * differences survive greyscale, which is the test that matters: colour
- * reinforces the pair and carries none of it. It also reads as what each is --
- * air is the lighter mark and water the heavier one.
+ * survive greyscale, which is the test that matters; colour reinforces the pair
+ * and carries none of it. It also reads as what each is — air is the lighter
+ * mark and water the heavier one.
  *
- * **And each runs on its own track, which is not decoration.** Built with one
- * radius for both, a day whose wind and swell came from the same quarter drew
- * the two needles exactly on top of each other: the page said two things and
- * showed one, and nothing failed. At La Jolla that is an ordinary day rather
- * than an edge case -- the swell runs west to north-west and the afternoon
- * wind west to south-west -- and it was found by looking at the picture.
- *
- * So the wind reaches from the ring almost to the sand and the swell occupies
- * the middle of that span, leaving the wind's outer and inner stretches always
- * exposed. The lengths differ as a consequence and carry no meaning: the two
- * are a speed and a height, in different units, and nothing on this dial
- * invites them to be compared as quantities.
+ * The lengths no longer differ. On the map the two needles ran on separate
+ * tracks so a day whose wind and swell came from one quarter could not draw
+ * them on top of each other — found by looking at the built page, and an
+ * ordinary day at La Jolla rather than an edge case. Two arrows in two labelled
+ * rows cannot overlap, so the tracks are gone with the dial that needed them.
  */
-const NEEDLES: Record<
+const GLYPHS: Record<
   CompassNeedleKind,
   {
     stroke: string;
     fill: string;
-    /** Where the arc is drawn. Each kind has its own, so two never overlap. */
-    arc: number;
-    /**
-     * How solid the arc is, and the two are not the same number.
-     *
-     * **They are set to the same measured contrast, not to the same opacity**,
-     * because the two hues do not weigh the same. At 0.65 over the sea the
-     * ocean arc reads 3.60:1 from painted pixels and the purple one 2.77:1 --
-     * under the brief's 3:1 for a graphical object, on the same setting that
-     * cleared it for the other. Tuned by measurement, they land at 3.60 and
-     * 3.64.
-     */
-    arcOpacity: number;
-    /** Where the shaft starts, out at the bearing. */
-    tail: number;
-    /** Where it ends, pointing at the beach. */
-    head: number;
+    /** How solid the wedge is. Faint: it is a range behind a reading. */
+    wedgeOpacity: number;
     width: number;
     /** Half the arrowhead's span across the shaft. */
     barb: number;
@@ -135,103 +151,161 @@ const NEEDLES: Record<
   wind: {
     stroke: "stroke-ocean",
     fill: "fill-ocean",
-    arc: RING_RADIUS,
-    arcOpacity: 0.65,
-    tail: 26,
-    head: 3,
-    width: 1.3,
-    barb: 1.7,
+    wedgeOpacity: 0.3,
+    width: 1.5,
+    barb: 1.9,
     solid: false,
   },
   swell: {
     stroke: "stroke-purple-deep",
     fill: "fill-purple-deep",
-    arc: 24,
-    arcOpacity: 0.8,
-    tail: 21,
-    head: 8,
-    width: 2.4,
-    barb: 2.2,
+    wedgeOpacity: 0.35,
+    width: 2,
+    barb: 2.6,
     solid: true,
   },
 };
 
-/** The two needles' geometry, exported so tests read it rather than repeat it. */
-export const NEEDLE_TRACKS = NEEDLES;
+/** The glyphs' geometry, exported so tests read it rather than repeat it. */
+export const NEEDLE_GLYPHS = GLYPHS;
 
 /**
- * The dial, drawn around whatever origin its parent translated it to.
+ * Beyond this, the eight-point word for a needle stops describing its own
+ * range.
  *
- * `ShoreMap` puts that origin on the beach's own stretch of coast rather than
- * at the middle of the frame, because the frame is sized by the sources: at
- * `mission-beach` a station nine kilometres away puts the frame's centre out in
- * the county somewhere, and a needle pointing at that would be pointing at
- * nothing.
+ * Not a threshold picked to suit the data: one compass point is exactly the
+ * width the words have, so a swing wider than one is a swing the words cannot
+ * describe and a reader is owed the number instead. It happens to separate the
+ * committed run cleanly — four days at 40 or 50, two past 170 — which is a check
+ * on the rule rather than the reason for it.
+ */
+const WIDE_SWING_DEG = 45;
+
+/**
+ * What one row says to a reader who is not looking at it.
+ *
+ * The visible row is abbreviated — a glyph, a word, a bearing — and this is the
+ * unabbreviated form. `role="img"` with a label is how `DaylightWeek` and
+ * `Placeholder` name a thing whose visible content is not its name; this repo
+ * does not use `sr-only`, and `ReadingCard` records why: the accessible-name
+ * algorithm joins inline text nodes with no separator, so a visually-hidden
+ * connective concatenates with its neighbours rather than reading as a phrase.
+ */
+export function needleSentence(needle: CompassNeedle): string {
+  const swing =
+    needle.spreadDeg > WIDE_SWING_DEG
+      ? `, swinging through ${Math.round(needle.spreadDeg)}° in daylight`
+      : "";
+  return (
+    `${needle.label}, from the ${compassWords(needle.fromDegT)}, ` +
+    `${Math.round(needle.fromDegT)}°${swing}`
+  );
+}
+
+/**
+ * The readout, laid over the corner of the map its caller chose.
+ *
+ * It renders the rows and nothing about where they stand: which corner is safe
+ * is a question about the coastline underneath, which this component cannot
+ * see. `ShoreMap` projects, asks `corner.ts` and positions this.
  */
 export function Compass({ needles }: { needles: readonly CompassNeedle[] }) {
   if (needles.length === 0) return null;
 
-  return (
-    <g data-compass-dial="">
-      <circle
-        cx={0}
-        cy={0}
-        r={RING_RADIUS}
-        fill="none"
-        className="stroke-fog"
-        strokeWidth={0.6}
-        strokeOpacity={0.45}
-        vectorEffect="non-scaling-stroke"
-      />
+  /*
+    The rows wrap rather than run on, which is ADR-0004's own resolution of the
+    same squeeze: content that no longer fits grows its container instead of
+    being clipped, because a taller block is a visible degradation and a line
+    running off the picture is an invisible one.
 
-      {/*
-        Heaviest first, so the light shaft is never the one underneath. The
-        list itself stays in reading order -- wind, then swell -- because that
-        is the order the sources below are read in, and drawing order is a
-        painting concern rather than a claim about which matters.
-      */}
-      {[...needles]
-        .sort((a, b) => NEEDLES[b.kind].width - NEEDLES[a.kind].width)
-        .map((needle) => (
-          <Needle key={needle.kind} needle={needle} />
-        ))}
-    </g>
+    It binds at 320 CSS px, which that ADR commits this site to. `SWELL
+    south-west 270°` is 147.6px at 10px against the 151.5px this box leaves
+    inside a 327px map and the 124px it leaves inside a 272px one -- so the
+    bearing drops under its own label at the narrow end and the row is one line
+    everywhere else. `corner.ts` records why that trade is available at all:
+    the width is the whole constraint and the height costs nothing.
+  */
+  return (
+    <div className="flex flex-col gap-1" data-readout="">
+      {needles.map((needle) => (
+        <Row key={needle.kind} needle={needle} />
+      ))}
+    </div>
   );
 }
 
-function Needle({ needle }: { needle: CompassNeedle }) {
-  const style = NEEDLES[needle.kind];
-  const tail = at(needle.fromDegT, style.tail);
-  const head = at(needle.fromDegT, style.head);
-  const span = style.tail - style.head;
+function Row({ needle }: { needle: CompassNeedle }) {
+  return (
+    <p
+      role="img"
+      aria-label={needleSentence(needle)}
+      className="text-2xs text-ink flex flex-wrap items-center gap-x-1 leading-none font-bold tabular-nums"
+      data-readout-row={needle.kind}
+    >
+      <Glyph needle={needle} />
+      <span className="uppercase" data-readout-label={needle.kind}>
+        {needle.label}
+      </span>{" "}
+      <span className="whitespace-nowrap" data-readout-bearing={needle.kind}>
+        {compassWords(needle.fromDegT)} {Math.round(needle.fromDegT)}°
+      </span>
+    </p>
+  );
+}
+
+/**
+ * One arrow and the band the direction moved through while the sun was up.
+ *
+ * A bare arrow on a day the wind swung through 200 degrees would state a
+ * direction the day did not have. Measured across the committed run, two days
+ * of seven have a daylight spread past 170 degrees and four sit at 40 or less,
+ * so the two cases look completely different — which is the point.
+ * `bearing.ts` computes the spread; this draws it.
+ */
+function Glyph({ needle }: { needle: CompassNeedle }) {
+  const style = GLYPHS[needle.kind];
+  const tail = at(needle.fromDegT, ARM);
+  const head = at(needle.fromDegT + 180, ARM);
 
   /*
     The two barbs of the arrowhead, set back along the shaft and out to either
     side. Built from the same `at` conversion rather than from a rotation
     matrix, so there is one place in this file that knows which way north is.
-  */
-  /*
-    The head is two and a half times as long as it is wide across.
 
-    Set back by less it draws an obtuse blob rather than an arrow, which is
-    what the swell's first version did once its shaft was shortened to clear
-    the wind's -- reviewed on the built page and called tacky, correctly. A
-    long, narrow head reads as a direction; a squat one reads as a shape.
+    The head is two and a half times as long as it is wide across. Set back by
+    less it draws an obtuse blob rather than an arrow, which is what the swell's
+    needle did once its shaft was shortened -- reviewed on the built page and
+    called tacky, correctly. A long, narrow head reads as a direction; a squat
+    one reads as a shape.
   */
-  const barbBack = at(needle.fromDegT, style.head + style.barb * 2.5);
+  const barbBack = at(needle.fromDegT + 180, ARM - style.barb * 2.2);
   const across = {
-    x: (tail.y - head.y) / span,
-    y: (head.x - tail.x) / span,
+    x: (tail.y - head.y) / (2 * ARM),
+    y: (head.x - tail.x) / (2 * ARM),
   };
+  const point = (x: number, y: number) => `${x.toFixed(2)},${y.toFixed(2)}`;
   const barbs = [
-    `${(barbBack.x + across.x * style.barb).toFixed(2)},${(barbBack.y + across.y * style.barb).toFixed(2)}`,
-    `${head.x.toFixed(2)},${head.y.toFixed(2)}`,
-    `${(barbBack.x - across.x * style.barb).toFixed(2)},${(barbBack.y - across.y * style.barb).toFixed(2)}`,
+    point(
+      barbBack.x + across.x * style.barb,
+      barbBack.y + across.y * style.barb,
+    ),
+    point(head.x, head.y),
+    point(
+      barbBack.x - across.x * style.barb,
+      barbBack.y - across.y * style.barb,
+    ),
   ].join(" ");
 
+  const half = GLYPH_UNITS / 2;
+
   return (
-    <>
-      {needle.spreadDeg > 0 && <Arc needle={needle} />}
+    <svg
+      viewBox={`${-half} ${-half} ${GLYPH_UNITS} ${GLYPH_UNITS}`}
+      className="h-4 w-4 shrink-0"
+      aria-hidden="true"
+      data-readout-glyph={needle.kind}
+    >
+      {needle.spreadDeg > 0 && <Wedge needle={needle} />}
 
       <line
         x1={Number(tail.x.toFixed(2))}
@@ -241,15 +315,14 @@ function Needle({ needle }: { needle: CompassNeedle }) {
         className={style.stroke}
         strokeWidth={style.width}
         strokeLinecap="round"
-        vectorEffect="non-scaling-stroke"
-        data-needle={needle.kind}
+        data-arrow={needle.kind}
       />
 
       {style.solid ? (
         <polygon
           points={barbs}
           className={style.fill}
-          data-needle-head={needle.kind}
+          data-arrow-head={needle.kind}
         />
       ) : (
         <polyline
@@ -259,96 +332,32 @@ function Needle({ needle }: { needle: CompassNeedle }) {
           strokeWidth={style.width}
           strokeLinecap="round"
           strokeLinejoin="round"
-          vectorEffect="non-scaling-stroke"
-          data-needle-head={needle.kind}
+          data-arrow-head={needle.kind}
         />
       )}
-
-      <Label needle={needle} tail={tail} />
-    </>
+    </svg>
   );
 }
 
 /**
- * Where the needle's own word sits, out beyond its tail.
+ * The band the direction moved through while the sun was up, as a filled cone.
  *
- * **Two arrows over a coastline do not say which is which**, and this map has
- * no legend by design — a boxed legend is one of the brief's anti-references,
- * and the design review already named the cloud legend as the only element
- * inside a frame that is chrome rather than data. A word at the tail is not a
- * legend: it is the label on the thing itself, which is what a legend is a
- * substitute for.
- *
- * **Horizontal, never rotated with its needle.** A label turned to follow a
- * bearing is upside down for half the compass. It is anchored away from the
- * dial instead — a needle out to the west puts its word further west — so the
- * text runs outward and never crosses the picture.
- *
- * The size is in plot units rather than in the page's `text-2xs`, because a CSS
- * pixel inside a hundred-unit viewBox is a hundredth of the map. 3.2 units is
- * about 15px on the widest map this page draws and 10.5px on the narrowest, at
- * 375 — which keeps it at ADR-0024's floor rather than under it.
+ * Behind the arrow's tail rather than around the whole glyph, because the
+ * spread is a range of directions the weather came *from* and the tail is where
+ * that is read. A settled day draws a splinter and an unsettled one draws most
+ * of a disc, and the difference is legible at 16px in a way an arc on a ring is
+ * not.
  */
-function Label({
-  needle,
-  tail,
-}: {
-  needle: CompassNeedle;
-  tail: { x: number; y: number };
-}) {
-  /*
-    Outside the arc, not just outside the tail. Set at the tail the word landed
-    on its own arc's track and the halo punched a hole through it -- visible on
-    the built page and picked up by the contrast probe, which kept sampling the
-    label's ink where it was looking for the band.
-  */
-  const out = at(needle.fromDegT, NEEDLES[needle.kind].arc + 4);
-  const eastward = tail.x >= 0;
-
-  return (
-    <text
-      x={Number(out.x.toFixed(2))}
-      y={Number(out.y.toFixed(2))}
-      textAnchor={eastward ? "start" : "end"}
-      dominantBaseline="middle"
-      fontSize={3.2}
-      className={`fill-ink stroke-cream uppercase ${
-        needle.kind === "wind" ? "font-bold" : "font-extrabold"
-      }`}
-      /*
-        A halo, not a badge. It exists so the word survives being drawn over
-        the coastline or the wash, and at 2.5 it read as a chip stuck on the
-        map -- which is the boxed legend this dial is meant not to have. 1.2 is
-        enough to separate the letters from what is behind them.
-      */
-      strokeWidth={1.2}
-      paintOrder="stroke"
-      strokeLinejoin="round"
-      data-needle-label={needle.kind}
-    >
-      {needle.label}
-    </text>
-  );
-}
-
-/**
- * The band the direction moved through while the sun was up.
- *
- * A stroked arc rather than a filled wedge from the centre. A wedge covering a
- * fifth of the map on a settled day and half of it on an unsettled one would
- * hide the coast underneath exactly when the reader most needs to compare the
- * two, and the arc says the same thing at the rim.
- */
-function Arc({ needle }: { needle: CompassNeedle }) {
-  const { arc: radius, arcOpacity, stroke } = NEEDLES[needle.kind];
+function Wedge({ needle }: { needle: CompassNeedle }) {
+  const { fill, wedgeOpacity } = GLYPHS[needle.kind];
   const half = needle.spreadDeg / 2;
-  const from = at(needle.fromDegT - half, radius);
-  const to = at(needle.fromDegT + half, radius);
+  const from = at(needle.fromDegT - half, WEDGE_RADIUS);
+  const to = at(needle.fromDegT + half, WEDGE_RADIUS);
 
   /*
     Which of the two arcs between the endpoints is meant. Without the flag a
-    200-degree swing draws as the 160-degree one on the other side of the dial,
-    which is not merely wrong but the opposite claim.
+    200-degree swing draws as the 160-degree one on the other side of the
+    glyph, which is not merely wrong but the opposite claim.
 
     The sweep flag is 1 because bearings increase clockwise and, in a space
     where y grows downward, a positive sweep is clockwise on screen.
@@ -358,44 +367,28 @@ function Arc({ needle }: { needle: CompassNeedle }) {
   return (
     <path
       d={
-        `M${from.x.toFixed(2)} ${from.y.toFixed(2)} ` +
-        `A ${radius} ${radius} 0 ${largeArc} 1 ${to.x.toFixed(2)} ${to.y.toFixed(2)}`
+        `M0 0 L${from.x.toFixed(2)} ${from.y.toFixed(2)} ` +
+        `A ${WEDGE_RADIUS} ${WEDGE_RADIUS} 0 ${largeArc} 1 ${to.x.toFixed(2)} ${to.y.toFixed(2)} Z`
       }
-      fill="none"
-      className={stroke}
-      strokeWidth={4}
-      strokeOpacity={arcOpacity}
-      strokeLinecap="butt"
-      vectorEffect="non-scaling-stroke"
-      data-arc={needle.kind}
+      className={fill}
+      fillOpacity={wedgeOpacity}
+      data-wedge={needle.kind}
     />
   );
 }
 
 /**
- * Beyond this, the eight-point word for the needle stops covering its own arc.
+ * Where each figure came from, printed beneath the picture.
  *
- * Not a threshold picked to suit the data: one compass point is exactly the
- * width the words have, so a swing wider than one is a swing the words cannot
- * describe and a reader is owed the number instead. It happens to separate the
- * committed run cleanly -- four days at 40 or 50, two past 170 -- which is a
- * check on the rule rather than the reason for it.
- */
-const WIDE_SWING_DEG = 45;
-
-/**
- * What the dial says, for a reader who is not looking at it.
- *
- * **Beside the picture rather than on it**, which is `ShoreMap`'s own rule for
- * its markers and for the same two reasons: a label inside a hundred-unit frame
- * either overlaps its neighbour or shrinks under the ten-pixel floor ADR-0024
- * refused to go below, and the map is one `role="img"` whose contents are not
- * in the accessibility tree at all. This block is the dial's text equivalent,
- * so it states both bearings in words and in degrees.
+ * **Beside the picture rather than on it**, which is `ShoreMap`'s own rule and
+ * has outlived the reason it was written for. It said this block was the dial's
+ * text equivalent, because the `<svg>` is one `role="img"` and nothing drawn
+ * inside it reaches the accessibility tree. The readout is HTML and is in that
+ * tree, so it is its own equivalent; what is left here is attribution.
  *
  * One provenance line per needle, which is `WeekGrid`'s resolution rather than
- * `StatGroup`'s contract: one dial carrying two publishers is a deliberate
- * break of one-group-one-source, answered by attributing each row.
+ * `StatGroup`'s contract: one instrument carrying two publishers is a
+ * deliberate break of one-group-one-source, answered by attributing each row.
  */
 export function CompassSources({
   needles,

--- a/src/components/conditions/DayCompass.test.tsx
+++ b/src/components/conditions/DayCompass.test.tsx
@@ -10,9 +10,12 @@ function needle(fromDegT: number): CompassNeedle {
     label: "Wind",
     fromDegT,
     spreadDeg: 20,
-    source: "this beach's own grid cell",
-    network: "National Weather Service, San Diego",
-    note: null,
+    figure: "11.5 mph",
+    provenance: {
+      label: "Biggest wind in daylight",
+      source: "this beach's own grid cell",
+      network: "National Weather Service, San Diego",
+    },
   };
 }
 
@@ -27,11 +30,11 @@ test("the readout opens on the first day, which is today", () => {
   // construction. A readout that read a clock could disagree with the heading.
   render(
     <SelectedDayProvider>
-      <DayCompassSources days={DAYS} />
+      <DayCompass days={DAYS} />
     </SelectedDayProvider>,
   );
 
-  expect(screen.getByText(/from the east, 90°/)).toBeDefined();
+  expect(screen.getByRole("img", { name: /from the east, 90°/ })).toBeDefined();
 });
 
 test("a day the compass has nothing for renders no readout", () => {
@@ -59,7 +62,7 @@ test("the readout renders outside the provider, showing its first day", () => {
   // The provider's default is the null state rather than a throw, so a region
   // rendered outside it degrades to "the first day and no choice" -- which is
   // exactly the state a reader with no JavaScript is in.
-  render(<DayCompassSources days={DAYS} />);
+  render(<DayCompass days={DAYS} />);
 
-  expect(screen.getByText(/from the east, 90°/)).toBeDefined();
+  expect(screen.getByRole("img", { name: /from the east, 90°/ })).toBeDefined();
 });

--- a/src/components/conditions/DayCompass.test.tsx
+++ b/src/components/conditions/DayCompass.test.tsx
@@ -21,10 +21,10 @@ const DAYS: CompassDay[] = [
   { localDate: "2026-08-18", needles: [needle(270)] },
 ];
 
-test("the dial opens on the first day, which is today", () => {
+test("the readout opens on the first day, which is today", () => {
   // The provider starts null and every consumer resolves it against its own
   // first column, so the server render and the first client render agree by
-  // construction. A dial that read a clock could disagree with the heading.
+  // construction. A readout that read a clock could disagree with the heading.
   render(
     <SelectedDayProvider>
       <DayCompassSources days={DAYS} />
@@ -34,14 +34,14 @@ test("the dial opens on the first day, which is today", () => {
   expect(screen.getByText(/from the east, 90°/)).toBeDefined();
 });
 
-test("a day the compass has nothing for draws no dial", () => {
+test("a day the compass has nothing for renders no readout", () => {
   const { container } = render(
     <SelectedDayProvider>
       <DayCompass days={[{ localDate: "2026-08-17", needles: [] }]} />
     </SelectedDayProvider>,
   );
 
-  expect(container.querySelector("[data-compass-dial]")).toBeNull();
+  expect(container.querySelector("[data-readout]")).toBeNull();
 });
 
 test("a beach with no days at all draws nothing rather than throwing", () => {
@@ -55,7 +55,7 @@ test("a beach with no days at all draws nothing rather than throwing", () => {
   expect(container.textContent).toBe("");
 });
 
-test("the dial renders outside the provider, showing its first day", () => {
+test("the readout renders outside the provider, showing its first day", () => {
   // The provider's default is the null state rather than a throw, so a region
   // rendered outside it degrades to "the first day and no choice" -- which is
   // exactly the state a reader with no JavaScript is in.

--- a/src/components/conditions/DayCompass.tsx
+++ b/src/components/conditions/DayCompass.tsx
@@ -1,22 +1,23 @@
 /**
- * The dial for the day a reader chose, on a map that is the same on all seven.
+ * The readout for the day a reader chose, on a map that is the same on all
+ * seven.
  *
  * **The smallest client island that makes this work.** `DayPanel` builds the
  * shore map once and hands it over as finished markup, because the beach, its
  * coast and the four places its figures come from do not change when somebody
- * picks Thursday. The needles do: each day has its own resultant bearing and
- * its own arc. Seven copies of the map would carry the coast seven times --
+ * picks Thursday. The readout does: each day has its own resultant bearing and
+ * its own spread. Seven copies of the map would carry the coast seven times --
  * measured at La Jolla, four and a half kilobytes of coordinates a copy, and
  * two hundred points at `del-mar-city-beach` -- to vary two numbers.
  *
- * So the map stays one server-rendered picture with a hole in it, and this
- * fills the hole. Seven days of needles is a few dozen numbers.
+ * So the map stays one server-rendered picture with two holes in it, and this
+ * fills them. Seven days of needles is a few dozen numbers.
  *
- * **Two components rather than one with a switch**, because the dial and its
- * words go in two different places: the dial inside the map's own drawing
- * space, where the projection puts it on the beach, and the words down in the
- * list beside the picture, where `ShoreMap` already keeps the names of things
- * it draws. Each is a line over one shared hook.
+ * **Two components rather than one with a switch**, because the readout and its
+ * attribution go in two different places: the readout over a corner of the
+ * picture, where `ShoreMap` positions it clear of the coastline, and the
+ * publishers down in the list beneath, where `ShoreMap` already keeps the names
+ * of things it draws. Each is a line over one shared hook.
  *
  * Rendered outside the provider it shows the first day and offers no choice,
  * which is `selectedDay.ts`'s deliberate default and the state a reader with a
@@ -32,7 +33,7 @@ import { resolveSelected, useSelectedDay } from "./selectedDay";
 export type CompassDay = {
   /** `YYYY-MM-DD` in Pacific. */
   localDate: string;
-  /** Empty on a day no feed gave a bearing for, which draws no dial. */
+  /** Empty on a day no feed gave a bearing for, which renders no readout. */
   needles: readonly CompassNeedle[];
 };
 
@@ -45,13 +46,13 @@ function useChosen(days: readonly CompassDay[]): CompassDay | undefined {
   return days.find((day) => day.localDate === showing) ?? days[0];
 }
 
-/** The dial itself, drawn into whatever origin `ShoreMap` translated it to. */
+/** The rows themselves, laid into whichever corner `ShoreMap` chose. */
 export function DayCompass({ days }: { days: readonly CompassDay[] }) {
   const day = useChosen(days);
   return day === undefined ? null : <Compass needles={day.needles} />;
 }
 
-/** What the dial says, for a reader not looking at it. */
+/** Where the readout's figures came from, printed beneath the picture. */
 export function DayCompassSources({ days }: { days: readonly CompassDay[] }) {
   const day = useChosen(days);
   return day === undefined ? null : <CompassSources needles={day.needles} />;

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -784,13 +784,78 @@ test("the map carries a readout for the day the reader chose", async () => {
 
   expect(container.querySelector("[data-readout-row='wind']")).not.toBeNull();
 
-  // Scoped to the row's own provenance. The sky wording names the same cell a few
-  // hundred pixels up, which is ADR-0029's permitted duplication and is why an
-  // unscoped query for that sentence finds two.
-  const row = screen.getByText(/^Wind, from the south, 180°/).closest("li")!;
-  expect(row.textContent).toContain(
+  // The row itself is the spoken equivalent now, so the bearing is read off its
+  // accessible name rather than off a sentence beneath the picture.
+  expect(
+    screen.getByRole("img", { name: /^Wind, from the south, 180°/ }),
+  ).toBeDefined();
+
+  // Scoped to the row's own provenance. The sky wording names the same cell a
+  // few hundred pixels up, which is ADR-0029's permitted duplication and is why
+  // an unscoped query for that sentence finds two.
+  const line = screen.getByText(/^Biggest wind in daylight/).closest("li")!;
+  expect(line.textContent).toContain(
     "this beach's own grid cell · National Weather Service, San Diego",
   );
+});
+
+test("the wind row prints the strongest daylight hour, to one decimal", async () => {
+  // The cell's speeds step 5, 8, 11, 14 through four six-hour blocks and
+  // daylight runs 6:14 AM to 7:32 PM, so the last block's 14 is the largest
+  // hour a reader could be there for. The whole day would say the same here;
+  // what the window changes is a day whose peak is at 2 AM.
+  //
+  // One decimal because four of the five places this page prints a wind figure
+  // use it and the fifth is issue #191. A sixth statement joining the four is
+  // what keeps that issue about one function rather than two.
+  const dates = [TODAY];
+  daylight(dates);
+  tideWeek(dates);
+  waveWeek(dates);
+  skyWeek(dates);
+  gridWeek(dates);
+  wordingWeek([{ localDate: TODAY, periodName: "Today", words: "Patchy Fog" }]);
+
+  const { container } = render(
+    <SelectedDayProvider>
+      {await DayPanel({ slug: "la-jolla-shores-beach" })}
+    </SelectedDayProvider>,
+  );
+
+  expect(
+    container.querySelector("[data-readout-figure='wind']")!.textContent,
+  ).toBe("14.0 mph");
+});
+
+test("the swell row prints the same figure the week grid does", async () => {
+  // One `WaveReading`, selected once by `readWaveWeek` and worded once by
+  // `swellFigure`, so the map and the grid cannot state different numbers for
+  // one day. The step's own time is not beside the figure -- it is in the
+  // provenance line, because a three-hour step is not a peak located to the
+  // minute and the readout has no room to say so.
+  const dates = [TODAY];
+  daylight(dates);
+  tideWeek(dates);
+  waveWeek(dates);
+  skyWeek(dates);
+  gridWeek(dates);
+  wordingWeek([{ localDate: TODAY, periodName: "Today", words: "Patchy Fog" }]);
+
+  const { container } = render(
+    <SelectedDayProvider>
+      {await DayPanel({ slug: "la-jolla-shores-beach" })}
+    </SelectedDayProvider>,
+  );
+
+  expect(
+    container.querySelector("[data-readout-figure='swell']")!.textContent,
+  ).toBe("1.8 ft · 15 s");
+  expect(
+    container.querySelector("[data-readout-row='swell']")!.textContent,
+  ).not.toContain("11:00 AM");
+
+  const line = screen.getByText(/^Biggest swell in daylight/).closest("li")!;
+  expect(line.textContent).toContain("for the three-hour step at 11:00 AM");
 });
 
 test("a cell that publishes no wind direction draws no readout row", async () => {
@@ -842,14 +907,17 @@ test("the readout carries a second row for the swell, from its own publisher", a
   );
 
   expect(container.querySelectorAll("[data-readout-row]")).toHaveLength(2);
+  expect(
+    screen.getByRole("img", { name: /^Swell, from the north-west, 315°/ }),
+  ).toBeDefined();
 
-  const row = screen
-    .getByText(/^Swell, from the north-west, 315°/)
-    .closest("li")!;
-  expect(row.textContent).toContain("MOP line D0481");
-  expect(row.textContent).toContain(
+  const line = screen.getByText(/^Biggest swell in daylight/).closest("li")!;
+  expect(line.textContent).toContain("MOP line D0481");
+  expect(line.textContent).toContain(
     "CDIP, Scripps Institution of Oceanography",
   );
+  // The line the model stands on, which the readout itself has no room for.
+  expect(line.textContent).toContain("about 0.1 km from this beach");
 });
 
 test("a beach with no swell model keeps its wind row", async () => {
@@ -877,8 +945,11 @@ test("a beach with no swell model keeps its wind row", async () => {
   );
 
   expect(container.querySelectorAll("[data-readout-row]")).toHaveLength(1);
-  expect(screen.getByText(/^Wind, from the south, 180°/)).toBeDefined();
-  expect(screen.queryByText(/^Swell, from/)).toBeNull();
+  expect(
+    screen.getByRole("img", { name: /^Wind, from the south, 180°/ }),
+  ).toBeDefined();
+  expect(screen.queryByRole("img", { name: /^Swell, from/ })).toBeNull();
+  expect(screen.queryByText(/^Biggest swell in daylight/)).toBeNull();
 });
 
 /* =========================================================================

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -162,7 +162,7 @@ function gridWeek(
    * Steady so the resultant is exactly the number written here and the
    * assertion can be an equality rather than a range -- the circular mean has
    * its own tests, and this one is about whether the wiring reaches the page.
-   * Different per day because a dial showing the wrong day is otherwise
+   * Different per day because a readout showing the wrong day is otherwise
    * invisible, which is the failure the whole client island exists around.
    */
   const directions = (localDate: string) => ({
@@ -757,9 +757,9 @@ test("the slot says what the layer will show, not what was found", async () => {
   );
 });
 
-test("the map carries a dial for the day the reader chose", async () => {
-  // The map is one picture for the whole week and the needles are not, so the
-  // coast stays server-rendered and only the dial moves. Asserted through the
+test("the map carries a readout for the day the reader chose", async () => {
+  // The map is one picture for the whole week and the readout is not, so the
+  // coast stays server-rendered and only the readout moves. Asserted through the
   // words rather than through the drawing, because the words are what a reader
   // not looking at the picture is given.
   const dates = [TODAY, TOMORROW];
@@ -782,9 +782,9 @@ test("the map carries a dial for the day the reader chose", async () => {
     </SelectedDayProvider>,
   );
 
-  expect(container.querySelector("[data-needle='wind']")).not.toBeNull();
+  expect(container.querySelector("[data-readout-row='wind']")).not.toBeNull();
 
-  // Scoped to the needle's own row. The sky wording names the same cell a few
+  // Scoped to the row's own provenance. The sky wording names the same cell a few
   // hundred pixels up, which is ADR-0029's permitted duplication and is why an
   // unscoped query for that sentence finds two.
   const row = screen.getByText(/^Wind, from the south, 180°/).closest("li")!;
@@ -793,7 +793,7 @@ test("the map carries a dial for the day the reader chose", async () => {
   );
 });
 
-test("a cell that publishes no wind direction draws no dial", async () => {
+test("a cell that publishes no wind direction draws no readout row", async () => {
   // The needle goes and the map stays. The picture is about where this beach
   // is, which does not depend on a bearing.
   const dates = [TODAY];
@@ -815,7 +815,7 @@ test("a cell that publishes no wind direction draws no dial", async () => {
     </SelectedDayProvider>,
   );
 
-  expect(container.querySelector("[data-needle='wind']")).toBeNull();
+  expect(container.querySelector("[data-readout-row='wind']")).toBeNull();
   expect(screen.queryByText(/Wind, from the/)).toBeNull();
   // The map itself is unaffected: it draws a place, and a place does not stop
   // existing because a forecast cell went quiet about the wind.
@@ -823,8 +823,8 @@ test("a cell that publishes no wind direction draws no dial", async () => {
   expect(container.querySelector("[data-segment]")).not.toBeNull();
 });
 
-test("the dial carries a second needle for the swell, from its own publisher", async () => {
-  // One dial, two publishers -- `StatGroup`'s one-group-one-source contract
+test("the readout carries a second row for the swell, from its own publisher", async () => {
+  // One readout, two publishers -- `StatGroup`'s one-group-one-source contract
   // broken on purpose and answered the way `WeekGrid` answers it, with a
   // provenance line per row rather than by splitting the component.
   const dates = [TODAY];
@@ -841,7 +841,7 @@ test("the dial carries a second needle for the swell, from its own publisher", a
     </SelectedDayProvider>,
   );
 
-  expect(container.querySelectorAll("[data-needle]")).toHaveLength(2);
+  expect(container.querySelectorAll("[data-readout-row]")).toHaveLength(2);
 
   const row = screen
     .getByText(/^Swell, from the north-west, 315°/)
@@ -852,8 +852,8 @@ test("the dial carries a second needle for the swell, from its own publisher", a
   );
 });
 
-test("a beach with no swell model keeps its wind needle", async () => {
-  // 26 of 51 beaches bind no MOP line. The dial loses a needle and keeps the
+test("a beach with no swell model keeps its wind row", async () => {
+  // 26 of 51 beaches bind no MOP line. The readout loses a row and keeps the
   // one it has, rather than the pair going down together.
   const dates = [TODAY];
   daylight(dates);
@@ -876,7 +876,7 @@ test("a beach with no swell model keeps its wind needle", async () => {
     </SelectedDayProvider>,
   );
 
-  expect(container.querySelectorAll("[data-needle]")).toHaveLength(1);
+  expect(container.querySelectorAll("[data-readout-row]")).toHaveLength(1);
   expect(screen.getByText(/^Wind, from the south, 180°/)).toBeDefined();
   expect(screen.queryByText(/^Swell, from/)).toBeNull();
 });

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -952,6 +952,47 @@ test("a beach with no swell model keeps its wind row", async () => {
   expect(screen.queryByText(/^Biggest swell in daylight/)).toBeNull();
 });
 
+test("a beach the traced coast does not reach gains its wind row", async () => {
+  // 23 of 51 beaches are in Mission Bay or San Diego Bay, where `mop-lines.json`
+  // traces no coast. The dial was withheld on every one of them together with
+  // its provenance, so nearly half the inventory printed no wind figure
+  // anywhere on the picture -- for a rule about a needle drawn over an empty
+  // frame rather than about a labelled block. ADR-0034.
+  //
+  // Modelled as it really is: no coast in the window, and no MOP line to bind,
+  // so the readout is the wind row alone.
+  const dates = [TODAY];
+  daylight(dates);
+  tideWeek(dates);
+  readWaveWeek.mockResolvedValue({
+    beachName: BINDING.beachName,
+    line: null,
+    state: {
+      kind: "no-line",
+      reason: "no MOP line is computed for this beach",
+    },
+  });
+  skyWeek(dates);
+  gridWeek(dates);
+  wordingWeek([{ localDate: TODAY, periodName: "Today", words: "Patchy Fog" }]);
+
+  const { container } = render(
+    <SelectedDayProvider>
+      {await DayPanel({ slug: "fiesta-island" })}
+    </SelectedDayProvider>,
+  );
+
+  // The picture this beach gets: its own two ends as a chord, and no coastline.
+  expect(container.querySelector("[data-coast]")).toBeNull();
+  expect(container.querySelector("[data-segment]")).not.toBeNull();
+
+  // And the figure it used to have nowhere to print.
+  expect(
+    container.querySelector("[data-readout-figure='wind']")!.textContent,
+  ).toBe("14.0 mph");
+  expect(screen.getByText(/^Biggest wind in daylight/)).toBeDefined();
+});
+
 /* =========================================================================
  * Who published the curve
  * ========================================================================= */

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -306,7 +306,7 @@ function cloudBandDescription(
  * Says what the picture is and nothing about what the shape of the coast
  * means. A reader hearing this should learn the same thing a reader seeing it
  * does: where this beach is on its own coast, and which side the water is on.
- * The dial's own bearings are spoken separately, under the picture, because
+ * The readout's own bearings are spoken separately, in its own rows, because
  * they change with the day and this does not.
  */
 function mapDescription(beachName: string): string {
@@ -605,7 +605,7 @@ export async function DayPanel({ slug }: { slug: string }) {
   /*
     The map is built once and handed over, outside the seven days, because it
     is the same picture on all seven: this beach, its own stretch of coast, and
-    the water beside it. Only the dial drawn on it changes with the day, and
+    the water beside it. Only the readout laid over it changes with the day, and
     that travels separately. It is also the one thing in this region that reads
     no feed -- `beaches.json` and `mop-lines.json` are committed -- so it cannot
     go quiet and does not belong behind a Suspense boundary.
@@ -711,8 +711,8 @@ export async function DayPanel({ slug }: { slug: string }) {
                 absence="We cannot place this beach on a map: the coordinates we hold for it are all one point."
                 noCoast="The coastline this site traces is the open coast, and it does not reach this beach."
                 coastCredit={`Shore traced from CDIP's model lines, which are computed a few hundred metres offshore — so the water's edge is drawn further out than the sand.`}
-                compass={<DayCompass days={compassDays} />}
-                compassSources={<DayCompassSources days={compassDays} />}
+                readout={<DayCompass days={compassDays} />}
+                readoutSources={<DayCompassSources days={compassDays} />}
               />
               {/*
                 The sighting layer from #121, reserved *on* the map rather than

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -74,14 +74,22 @@ import {
   GRID_NETWORK,
   GRID_SOURCE,
   gridCellCaveat,
+  windFigure,
 } from "./gridCell";
 import {
   MOP_MODEL_NOTE,
   MOP_NETWORK,
   mopLineDistanceKm,
   mopLineSource,
+  swellFigure,
+  swellStepNote,
 } from "./mopLine";
-import { gridWindReadings, needleFrom, swellReadings } from "./needles";
+import {
+  gridWindReadings,
+  needleFrom,
+  peakInDaylight,
+  swellReadings,
+} from "./needles";
 import type { ProvenanceFacts } from "./ProvenanceLine";
 import { ShoreMap } from "./ShoreMap";
 import { shoreViewFor } from "./shore";
@@ -663,6 +671,38 @@ export async function DayPanel({ slug }: { slug: string }) {
             swellReadings(swellDay.hours, day.sunriseMs, day.sunsetMs),
           );
 
+    /*
+      How much of each there was, worded here because the copy on this page is
+      the caller's.
+
+      **Both are the largest thing the daylight window holds**, which is one
+      rule and is why the two rows can be labelled the same way. The swell's
+      selection is `readWaveWeek`'s and is a three-hour step CDIP published; the
+      wind's is made here out of hours the gridpoint publishes one by one, so
+      the wind figure is exact to the hour and the swell figure can sit up to
+      ninety minutes off its real peak. That difference is what the swell's
+      provenance line says and the wind's does not.
+
+      **One decimal on the wind, which is the precision the chart states.** Four
+      of the five places this page prints a wind figure use `toFixed(1)` and the
+      fifth uses `toFixed(0)`, which is issue #191 -- 11.5 spoken as 12 to the
+      one reader who cannot see the axis. This is a sixth statement of that
+      figure and it joins the four rather than the one, so #191 stays a defect
+      about `gridDescription` alone rather than gaining a second site.
+    */
+    const windPeak =
+      gridDay === undefined
+        ? null
+        : peakInDaylight(gridDay.windMph, day.sunriseMs, day.sunsetMs);
+
+    /*
+      The swell's estimate, taken beside the needle rather than inside the
+      branch that pushes the row. `readWaveWeek` made this selection once and
+      the week grid prints the same object, which is what stops the map and the
+      grid stating different numbers for one day.
+    */
+    const reading = swellDay === undefined ? null : swellDay.daylight;
+
     const needles: CompassNeedle[] = [];
 
     /*
@@ -677,9 +717,23 @@ export async function DayPanel({ slug }: { slug: string }) {
         label: "Wind",
         fromDegT: wind.fromDegT,
         spreadDeg: wind.spreadDeg,
-        source: GRID_SOURCE,
-        network: GRID_NETWORK,
-        note: cellNote,
+        figure: windFigure(windPeak),
+        provenance: {
+          /*
+            The superlative is in the label, which is `WaveWeek`'s rule and its
+            reason: a single figure under the bare word invites a reader to take
+            it for the day's typical wind, which is the one thing it is not.
+
+            No distance, which is the omission the cloud row and the chart's own
+            cell line already make: a cell is a 2.5 km square of map with the
+            beach somewhere inside it, so "about n km from this beach" would be
+            a figure about nothing.
+          */
+          label: "Biggest wind in daylight",
+          source: GRID_SOURCE,
+          network: GRID_NETWORK,
+          note: cellNote,
+        },
       });
     }
 
@@ -689,9 +743,22 @@ export async function DayPanel({ slug }: { slug: string }) {
         label: "Swell",
         fromDegT: swell.fromDegT,
         spreadDeg: swell.spreadDeg,
-        source: mopLineSource(waves.line.id),
-        network: MOP_NETWORK,
-        note: MOP_MODEL_NOTE,
+        figure: swellFigure(reading),
+        provenance: {
+          label: "Biggest swell in daylight",
+          source: mopLineSource(waves.line.id),
+          network: MOP_NETWORK,
+          distanceKm: mopLineDistanceKm(waves.line.distanceM),
+          /*
+            The step's own time, which used to be printed beside the figure and
+            belongs here instead. `WaveReading.timeLabel` is a bucket rather
+            than a peak located to the minute -- MOP publishes every three hours
+            -- so a reader owed the figure is also owed which three hours it is
+            for, and the readout has no room to say it. Withheld along with the
+            figure on a day the forecast does not reach.
+          */
+          note: swellStepNote(reading),
+        },
       });
     }
 

--- a/src/components/conditions/ShoreMap.test.tsx
+++ b/src/components/conditions/ShoreMap.test.tsx
@@ -214,16 +214,15 @@ test("the readout moves to the side the drawing leaves open", () => {
   expect(overlay.getAttribute("data-readout-corner")).not.toBe("top-left");
 });
 
-test("a beach the coast does not reach gets no readout", () => {
-  // Cole's rule, and the reason for it: a bearing is worth reading against a
-  // coastline and is a bare gauge without one -- which is the anti-reference
-  // the brief opens with. 23 of 51 beaches are in this state.
+test("a beach the coast does not reach still gets its readout", () => {
+  // 23 of 51 beaches are in this state, and the dial was withheld on all of
+  // them -- so nearly half the inventory printed no wind figure anywhere on the
+  // picture, for a rule about a needle drawn over an empty frame. A labelled
+  // block with units and a publisher under it is not that thing. ADR-0034.
   //
   // The segment here is the beach's own two ends and NOT null, because that is
   // what `shore.ts` draws on 22 of those 23: with no coast to mark a run of, a
-  // chord is the only thing that says where the beach is. Written with a null
-  // segment this test passes with the coast check deleted, which is what
-  // mutating it revealed.
+  // chord is the only thing that says where the beach is.
   const { container } = render(
     <ShoreMap
       {...PROPS}
@@ -233,21 +232,26 @@ test("a beach the coast does not reach gets no readout", () => {
         { lat: 32.78, lon: -117.235 },
       ]}
       readout={<p data-test-readout="">Wind</p>}
-      readoutSources={<p>Wind, from the west, 281°</p>}
+      readoutSources={<p>Biggest wind in daylight</p>}
     />,
   );
 
-  expect(container.querySelector("[data-readout-corner]")).toBeNull();
-  expect(container.querySelector("[data-test-readout]")).toBeNull();
-  expect(screen.queryByText("Wind, from the west, 281°")).toBeNull();
+  expect(container.querySelector("[data-test-readout]")).not.toBeNull();
+  expect(screen.getByText("Biggest wind in daylight")).toBeTruthy();
   // The beach is still placed, which is the one question the picture has to
-  // answer when there is no shoreline to draw.
+  // answer when there is no shoreline to draw, and the readout does not cover
+  // the chord that answers it.
   expect(container.querySelector("[data-segment]")).not.toBeNull();
+  // And the map still says the traced coast does not reach here, which the
+  // readout neither replaces nor contradicts.
+  expect(screen.getByText(PROPS.noCoast)).toBeTruthy();
 });
 
-test("a beach whose two ends are one point gets no readout either", () => {
-  // `mission-bay-vacation-isle`, whose segment upper equals its lower, so
-  // there is neither a coast nor a chord on the picture.
+test("a beach with nothing drawn at all still gets its readout", () => {
+  // `mission-bay-vacation-isle`, whose segment upper equals its lower, so there
+  // is neither a coast nor a chord on the picture. Every corner is clear, so
+  // the first is taken -- there is nothing for the block to be measured against
+  // and nothing for it to cover.
   const { container } = render(
     <ShoreMap
       {...PROPS}
@@ -257,7 +261,24 @@ test("a beach whose two ends are one point gets no readout either", () => {
     />,
   );
 
+  expect(container.querySelector("[data-test-readout]")).not.toBeNull();
+  expect(
+    container
+      .querySelector("[data-readout-corner]")!
+      .getAttribute("data-readout-corner"),
+  ).toBe("top-left");
+});
+
+test("a day with no bearings gets no readout and no sources", () => {
+  // The withholding that remains, and it is the caller's rather than the
+  // coast's: `DayCompass` renders nothing on a day no feed gave a bearing for,
+  // and the sources go with it rather than naming a row nobody can see.
+  const { container } = render(
+    <ShoreMap {...PROPS} readout={null} readoutSources={<p>Orphaned</p>} />,
+  );
+
   expect(container.querySelector("[data-readout-corner]")).toBeNull();
+  expect(screen.queryByText("Orphaned")).toBeNull();
 });
 
 test("the readout's sources are listed beneath the picture", () => {

--- a/src/components/conditions/ShoreMap.test.tsx
+++ b/src/components/conditions/ShoreMap.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { projectionFor } from "@/lib/coastline";
+import { READOUT_BOX } from "./corner";
 import { ShoreMap } from "./ShoreMap";
 
 /** A short run of coast running due north, west-facing like the real one. */
@@ -149,26 +150,71 @@ test("the drawn coast names what it was drawn from", () => {
   expect(container).toBeTruthy();
 });
 
-test("the dial is anchored on the beach, not in the middle of the frame", () => {
-  // The frame is sized by the beach and the line off it, so the middle of the
-  // frame is near the beach but is not the beach. A dial there would draw
-  // needles arriving at open water rather than at the sand.
+test("the readout lies over the picture, not inside its drawing space", () => {
+  // ADR-0034. The dial used to be translated onto the beach's own stretch of
+  // coast, where it covered the one thing the map exists to show. This is an
+  // HTML overlay positioned against the map's box, so it is in the
+  // accessibility tree and its type is not measured in hundredths of a frame.
   const { container } = render(
-    <ShoreMap {...PROPS} compass={<circle data-test-dial="" r={1} />} />,
+    <ShoreMap {...PROPS} readout={<p data-test-readout="">Wind</p>} />,
   );
 
-  const anchor = container.querySelector("svg [data-compass-anchor]")!;
-  const project = projectionFor(BOUNDS, { width: 100, height: 100 });
-  const middle = PROPS.segment[Math.floor(PROPS.segment.length / 2)];
-  const at = project(middle.lat, middle.lon);
-
-  expect(anchor.getAttribute("transform")).toBe(
-    `translate(${at.x.toFixed(2)} ${at.y.toFixed(2)})`,
-  );
-  expect(anchor.querySelector("[data-test-dial]")).not.toBeNull();
+  expect(container.querySelector("svg [data-test-readout]")).toBeNull();
+  const overlay = container.querySelector("[data-readout-corner]")!;
+  expect(overlay.querySelector("[data-test-readout]")).not.toBeNull();
 });
 
-test("a beach the coast does not reach gets no dial", () => {
+test("the readout stands in a corner the coastline leaves free", () => {
+  // The corner is measured rather than fixed, and `corner.test.ts` holds that
+  // for the whole inventory. This is the wiring: whichever corner is chosen,
+  // the overlay is anchored to that corner's two sides and reserves the box
+  // `corner.ts` kept clear.
+  const { container } = render(
+    <ShoreMap {...PROPS} readout={<p data-test-readout="">Wind</p>} />,
+  );
+
+  const overlay = container.querySelector(
+    "[data-readout-corner]",
+  )! as HTMLElement;
+  const corner = overlay.getAttribute("data-readout-corner")!;
+
+  expect(["top-left", "top-right", "bottom-left", "bottom-right"]).toContain(
+    corner,
+  );
+  expect(overlay.style.width).toBe(`${READOUT_BOX.width}%`);
+  expect(overlay.style.maxHeight).toBe(`${READOUT_BOX.height}%`);
+
+  // This window's coast runs up the middle of the frame, so the top-left is
+  // free and the block stays where the reader's eye starts.
+  expect(corner).toBe("top-left");
+  expect(overlay.style.top).toBe("0px");
+  expect(overlay.style.left).toBe("0px");
+});
+
+test("the readout moves to the side the drawing leaves open", () => {
+  // A coast running through the top-left, which is the shape 21 of 47 beaches
+  // have and the reason the corner is not fixed.
+  const { container } = render(
+    <ShoreMap
+      {...PROPS}
+      coast={[
+        { id: "D0500", lat: 32.884, lon: -117.274 },
+        { id: "D0501", lat: 32.87, lon: -117.26 },
+        { id: "D0502", lat: 32.85, lon: -117.25 },
+      ]}
+      segment={[
+        { lat: 32.884, lon: -117.274 },
+        { lat: 32.87, lon: -117.26 },
+      ]}
+      readout={<p data-test-readout="">Wind</p>}
+    />,
+  );
+
+  const overlay = container.querySelector("[data-readout-corner]")!;
+  expect(overlay.getAttribute("data-readout-corner")).not.toBe("top-left");
+});
+
+test("a beach the coast does not reach gets no readout", () => {
   // Cole's rule, and the reason for it: a bearing is worth reading against a
   // coastline and is a bare gauge without one -- which is the anti-reference
   // the brief opens with. 23 of 51 beaches are in this state.
@@ -186,42 +232,59 @@ test("a beach the coast does not reach gets no dial", () => {
         { lat: 32.77, lon: -117.24 },
         { lat: 32.78, lon: -117.235 },
       ]}
-      compass={<circle data-test-dial="" r={1} />}
-      compassSources={<p>Wind, from the west, 281°</p>}
+      readout={<p data-test-readout="">Wind</p>}
+      readoutSources={<p>Wind, from the west, 281°</p>}
     />,
   );
 
-  expect(container.querySelector("[data-compass-anchor]")).toBeNull();
-  expect(container.querySelector("[data-test-dial]")).toBeNull();
+  expect(container.querySelector("[data-readout-corner]")).toBeNull();
+  expect(container.querySelector("[data-test-readout]")).toBeNull();
   expect(screen.queryByText("Wind, from the west, 281°")).toBeNull();
   // The beach is still placed, which is the one question the picture has to
   // answer when there is no shoreline to draw.
   expect(container.querySelector("[data-segment]")).not.toBeNull();
 });
 
-test("a beach whose two ends are one point gets no dial either", () => {
+test("a beach whose two ends are one point gets no readout either", () => {
   // `mission-bay-vacation-isle`, whose segment upper equals its lower, so
-  // there is neither a coast nor a chord to stand a dial on.
+  // there is neither a coast nor a chord on the picture.
   const { container } = render(
     <ShoreMap
       {...PROPS}
       coast={[]}
       segment={null}
-      compass={<circle data-test-dial="" r={1} />}
+      readout={<p data-test-readout="">Wind</p>}
     />,
   );
 
-  expect(container.querySelector("[data-compass-anchor]")).toBeNull();
+  expect(container.querySelector("[data-readout-corner]")).toBeNull();
 });
 
-test("the needles' sources are listed beneath the picture", () => {
+test("the readout's sources are listed beneath the picture", () => {
   render(
     <ShoreMap
       {...PROPS}
-      compass={<circle data-test-dial="" r={1} />}
-      compassSources={<p>Wind, from the west, 281°</p>}
+      readout={<p data-test-readout="">Wind</p>}
+      readoutSources={<p>Wind, from the west, 281°</p>}
     />,
   );
 
   expect(screen.getByText("Wind, from the west, 281°")).toBeTruthy();
+});
+
+test("the overlay is measured against the picture alone", () => {
+  // The wrapper the readout is positioned against holds the `<svg>` and nothing
+  // else. With the coast credit inside it the box would not be square, and the
+  // readout's footprint is stated in the map's own drawing units precisely
+  // because the two agree.
+  const { container } = render(
+    <ShoreMap {...PROPS} readout={<p data-test-readout="">Wind</p>} />,
+  );
+
+  const positioned = container.querySelector(
+    "[data-readout-corner]",
+  )!.parentElement!;
+
+  expect(positioned.querySelector("svg")).not.toBeNull();
+  expect(positioned.textContent).not.toContain(PROPS.coastCredit);
 });

--- a/src/components/conditions/ShoreMap.tsx
+++ b/src/components/conditions/ShoreMap.tsx
@@ -92,8 +92,13 @@ export type ShoreMapProps = {
    * map's box, and which corner it lands in is measured rather than fixed —
    * see `corner.ts`.
    *
-   * Withheld along with everything else when there is no coast to read a
-   * bearing against. See `readoutSources`.
+   * **Rendered on every beach, including the 23 the traced coast does not
+   * reach.** The dial was withheld there, on the rule that a bearing read
+   * against no shoreline is the bare gauge the brief's anti-references open
+   * with. That rule was about a needle drawn over an empty frame; a labelled
+   * readout with units, a word for the direction and a provenance line beneath
+   * is not that thing. Withholding it meant nearly half the inventory printed
+   * no wind figure anywhere on the picture. See ADR-0034.
    */
   readout?: ReactNode;
   /**
@@ -103,10 +108,11 @@ export type ShoreMapProps = {
    * than on it: the map is already the densest thing in this column, and
    * `ShoreMap`'s own coast credit sits in the same place for the same reason.
    *
-   * **Both halves go together, and go together with the coast.** A readout with
-   * its sources missing is an unattributed figure; sources printed under a map
-   * with no readout name a bearing nobody can see. On the 23 beaches the traced
-   * coast does not reach, neither is rendered.
+   * **Both halves go together.** A readout with its sources missing is an
+   * unattributed figure, and sources printed under a map with no readout name a
+   * bearing nobody can see. Neither is now tied to the coast: they arrive
+   * together on all 51 beaches, or not at all on a day no feed gave a bearing
+   * for, which is the caller's decision rather than this component's.
    */
   readoutSources?: ReactNode;
 };
@@ -231,21 +237,24 @@ export function ShoreMap({
       : segment.map((point) => project(point.lat, point.lon));
 
   /*
-    Which corner the readout stands in, or null when there is nothing to read a
-    bearing against.
+    Which corner the readout stands in, or null when there is no readout.
 
-    The condition is the coast, not the readout's size: on the 23 beaches the
-    traced coastline does not reach, a bearing has no shoreline to be read
-    against and is the bare gauge the brief's anti-references open with.
+    **The coast is no longer a condition**, which is the change ADR-0034's last
+    clause records. It was one: a bearing read against no shoreline was held to
+    be the bare gauge the brief opens its anti-references with, so the 23
+    beaches in Mission Bay and San Diego Bay printed no wind figure anywhere on
+    the picture. That objection was about a needle drawn over an empty frame,
+    and this is a labelled block with units and a publisher under it.
 
     The corner is measured against everything the map draws -- the windowed
     coast and this beach's own stretch -- rather than against the segment alone.
     The plan asked only for the segment; measured, an adaptive corner clears
     both on every beach in the inventory, so there was no reason but arithmetic
-    to leave the coastline out and the arithmetic did not charge for it.
+    to leave the coastline out and the arithmetic did not charge for it. On a
+    beach with neither, every corner is clear and the first is taken.
   */
   const corner =
-    readout === null || !hasCoast || drawnSegment.length === 0
+    readout === null
       ? null
       : cornerFor([...drawn, ...drawnSegment], READOUT_BOX, FRAME);
 

--- a/src/components/conditions/ShoreMap.tsx
+++ b/src/components/conditions/ShoreMap.tsx
@@ -45,6 +45,7 @@
 import type { ReactNode } from "react";
 import type { Bounds, Position, ShorePoint } from "@/lib/coastline";
 import { projectionFor } from "@/lib/coastline";
+import { cornerFor, READOUT_BOX, readoutStyle } from "./corner";
 
 export type ShoreMapProps = {
   /** The windowed coast in walk order. Empty draws no shoreline and says so. */
@@ -78,35 +79,36 @@ export type ShoreMapProps = {
    */
   coastCredit: string;
   /**
-   * The dial, already rendered, placed in the map's own drawing space.
+   * The weather readout, already rendered, laid over a corner of the picture.
    *
-   * A slot rather than data, because the needles change with the day a reader
+   * A slot rather than data, because the readout changes with the day a reader
    * picks and this picture does not: the map is built once on the server and
    * this is the one part of it that varies. `DayCompass` is what fills it.
    *
-   * It is translated onto the beach's own stretch of coast rather than left at
-   * the frame's middle, because the frame is sized by the sources -- at
-   * `mission-beach` a station nine kilometres away puts the middle of the frame
-   * out in the county, and needles arriving there arrive at nothing.
+   * **HTML over the frame rather than a group inside it**, which is the change
+   * ADR-0034 records. It used to be translated into the map's own drawing space
+   * and anchored on the beach's stretch of coast, where it covered the one
+   * thing the picture exists to show. It is now positioned in CSS against the
+   * map's box, and which corner it lands in is measured rather than fixed —
+   * see `corner.ts`.
    *
    * Withheld along with everything else when there is no coast to read a
-   * bearing against. See `compassSources`.
+   * bearing against. See `readoutSources`.
    */
-  compass?: ReactNode;
+  readout?: ReactNode;
   /**
-   * What the dial says, printed beneath the picture.
+   * Where the readout's figures came from, printed beneath the picture.
    *
-   * Two slots and not one, because the dial is drawn inside the frame and read
-   * outside it. The `<svg>` is one `role="img"`, so nothing drawn in it reaches
-   * the accessibility tree, and this block is the dial's text equivalent rather
-   * than a caption on it.
+   * Two slots and not one, because attribution belongs under the picture rather
+   * than on it: the map is already the densest thing in this column, and
+   * `ShoreMap`'s own coast credit sits in the same place for the same reason.
    *
-   * **Both halves go together, and go together with the coast.** A dial drawn
-   * with its sources missing is an unattributed figure; sources printed under a
-   * map with no dial name a needle nobody can see. On the 23 beaches the traced
+   * **Both halves go together, and go together with the coast.** A readout with
+   * its sources missing is an unattributed figure; sources printed under a map
+   * with no readout name a bearing nobody can see. On the 23 beaches the traced
    * coast does not reach, neither is rendered.
    */
-  compassSources?: ReactNode;
+  readoutSources?: ReactNode;
 };
 
 /**
@@ -118,6 +120,17 @@ export type ShoreMapProps = {
  */
 const WIDTH = 100;
 const HEIGHT = 100;
+
+/**
+ * The same two numbers as a box, for the things that reason about the frame
+ * rather than draw into it.
+ *
+ * One definition, passed to both, so the readout's footprint and the map's
+ * viewBox cannot drift apart. `corner.ts` measures in these units and
+ * `readoutStyle` converts them to percentages, which is exact because the frame
+ * is square and the picture is drawn `w-full` at `h-auto`.
+ */
+const FRAME = { width: WIDTH, height: HEIGHT };
 
 /**
  * Far enough that the sea polygon always leaves the frame.
@@ -192,8 +205,8 @@ export function ShoreMap({
   absence,
   noCoast,
   coastCredit,
-  compass = null,
-  compassSources = null,
+  readout = null,
+  readoutSources = null,
 }: ShoreMapProps) {
   if (bounds === null) {
     return <p className="text-2xs text-fog italic">{absence}</p>;
@@ -212,93 +225,117 @@ export function ShoreMap({
 
   const sea = hasCoast ? seaPath(path, drawn) : null;
 
-  /*
-    Where the dial stands: the middle of the beach's own drawn stretch.
+  const drawnSegment =
+    segment === null || segment.length < 2
+      ? []
+      : segment.map((point) => project(point.lat, point.lon));
 
-    Null wherever that stretch is not a run of the coast, which is exactly the
-    23 beaches the traced coastline does not reach. That is not an
-    implementation detail standing in for the rule -- a bearing read against no
-    shoreline is the bare gauge the brief's anti-references open with -- but the
-    two conditions are the same one, so the map cannot draw a dial it has
-    nothing to draw it against.
+  /*
+    Which corner the readout stands in, or null when there is nothing to read a
+    bearing against.
+
+    The condition is the coast, not the readout's size: on the 23 beaches the
+    traced coastline does not reach, a bearing has no shoreline to be read
+    against and is the bare gauge the brief's anti-references open with.
+
+    The corner is measured against everything the map draws -- the windowed
+    coast and this beach's own stretch -- rather than against the segment alone.
+    The plan asked only for the segment; measured, an adaptive corner clears
+    both on every beach in the inventory, so there was no reason but arithmetic
+    to leave the coastline out and the arithmetic did not charge for it.
   */
-  const anchor =
-    compass === null || !hasCoast || segment === null || segment.length < 2
+  const corner =
+    readout === null || !hasCoast || drawnSegment.length === 0
       ? null
-      : (() => {
-          const middle = segment[Math.floor(segment.length / 2)];
-          return project(middle.lat, middle.lon);
-        })();
+      : cornerFor([...drawn, ...drawnSegment], READOUT_BOX, FRAME);
+
+  const rightHanded = corner === "top-right" || corner === "bottom-right";
 
   return (
     <div>
-      <svg
-        role="img"
-        aria-label={description}
-        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-        className="rounded-tile border-[1.5px] border-ocean block h-auto w-full bg-white/60"
-      >
+      {/*
+        The wrapper the readout is positioned against, and it wraps the picture
+        alone. The coast credit below must stay outside it: an overlay measured
+        against a box that included a line of prose would be measured against a
+        box that is not square, and the readout's footprint is in the map's own
+        units precisely because those two agree.
+      */}
+      <div className="relative">
+        <svg
+          role="img"
+          aria-label={description}
+          viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+          className="rounded-tile border-[1.5px] border-ocean block h-auto w-full bg-white/60"
+        >
+          {/*
+            One wash, no gradient and no depth. The sea is the only filled
+            region on this map, so a reader can tell water from land at a glance
+            without a legend -- and it is a flat tint rather than a shaded one,
+            because shading implies depth and depth here would be invented.
+          */}
+          {sea !== null && (
+            <path
+              d={sea.d}
+              className="fill-ocean"
+              fillOpacity={0.16}
+              data-sea=""
+            />
+          )}
+
+          {hasCoast && (
+            <path
+              d={path}
+              fill="none"
+              className="stroke-ocean"
+              strokeWidth={1.2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              vectorEffect="non-scaling-stroke"
+              data-coast=""
+            />
+          )}
+
+          {/*
+            This beach's own stretch, heavier than the coast it sits on. Weight
+            rather than only hue: the two are the same ocean, so a reader who
+            sees no colour still sees which part of the shore they chose.
+          */}
+          {drawnSegment.length > 0 && (
+            <path
+              d={drawnSegment
+                .map(
+                  (at, index) =>
+                    `${index === 0 ? "M" : "L"}${at.x.toFixed(2)} ${at.y.toFixed(2)}`,
+                )
+                .join(" ")}
+              fill="none"
+              className="stroke-purple-deep"
+              strokeWidth={3.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              vectorEffect="non-scaling-stroke"
+              data-segment=""
+            />
+          )}
+        </svg>
+
         {/*
-          One wash, no gradient and no depth. The sea is the only filled region
-          on this map, so a reader can tell water from land at a glance without
-          a legend -- and it is a flat tint rather than a shaded one, because
-          shading implies depth and depth here would be invented.
+          Over the picture rather than in it, in the corner the geometry left
+          free. The box is set from `READOUT_BOX` rather than from the content,
+          so what the overlay occupies and what `cornerFor` was asked to keep
+          clear are one number: a block that grew past its footprint would make
+          the inventory-wide check a claim about a box nothing draws.
         */}
-        {sea !== null && (
-          <path
-            d={sea.d}
-            className="fill-ocean"
-            fillOpacity={0.16}
-            data-sea=""
-          />
-        )}
-
-        {hasCoast && (
-          <path
-            d={path}
-            fill="none"
-            className="stroke-ocean"
-            strokeWidth={1.2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            vectorEffect="non-scaling-stroke"
-            data-coast=""
-          />
-        )}
-
-        {/*
-          This beach's own stretch, heavier than the coast it sits on. Weight
-          rather than only hue: the two are the same ocean, so a reader who sees
-          no colour still sees which part of the shore they chose.
-        */}
-        {segment !== null && segment.length > 1 && (
-          <path
-            d={segment
-              .map((point, index) => {
-                const at = project(point.lat, point.lon);
-                return `${index === 0 ? "M" : "L"}${at.x.toFixed(2)} ${at.y.toFixed(2)}`;
-              })
-              .join(" ")}
-            fill="none"
-            className="stroke-purple-deep"
-            strokeWidth={3.5}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            vectorEffect="non-scaling-stroke"
-            data-segment=""
-          />
-        )}
-
-        {/* Last, so the dial sits over the coast rather than under it. */}
-        {anchor !== null && (
-          <g
-            transform={`translate(${anchor.x.toFixed(2)} ${anchor.y.toFixed(2)})`}
-            data-compass-anchor=""
+        {corner !== null && (
+          <div
+            className={`absolute flex p-1.5 ${rightHanded ? "justify-end" : "justify-start"}`}
+            style={readoutStyle(corner, READOUT_BOX, FRAME)}
+            data-readout-corner={corner}
           >
-            {compass}
-          </g>
+            {readout}
+          </div>
         )}
-      </svg>
+      </div>
 
       {hasCoast ? (
         <p className="text-2xs text-fog mt-2 italic">{coastCredit}</p>
@@ -306,7 +343,7 @@ export function ShoreMap({
         <p className="text-2xs text-fog mt-2 italic">{noCoast}</p>
       )}
 
-      {anchor !== null && compassSources}
+      {corner !== null && readoutSources}
     </div>
   );
 }

--- a/src/components/conditions/WaveWeek.test.tsx
+++ b/src/components/conditions/WaveWeek.test.tsx
@@ -1,5 +1,6 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { swellFigure } from "./mopLine";
 import { WaveWeek, WAVE_WEEK_ROW } from "./WaveWeek";
 
 const DAYLIGHT = { timeLabel: "2:00 PM", heightFt: 2.618, periodS: 13.333333 };
@@ -22,6 +23,17 @@ test("the daylight swell leads: time, then height and period", () => {
   const { container } = render(<WaveWeek day={{ daylight: DAYLIGHT }} />);
 
   expect(container.textContent).toContain("2:00 PM 2.6 ft · 13 s");
+});
+
+test("the figure is worded by the helper the shore map's readout also uses", () => {
+  // The map prints this same `WaveReading` -- the same three-hour step,
+  // selected once by `readWaveWeek` -- a screen away, so the two must not be
+  // able to state different numbers for one day. Asserted against
+  // `swellFigure` rather than against a literal, because a literal in both
+  // suites is exactly the pair of copies this is meant to rule out.
+  const { container } = render(<WaveWeek day={{ daylight: DAYLIGHT }} />);
+
+  expect(container.textContent).toContain(swellFigure(DAYLIGHT)!);
 });
 
 /**

--- a/src/components/conditions/WaveWeek.tsx
+++ b/src/components/conditions/WaveWeek.tsx
@@ -37,20 +37,21 @@
  * alike in a column — which is why `ConditionsNotes` says which is which rather
  * than leaving a reader to assume they are the same kind of figure.
  *
- * **Whole seconds.** CDIP publishes the peak period as a float — 16.666668 —
- * because it is the reciprocal of a spectral frequency bin, not a measurement
- * to six decimal places. The buoy card beside this one prints whole seconds
- * because NDBC publishes whole seconds, and two wave products on one page
- * printing periods to different precisions would imply one of them is the more
- * exact.
+ * **The two figures are worded by `swellFigure`, not here**, because the shore
+ * map's readout prints the same `WaveReading` — the same three-hour step,
+ * selected once by `readWaveWeek` — a screen away. Two call sites each wording
+ * one fact is what `ProvenanceLine`'s docstring records the cost of, and here
+ * the cost would be the grid and the map stating different numbers for
+ * Thursday. That helper carries the reasons that used to be written here: whole
+ * seconds, because CDIP publishes the period as the reciprocal of a spectral
+ * frequency bin and the buoy card beside this prints whole seconds; and an
+ * interpunct rather than a space, because "0.8 ft 5 s" is two numbers a reader
+ * has to separate.
  *
- * **One line, at every width**, with an interpunct between the two figures
- * rather than a space — "0.8 ft 5 s" is two numbers a reader has to separate,
- * and ` · ` is what `ProvenanceLine` already uses to separate facts in running
- * text. Measured: `11:00 AM 0.7 ft · 6 s` is 117px against 125px in the
- * narrowest seven-column cell the grid now has, and 189px at 1024. This is the
- * longest line in the cell and the one that decided seven columns could not
- * start before `xl`.
+ * **One line, at every width.** Measured: `11:00 AM 0.7 ft · 6 s` is 117px
+ * against 125px in the narrowest seven-column cell the grid now has, and 189px
+ * at 1024. This is the longest line in the cell and the one that decided seven
+ * columns could not start before `xl`.
  *
  * **No cell where the forecast does not reach.** That is the caller's doing
  * rather than this component's: `readWaveWeek` returns only the days it has,
@@ -68,6 +69,7 @@
  */
 
 import type { WaveWeekDay } from "@/lib/conditions";
+import { swellFigure } from "./mopLine";
 import { SWELL_TONE } from "./weekTone";
 
 /** What every day of this row shares: the words that name it, and its colour. */
@@ -93,10 +95,7 @@ export function WaveWeek({ day }: { day: Pick<WaveWeekDay, "daylight"> }) {
         `ReadingCard` records hitting in the accessible-name algorithm.
       */}
       <span className="font-extrabold">{day.daylight.timeLabel}</span>{" "}
-      <span className="text-fog">
-        {day.daylight.heightFt.toFixed(1)} ft ·{" "}
-        {Math.round(day.daylight.periodS)} s
-      </span>
+      <span className="text-fog">{swellFigure(day.daylight)}</span>
     </>
   );
 }

--- a/src/components/conditions/corner.test.ts
+++ b/src/components/conditions/corner.test.ts
@@ -1,0 +1,190 @@
+import { expect, test } from "vitest";
+import { allBeaches } from "@/lib/beaches";
+import { projectionFor } from "@/lib/coastline";
+import {
+  clearanceAt,
+  cornerFor,
+  READOUT_BOX,
+  readoutStyle,
+  type Box,
+  type Corner,
+  type PlotPoint,
+} from "./corner";
+import { shoreViewFor } from "./shore";
+
+const FRAME: Box = { width: 100, height: 100 };
+
+/**
+ * The rectangle a corner's box occupies, worked out here rather than read off
+ * the module under test.
+ *
+ * The inventory check below has to be able to fail when `clearanceAt` is wrong,
+ * and asserting through `clearanceAt` -- which is what `cornerFor` decides with
+ * -- could only ever agree with itself.
+ */
+function rectFor(corner: Corner, box: Box, frame: Box) {
+  const top = corner === "top-left" || corner === "top-right";
+  const left = corner === "top-left" || corner === "bottom-left";
+  return {
+    x0: left ? 0 : frame.width - box.width,
+    x1: left ? box.width : frame.width,
+    y0: top ? 0 : frame.height - box.height,
+    y1: top ? box.height : frame.height,
+  };
+}
+
+function covered(corner: Corner, box: Box, frame: Box, points: PlotPoint[]) {
+  const rect = rectFor(corner, box, frame);
+  return points.filter(
+    (point) =>
+      point.x > rect.x0 &&
+      point.x < rect.x1 &&
+      point.y > rect.y0 &&
+      point.y < rect.y1,
+  );
+}
+
+/** Everything one beach's map draws, in the map's own units. */
+function drawnPoints(beach: Parameters<typeof shoreViewFor>[0]): PlotPoint[] {
+  const view = shoreViewFor(beach);
+  if (view.bounds === null) return [];
+  const project = projectionFor(view.bounds, FRAME);
+  return [...view.coast, ...(view.segment ?? [])].map((point) =>
+    project(point.lat, point.lon),
+  );
+}
+
+test("the readout's corner covers nothing the map draws, on every beach", () => {
+  // The check the plan asked for, widened while it was being written. It walks
+  // the whole inventory rather than asserting something about one beach that
+  // happened to look right, and it measures against the windowed coastline as
+  // well as this beach's own stretch -- the plan asked only for the stretch,
+  // and measurement said the coastline was free.
+  const offenders = allBeaches()
+    .map((beach) => {
+      const points = drawnPoints(beach);
+      if (points.length === 0) return null;
+      const corner = cornerFor(points, READOUT_BOX, FRAME);
+      const hits = covered(corner, READOUT_BOX, FRAME, points);
+      return hits.length === 0 ? null : `${beach.slug} (${corner})`;
+    })
+    .filter((offender): offender is string => offender !== null);
+
+  expect(offenders).toEqual([]);
+});
+
+test("a fixed top-left corner could not have passed that check", () => {
+  // The decision this module exists for, held by the gate rather than by the
+  // addendum that argued it. `map-weather-readout.md` fixed the block at the
+  // top-left; run before the block was built, the check above says the fixed
+  // rule is false. Asserted as "at least one beach" rather than by naming
+  // `childrens-pool` and its 8.3 units, so it stays true while the inventory
+  // moves and fails only if the reason itself goes away.
+  const blocked = allBeaches().filter((beach) => {
+    const points = drawnPoints(beach);
+    return (
+      points.length > 0 &&
+      covered("top-left", READOUT_BOX, FRAME, points).length > 0
+    );
+  });
+
+  expect(blocked.length).toBeGreaterThan(0);
+});
+
+test("the top-left is kept wherever it is free", () => {
+  // The price of an adaptive corner is that the block moves between beaches,
+  // so it moves as little as the geometry allows: the reading order is the
+  // preference order, and a clear top-left wins even when another corner is
+  // roomier.
+  const roomierElsewhere: PlotPoint[] = [
+    // Nothing within the top-left box, and the whole right side empty.
+    { x: 60, y: 60 },
+  ];
+
+  expect(cornerFor(roomierElsewhere, READOUT_BOX, FRAME)).toBe("top-left");
+});
+
+test("the block moves when its own corner is covered", () => {
+  const acrossTheTopLeft: PlotPoint[] = [
+    { x: 10, y: 10 },
+    { x: 40, y: 5 },
+  ];
+
+  // The top band is not empty, so the top-left is gone; the same band leaves 60
+  // units clear measured from the right, so the block takes the next corner in
+  // reading order rather than dropping to the bottom of the picture.
+  expect(cornerFor(acrossTheTopLeft, READOUT_BOX, FRAME)).toBe("top-right");
+});
+
+test("a chord corner to corner leaves the other diagonal", () => {
+  // The shape that broke the fixed rule. Where no coast is traced, the beach's
+  // own two ends are drawn as a chord between the frame's margin corners, so
+  // one diagonal pair is always blocked and the other always free.
+  const chord: PlotPoint[] = [
+    { x: 8, y: 8 },
+    { x: 50, y: 50 },
+    { x: 92, y: 92 },
+  ];
+
+  expect(cornerFor(chord, READOUT_BOX, FRAME)).toBe("top-right");
+});
+
+test("no corner fits, and the roomiest one is taken rather than none", () => {
+  // Unreachable through the committed inventory, which is what the first test
+  // proves. It is covered here rather than left to a beach nobody has yet
+  // added: a readout that vanished would be a silent failure, and a throw
+  // would take the whole page with it.
+  const everywhere: PlotPoint[] = [
+    { x: 5, y: 5 },
+    { x: 20, y: 5 },
+    { x: 95, y: 5 },
+    { x: 5, y: 95 },
+    { x: 95, y: 95 },
+  ];
+
+  // The top-right band is blocked at 5 units in from the right, the top-left at
+  // 5 from the left, and both bottom corners at 5 -- so nothing fits and the
+  // widest of them is the answer.
+  expect(cornerFor(everywhere, READOUT_BOX, FRAME)).toBe("top-left");
+});
+
+test("an empty band leaves the whole side clear", () => {
+  expect(clearanceAt("top-left", [{ x: 1, y: 99 }], READOUT_BOX, FRAME)).toBe(
+    FRAME.width,
+  );
+});
+
+test("clearance is measured from the corner's own side", () => {
+  const point: PlotPoint[] = [{ x: 30, y: 5 }];
+
+  expect(clearanceAt("top-left", point, READOUT_BOX, FRAME)).toBe(30);
+  expect(clearanceAt("top-right", point, READOUT_BOX, FRAME)).toBe(70);
+});
+
+test("the overlay is placed in percentages of the map's own box", () => {
+  // The width the CSS reserves and the width `cornerFor` kept clear are one
+  // number rather than two that have to be kept in step. That only works
+  // because the frame is square and the map is drawn `w-full` at `h-auto`, so
+  // one drawing unit is one percent on both axes.
+  expect(readoutStyle("top-left", READOUT_BOX, FRAME)).toEqual({
+    width: `${READOUT_BOX.width}%`,
+    maxHeight: `${READOUT_BOX.height}%`,
+    top: "0",
+    left: "0",
+  });
+
+  expect(readoutStyle("bottom-right", READOUT_BOX, FRAME)).toEqual({
+    width: `${READOUT_BOX.width}%`,
+    maxHeight: `${READOUT_BOX.height}%`,
+    bottom: "0",
+    right: "0",
+  });
+});
+
+test("the footprint stays inside what the inventory can hold", () => {
+  // 50.5 units is the widest readout any placement rule survives on its worst
+  // beach, measured across all 51. This is the ceiling written down where a
+  // later slice adding a field to a row will run into it -- the rows have
+  // vertical room to spend and none to spare across.
+  expect(READOUT_BOX.width).toBeLessThanOrEqual(50);
+});

--- a/src/components/conditions/corner.ts
+++ b/src/components/conditions/corner.ts
@@ -1,0 +1,188 @@
+/**
+ * Which corner of the shore map the weather readout stands in.
+ *
+ * **The corner is chosen per beach, and that reverses what the plan wrote
+ * down.** `map-weather-readout.md` fixed the block at the top-left on all 51
+ * beaches, on the grounds that a control which moves between Del Mar and
+ * Coronado is a control a reader has to find again, and put a test on it: walk
+ * every beach through `shoreViewFor`, project, and fail if the readout's box
+ * covers what the map draws. Run before the block was built rather than after,
+ * that test says the fixed corner has nowhere to stand.
+ *
+ * Measured across the inventory, as the widest readout each rule survives on its
+ * worst beach — and the three figures do not move at any readout height from 12
+ * units to 40:
+ *
+ * | placement                | widest readout | worst beach                  |
+ * | ------------------------ | ------------ | ------------------------------ |
+ * | fixed top-left           | 8.3 units    | `childrens-pool`               |
+ * | top, side flips          | 19.0 units   | `la-jolla-cove`                |
+ * | any of the four corners  | 50.5 units   | `mission-bay-visitor-s-center` |
+ *
+ * 8.3 units is about 27px on the 328px map a phone draws, against the 150px two
+ * rows of four fields need. **The cause is structural rather than unlucky**: on
+ * the beaches with no traced coast, `beachStretch` draws the beach's own two
+ * ends, so the segment is a chord between the frame's margin corners and always
+ * blocks one diagonal pair. `childrens-pool` reads 8 units clear at the
+ * top-left, 8 at the bottom-right, 92 at each of the others.
+ *
+ * **The half of the plan's rejection that was wrong is the reason this file
+ * exists.** It said an adaptive corner "becomes untestable in the useful
+ * direction — you can assert it moved, not that it landed somewhere good". The
+ * property is exactly as assertable either way, and it is the fixed rule that
+ * cannot be verified, because it is false. `corner.test.ts` walks all 51.
+ *
+ * **Pure, and the seam.** It takes projected points and a box and answers with
+ * a corner. It reads no file, resolves no beach and renders nothing, so the
+ * inventory-wide check calls it directly rather than through a rendered map.
+ */
+
+/** Where the readout stands, named as a reader would describe it. */
+export type Corner = "top-left" | "top-right" | "bottom-left" | "bottom-right";
+
+/** A footprint in the map's own drawing units. */
+export interface Box {
+  readonly width: number;
+  readonly height: number;
+}
+
+/** A point in the map's own drawing units, as `projectionFor` returns them. */
+export interface PlotPoint {
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * The readout's footprint, in the map's drawing units.
+ *
+ * **50 is the ceiling the inventory sets, not a size that was liked.** The
+ * worst beach leaves 50.5 units clear in its roomiest corner, so a wider block
+ * would be one no placement rule can keep off the picture. The map's frame is
+ * 100 units square and is drawn `w-full` at `h-auto`, so a unit is one percent
+ * of the rendered box on both axes — which is what lets the overlay be sized in
+ * CSS percentages and still be the same box this file reasons about.
+ *
+ * **The height is free and the width is not**, which is the measurement that
+ * decides what the rows may say. The widest readout any corner allows is 50.5
+ * units at a band 14 units deep, and *still* 50.5 at 20, 25, 30, 35 and 40 --
+ * it only moves at 50, where it drops to 50.0. What blocks a corner is a stroke
+ * crossing it diagonally, and a deeper band meets the same stroke at nearly the
+ * same place.
+ *
+ * So the rows have vertical room to spend and none at all to spare across, and
+ * that is why a row wraps rather than running on: at 10px, `SWELL south-west
+ * 270°` is 147.6px against the 151.5px a 327px map leaves inside this box, and
+ * a 320px viewport -- which ADR-0004 commits this site to -- leaves 124px. 30
+ * units is 81.6px there, which holds two needles of two lines each.
+ */
+export const READOUT_BOX: Box = { width: 50, height: 30 };
+
+/**
+ * The order corners are tried in, and it is the reader's rather than the
+ * geometry's.
+ *
+ * Top-left first because that is where the plan wanted the block and where a
+ * reader's eye starts, and it is clear on over half the inventory. The block
+ * moves only when the beach underneath leaves it nowhere else to go, which is
+ * the smallest amount of moving that answers the measurement.
+ */
+export const CORNER_ORDER: readonly Corner[] = [
+  "top-left",
+  "top-right",
+  "bottom-left",
+  "bottom-right",
+];
+
+/**
+ * How wide a box of this height can be in this corner before it covers a point.
+ *
+ * The band is the strip of the frame the box's height reaches into; a point
+ * outside that strip cannot be covered however wide the box is. Inside it, the
+ * widest safe box stops at the nearest point, measured from the corner's own
+ * side. `frame.width` when the strip is empty, which is the whole side.
+ */
+export function clearanceAt(
+  corner: Corner,
+  points: readonly PlotPoint[],
+  box: Box,
+  frame: Box,
+): number {
+  const top = corner === "top-left" || corner === "top-right";
+  const left = corner === "top-left" || corner === "bottom-left";
+
+  const inBand = points.filter((point) =>
+    top ? point.y < box.height : point.y > frame.height - box.height,
+  );
+  if (inBand.length === 0) return frame.width;
+
+  return Math.min(
+    ...inBand.map((point) => (left ? point.x : frame.width - point.x)),
+  );
+}
+
+/**
+ * The corner this beach's readout stands in.
+ *
+ * **The first corner that fits, and the roomiest one when none does.** Falling
+ * back rather than throwing is not a swallowed failure: the caller has a block
+ * to draw either way, and a beach with no clear corner is a fact about the
+ * inventory that belongs in a gate rather than in a runtime branch. The check
+ * in `corner.test.ts` is what holds it, and it holds it for all 51 beaches at
+ * once rather than for whichever one a reader happens to open.
+ *
+ * Deterministic, and computed from committed geometry alone, so a beach's
+ * corner is the same on every visit and in every render.
+ */
+export function cornerFor(
+  points: readonly PlotPoint[],
+  box: Box,
+  frame: Box,
+): Corner {
+  let roomiest: Corner = CORNER_ORDER[0];
+  let mostRoom = -1;
+
+  for (const corner of CORNER_ORDER) {
+    const room = clearanceAt(corner, points, box, frame);
+    if (room >= box.width) return corner;
+    if (room > mostRoom) {
+      mostRoom = room;
+      roomiest = corner;
+    }
+  }
+
+  return roomiest;
+}
+
+/**
+ * Where the overlay sits inside the map's box, as CSS.
+ *
+ * Percentages rather than pixels, because the map is drawn `w-full` inside a
+ * square frame: one drawing unit is one percent of the rendered box, so the
+ * width declared here and the width `cornerFor` reasoned about are the same
+ * number rather than two numbers that have to be kept in step.
+ */
+export function readoutStyle(
+  corner: Corner,
+  box: Box,
+  frame: Box,
+): {
+  width: string;
+  maxHeight: string;
+  top?: string;
+  bottom?: string;
+  left?: string;
+  right?: string;
+} {
+  const width = `${(box.width / frame.width) * 100}%`;
+  const maxHeight = `${(box.height / frame.height) * 100}%`;
+  const vertical =
+    corner === "top-left" || corner === "top-right"
+      ? { top: "0" }
+      : { bottom: "0" };
+  const horizontal =
+    corner === "top-left" || corner === "bottom-left"
+      ? { left: "0" }
+      : { right: "0" };
+
+  return { width, maxHeight, ...vertical, ...horizontal };
+}

--- a/src/components/conditions/corner.ts
+++ b/src/components/conditions/corner.ts
@@ -71,11 +71,21 @@ export interface PlotPoint {
  *
  * So the rows have vertical room to spend and none at all to spare across, and
  * that is why a row wraps rather than running on: at 10px, `SWELL south-west
- * 270°` is 147.6px against the 151.5px a 327px map leaves inside this box, and
- * a 320px viewport -- which ADR-0004 commits this site to -- leaves 124px. 30
- * units is 81.6px there, which holds two needles of two lines each.
+ * 270° 3.4 ft · 14 s` is 210.1px against the 151.5px a 327px map leaves inside
+ * this box, and the 124px a 320px viewport leaves -- a width ADR-0004 commits
+ * this site to. At 124px that row is three lines, so two of them plus the
+ * padding is 88px, which is 32.4 units of the 272px map a 320px viewport draws.
+ *
+ * **35 rather than 40, which is where the free range ends.** The height a box
+ * declares decides how deep a band `cornerFor` searches, so a taller box is a
+ * more cautious one and moves the readout off the top-left more often than the
+ * ink requires. Measured across the inventory: 35 chooses the same corner as 30
+ * on all 50 beaches that draw one, and 40 moves three more of them --
+ * `pacific-beach`, `mission-bay-de-anza-cove` and `mission-bay-sea-world`. So
+ * this is the smallest height that holds the tallest thing the rows can wrap
+ * to, which is the least moving the geometry asks for.
  */
-export const READOUT_BOX: Box = { width: 50, height: 30 };
+export const READOUT_BOX: Box = { width: 50, height: 35 };
 
 /**
  * The order corners are tried in, and it is the reader's rather than the

--- a/src/components/conditions/gridCell.test.ts
+++ b/src/components/conditions/gridCell.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import { windFigure } from "./gridCell";
+
+describe("windFigure", () => {
+  test("one decimal, which is the precision the day chart states", () => {
+    // Four of the five places this page prints a wind figure use one decimal
+    // and the fifth uses none, which is issue #191: the same reader is told the
+    // day tops at 12 mph and then, on reaching the hour it happens at, that it
+    // is 11.5. A sixth statement of that figure joins the four.
+    expect(windFigure(11.52)).toBe("11.5 mph");
+  });
+
+  test("keeps a trailing zero on a whole number", () => {
+    // "14 mph" and "14.0 mph" claim different precisions, and the axis this
+    // figure has to agree with prints the second.
+    expect(windFigure(14)).toBe("14.0 mph");
+  });
+
+  test("no speed is no figure, rather than a drawn calm", () => {
+    // A cell that published a direction and no speed is a ragged forecast, not
+    // a fault, and `mopLineDistanceKm` has the same shape for the same reason.
+    expect(windFigure(null)).toBeNull();
+  });
+});

--- a/src/components/conditions/gridCell.ts
+++ b/src/components/conditions/gridCell.ts
@@ -66,6 +66,27 @@ export function gridCellCaveat(elevationM: number | null): string | null {
 }
 
 /**
+ * A wind speed as this page states it.
+ *
+ * **One decimal, which is the precision the day chart states.** Four of the
+ * five places this page prints a wind figure use it and the fifth uses none --
+ * that is issue #191, where a reader is told the day tops at 12 mph and then,
+ * on reaching the hour it happens at, that it is 11.5. Anything printing a
+ * sixth wind figure joins the four rather than the one, so that issue stays a
+ * defect about `gridDescription` alone.
+ *
+ * The trailing zero is kept for the same reason `swellFigure` keeps one: "14
+ * mph" and "14.0 mph" claim different precisions, and the axis this figure has
+ * to agree with prints the second.
+ *
+ * `null` in and `null` out, like `mopLineDistanceKm`: a cell that published a
+ * direction and no speed is a ragged forecast, not a fault.
+ */
+export function windFigure(mph: number | null): string | null {
+  return mph === null ? null : `${mph.toFixed(1)} mph`;
+}
+
+/**
  * A forecast phenomenon in the register the page already writes in.
  *
  * The service publishes `fog` with coverage `patchy`, and its own plain-language

--- a/src/components/conditions/mopLine.test.ts
+++ b/src/components/conditions/mopLine.test.ts
@@ -4,6 +4,8 @@ import {
   MOP_NETWORK,
   mopLineDistanceKm,
   mopLineSource,
+  swellFigure,
+  swellStepNote,
 } from "./mopLine";
 
 describe("mopLineSource", () => {
@@ -47,5 +49,58 @@ describe("the words the page uses about this feed", () => {
     // ADR-0016 turns on a reader being able to tell the modelled height from
     // the measured one on the same page.
     expect(MOP_MODEL_NOTE).toContain("not a measurement");
+  });
+});
+
+describe("swellFigure", () => {
+  test("one decimal of feet and whole seconds", () => {
+    // CDIP publishes the peak period as the reciprocal of a spectral frequency
+    // bin -- 16.666668 -- rather than as a measurement to six decimal places,
+    // and the buoy card beside this prints whole seconds because NDBC does.
+    expect(swellFigure({ heightFt: 3.42, periodS: 16.666668 })).toBe(
+      "3.4 ft · 17 s",
+    );
+  });
+
+  test("keeps a trailing zero, because the figure is a measurement", () => {
+    // "2 ft" and "2.0 ft" claim different precisions, and the grid's other
+    // heights are all one decimal.
+    expect(swellFigure({ heightFt: 2, periodS: 14 })).toBe("2.0 ft · 14 s");
+  });
+
+  test("separates the two figures rather than running them together", () => {
+    // "0.8 ft 5 s" is two numbers a reader has to separate. The interpunct is
+    // what `ProvenanceLine` already uses to separate facts in running text.
+    expect(swellFigure({ heightFt: 0.8, periodS: 5 })).toContain(" · ");
+  });
+
+  test("no estimate is no figure, rather than a drawn flat sea", () => {
+    // The shape `mopLineDistanceKm` already has, and here for the same reason:
+    // a day the forecast does not reach is a ragged forecast rather than a
+    // fault, and a caller that branched on it would be a second place deciding
+    // what a missing estimate looks like.
+    expect(swellFigure(null)).toBeNull();
+  });
+});
+
+describe("swellStepNote", () => {
+  test("names the three-hour step the estimate is for", () => {
+    // MOP publishes every three hours, so the real peak can fall up to ninety
+    // minutes either side of the time printed. The word "step" is what keeps a
+    // reader from taking it for a peak located to the minute, the way the tide
+    // row's turning point above it is.
+    expect(swellStepNote({ timeLabel: "2:00 PM" })).toContain(
+      "for the three-hour step at 2:00 PM",
+    );
+  });
+
+  test("keeps saying the figure is modelled, with or without a time", () => {
+    // ADR-0016 turns on a reader being able to tell the modelled height from
+    // the measured one on the same page, so the clause survives the absence.
+    expect(swellStepNote({ timeLabel: "2:00 PM" })).toContain(
+      "not a measurement",
+    );
+    expect(swellStepNote(null)).toContain("not a measurement");
+    expect(swellStepNote(null)).not.toContain("three-hour step");
   });
 });

--- a/src/components/conditions/mopLine.ts
+++ b/src/components/conditions/mopLine.ts
@@ -48,6 +48,62 @@ export function mopLineSource(lineId: string): string {
 }
 
 /**
+ * A swell estimate as one figure: how big, and how far apart.
+ *
+ * **Two components print this and they must not disagree**, which is the whole
+ * reason it is here rather than inside either. The week grid's wave cell and
+ * the shore map's readout both render one `WaveReading` -- the same three-hour
+ * step, selected once by `readWaveWeek` -- so the map and the grid printing
+ * different numbers for Thursday would be the page contradicting itself about a
+ * figure it holds once. `ProvenanceLine`'s docstring records what two call
+ * sites each wording one fact cost this repo the last time.
+ *
+ * **Whole seconds**, because CDIP publishes the peak period as a float --
+ * 16.666668 -- as the reciprocal of a spectral frequency bin rather than as a
+ * measurement to six decimal places, and the buoy card beside this prints whole
+ * seconds because NDBC publishes whole seconds.
+ *
+ * **An interpunct between the two figures rather than a space.** "0.8 ft 5 s"
+ * is two numbers a reader has to separate, and ` · ` is what `ProvenanceLine`
+ * already uses to separate facts in running text on this page.
+ *
+ * `null` in and `null` out, which is `mopLineDistanceKm`'s shape and is here
+ * for the same reason: the absence is a fact about a ragged forecast, and a
+ * caller that had to branch on it would be the second place deciding what a
+ * missing estimate looks like.
+ */
+export function swellFigure(
+  reading: { heightFt: number; periodS: number } | null,
+): string | null {
+  return reading === null
+    ? null
+    : `${reading.heightFt.toFixed(1)} ft · ${Math.round(reading.periodS)} s`;
+}
+
+/**
+ * What the attribution says about *when* an estimate is for.
+ *
+ * **A three-hour step, not a peak located to the minute.** MOP publishes every
+ * three hours, so a `WaveReading` is the step that carried the largest height
+ * and the real peak can fall up to ninety minutes either side of the time
+ * printed. The tide row's time is a turning point NOAA computed and the two
+ * look alike, which is why `ConditionsNotes` says which is which -- and why the
+ * word "step" is in this sentence rather than a bare clock time.
+ *
+ * It sits on the provenance line rather than beside the figure because the
+ * shore map's readout has no room for a fifth field, and because when an
+ * estimate is for is a fact about the model rather than about the sea.
+ *
+ * The model clause alone where there is no estimate to time, which is a day the
+ * forecast does not reach rather than a fault.
+ */
+export function swellStepNote(reading: { timeLabel: string } | null): string {
+  return reading === null
+    ? MOP_MODEL_NOTE
+    : `${MOP_MODEL_NOTE}, for the three-hour step at ${reading.timeLabel}`;
+}
+
+/**
  * How far the line stands, in kilometres, rounded — or null when the binding
  * recorded no distance.
  *

--- a/src/components/conditions/needles.test.ts
+++ b/src/components/conditions/needles.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { GridDaySeries } from "@/lib/conditions";
-import { gridWindReadings, needleFrom, swellReadings } from "./needles";
+import {
+  gridWindReadings,
+  needleFrom,
+  peakInDaylight,
+  swellReadings,
+} from "./needles";
 
 /** 2026-08-17 in Pacific: sunrise 06:15, sunset 19:30, as epoch milliseconds. */
 const SUNRISE = Date.UTC(2026, 7, 17, 13, 15);
@@ -186,5 +191,61 @@ describe("swellReadings", () => {
 
   it("has nothing to read from a day with no estimates in daylight", () => {
     expect(swellReadings([], SUNRISE, SUNSET)).toEqual([]);
+  });
+});
+
+describe("peakInDaylight", () => {
+  it("takes the largest hour a reader could have been there for", () => {
+    // The wind's answer to `WaveReading`, and deliberately the same rule: the
+    // largest thing the daylight window holds.
+    expect(
+      peakInDaylight(
+        published([
+          { atMs: hour(14), value: 6 },
+          { atMs: hour(20), value: 11.5 },
+          { atMs: hour(23), value: 9 },
+        ]),
+        SUNRISE,
+        SUNSET,
+      ),
+    ).toBe(11.5);
+  });
+
+  it("passes over a bigger hour that falls outside daylight", () => {
+    // The whole point of the window. A 2 AM gust is not the day a reader is
+    // planning, and reporting it as the day's wind would be reporting weather
+    // nobody could stand in.
+    expect(
+      peakInDaylight(
+        published([
+          { atMs: hour(3), value: 30 },
+          { atMs: hour(20), value: 8 },
+        ]),
+        SUNRISE,
+        SUNSET,
+      ),
+    ).toBe(8);
+  });
+
+  it("has no answer where the cell declared none", () => {
+    expect(
+      peakInDaylight(
+        { kind: "absent", reason: "this cell publishes no wind speed" },
+        SUNRISE,
+        SUNSET,
+      ),
+    ).toBeNull();
+  });
+
+  it("has no answer on a day the forecast does not reach", () => {
+    // Null rather than zero. A ragged row is a forecast doing what forecasts
+    // do, and a zero would be a drawn calm nobody predicted.
+    expect(
+      peakInDaylight(
+        published([{ atMs: hour(3), value: 12 }]),
+        SUNRISE,
+        SUNSET,
+      ),
+    ).toBeNull();
   });
 });

--- a/src/components/conditions/needles.ts
+++ b/src/components/conditions/needles.ts
@@ -96,6 +96,39 @@ export function swellReadings(
 }
 
 /**
+ * The largest value this series reaches while the sun is up, or nothing.
+ *
+ * **The wind's answer to `WaveReading`**, and deliberately the same rule. CDIP
+ * publishes a three-hour step and `readWaveWeek` selects the daylight one that
+ * carried the largest height; the gridpoint publishes every hour and nothing
+ * selects among them, so this does. Both figures are then the largest thing the
+ * daylight window holds, which is what lets the two rows of the readout be
+ * worded once instead of each explaining its own selection.
+ *
+ * **Daylight rather than the whole day**, for the reason `gridWindReadings`
+ * gives above and `ADR-0023` gives for the week: a figure a reader cannot be
+ * there for is not the figure they came for.
+ *
+ * `null` on an absent series and on a day whose daylight window the forecast
+ * does not reach -- a ragged row is a forecast doing what forecasts do, and a
+ * zero would be a drawn calm that nobody predicted.
+ */
+export function peakInDaylight(
+  series: GridDaySeries,
+  sunriseMs: number,
+  sunsetMs: number,
+): number | null {
+  if (series.kind !== "published") return null;
+
+  let peak: number | null = null;
+  for (const hour of series.hours) {
+    if (hour.atMs < sunriseMs || hour.atMs >= sunsetMs) continue;
+    if (peak === null || hour.value > peak) peak = hour.value;
+  }
+  return peak;
+}
+
+/**
  * A day's readings as one needle, or nothing to draw.
  *
  * **Both numbers or neither.** An arc with no needle in it says the wind had a

--- a/src/components/conditions/selectedDay.test.tsx
+++ b/src/components/conditions/selectedDay.test.tsx
@@ -12,7 +12,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { localMidnightOf } from "@/lib/pacific-time";
 import { ChosenDay, type DayView } from "./ChosenDay";
-import { DayCompassSources, type CompassDay } from "./DayCompass";
+import { DayCompass, type CompassDay } from "./DayCompass";
 import { SelectedDayProvider } from "./selectedDay";
 import { WeekGrid, type WeekDay, type WeekRow } from "./WeekGrid";
 import type { SparkPoint } from "./DaySpark";
@@ -119,9 +119,12 @@ const COMPASS_DAYS: CompassDay[] = DATES.map((localDate, index) => ({
       label: "Wind",
       fromDegT: [90, 180, 270][index],
       spreadDeg: 20,
-      source: "this beach's own grid cell",
-      network: "National Weather Service, San Diego",
-      note: null,
+      figure: "11.5 mph",
+      provenance: {
+        label: "Biggest wind in daylight",
+        source: "this beach's own grid cell",
+        network: "National Weather Service, San Diego",
+      },
     },
   ],
 }));
@@ -358,15 +361,17 @@ test("the readout on the map follows the chosen day, and the map does not", () =
   const { container } = renderBoth(
     <>
       <p data-test-coast="">One coastline, drawn once</p>
-      <DayCompassSources days={COMPASS_DAYS} />
+      <DayCompass days={COMPASS_DAYS} />
     </>,
   );
 
-  expect(screen.getByText(/from the east, 90°/)).toBeDefined();
+  expect(screen.getByRole("img", { name: /from the east, 90°/ })).toBeDefined();
 
   fireEvent.click(container.querySelector(`[data-day-choice="${DATES[2]}"]`)!);
 
-  expect(screen.getByText(/from the west, 270°/)).toBeDefined();
-  expect(screen.queryByText(/from the east, 90°/)).toBeNull();
+  expect(
+    screen.getByRole("img", { name: /from the west, 270°/ }),
+  ).toBeDefined();
+  expect(screen.queryByRole("img", { name: /from the east, 90°/ })).toBeNull();
   expect(screen.getByText("One coastline, drawn once")).toBeDefined();
 });

--- a/src/components/conditions/selectedDay.test.tsx
+++ b/src/components/conditions/selectedDay.test.tsx
@@ -107,7 +107,7 @@ const VIEWS = DATES.map((_, index) => dayView(index));
 /**
  * One needle per day, each from a different quarter.
  *
- * The dial travels beside the map rather than inside `DayView`, because the map
+ * The readout travels beside the map rather than inside `DayView`, because the map
  * is one picture for the whole week and the needles are not. That makes it a
  * second consumer of the same choice, which is what this file exists to assert.
  */
@@ -350,7 +350,7 @@ test("a region outside the provider shows its first day rather than failing", ()
   expect(drawnDay(container)).toBe(`Tide on ${DATES[0]}`);
 });
 
-test("the dial on the map follows the chosen day, and the map does not", () => {
+test("the readout on the map follows the chosen day, and the map does not", () => {
   // The second consumer of the one choice. The needles are per day and the
   // coast is not, so the picture stays exactly where it was while the bearing
   // under it changes -- which is the whole reason the compass is a client

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -330,8 +330,22 @@ export default defineConfig({
         // unit test can call it. The alternative was four branches covered by
         // nothing and explained here, which is what this file already carries
         // too much of.
+        //
+        // BRANCHES LOWERED 2026-08-31 under REASON 2, by the readout reaching
+        // all 51 beaches. Nothing became untested: the coast gate --
+        // `!hasCoast || drawnSegment.length === 0` -- was fully covered and is
+        // deleted, so three branch arms left and the surviving denominator
+        // tilts further toward the 0% entry plumbing.
+        //
+        //   branches 1815/2032 -> 1812/2029   89.32 -> 89.30
+        //
+        // **The numerator fell by exactly what the denominator did**, which is
+        // what says every deleted arm was covered; a regression drops the
+        // numerator alone and reads identically in the failure message. The
+        // other three are unmoved, because the slice deleted a condition rather
+        // than a statement, a function or a line.
         statements: 89.62,
-        branches: 89.32,
+        branches: 89.3,
         functions: 94.37,
         lines: 89.32,
       },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -286,12 +286,32 @@ export default defineConfig({
       // and `DayPanel` at 97.53% statements, whose uncovered statement is the
       // sentence for a CDIP outage that suite does not provoke.
       thresholds: {
-        // Back up a hundredth of a point each when the needles gained their
-        // labels, which are covered like everything else in `Compass.tsx`.
-        statements: 89.44,
-        branches: 88.94,
-        functions: 94.28,
-        lines: 89.14,
+        // RAISED 2026-08-31, all four, by the map's corner readout (#192).
+        // The ordinary direction and the easy case -- the signature is all
+        // four moving the same way, with both halves of every ratio growing
+        // and the numerators growing faster:
+        //
+        //   statements 2749/3069  89.44 -> 89.57
+        //   branches   1793/2010  88.94 -> 89.20
+        //   functions   634/672   94.28 -> 94.34
+        //   lines      2481/2779  89.14 -> 89.27
+        //
+        // `corner.ts` arrived at 100% on all four and does not appear in the
+        // report's table at all; `Compass.tsx` went back to 100% on all four
+        // as the dial's geometry left it. The two files this slice modified
+        // and did not finish clean are named rather than absorbed, and both
+        // are unchanged from before it: `ShoreMap.tsx` at 97.29% branches,
+        // whose one uncovered branch is the `|| 1` divide-by-zero guard for a
+        // drawn run whose ends project to the same point, and `DayPanel.tsx`
+        // at 97.7% statements, whose uncovered statement is the sentence for a
+        // CDIP outage that suite does not provoke.
+        //
+        // Nothing new is excluded. The same 0% entry-plumbing files named
+        // above still drag all four down in plain sight.
+        statements: 89.57,
+        branches: 89.2,
+        functions: 94.34,
+        lines: 89.27,
       },
     },
   },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -308,10 +308,32 @@ export default defineConfig({
         //
         // Nothing new is excluded. The same 0% entry-plumbing files named
         // above still drag all four down in plain sight.
-        statements: 89.57,
-        branches: 89.2,
-        functions: 94.34,
-        lines: 89.27,
+        //
+        // RAISED again 2026-08-31, all four, by the magnitudes joining the
+        // readout's rows. Both halves of every ratio grew and the numerators
+        // grew faster:
+        //
+        //   statements 2764/3084  89.57 -> 89.62
+        //   branches   1815/2032  89.20 -> 89.32
+        //   functions   638/676   94.34 -> 94.37
+        //   lines      2493/2791  89.27 -> 89.32
+        //
+        // **Branches went down before they went up, and the dip is the part
+        // worth recording.** Wording the two magnitudes inline in `DayPanel`
+        // added four branches for the same fact -- a source that gave a
+        // direction and no magnitude -- and none of them could be reached from
+        // that component: a wind needle exists only where the speeds and the
+        // bearings joined, so a null peak beside a drawn needle is not a state
+        // `DayPanel` can be put in. Moving the wording into `windFigure`,
+        // `swellFigure` and `swellStepNote` -- null in, null out, which is
+        // `mopLineDistanceKm`'s shape -- put each of those arms somewhere a
+        // unit test can call it. The alternative was four branches covered by
+        // nothing and explained here, which is what this file already carries
+        // too much of.
+        statements: 89.62,
+        branches: 89.32,
+        functions: 94.37,
+        lines: 89.32,
       },
     },
   },


### PR DESCRIPTION
Closes #192.

The dial leaves the shore map. In its place, two rows in a corner of the
picture: an arrow pointing the way the weather travels, a faint wedge behind it
for the range the direction swung through in daylight, the word for that
direction, its degrees, and how much of it there was.

```
↗ WIND   west 270°   11.5 mph
↗ SWELL  west 284°   1.3 ft · 6 s
```

PR 1 of 3 from [`docs/plans/map-weather-readout.md`](docs/plans/map-weather-readout.md).
#193 and #194 are unblocked by it and are not in here.

---

## One decision in the plan did not survive its own test

The plan fixed the block at the map's top-left and put a check on it: walk all 51
beaches through `shoreViewFor`, project, and fail if the block's box covers what
the map draws. **Run before the block was built rather than after, that check
says the fixed corner has nowhere to stand.**

The widest readout each placement rule survives on its worst beach — and the
three figures do not move at any readout height from 12 units to 40:

| placement                        | widest readout | worst beach                    |
| -------------------------------- | -------------- | ------------------------------ |
| fixed top-left                   | **8.3 units**  | `childrens-pool`               |
| top, side flipping left/right    | **19.0 units** | `la-jolla-cove`                |
| the roomiest of the four corners | **50.5 units** | `mission-bay-visitor-s-center` |

8.3 units is about 27px on the 327px map a 375px viewport draws. At a realistic
46 × 14 the fixed block sits on the beach's own stretch on **21 of the 47
beaches that draw one**, including the default beach. The cause is structural
rather than unlucky: where no coast is traced, `beachStretch` draws the beach's
own two ends, so the segment is a chord between the frame's margin corners and
always blocks one diagonal pair.

Cole chose the adaptive corner. It is argued in the branch's first commit as a
dated addendum to the plan, and in ADR-0034. Half of the plan's reason for
rejecting it is recorded as wrong: it said an adaptive corner "becomes
untestable in the useful direction", and the property is exactly as assertable
either way — it is the *fixed* rule that cannot be verified, because it is
false.

`childrens-pool` on the built page is the case in one picture: the chord runs
from the top-left corner to the bottom-right, and the readout stands in the
top-right.

---

## The slices

**1 — `Record that the readout's corner is chosen per beach`.** The plan file
gains a dated addendum with the measurement above. Docs only.

**2 — `Move the map's weather off the coast into a corner readout`.** ADR-0034,
then the block. The ring and the arc go together, because the ring's only
justification was giving the arc something to be a portion of and at corner size
the arc cannot be judged. `RING_RADIUS`, `NEEDLE_TRACKS`, the two needle tracks
and `ShoreMap`'s `anchor` are gone. Each row is one `role="img"` carrying the
unabbreviated sentence, so the block is its own spoken equivalent rather than a
picture needing one. New pure module `corner.ts` is the seam; `corner.test.ts`
walks all 51 beaches and fails if the chosen corner covers anything the map
draws — the beach's own stretch **and** the whole windowed coastline, which the
plan did not ask for and measurement said was free. `CONTEXT.md`'s `Dial` entry
becomes `Readout`.

**3 — `Put how much there was on the readout's rows`.** The swell reuses the
`WaveReading` the week grid prints, worded by a new shared `swellFigure`, so the
map and the grid cannot state different numbers for one day. The wind takes the
largest daylight hour, mirroring that rule. The step's time leaves the figure
for the provenance line, and `CompassSources` drops to attribution.

**4 — `Give the readout to the 23 beaches with no traced coast`.** The coast
stops being a condition. Mission Bay and San Diego Bay gain a wind row and its
publisher where they had neither.

---

## Measured on the built page

Production build, three viewports, `ocean-beach` and `la-jolla-shores-beach`
(the widest rows the inventory prints):

| viewport | map   | box reserved | ink   | lines | inside the box |
| -------- | ----- | ------------ | ----- | ----- | -------------- |
| 1536     | 472px | 236px        | 210px | 1     | yes            |
| 375      | 327px | 163.5px      | 151px | 2     | yes            |
| 320      | 272px | 136px        | 124px | 3     | yes            |

`SWELL south-west 246° 2.3 ft · 14 s` is 210.1px at `text-2xs` against the 124px
a 320px viewport leaves inside the box, so **the row wraps rather than running
on** — which is ADR-0004's own resolution of the same squeeze, since that ADR
commits this site to 320 CSS px and prefers content that grows its container to
content that is clipped. The height is affordable because clearance does not
move between a band 14 units deep and one 40 deep; the width is the whole
constraint, and 50 units is its ceiling.

The box is 35 units tall rather than 40: 35 holds the tallest wrapped block and
chooses the same corner as 30 on all 50 beaches that draw one, where 40 moves
three more off the top-left.

The 23 bay beaches were checked individually — `fiesta-island`,
`mission-bay-sea-world`, `childrens-pool`, `spanish-landing-park`,
`mission-bay-visitor-s-center` each print a wind row and a provenance line where
they printed nothing.

---

## Interaction with #191

That issue reports the wind figure stated at two precisions across five places.
This adds a sixth, and it **joins the four rather than the one**: `windFigure`
is `toFixed(1)`, like the axis, the summary sentence, the per-hour readout and
the per-hour label. #191 stays a defect about `gridDescription` alone.

## What I did not do

- **The plan says slice 3 leaves `CompassSources` as "bare provenance lines".**
  It is bare of bearings, but each line carries `ProvenanceLine`'s `label` —
  "Biggest wind in daylight" — for two reasons the plan did not weigh. Two lines
  under one picture have to say which is which now that neither restates its
  bearing; and `WaveWeek` records that a single figure under the bare word
  invites a reader to take it for the day's typical swell, "which is the one
  thing it is not", so the superlative is not optional. The readout has no width
  for it, and this line is directly beneath the figure.
- **The plan's mock reads `WNW 281°`.** That is a sixteen-point rose, and
  `bearing.ts` deliberately holds this page to eight so the map and the measured
  air card cannot call one bearing two things. The rows print `west 281°`.
- **No plan-file historical note.** The plan covers #193 and #194 too and is
  still in flight.
- **Noticed and not filed:** `ShoreMap.tsx`'s one uncovered branch is still the
  `|| 1` divide-by-zero guard for a drawn run whose two ends project to the same
  point, unchanged by this work and unreachable through committed data.

## Verification

`npm run gate`, at `151ecd6`:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… sea-side
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

1,499 tests across 95 files. Coverage after the branch:

```
Statements   : 89.62% ( 2764/3084 )
Branches     : 89.30% ( 1812/2029 )
Functions    : 94.37% (  638/676  )
Lines        : 89.32% ( 2493/2791 )
```

Three of the four rise against the floor this branch started from; branches rise
and then give two hundredths back in slice 4, where the coast gate was deleted
and numerator and denominator fall by the same three. `vitest.config.mts`
carries the arithmetic.

**The two tests that assert the reversal were mutation-checked**, because a test
that inverts an existing one can pass for the wrong reason: putting `!hasCoast`
back into `ShoreMap`'s condition fails "a beach the coast does not reach still
gets its readout", "a beach with nothing drawn at all still gets its readout"
and "a beach the traced coast does not reach gains its wind row", and nothing
else.

## Needs a human

Whether the block reads correctly to a person is not something a gate can
assert. Worth a look at `la-jolla-shores-beach` (bottom-right, two rows),
`coronado-city-beaches` (top-left, one row) and `childrens-pool` (top-right,
over a chord with no coastline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GwPvqm8B8iDYG7EKyPft1
