### PR TITLE
Give the page one selected hour, starting at now

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -195,6 +195,17 @@ The large plot inside the day panel: twenty-four hours across, night shaded,
 cloud as a band above, one of four series drawn at a time behind four tabs.
 _Avoid_: graph, the plot, day chart, timeline
 
+**Selected hour**:
+The one hour of the chosen day the day panel is showing. The hour chart marks
+it and states its figures — the hour, the reading, the sky and whether the sun
+was up. It **starts at the hour it is now**, and on the six days that are not
+today that means the same hour of the clock, so all seven behave alike. A
+reader who picks a different one keeps it as they move across the week and as
+they change product, which is how one hour is compared from day to day
+(ADR-0035). Night hours are ordinary: the panel draws the whole day, so an hour
+before dawn can be chosen and is stated like any other.
+_Avoid_: scrubbed hour, hovered hour, current time, the cursor, timestamp
+
 **Shore map**:
 The square picture beside the hour chart: this beach's own stretch of coast
 drawn heavier than the shore either side of it, and the open water washed in

--- a/docs/adr/0035-the-page-has-one-selected-hour.md
+++ b/docs/adr/0035-the-page-has-one-selected-hour.md
@@ -1,0 +1,255 @@
+# 0035 — The page has one selected hour, and it starts at now
+
+Date: 2026-08-31. Status: accepted. Supersedes one clause of ADR-0027, **"The
+compass may not follow the selected hour"**; the rest of that decision, including
+all four of its conditions, is unchanged and still binds. Reverses `ChosenDay`'s
+rule that a chosen hour does not survive a day change. Adds the `Selected hour`
+entry to `CONTEXT.md`, updated in the same pull request. Corrects one sentence of
+ADR-0034, below. ADR-0032 and ADR-0034 are otherwise untouched.
+
+## Context
+
+`HourChart` can be asked which hour a reader is looking at — ADR-0027 built that,
+with a prev/next pair clearing ADR-0004's touch floor and a roving tabindex. The
+readout in the corner of the shore map does not listen. A reader stepping through
+the afternoon watches the chart's figures change while the wind and swell rows
+sit on a day aggregate. That is issue #193.
+
+ADR-0027 declined this explicitly, and its reason is not about hover:
+
+> a needle whose meaning changes depending on what was last clicked is a
+> different instrument from one showing the day's dominant direction […] Anyone
+> building `Compass` in #173 should read that rejection as standing.
+
+**The first design for #193 conceded that objection rather than answering it.**
+It proposed a block with two modes — the day's figures on arrival, one hour's
+after a click — and argued the wedge disambiguated them: the wedge is the day's
+swing, the arrow is this hour read against it. It does not disambiguate. With
+nothing selected the arrow sits at the day's resultant, which is inside the
+wedge by construction; with 3 PM selected it sits at 3 PM's bearing, also inside
+it. **The two modes draw the same picture**, which is precisely the needle
+ADR-0027 refuses.
+
+Asked what the map should show, the reviewer's answer was neither half of that
+design: the current wind and swell, and then whatever hour the reader moves to.
+
+**With no day mode, there is nothing to change meaning between.** The arrow is
+the wind at one hour, before any click and after every one. ADR-0027's real
+demand — "two needles that always mean the same thing on all seven days is worth
+more than one striking exception" — is met literally instead of argued around,
+and it is met by removing the exception rather than by justifying it.
+
+## Decision
+
+**The page holds one selected hour, shared by the hour chart and the map's
+readout, and it starts at the current hour.**
+
+- **It is an hour, not an instant.** `selectedMs` is `useState` local to
+  `HourChart` today. It lifts into a context mirroring `selectedDay.ts`,
+  including that module's deliberate default: rendered outside the provider a
+  region shows the default and offers no choice, which is the state a reader
+  with a blocked script is in. An hour survives a tab change — which is the
+  property `HourChart`'s comment gives for holding an instant in the first place
+  — **and** a day change, which an instant cannot.
+
+- **The default is the current clock hour, resolved against whichever day is
+  showing.** Six of the seven days have no "now": `DayPanel` sets `nowMs` from
+  `day.isToday` and null otherwise. So at 3:40 PM every day defaults to its own
+  3 PM. One rule, one meaning on all seven days, and it is how a forecast is
+  actually read — what is Thursday like at this time.
+
+- **That hour is computed on the server and passed down.** The page carries
+  `revalidate = 900`, so a client reading its own clock would disagree with a
+  fifteen-minute-old cache across an hour boundary and hydrate wrong. `nowMs`
+  already works this way for the chart's now-line; this needs the Pacific clock
+  hour instead, because six days carry no `nowMs`.
+
+- **The chart arrives with that hour marked, and says what it is.** The
+  selection's guide and mark are already outside `HourChart`'s `mounted` gate,
+  so a default selection renders them on the server for free. Its sentence is
+  not, and moves out with them: a marked point with no explanation is worse for
+  a reader without JavaScript than either extreme. **The prev/next pair and the
+  hour columns stay gated**, which is the half of ADR-0027's rule that was about
+  controls being dead rather than about statements being absent. A readout that
+  is filled on arrival makes no announcement, because `aria-live` does not
+  announce initial content.
+
+- **A chosen hour carries across days.** Reverses `ChosenDay`, which presents
+  the opposite as a virtue — "The _hour_ they chose does not survive, and that
+  also falls out rather than being arranged." It fell out of holding an instant.
+  Reverting a reader's deliberate choice on every day change is the one thing
+  they cannot have meant, and comparing one hour across the week is the
+  comparison `ChosenDay` itself says the week selector exists for.
+
+- **The readout shows that hour, and the wedge stays the day's daylight swing.**
+  The arrow is no longer daylight-bound and the wedge still is, so at a night
+  hour the arrow may sit outside its own wedge. That is a true statement — that
+  hour's wind came from a direction it never came from while the sun was up —
+  and `needleSentence` already qualifies the wedge as "in daylight", so the
+  accessible form is correct and only the visual is unqualified.
+
+- **A caption names the hour, and it is always present.** Without it the block
+  changes its numbers with nothing visible saying what they now mean, which is
+  the failure this page is least entitled to ship. Always present rather than
+  appearing on click, so the reserved box matches the ink in both states and the
+  block never jumps. It also closes a gap that exists today: the block prints
+  `11.5 mph` with no visible statement that it is the daylight peak.
+
+- **The swell row is the nearest published step within ninety minutes, whole.**
+  Each of CDIP's estimates owns the three hours centred on it, which is the
+  bucket `ConditionsNotes` already explains; outside any bucket the row is
+  withheld, and takes its provenance line with it under ADR-0032's existing
+  rule. Height, period and direction all come off that one step, so the row
+  never puts two instants beside each other — which is what `periodS` joining
+  `WaveHour` is for.
+
+- **The day's biggest wind moves into the provenance line rather than being
+  lost.** See the correction below: the readout is the only place this page
+  states that figure. `WaveWeek`'s rule already puts the superlative in the
+  provenance label, so the label gains the figure and its hour. The lines sit
+  outside the readout's box, so this costs none of the width that is the block's
+  whole constraint.
+
+**What this costs is the day-dominant direction, which leaves the map.** That is
+the price and it is not disguised. The day survives as the wedge, which is the
+reading ADR-0034 built the wedge for: a narrow one is a day that had a direction,
+a near-blob is a day that did not.
+
+## ADR-0027's four conditions still bind, and are met
+
+- **Not by hovering.** Selection is by click, tap or key. Unchanged.
+- **Only additively.** Nothing drawn or written goes behind a gesture. The one
+  figure this design would otherwise have removed — the day's biggest wind — is
+  kept, in the provenance line, which is why that clause above exists.
+- **With a control that meets the touch floor.** No new control is added, so the
+  prev/next pair's guarantee is inherited rather than re-owed.
+- **Reachable without a mouse, and announced.** The roving tabindex is unchanged.
+  The readout stays the page's one live region for this change: the corner block
+  is not `aria-live`, because two live regions firing on one arrow-press means a
+  keyboard reader hears the same change twice.
+
+**ADR-0025 is untouched.** The plot still renders complete on the server. What
+the server render gains is a marked point and its sentence; what it still refuses
+is a button, and ADR-0027's test asserting that is unchanged.
+
+## A correction to ADR-0034
+
+ADR-0034 justifies drawing the readout on all 51 beaches partly on this: the cost
+of withholding it "was that nearly half the inventory printed no wind figure
+anywhere on the picture — **the same figure the week grid above states for every
+one of those beaches**."
+
+**The week grid states no wind figure.** `WeekPanel` declines it deliberately and
+says why: temperature and wind "come from the air station rather than an
+airport", ADR-0012 records them as among the best-founded readings here, and
+"moving those to a forecast is the displacement ADR-0019 declined to decide".
+The grid's rows are tides, swell, daylight and sky.
+
+ADR-0034's decision is unaffected — the argument for drawing the block on all 51
+beaches stands on its own without that clause, and stands more strongly, because
+the figure was not available elsewhere after all. What the error did was hide
+this decision's real cost until it was looked for, which is why it is recorded
+here rather than left as a stale sentence in a merged document.
+
+## What this does not license
+
+**No readout may form a judgement**, which is ADR-0009's line and unchanged. The
+caption names an hour; it does not say whether that hour is good.
+
+**The wedge is not the arrow.** It stays the daylight swing on all seven days and
+does not follow the selection. A wedge that meant daylight sometimes and midnight
+to midnight at other times would be this decision's own ambiguity, moved from the
+arrow to the mark behind it.
+
+**A tooltip is still refused**, and hover still does not exist here.
+
+## Alternatives considered
+
+**Keep ADR-0027's clause and close #193.** Defensible: the clause was recorded
+and the chart already tells a reader which hour they chose. Rejected because the
+mismatch it leaves is real — the same page states an hour in one region and a day
+aggregate in the region beside it, with nothing saying so — and because the
+clause's actual demand is satisfiable rather than merely arguable.
+
+**The two-mode block the plan proposed**: day figures on arrival, the hour after
+a click. Rejected above — the two modes draw the same picture, so it is the
+needle ADR-0027 refuses with an extra step.
+
+**Today shows now; the other six days show the daylight peak.** Reads well, and
+matches what a reader plausibly wants from each. Rejected: the figures change
+meaning when a reader steps from today to Friday, with no click on the map. That
+is the two-mode failure moved from the click to the day selector, where it is
+harder to notice.
+
+**The first daylight hour on all seven days**, so nothing depends on a wall
+clock and the page renders identically whenever it is built. Trivially testable
+and cache-stable. Rejected: it is not the current wind, which is the thing asked
+for on the day a reader is standing in.
+
+**The context defaults to null and the readout resolves null as "now".** Leaves
+`HourChart`'s arrival state exactly as shipped. Rejected: nothing in the chart
+then points at the hour the map is showing, on the six days that have no
+now-line, so a reader cannot see where the figures came from.
+
+**A chosen hour resets on a day change**, keeping `ChosenDay`'s docstring true.
+Rejected: the default already resolves per day, so the shared value is an hour
+either way, and reverting a deliberate choice buys nothing but a sentence.
+
+**Widen the wedge to the whole day** so the arrow is always inside it. The more
+consistent rule, and it costs the thing the wedge is for: `needles.ts` records
+that the committed run swings across north in its first three hours — 340, 20,
+150 — so a wedge measured end to end draws a near-blob on a day that was settled
+from sunrise onward. It also narrows the daylight rule ADR-0023, `WaveWeek` and
+the week grid all hold, for one mark.
+
+**The swell row holds the last published step at or before the hour**, which is
+what the plan wrote. Rejected on measurement: it is up to three hours stale where
+the nearest is at most ninety minutes, and it has no answer at all at 00:00 and
+01:00, because `hourlyWaveHeights` interpolates only forward and
+`waveHoursByDate` buckets the previous day's 23:00 publication to the previous
+date. Those hours were unreachable while the block was daylight-bound.
+
+**Withhold the swell row on every unpublished hour**, so it appears only where
+CDIP spoke. Maximally honest. Rejected: the row would blink on and off five
+times in eight as a reader steps hour by hour, and a reader landing on an
+unpublished hour sees a map that looks broken rather than reticent.
+
+**Mark the daylight peak on the wind curve** instead of stating it in the
+provenance. Keeps the readout pure. Rejected: a fifth mark on a plot already
+carrying a now-line, night bands, a cloud band, published-point marks and the
+selection guide — and it would need a rule for the other three tabs.
+
+## Consequences
+
+- **A second client fact joins `selectedDay`**, with the same shape and the same
+  out-of-provider default, so the two are read the same way. That is now a
+  pattern rather than a one-off, and a third would have somewhere to look.
+- **`ChosenDay`'s docstring is wrong until it is updated**, and it is updated in
+  the same pull request. Its argument for why the chart is not keyed on the day
+  survives; only its claim about the hour does not.
+- **`needles.ts` keeps its daylight half and gains an hourly one.** The wedge
+  still needs `gridWindReadings`, and `peakInDaylight` still feeds the day figure
+  that moved into the provenance line — so nothing there is deleted.
+- **The map and the week grid may print different swell numbers for one day**,
+  and `DayPanel` currently records the opposite as an invariant. The grid states
+  the day's biggest daylight step and the map states the hour a reader is looking
+  at. Each is labelled by its own caption and its own provenance line, which is
+  the condition ADR-0010 and ADR-0029 set rather than an exception to them.
+- **`READOUT_BOX` grows from 35 to 40 units** to hold the caption, which
+  `corner.ts` measured as moving three beaches to a different corner:
+  `pacific-beach`, `mission-bay-de-anza-cove` and `mission-bay-sea-world`.
+- **This decision ships in two pull requests.** The context, the lift and the
+  chart's arrival state land with this document; the readout's caption, its
+  per-hour rows, the box growing and `periodS` land in the next one, and #194's
+  animated field is blocked on that rather than on this. The decision is one
+  decision and is written once; splitting it to match the branches would leave
+  neither half able to state the argument.
+- **`HourChart`'s hour arithmetic is wrong on the two DST days a year**, and this
+  decision inherits it rather than fixing or worsening it. The hour is derived as
+  `Math.round((point.atMs - startMs) / HOUR_MS)`, which is an index into the day,
+  and `hourLabel` reads it as a clock hour — but `localMidnightOf` resolves the
+  zone offset twice, so a fall-back day is 25 hours long and index 24 renders
+  "12 PM", colliding with noon. The shared hour uses that same index convention
+  and the caption prints through that same `hourLabel`, so the chart and the map
+  can never disagree about what to call an hour, correct or not, and the fix
+  stays a single-site one.

--- a/docs/plans/map-weather-readout.md
+++ b/docs/plans/map-weather-readout.md
@@ -424,3 +424,185 @@ Everything else in this plan is unchanged. The ADR in slice 2 records the corner
 choice alongside the dial leaving the map, because both are the same decision
 seen from two sides: the readout stops covering the picture, and where it stands
 is what makes that true.
+
+## Addendum — 2026-08-31: the readout is an hour instrument, and its default is now
+
+**Grilled before slice 5 started, the design above turned out to be answering
+the wrong question.** It proposed a block with two modes: the day's figures on
+arrival, one hour's once something was clicked. Asked what the map should show,
+the reviewer's answer was neither half of that — **the current wind and swell,
+and then whatever hour the reader moves to.**
+
+That is a different instrument, and a better answer to the clause it has to
+supersede.
+
+### What it fixes in the argument above
+
+The reversal was argued here as: "the wedge is the day's swing and means the
+same thing on all seven days, and the arrow is this hour read against it." That
+concedes ADR-0027's objection rather than answering it. The clause says a needle
+"whose meaning changes depending on what was last clicked is a different
+instrument from one showing the day's dominant direction" — and a block that is
+a day aggregate before the first click and an hour after it is _precisely_ that
+needle. The wedge behind it does not disambiguate: with nothing selected the
+arrow sits at the day's resultant, which is inside the wedge by construction,
+and with 3 PM selected it sits at 3 PM's bearing, also inside it. The two modes
+draw the same picture.
+
+**With no day mode, there is nothing to change meaning between.** The arrow is
+the wind at one hour, before any click and after every one. ADR-0027's real
+demand — "two needles that always mean the same thing on all seven days" — is
+met literally rather than argued around.
+
+**What that costs is the day-dominant direction, which leaves the map.** That is
+the honest price and the ADR states it rather than routing around it. The day
+survives as the wedge: a narrow one is a day that had a direction and a near-blob
+is a day that did not, which is the reading ADR-0034 already built the wedge for.
+The week grid and the hour chart carry the day's figures either way.
+
+### The six decisions
+
+**The caption is always present, and it names the hour.** Without it the block
+still changes its numbers with nothing visible saying what they now mean, which
+is the failure this page is least entitled to ship. It also closes a gap that
+exists today: the block prints `11.5 mph` with no visible statement that it is
+the daylight peak — that fact lives only in the provenance line under the map.
+
+Its cost is measured rather than assumed. `READOUT_BOX` is `{ width: 50, height:
+35 }`, and 35 was chosen as "the smallest height that holds the tallest thing the
+rows can wrap to" — at 320px the two rows wrap to three lines each, 88px, 32.4 of
+the 35 units. A third line needs about five more, so the box goes to 40, which
+`corner.ts` measured as moving three beaches to a different corner:
+`pacific-beach`, `mission-bay-de-anza-cove` and `mission-bay-sea-world`. Always
+present rather than appearing on click, so the reserved box matches the ink in
+both states and the block never jumps.
+
+**The default is the current clock hour, resolved against whichever day is
+showing.** Six of the seven days have no "now" — `DayPanel` sets `nowMs` from
+`day.isToday` and null otherwise — so "the current hour" needs a rule for
+Thursday. It is the same clock hour: at 3:40 PM every day defaults to its own
+3 PM. One rule, one meaning on all seven days, and it is how a parent reads a
+forecast — what is Thursday like at this time.
+
+Rejected: today shows now and the other six show the daylight peak. It reads
+well until a reader steps from today to Friday and the figures change meaning
+with no click, which is the two-mode failure moved from the click to the day
+selector.
+
+**The current hour is computed on the server and passed down.** The page carries
+`revalidate = 900`, so a client that read its own clock would disagree with a
+fifteen-minute-old cache across an hour boundary and hydrate wrong. `nowMs`
+already works exactly this way for the chart's now-line; this needs the Pacific
+clock hour instead, because six days carry no `nowMs`.
+
+**The chart arrives with that hour marked.** One selected hour, stated in two
+places, agreeing. The alternative — the context defaults to null and the readout
+resolves null as "now" — leaves nothing in the chart pointing at the hour the map
+is showing on the six days that have no now-line, so a reader cannot see where
+the figures came from. `aria-live` does not announce initial content, so a
+readout that is filled on arrival makes no announcement on load.
+
+**A chosen hour carries across days.** It already had to: the default resolves
+per day, so the shared value is an hour rather than an instant, and an hour
+survives a day change by construction. Letting a deliberate choice do anything
+else would mean a reader who picked 5 PM watches the page silently revert it on
+every day change — and comparing one hour across the week is the comparison
+`ChosenDay` says the week selector exists for.
+
+This reverses `ChosenDay`'s docstring, which presents the opposite as a virtue:
+"The _hour_ they chose does not survive, and that also falls out rather than
+being arranged." It fell out of holding an instant. An hour is strictly more
+portable — it survives tab changes, which is the property `HourChart`'s comment
+gives for choosing an instant in the first place, _and_ day changes, which an
+instant cannot.
+
+**The wedge stays the daylight swing, and the arrow may leave it at night.** The
+reviewer asked for the selected hour to be reflected even at night, so the arrow
+is no longer daylight-bound and the wedge still is. At 3 AM it can therefore sit
+outside its own wedge, which is a true statement — that hour's wind came from a
+direction it never came from while the sun was up — and `needleSentence` already
+qualifies the wedge as "in daylight", so the accessible form is correct and only
+the visual is unqualified.
+
+Rejected: widening the wedge to the whole day so the arrow is always inside it.
+It is the more consistent rule and it costs the thing the wedge is for.
+`needles.ts` records why: the committed run swings across north in its first
+three hours — 340, 20, 150 — so a wedge measured end to end draws a near-blob on
+a day that was settled from sunrise onward, and it narrows the daylight rule that
+ADR-0023, `WaveWeek` and the week grid all hold, for one mark.
+
+**The swell row is the nearest published step within ninety minutes, whole.**
+The plan said "the last published estimate", which is up to three hours stale
+where the nearest is at most ninety minutes, and has no answer at all at 00:00
+and 01:00 — `hourlyWaveHeights` interpolates only forward, and `waveHoursByDate`
+buckets the previous day's 23:00 publication to the previous date. Those hours
+were unreachable while the block was daylight-bound and are reachable now.
+
+Each published estimate owns the three hours centred on it, which is the bucket
+`ConditionsNotes` already explains. Outside any bucket the row is withheld,
+which covers both the start of the day and the holes a refused estimate leaves —
+`hourlyWaveHeights` does not bridge those, "nothing inside it claims a figure",
+and a map holding a four-and-a-half-hour-old estimate where the chart claims
+none would be the louder of the two saying the less honest thing. A withheld row
+takes its provenance line with it, which is ADR-0032's existing rule.
+
+**And the row is one estimate rather than a mix.** Height, period and direction
+all come off the same published step, with one time named. `WaveHour` carries an
+interpolated `heightFt` on every hour and a `directionDegT` only where CDIP
+issued one, so reading the row field by field would put two instants in one row.
+This is what `periodS` joining `WaveHour` is actually for: the committed fixture
+moves 16.67 s to 15.38 s between published points, so the period cannot come from
+the day's `WaveReading` either.
+
+### What this costs that the plan claimed
+
+**The map and the week grid will print different swell numbers for one day, and
+that invariant was stated.** `DayPanel` records it: the swell figure "is
+`swellFigure`, so the week grid and this readout cannot print different numbers
+for Thursday". The grid states the day's biggest daylight step; the map now
+states the hour a reader is looking at. Two different facts, each labelled by its
+own caption and its own provenance line — which is the condition ADR-0010 and
+ADR-0029 both set, rather than an exception to them.
+
+The same goes for the wind: `peakInDaylight` no longer feeds the readout's
+figure. The wedge still needs `gridWindReadings`, so `needles.ts` keeps its
+daylight half and gains an hourly one beside it.
+
+### Slice 2 splits in two
+
+The work above is four implementation slices across `HourChart` (1,199 lines and
+a 46 KB test), `DayPanel`, `Compass`, `DayCompass`, `corner.ts`, `needles.ts` and
+`conditions.ts` (a 71 KB test) — past the guide CLAUDE.md sets. It splits where
+the dependency really is:
+
+**PR 2a — the chart owns an hour (#193).** This addendum, the ADR, the
+`selectedHour` context, `HourChart` lifting into it with the current clock hour
+as its default, and the `Selected hour` entry in `CONTEXT.md`. The map still
+shows the day at the end of it; what lands is a chart that arrives with an hour
+marked and keeps it across days and tabs.
+
+**PR 2b — the readout follows it.** Blocked on 2a. The caption, the per-hour
+wind row, `READOUT_BOX` to 40 with `corner.test.ts` re-measured, `periodS` on
+`WaveHour`, the per-hour swell row, and the `Readout` entry in `CONTEXT.md`.
+PR 3 (#194) is blocked on this rather than on 2a, because the animated field's
+parameters are the hour's.
+
+**The ADR is whole and lands in 2a**, rather than being split to match the
+branches. It is one decision — the page has one selected hour, it defaults to
+now, and the readout shows it — and two ADRs describing halves of it would leave
+neither able to state the argument. It says which half ships where.
+
+### Noticed, not fixed
+
+`HourChart` derives an hour as `Math.round((point.atMs - startMs) / HOUR_MS)` and
+hands it to `hourLabel`, which reads it as a clock hour. `localMidnightOf`
+resolves the zone offset twice, so `startMs` and `endMs` are true local midnights
+and a DST day is 23 or 25 hours long: on the fall-back day index 24 renders
+"12 PM", colliding with noon, and every hour after 2 AM is off by one. The
+forecast window is seven days, so it is reachable twice a year.
+
+It predates this work and is its own slice. What this plan owes it is not to make
+it worse: the shared hour uses `HourChart`'s existing index convention and the
+readout's caption prints through the same `hourLabel`, so the chart and the map
+can never disagree about what to call an hour — correct or not — and the fix
+stays a single-site one.

--- a/docs/plans/map-weather-readout.md
+++ b/docs/plans/map-weather-readout.md
@@ -460,7 +460,7 @@ survives as the wedge: a narrow one is a day that had a direction and a near-blo
 is a day that did not, which is the reading ADR-0034 already built the wedge for.
 The week grid and the hour chart carry the day's figures either way.
 
-### The six decisions
+### The seven decisions
 
 **The caption is always present, and it names the hour.** Without it the block
 still changes its numbers with nothing visible saying what they now mean, which
@@ -564,9 +564,37 @@ states the hour a reader is looking at. Two different facts, each labelled by it
 own caption and its own provenance line — which is the condition ADR-0010 and
 ADR-0029 both set, rather than an exception to them.
 
-The same goes for the wind: `peakInDaylight` no longer feeds the readout's
-figure. The wedge still needs `gridWindReadings`, so `needles.ts` keeps its
-daylight half and gains an hourly one beside it.
+**The day's biggest wind is the page's only statement of that figure, and
+ADR-0034 says otherwise.** That ADR justifies drawing the readout on all 51
+beaches partly on the cost of withholding it — "nearly half the inventory printed
+no wind figure anywhere on the picture, the same figure the week grid above
+states for every one of those beaches". The week grid states no wind figure.
+`WeekPanel` declines it deliberately and says why: temperature and wind "come
+from the air station rather than an airport", and "moving those to a forecast is
+the displacement ADR-0019 declined to decide". The grid's rows are tides, swell,
+daylight and sky.
+
+So `peakInDaylight` feeding `windFigure` at `DayPanel.tsx:696` is the only place
+this page states the day's biggest wind, and an hour instrument would remove it.
+**It moves into the provenance line instead of being lost.** `WaveWeek`'s rule
+already puts the superlative in the provenance label — "Biggest wind in
+daylight" — so the label gains the figure and the hour it happened at. The lines
+sit outside the readout's box, so this costs none of the width that is the
+block's whole constraint, and it puts the day and the hour a few centimetres
+apart where they can be compared.
+
+Rejected: accepting the loss, on the grounds that the peak is the top of the
+wind curve and a reader can select that hour. It is the closest this design comes
+to breaching ADR-0027's "only additively" condition, and a figure that is on the
+page today and gone tomorrow with nothing announcing it is what "nothing fails
+silently" is for. Also rejected: marking the peak hour on the curve, which is a
+fifth mark on a plot already carrying a now-line, night bands, a cloud band,
+published-point marks and the selection guide, and would need a rule for the
+other three tabs.
+
+`needles.ts` therefore keeps its daylight half and gains an hourly one beside it:
+the wedge still needs `gridWindReadings`, and `peakInDaylight` still feeds the
+figure that moved.
 
 ### Slice 2 splits in two
 

--- a/src/components/conditions/ChosenDay.tsx
+++ b/src/components/conditions/ChosenDay.tsx
@@ -19,10 +19,17 @@
  *
  * **The chart is not keyed on the day, deliberately.** Changing the day keeps
  * the same `HourChart` mounted, so the tab a reader chose stays chosen as they
- * move across the week -- which is the comparison the tabs exist for. The
- * *hour* they chose does not survive, and that also falls out rather than being
- * arranged: `HourChart` holds the selection as an instant, and an instant on
- * Tuesday matches no point in Thursday.
+ * move across the week -- which is the comparison the tabs exist for.
+ *
+ * **The hour survives too, and it did not always.** It used to fall out of
+ * `HourChart` holding the selection as an instant: an instant on Tuesday
+ * matches no point in Thursday, so the selection cleared itself. That was
+ * recorded here as a virtue and it was not one. The hour is now the page's
+ * rather than the chart's -- `selectedHour.tsx` -- and it is held as an hour of
+ * the day, so it resolves against whichever day is showing. A reader comparing
+ * 5 PM across the week is doing the same thing with the hour that the tabs let
+ * them do with the product, on the region this file already says the week
+ * selector exists to make comparable.
  *
  * **The heading names the day, because the region no longer always means
  * today.** It says "Today, hour by hour" on arrival and on today, and the

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -406,10 +406,57 @@ test("the swell tab marks CDIP's own estimates and no others", async () => {
   fireEvent.click(container.querySelector('[data-series-tab="swell"]')!);
 
   const plot = container.querySelector('svg[aria-label^="Swell today"]');
-  expect(plot?.querySelectorAll("circle")).toHaveLength(8);
+  // Scoped to the published marks rather than every circle in the plot: the
+  // chart now arrives on an hour, so its selection mark is a circle too, and
+  // counting all of them would count the reader's position as an estimate.
+  expect(plot?.querySelectorAll("[data-marks] circle")).toHaveLength(8);
   // And the sentence says it too, for a reader who gets no marks at all.
   expect(plot?.getAttribute("aria-label")).toContain(
     "publishes every three hours and issued 8 estimates",
+  );
+});
+
+test("the panel opens on the hour it is now, taken from the daylight read", () =>
+  DayPanel({ slug: "la-jolla-shores-beach" }).then((node) => {
+    // The one place the current hour is actually computed. `NOW` is 2 PM, and
+    // the read that carries it is the same one the "now" line is drawn from --
+    // which is why they cannot name different hours.
+    const { container } = render(node);
+
+    expect(container.querySelector("[data-selected-mark]")).not.toBeNull();
+    expect(
+      container.querySelector("[data-hour-readout]")?.textContent,
+    ).toContain("2 PM");
+  }));
+
+test("a read that names no day today selects no hour, rather than midnight", async () => {
+  // Unreachable through `weekOfDays`, which builds its array from today
+  // outward -- so this asserts the shape of the failure rather than a state the
+  // page reaches. It is here because the alternative was passing a made-up hour
+  // to satisfy the signature, and a page whose read went wrong selecting
+  // midnight plausibly is worse than selecting nothing visibly.
+  readDaylightWeek.mockReturnValue({
+    beachName: BINDING.beachName,
+    atMs: NOW,
+    days: [TODAY, TOMORROW].map((localDate) => ({
+      localDate,
+      dayLabel: "Mon, Aug 17",
+      dateLabel: "Mon, Aug 17",
+      isToday: false,
+      sunriseLabel: "6:14 AM",
+      sunsetLabel: "7:32 PM",
+      sunriseMs: localMidnightOf(localDate) + 6 * HOUR + 14 * 60_000,
+      sunsetMs: localMidnightOf(localDate) + 19 * HOUR + 32 * 60_000,
+    })),
+  });
+
+  const { container } = render(
+    await DayPanel({ slug: "la-jolla-shores-beach" }),
+  );
+
+  expect(container.querySelector("[data-selected-mark]")).toBeNull();
+  expect(container.querySelector("[data-hour-readout]")?.textContent).toBe(
+    "Pick an hour to read it.",
   );
 });
 
@@ -506,7 +553,9 @@ test("the wind tab marks each block the office issued, not every hour", async ()
 
   const plot = container.querySelector('svg[aria-label^="Wind today"]');
   expect(plot).not.toBeNull();
-  expect(plot?.querySelectorAll("circle")).toHaveLength(4);
+  // The published marks, not the selection mark beside them. See the swell
+  // tab's own count above.
+  expect(plot?.querySelectorAll("[data-marks] circle")).toHaveLength(4);
   expect(plot?.getAttribute("aria-label")).toContain(
     "in blocks rather than by the hour, and this day's is made of 4 of them",
   );

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -69,6 +69,8 @@ import { MeasuredToday } from "./MeasuredToday";
 import { ReservedSlot } from "../ui/ReservedSlot";
 import type { CompassNeedle } from "./Compass";
 import { DayCompass, DayCompassSources, type CompassDay } from "./DayCompass";
+import { hourOfDay } from "./dayFrame";
+import { SelectedHourProvider } from "./selectedHour";
 import {
   GRID_MODEL_NOTE,
   GRID_NETWORK,
@@ -765,23 +767,48 @@ export async function DayPanel({ slug }: { slug: string }) {
     return { localDate: day.localDate, needles };
   });
 
+  /*
+    Which hour it is now, as an index into any of the seven days.
+
+    Computed here rather than in the client, because the page carries
+    `revalidate = 900` and a client reading its own clock would disagree with a
+    fifteen-minute-old cached render across an hour boundary and hydrate wrong.
+    It is the same reason `nowMs` is a prop rather than a `Date.now()` in the
+    plot, and the value comes from the same read, so the chart's now-line and
+    the hour it arrives on cannot name different hours.
+
+    `isToday` from the daylight read rather than `nowMs !== null` on the built
+    days, which is the distinction `nowMs`'s own comment above draws: six days
+    carry null and reading that as a contract would be reading a coincidence of
+    construction. `undefined` is unreachable -- `weekOfDays` is built from this
+    same instant, so exactly one of the seven is today -- and it is answered
+    with null rather than a made-up hour, because a page whose read went wrong
+    should select nothing visibly rather than midnight plausibly.
+  */
+  const today = daylight.days.find((day) => day.isToday);
+  const currentHour =
+    today === undefined
+      ? null
+      : hourOfDay(daylight.atMs, localMidnightOf(today.localDate));
+
   return (
     <section aria-labelledby="day-panel-heading">
-      <ChosenDay
-        days={days}
-        map={
-          shore === null ? null : (
-            <>
-              <ShoreMap
-                {...shore}
-                description={mapDescription(beach!.name)}
-                absence="We cannot place this beach on a map: the coordinates we hold for it are all one point."
-                noCoast="The coastline this site traces is the open coast, and it does not reach this beach."
-                coastCredit={`Shore traced from CDIP's model lines, which are computed a few hundred metres offshore — so the water's edge is drawn further out than the sand.`}
-                readout={<DayCompass days={compassDays} />}
-                readoutSources={<DayCompassSources days={compassDays} />}
-              />
-              {/*
+      <SelectedHourProvider currentHour={currentHour}>
+        <ChosenDay
+          days={days}
+          map={
+            shore === null ? null : (
+              <>
+                <ShoreMap
+                  {...shore}
+                  description={mapDescription(beach!.name)}
+                  absence="We cannot place this beach on a map: the coordinates we hold for it are all one point."
+                  noCoast="The coastline this site traces is the open coast, and it does not reach this beach."
+                  coastCredit={`Shore traced from CDIP's model lines, which are computed a few hundred metres offshore — so the water's edge is drawn further out than the sand.`}
+                  readout={<DayCompass days={compassDays} />}
+                  readoutSources={<DayCompassSources days={compassDays} />}
+                />
+                {/*
                 The sighting layer from #121, reserved *on* the map rather than
                 instead of it. Until this slice the slot stood where a map would
                 go and said a map was coming; the map is here, so what is
@@ -796,18 +823,19 @@ export async function DayPanel({ slug }: { slug: string }) {
                 which mocks this component and would pass while the slot said
                 nothing at all. No issue number, per the standing rule.
               */}
-              <div className="mt-4">
-                <ReservedSlot
-                  emoji="🐙"
-                  headline="Sightings will be drawn on this map."
-                  detail="Will show octopus, nudibranchs, sea hares and leopard sharks logged near this beach in the past week — reported by naturalists, not surveyed by us."
-                  density="row"
-                />
-              </div>
-            </>
-          )
-        }
-      />
+                <div className="mt-4">
+                  <ReservedSlot
+                    emoji="🐙"
+                    headline="Sightings will be drawn on this map."
+                    detail="Will show octopus, nudibranchs, sea hares and leopard sharks logged near this beach in the past week — reported by naturalists, not surveyed by us."
+                    density="row"
+                  />
+                </div>
+              </>
+            )
+          }
+        />
+      </SelectedHourProvider>
     </section>
   );
 }

--- a/src/components/conditions/HourChart.test.tsx
+++ b/src/components/conditions/HourChart.test.tsx
@@ -1,10 +1,40 @@
 import { describe, expect, test } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  fireEvent,
+  render as renderBare,
+  screen,
+} from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
+import type { ReactElement } from "react";
 import { HourChart, NARROW_FRAME } from "./HourChart";
+import { SelectedHourProvider } from "./selectedHour";
 import { TOUCH_TARGET } from "../ui/touchTarget";
 import type { SparkPoint } from "./DaySpark";
 import { localMidnightOf } from "@/lib/pacific-time";
+
+/**
+ * Every render mounts the chart the way the page does: inside the hour
+ * provider.
+ *
+ * **The chart no longer owns the hour**, so rendering it bare tests an
+ * arrangement the page never builds -- one where the columns and the stepper
+ * are drawn and the context's no-op `choose` swallows every press. `WeekGrid`
+ * has had the same property since `selectedDay.tsx` and answers it the same
+ * way: the component's own tests mount it under its provider, and what the
+ * provider and its consumers do to each other is asserted at the seam, in
+ * `selectedHour.test.tsx`.
+ *
+ * `currentHour` is null here rather than an hour, which is the read-went-wrong
+ * degradation `selectedHour.tsx` documents. It is the right fixture for this
+ * file: it keeps every test's premise -- nothing is selected until something
+ * selects it -- so these go on asserting this component's own behaviour rather
+ * than the default's, which is the seam's to assert.
+ */
+function render(ui: ReactElement) {
+  return renderBare(
+    <SelectedHourProvider currentHour={null}>{ui}</SelectedHourProvider>,
+  );
+}
 
 /**
  * One ordinary Pacific day. Every instant is derived from it rather than

--- a/src/components/conditions/HourChart.test.tsx
+++ b/src/components/conditions/HourChart.test.tsx
@@ -809,9 +809,15 @@ describe("what a reader without JavaScript gets", () => {
     // reader with a blocked script ever sees. ADR-0025 requires the plot itself
     // to render here -- it is the page's primary content -- and
     // `BeachSelector`'s docstring records the other half: a control that
-    // silently does nothing is worse than no control. There is nothing to fall
-    // back *to* for per-hour detail, since that detail is not on the page in
-    // any other form, so the honest fallback is no affordance at all.
+    // silently does nothing is worse than no control.
+    //
+    // **The readout is on the other side of that line now**, which is ADR-0035.
+    // It used to be gated with the buttons and asserted absent here; it is a
+    // stated fact rather than an affordance, and the page opens on an hour, so
+    // withholding it would leave this reader looking at a marked point with no
+    // word about which hour it marks. What stays absent is anything they could
+    // press. The hour itself is `selectedHour.test.tsx`'s to assert, because
+    // the value comes from the provider rather than from this component.
     const markup = renderToStaticMarkup(
       <HourChart
         {...PROPS}
@@ -827,11 +833,12 @@ describe("what a reader without JavaScript gets", () => {
     expect(markup).toContain("data-now");
     expect(markup).toContain("Low 0.2 ft");
     expect(markup).toContain("12 AM");
+    expect(markup).toContain("data-hour-readout");
 
-    // And not one dead button.
+    // And not one dead button, nor an instruction to press one.
     expect(markup).not.toContain("data-hour-column");
     expect(markup).not.toContain("data-hour-prev");
-    expect(markup).not.toContain("data-hour-readout");
+    expect(markup).not.toContain("Pick an hour");
     expect(markup).not.toContain("<button");
   });
 });

--- a/src/components/conditions/HourChart.tsx
+++ b/src/components/conditions/HourChart.tsx
@@ -91,6 +91,19 @@
  * `BeachSelector`'s `noscript` list exists to prevent. The chart itself still
  * renders on the server, complete, which is what ADR-0025 requires.
  *
+ * **The selection is not a control, and does not wait with them.** The chart
+ * arrives on the current hour rather than on nothing, so the guide and the mark
+ * are in the server's render -- and a reader without JavaScript gets a stated
+ * hour they cannot change rather than an affordance that does not work. That is
+ * the distinction the rule above was always drawing: a dead button is a lie
+ * about what the page can do, and a printed fact is not.
+ *
+ * **The hour belongs to the page rather than to this component.** The map's
+ * readout shows it too, and the two regions stating different things about one
+ * day is what #193 was. `selectedHour.tsx` holds it and holds the argument;
+ * ADR-0035 records why a readout that follows the hour no longer breaches
+ * ADR-0027's clause against one that does.
+ *
  * **The "now" line appears on today and on no other day.** A vertical rule at
  * an instant is a claim about the present, and drawing one on Thursday would
  * say the reader is standing in Thursday. The instant comes from
@@ -101,8 +114,9 @@
 "use client";
 
 import { useId, useState } from "react";
-import { nightBands } from "./dayFrame";
+import { hourOfDay, nightBands } from "./dayFrame";
 import { useHydrated } from "./hydrated";
+import { resolveHour, useSelectedHour } from "./selectedHour";
 import type { SparkPoint } from "./DaySpark";
 import { ProvenanceLine, type ProvenanceFacts } from "./ProvenanceLine";
 import { TOUCH_TARGET } from "../ui/touchTarget";
@@ -411,19 +425,29 @@ export function HourChart({
   cloudDescription = "Cloud cover through the day.",
   nowMs = null,
 }: HourChartProps) {
-  /**
-   * The chosen hour, held as an instant rather than as an index into `points`.
-   *
-   * **So that switching tabs keeps the hour.** An index means something
-   * different in each series -- the tide has twenty-four points and a swell
-   * that ran out at teatime has fewer -- so index 9 would land on 9 AM in one
-   * and mid-afternoon in another. An instant means the same thing in all four,
-   * and a tab with no point at that instant simply has nothing selected, which
-   * is the honest answer rather than the nearest one.
-   */
-  const [selectedMs, setSelectedMs] = useState<number | null>(null);
+  /*
+    The chosen hour is the page's rather than this component's, because the
+    map's readout shows it too and the two regions stating different things
+    about one day is the whole of #193. `selectedHour.tsx` holds the argument
+    for its shape; what matters here is that it is an hour of the day rather
+    than a position in `points`.
+
+    **Which is what kept the hour across a tab change, and now keeps it across
+    a day change too.** A position means something different in each series --
+    the tide has twenty-four points and a swell that ran out at teatime has
+    fewer -- so index 9 would land on 9 AM in one and mid-afternoon in another.
+    An hour means the same thing in all four and on all seven days, and a series
+    with no point at that hour simply has nothing selected, which is the honest
+    answer rather than the nearest one. This component held an instant for the
+    first half of that; an hour is the same argument carried one step further.
+  */
+  const { selected: chosenHour, choose, currentHour } = useSelectedHour();
+  const shownHour = resolveHour(chosenHour, currentHour);
   const [tab, setTab] = useState(0);
   const tabIds = useId();
+
+  /** This day's own hour for a point, through the one module that defines it. */
+  const hourOf = (point: SparkPoint) => hourOfDay(point.atMs, startMs);
 
   /*
     The controls exist only once they can work. Rendered on the server they
@@ -652,29 +676,26 @@ export function HourChart({
 
   /** Cloud by the hour it covers, so a readout can name the sky at that hour. */
   const cloudByHour = new Map(
-    cloud.map((hour) => [
-      Math.round((hour.atMs - startMs) / HOUR_MS),
-      hour.value,
-    ]),
+    cloud.map((hour) => [hourOfDay(hour.atMs, startMs), hour.value]),
   );
 
   /**
-   * Where the chosen instant falls in *this* series, or -1 when it does not.
+   * Where the shown hour falls in *this* series, or -1 when it does not.
    *
    * Exact rather than nearest. A swell tab whose forecast ran out at teatime
    * has no 8 PM, and quietly selecting 5 PM instead would put a figure under a
-   * heading the reader chose for a different hour.
+   * heading the reader chose for a different hour. It is also what makes the
+   * arrival state honest: the current hour is resolved the same way as a chosen
+   * one, so a series that does not reach now shows no selection rather than
+   * being given the nearest point it happens to hold.
    */
   const selected =
-    selectedMs === null
+    shownHour === null
       ? -1
-      : points.findIndex((point) => point.atMs === selectedMs);
+      : points.findIndex((point) => hourOf(point) === shownHour);
 
   const selectedPoint = selected === -1 ? null : (points[selected] ?? null);
-  const selectedHour =
-    selectedPoint === null
-      ? null
-      : Math.round((selectedPoint.atMs - startMs) / HOUR_MS);
+  const selectedHour = selectedPoint === null ? null : shownHour;
 
   /**
    * What one hour says when it is chosen.
@@ -704,7 +725,7 @@ export function HourChart({
   /** Select by position in this series, which is how both controls move. */
   const selectAt = (index: number) => {
     const point = points[Math.min(points.length - 1, Math.max(0, index))];
-    if (point !== undefined) setSelectedMs(point.atMs);
+    if (point !== undefined) choose(hourOf(point));
   };
 
   /** Move the selection, wrapping at neither end: a day has two ends and they hold. */
@@ -1047,7 +1068,7 @@ export function HourChart({
                 data-hour-columns
               >
                 {points.map((point, index) => {
-                  const hour = Math.round((point.atMs - startMs) / HOUR_MS);
+                  const hour = hourOf(point);
                   const cloudAt = cloudByHour.get(hour);
                   return (
                     <button

--- a/src/components/conditions/HourChart.tsx
+++ b/src/components/conditions/HourChart.tsx
@@ -1142,10 +1142,20 @@ export function HourChart({
           `aria-live="polite"` because the change is the whole point and a
           reader moving through the hours with the arrow keys is not looking at
           this line. A reserved minimum height keeps the page from jumping when
-          the first hour is chosen.
+          the first hour is chosen. It announces nothing on arrival, because a
+          live region does not announce the content it is born with -- which is
+          what lets the chart open on an hour without speaking over the page.
+
+          **The sentence is not gated on hydration and the buttons are**, which
+          is ADR-0035 drawing the line ADR-0027's rule was always about. A
+          button that cannot work is a lie about what the page can do; a stated
+          fact is not, and the mark it explains is in the server's render
+          either way. Gating the sentence with the buttons would leave a reader
+          without a script looking at a marked hour and no word about which
+          hour it is.
         */}
-        {mounted && (
-          <div className="mt-4 flex flex-wrap items-center gap-2">
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          {mounted && (
             <div className="flex gap-1.5">
               <button
                 type="button"
@@ -1166,15 +1176,25 @@ export function HourChart({
                 Later →
               </button>
             </div>
-            <p
-              className="text-2xs leading-relaxed min-h-4 flex-1 text-ocean"
-              aria-live="polite"
-              data-hour-readout
-            >
-              {readout() ?? "Pick an hour to read it."}
-            </p>
-          </div>
-        )}
+          )}
+          <p
+            className="text-2xs leading-relaxed min-h-4 flex-1 text-ocean"
+            aria-live="polite"
+            data-hour-readout
+          >
+            {/*
+              The invitation is offered only where it can be accepted.
+
+              Without a script there is no way to pick an hour, so "Pick an hour
+              to read it." would be an instruction to use a control that is not
+              there -- the same failure the buttons are gated to avoid, in
+              words instead of in a button. It is reached only when this series
+              does not run as far as the hour the page opened on, because the
+              hour is otherwise always resolved.
+            */}
+            {readout() ?? (mounted ? "Pick an hour to read it." : "")}
+          </p>
+        </div>
 
         <p className="text-2xs leading-relaxed mt-3 text-fog">
           Low {lowValue.toFixed(1)} {unitLabel}, high {highValue.toFixed(1)}{" "}

--- a/src/components/conditions/dayFrame.ts
+++ b/src/components/conditions/dayFrame.ts
@@ -40,6 +40,34 @@ export interface DayBounds {
   sunsetMs: number;
 }
 
+const HOUR_MS = 3_600_000;
+
+/**
+ * Which hour of its day an instant falls in.
+ *
+ * **The one place the convention lives.** The chart draws the hours and the day
+ * panel computes which one is now, so without a shared definition the two could
+ * name one hour differently -- and the readout on the map reads the same value
+ * again. That is this module's own argument applied past the night band: two
+ * plots agreeing about a quantity is enforceable only when there is one
+ * definition of it.
+ *
+ * It is here rather than beside the selection it feeds because the selection
+ * module is `"use client"`, and the default is computed on the server. The
+ * hour's definition is day geometry; which hour a reader chose is not.
+ *
+ * **It is an index into the day rather than a clock hour**, and on the two days
+ * a year this coast changes offset the two diverge: `localMidnightOf` resolves
+ * the zone offset twice, so a fall-back day is twenty-five hours long. The
+ * chart's `hourLabel` reads this index as a clock hour and is wrong for it on
+ * those days. That defect predates the sharing and is inherited here rather
+ * than forked, so the two regions stay wrong together rather than
+ * disagreeing -- see ADR-0035's last consequence.
+ */
+export function hourOfDay(atMs: number, dayStartMs: number): number {
+  return Math.round((atMs - dayStartMs) / HOUR_MS);
+}
+
 /**
  * The dark ends of one day, in the caller's own plot units.
  *

--- a/src/components/conditions/selectedDay.test.tsx
+++ b/src/components/conditions/selectedDay.test.tsx
@@ -14,6 +14,7 @@ import { localMidnightOf } from "@/lib/pacific-time";
 import { ChosenDay, type DayView } from "./ChosenDay";
 import { DayCompass, type CompassDay } from "./DayCompass";
 import { SelectedDayProvider } from "./selectedDay";
+import { SelectedHourProvider } from "./selectedHour";
 import { WeekGrid, type WeekDay, type WeekRow } from "./WeekGrid";
 import type { SparkPoint } from "./DaySpark";
 
@@ -138,7 +139,20 @@ function renderBoth(map: React.ReactNode = null) {
         days={DAYS}
         rows={[TIDE_ROW]}
       />
-      <ChosenDay days={VIEWS} map={map} />
+      {/*
+        The hour provider inside the day one, which is the nesting `DayPanel`
+        builds: the week does not need the hour, and the day region does. It is
+        here rather than in the tests that use it because the day selection is
+        no longer separable from it -- a chosen hour now has to survive a change
+        of day, which is a fact about the pair.
+
+        `currentHour` is null so these tests keep their premise that the page
+        opens with no hour chosen. What the default does instead is
+        `selectedHour.test.tsx`'s to assert.
+      */}
+      <SelectedHourProvider currentHour={null}>
+        <ChosenDay days={VIEWS} map={map} />
+      </SelectedHourProvider>
     </SelectedDayProvider>,
   );
 }
@@ -283,9 +297,8 @@ test("the 'now' line follows today, and does not follow the choice", () => {
 
 test("the tab a reader chose survives a change of day", () => {
   // The comparison the tabs exist for is across days, so the chart is not keyed
-  // on the day and stays mounted. The chosen *hour* does not survive, and that
-  // falls out rather than being arranged: the selection is an instant, and an
-  // instant on Monday matches no point in Wednesday.
+  // on the day and stays mounted. The chosen hour survives with it -- see
+  // `selectedHour.test.tsx`, which owns that half now.
   const { container } = renderBoth();
 
   fireEvent.click(container.querySelector('[data-series-tab="swell"]')!);
@@ -295,7 +308,12 @@ test("the tab a reader chose survives a change of day", () => {
   expect(drawnDay(container)).toBe(`Swell on ${DATES[2]}`);
 });
 
-test("the chosen hour does not survive it, because that instant is not in this day", () => {
+test("the chosen hour survives it too, resolved against the new day", () => {
+  // The reversal ADR-0035 records, asserted where the day selection lives.
+  // This used to assert the opposite -- that the hour cleared itself, because
+  // the selection was an instant and an instant on Monday matches no point in
+  // Tuesday. That was the accident being read as a feature: a reader who chose
+  // 9 AM to compare it across the week got it taken away on every step.
   const { container } = renderBoth();
 
   fireEvent.click(container.querySelector('[data-hour-column="9"]')!);
@@ -304,9 +322,13 @@ test("the chosen hour does not survive it, because that instant is not in this d
   );
 
   fireEvent.click(container.querySelector(`[data-day-choice="${DATES[1]}"]`)!);
-  expect(container.querySelector("[data-hour-readout]")?.textContent).toBe(
-    "Pick an hour to read it.",
+  expect(container.querySelector("[data-hour-readout]")?.textContent).toContain(
+    "9 AM",
   );
+  // And it is the new day's 9 AM rather than a stale reading: this fixture's
+  // curves differ per day, so a chart still showing Monday's figure would say
+  // so here.
+  expect(drawnDay(container)).toBe(`Tide on ${DATES[1]}`);
 });
 
 test("without a script the week is whole and offers no control", () => {

--- a/src/components/conditions/selectedHour.test.tsx
+++ b/src/components/conditions/selectedHour.test.tsx
@@ -1,0 +1,293 @@
+/**
+ * The hour the page is showing, asserted at the seam that owns it.
+ *
+ * Neither component owns this behaviour. The chart offers the choice, the
+ * default comes from a read neither of them makes, and -- once the readout
+ * follows in the next pull request -- a second region answers the same fact.
+ * `selectedDay.test.tsx` made the same argument for the day and this follows
+ * it: render the real components inside the real provider, rather than testing
+ * each half against a mock of the other and proving nothing about the pair.
+ *
+ * **The day is here too, because the two selections interact.** A chosen hour
+ * has to survive a change of day, and that is a claim about both providers
+ * nested the way `DayPanel` nests them.
+ */
+
+import { expect, test } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { localMidnightOf } from "@/lib/pacific-time";
+import { ChosenDay, type DayView } from "./ChosenDay";
+import { SelectedDayProvider } from "./selectedDay";
+import { hourOfDay } from "./dayFrame";
+import { SelectedHourProvider, resolveHour } from "./selectedHour";
+import { WeekGrid, type WeekDay, type WeekRow } from "./WeekGrid";
+import type { SparkPoint } from "./DaySpark";
+
+const HOUR = 3_600_000;
+const DATES = ["2026-08-17", "2026-08-18", "2026-08-19"];
+
+const DAYS: WeekDay[] = DATES.map((localDate, index) => ({
+  localDate,
+  dayLabel: ["Mon, Aug 17", "Tue, Aug 18", "Wed, Aug 19"][index],
+  dateLabel: ["Aug 17", "Aug 18", "Aug 19"][index],
+  isToday: index === 0,
+}));
+
+const TIDE_ROW: WeekRow = {
+  label: "Lowest tide",
+  cells: Object.fromEntries(DATES.map((date) => [date, "6:41 PM"])),
+};
+
+/**
+ * A curve whose value encodes the day and the hour it belongs to.
+ *
+ * The readout prints the value, so an assertion on the readout's text is an
+ * assertion about *which day's* hour is drawn -- which is the thing that can go
+ * wrong when one value is resolved against seven frames.
+ */
+function points(dayIndex: number, hours = 24): SparkPoint[] {
+  return Array.from({ length: hours }, (_, hour) => ({
+    atMs: localMidnightOf(DATES[dayIndex]) + hour * HOUR,
+    value: dayIndex * 100 + hour,
+    published: true,
+  }));
+}
+
+function dayView(index: number, tideHours = 24): DayView {
+  const localDate = DATES[index];
+  const isToday = index === 0;
+  const startMs = localMidnightOf(localDate);
+  return {
+    localDate,
+    dayName: isToday ? "Today" : DAYS[index].dayLabel,
+    chartWhen: isToday ? "today" : `on ${DAYS[index].dayLabel}`,
+    startMs,
+    endMs: startMs + 24 * HOUR,
+    sunriseMs: startMs + 6 * HOUR,
+    sunsetMs: startMs + 19 * HOUR,
+    nowMs: isToday ? startMs + 14 * HOUR : null,
+    cloud: [],
+    series: [
+      {
+        key: "tide",
+        label: "Tide",
+        unitLabel: "ft",
+        points: points(index, tideHours),
+        description: `Tide on ${localDate}`,
+        absence: "No tide series.",
+        provenance: null,
+      },
+      {
+        key: "swell",
+        label: "Swell",
+        unitLabel: "ft",
+        points: points(index),
+        description: `Swell on ${localDate}`,
+        absence: "No swell series.",
+        provenance: null,
+      },
+    ],
+    wording: <p>Words for {localDate}</p>,
+    measured: <p>Measured on {localDate}</p>,
+  };
+}
+
+/** The two providers nested the way `DayPanel` nests them. */
+function renderPage(
+  currentHour: number | null,
+  views = DATES.map((_, i) => dayView(i)),
+) {
+  return render(
+    <SelectedDayProvider>
+      <WeekGrid
+        headingId="week-heading"
+        title="The week ahead"
+        days={DAYS}
+        rows={[TIDE_ROW]}
+      />
+      <SelectedHourProvider currentHour={currentHour}>
+        <ChosenDay days={views} map={null} />
+      </SelectedHourProvider>
+    </SelectedDayProvider>,
+  );
+}
+
+function readout(container: HTMLElement): string {
+  return container.querySelector("[data-hour-readout]")?.textContent ?? "";
+}
+
+test("the page opens on the current hour rather than on nothing", () => {
+  // The whole of the default. Before ADR-0035 the chart arrived with nothing
+  // selected and the map beside it showed a day aggregate; it now arrives on an
+  // hour, which is what lets one instrument mean one thing.
+  const { container } = renderPage(14);
+
+  expect(readout(container)).toContain("2 PM");
+  expect(container.querySelector("[data-selected-mark]")).not.toBeNull();
+});
+
+test("the arriving hour is this day's, not an instant from another", () => {
+  // The value encodes the day, so a chart resolving the hour against the wrong
+  // frame prints a number from the wrong hundred.
+  const { container } = renderPage(14);
+
+  // Day 0, hour 14.
+  expect(readout(container)).toContain("14.0 ft");
+});
+
+test("every day opens on the same clock hour, resolved against itself", () => {
+  // Six of the seven days have no `nowMs` at all, so "the current hour" needs a
+  // rule for Thursday, and this is it: the same clock hour on all seven. A rule
+  // that showed the day aggregate on the other six would make the readout mean
+  // two things depending on which day was chosen, which is the ambiguity
+  // ADR-0027 refuses.
+  const { container } = renderPage(14);
+
+  fireEvent.click(container.querySelector(`[data-day-choice="${DATES[2]}"]`)!);
+
+  expect(readout(container)).toContain("2 PM");
+  // Day 2, hour 14 -- so it resolved against the new day rather than carrying
+  // the old day's figure across.
+  expect(readout(container)).toContain("214.0 ft");
+});
+
+test("a chosen hour survives a change of day", () => {
+  // The reversal of `ChosenDay`'s old rule, and the reason for it: comparing one
+  // hour across the week is what the week selector is for, and a selection that
+  // cleared itself on every step made that impossible.
+  const { container } = renderPage(14);
+
+  fireEvent.click(container.querySelector('[data-hour-column="9"]')!);
+  expect(readout(container)).toContain("9 AM");
+
+  fireEvent.click(container.querySelector(`[data-day-choice="${DATES[1]}"]`)!);
+  expect(readout(container)).toContain("9 AM");
+  expect(readout(container)).toContain("109.0 ft");
+});
+
+test("a chosen hour survives a change of tab", () => {
+  // The property the selection had when it was an instant, kept now that it is
+  // an hour. An index would not have it: the two series need not be the same
+  // length.
+  const { container } = renderPage(14);
+
+  fireEvent.click(container.querySelector('[data-hour-column="9"]')!);
+  fireEvent.click(container.querySelector('[data-series-tab="swell"]')!);
+
+  expect(readout(container)).toContain("9 AM");
+});
+
+test("a series that does not reach the hour selects nothing, not the nearest", () => {
+  // Exact rather than nearest, which matters most on arrival: a swell forecast
+  // that ran out at teatime must not be given 5 PM's figure under a heading a
+  // reader never chose. The tide here stops at 10 AM and the current hour is
+  // 2 PM.
+  const views = [dayView(0, 10), dayView(1), dayView(2)];
+  const { container } = renderPage(14, views);
+
+  expect(readout(container)).toBe("Pick an hour to read it.");
+  expect(container.querySelector("[data-selected-mark]")).toBeNull();
+
+  // And the tab beside it, which does reach 2 PM, still shows it -- so this is
+  // the series answering honestly rather than the hour being lost.
+  fireEvent.click(container.querySelector('[data-series-tab="swell"]')!);
+  expect(readout(container)).toContain("2 PM");
+});
+
+test("no current hour selects nothing, which is what a failed read looks like", () => {
+  // `weekOfDays` is built from the same instant the daylight read carries, so
+  // exactly one of the seven days is today and this is unreachable. It is
+  // answered with null rather than a made-up hour because selecting midnight
+  // plausibly is worse than selecting nothing visibly.
+  const { container } = renderPage(null);
+
+  expect(readout(container)).toBe("Pick an hour to read it.");
+  expect(container.querySelector("[data-selected-mark]")).toBeNull();
+});
+
+test("the server render carries the hour, and still carries no control", () => {
+  // ADR-0027 mounts the controls only once they can work; ADR-0035 draws the
+  // line that rule was always drawing, which is between a dead button and a
+  // printed fact. The mark is the fact and it is not gated on hydration, so a
+  // reader without a script arrives on an hour like everyone else.
+  //
+  // Asserted on the mark rather than on the hour's words: `hourLabel` writes
+  // every axis label, so `toContain("2 PM")` is true of a chart with nothing
+  // selected at all and would pass without this feature existing.
+  const markup = renderToStaticMarkup(
+    <SelectedDayProvider>
+      <SelectedHourProvider currentHour={14}>
+        <ChosenDay days={DATES.map((_, i) => dayView(i))} map={null} />
+      </SelectedHourProvider>
+    </SelectedDayProvider>,
+  );
+
+  expect(markup).toContain("data-selected-mark");
+  expect(markup).toContain("data-selected-guide");
+  expect(markup).not.toContain("data-hour-prev");
+  expect(markup).not.toContain("data-hour-column");
+});
+
+test("without a current hour the server render marks nothing", () => {
+  // The control on the test above: it fails if the mark is drawn unconditionally
+  // rather than because an hour was resolved.
+  const markup = renderToStaticMarkup(
+    <SelectedDayProvider>
+      <SelectedHourProvider currentHour={null}>
+        <ChosenDay days={DATES.map((_, i) => dayView(i))} map={null} />
+      </SelectedHourProvider>
+    </SelectedDayProvider>,
+  );
+
+  expect(markup).not.toContain("data-selected-mark");
+});
+
+test("outside the provider the chart selects nothing, and its columns are inert", () => {
+  // Worth pinning rather than leaving to fall out. The chart used to hold the
+  // hour itself, so it worked alone; it no longer does, and the context's
+  // default `choose` swallows the press. `WeekGrid` has had exactly this shape
+  // since `selectedDay.tsx` -- a region outside its provider shows a default
+  // and offers no choice -- and this follows it rather than inventing a second
+  // mechanism for one problem.
+  //
+  // It is not a state the page reaches: `DayPanel` mounts the provider around
+  // the same subtree it renders the chart into, so the two cannot come apart
+  // without someone rewriting that file.
+  const { container } = render(
+    <ChosenDay days={DATES.map((_, i) => dayView(i))} map={null} />,
+  );
+
+  expect(readout(container)).toBe("Pick an hour to read it.");
+
+  fireEvent.click(container.querySelector('[data-hour-column="9"]')!);
+
+  expect(readout(container)).toBe("Pick an hour to read it.");
+  expect(container.querySelector("[data-selected-mark]")).toBeNull();
+});
+
+test("the hour is an index into its own day, from one definition", () => {
+  // The convention the chart and the readout share. It is asserted here rather
+  // than left to the two components because the whole point of the module is
+  // that there is one of it -- `dayFrame.ts` holds the night band for the same
+  // reason.
+  const startMs = localMidnightOf(DATES[0]);
+
+  expect(hourOfDay(startMs, startMs)).toBe(0);
+  expect(hourOfDay(startMs + 14 * HOUR, startMs)).toBe(14);
+  // Half past still belongs to the hour it is inside.
+  expect(hourOfDay(startMs + 14 * HOUR + 20 * 60_000, startMs)).toBe(14);
+});
+
+test("a chosen hour outranks the current one, and null falls back to it", () => {
+  // One function rather than `selected ?? currentHour` in two components, for
+  // `resolveSelected`'s reason: the two regions resolving the default
+  // differently would show up only on a page nobody had clicked yet, and would
+  // show up as them disagreeing about the hour -- which is the defect this
+  // whole change is fixing.
+  expect(resolveHour(9, 14)).toBe(9);
+  expect(resolveHour(null, 14)).toBe(14);
+  expect(resolveHour(null, null)).toBeNull();
+  // Midnight is a real choice, not an absent one.
+  expect(resolveHour(0, 14)).toBe(0);
+});

--- a/src/components/conditions/selectedHour.test.tsx
+++ b/src/components/conditions/selectedHour.test.tsx
@@ -227,6 +227,43 @@ test("the server render carries the hour, and still carries no control", () => {
   expect(markup).toContain("data-selected-guide");
   expect(markup).not.toContain("data-hour-prev");
   expect(markup).not.toContain("data-hour-column");
+
+  // And the sentence that says which hour the mark is, which is gated with the
+  // facts rather than with the buttons. Read out of the readout element rather
+  // than off the whole markup: `hourLabel` writes every axis label, so a bare
+  // search for "2 PM" would pass on a chart with nothing selected at all.
+  const sentence = markup
+    .split("data-hour-readout")[1]
+    ?.split("</p>")[0]
+    .replace(/^[^>]*>/, "");
+  expect(sentence).toContain("2 PM");
+  expect(sentence).toContain("14.0 ft");
+  expect(sentence).not.toContain("Pick an hour");
+});
+
+test("without a script the invitation to pick an hour is not offered", () => {
+  // The fallback wording is a control's instruction, so it is gated like one.
+  // Reached here because this day's tide stops at 10 AM and the page opens on
+  // 2 PM -- a reader with a script is told to pick an hour and can; a reader
+  // without one would be told to use a control that is not on the page.
+  const markup = renderToStaticMarkup(
+    <SelectedDayProvider>
+      <SelectedHourProvider currentHour={14}>
+        <ChosenDay days={[dayView(0, 10), dayView(1), dayView(2)]} map={null} />
+      </SelectedHourProvider>
+    </SelectedDayProvider>,
+  );
+
+  expect(markup).toContain("data-hour-readout");
+  expect(markup).not.toContain("Pick an hour");
+
+  // With a script, the same state does offer it.
+  const { container } = renderPage(14, [
+    dayView(0, 10),
+    dayView(1),
+    dayView(2),
+  ]);
+  expect(readout(container)).toBe("Pick an hour to read it.");
 });
 
 test("without a current hour the server render marks nothing", () => {

--- a/src/components/conditions/selectedHour.tsx
+++ b/src/components/conditions/selectedHour.tsx
@@ -1,0 +1,142 @@
+/**
+ * Which hour of the day the page is showing, shared between the plot that
+ * offers the choice and the readout that was ignoring it.
+ *
+ * **One selected hour, and no day mode.** `HourChart` held this as its own
+ * `useState` and the map's readout showed a day aggregate beside it, so the two
+ * regions stated different things about one day. ADR-0027 refused the obvious
+ * fix -- a needle "whose meaning changes depending on what was last clicked" --
+ * and ADR-0035 supersedes that clause by removing the thing that changes: the
+ * readout has no day mode to switch out of, because it shows an hour before any
+ * click as well as after every one.
+ *
+ * **An hour, not an instant.** `HourChart`'s own comment gives the reason it
+ * held an instant: an index means something different in each of the four
+ * series, so index 9 is 9 AM in one and mid-afternoon in another. An hour
+ * survives a tab change for that same reason -- it is resolved against each
+ * series by its own `atMs` -- *and* survives a day change, which an instant
+ * cannot, because an instant on Tuesday matches no point in Thursday. That
+ * second property is the one this file is for: the default resolves per day, so
+ * the shared value had to be a day-relative one either way, and a reader who
+ * chose 5 PM watching the page revert it on every day change is the one thing
+ * they cannot have meant.
+ *
+ * **Null means "whatever hour it is now", and nothing here reads a clock.**
+ * `selectedDay.ts` starts null and lets each consumer resolve it against its own
+ * first column, for the reason that only `conditions.ts` honestly knows what
+ * today is. The same holds twice over here: the page carries `revalidate = 900`,
+ * so a client reading its own clock would disagree with a fifteen-minute-old
+ * cached render across an hour boundary and hydrate wrong. `currentHour` is
+ * therefore supplied by the server read that already knows which day is today,
+ * and the server render and the first client render agree by construction.
+ *
+ * **The hour is an index into the day, which is `HourChart`'s convention rather
+ * than a new one.** That component derives an hour as
+ * `Math.round((atMs - startMs) / HOUR_MS)` and prints it through `hourLabel`,
+ * which reads an index as a clock hour -- and `localMidnightOf` resolves the
+ * zone offset twice, so a fall-back day is twenty-five hours long and the two
+ * diverge. That defect predates this file and is not fixed here; what this file
+ * owes it is not to introduce a second, disagreeing convention, so that the
+ * chart and the readout can never call one hour by two names and the fix stays
+ * a single-site one. See ADR-0035's last consequence.
+ */
+
+"use client";
+
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+type SelectedHour = {
+  /** The hour a reader chose, as an index into the day, or null for "now". */
+  selected: number | null;
+  choose: (hour: number) => void;
+  /**
+   * Which hour is now, as an index into any of the seven days.
+   *
+   * The same number on all seven, deliberately: at 3:40 PM every day shows its
+   * own 3 PM. Six of them have no "now" at all -- `DayPanel` sets `nowMs` from
+   * `day.isToday` and null otherwise -- so "the current hour" needs a rule for
+   * Thursday, and the same clock hour is the one rule that means the same thing
+   * on all of them.
+   *
+   * `null` outside the provider, where nobody has supplied a clock.
+   */
+  currentHour: number | null;
+};
+
+/**
+ * The default is the null state rather than a throw, which is `selectedDay.ts`'s
+ * choice and is made here for its reason.
+ *
+ * A chart rendered outside the provider selects nothing and offers no choice,
+ * which is the state it shipped in and a working degradation rather than a
+ * blank one. It is also what a test rendering one component in isolation gets,
+ * so the isolation does not have to be arranged.
+ */
+const SelectedHourContext = createContext<SelectedHour>({
+  selected: null,
+  choose: () => {},
+  currentHour: null,
+});
+
+export function SelectedHourProvider({
+  currentHour,
+  children,
+}: {
+  /**
+   * Which hour is now. Computed by the caller from the read that knows which
+   * day is today, never from a clock read here -- see the header.
+   *
+   * Nullable because the caller cannot prove to a type checker what it knows
+   * structurally: `weekOfDays` is built from the same instant, so exactly one
+   * of the seven days is today, always. Passing a made-up hour to satisfy the
+   * signature would select midnight on a page whose read had gone wrong; null
+   * selects nothing, which is what this chart did before it had a default and
+   * is visible rather than plausible.
+   */
+  currentHour: number | null;
+  children: ReactNode;
+}) {
+  const [selected, setSelected] = useState<number | null>(null);
+  return (
+    <SelectedHourContext value={{ selected, choose: setSelected, currentHour }}>
+      {children}
+    </SelectedHourContext>
+  );
+}
+
+export function useSelectedHour(): SelectedHour {
+  return useContext(SelectedHourContext);
+}
+
+/**
+ * `hourOfDay` lives in `dayFrame.ts` rather than here, and the build is what
+ * said so.
+ *
+ * This module is `"use client"`, so everything it exports is a client
+ * reference and `DayPanel` -- a server component -- cannot call it. That is not
+ * a packaging detail: the hour's *definition* is day geometry, shared by a
+ * server component that computes the default and a client one that draws it,
+ * where everything in this file is about a choice a reader makes. `dayFrame.ts`
+ * is already the module for "the geometry two plots of one day must agree
+ * about", and the reason given there is this one exactly.
+ */
+
+/**
+ * The chosen hour, or the one it is now, or nothing.
+ *
+ * One function rather than `selected ?? currentHour` written in two components,
+ * for `resolveSelected`'s reason and not a weaker version of it: the plot and
+ * the readout resolving the default differently is the exact failure this file
+ * exists to prevent, it would show up only on a page nobody had clicked yet,
+ * and it would show up as the two regions disagreeing about the hour -- which
+ * is the defect this whole change is fixing.
+ *
+ * `null` only when there is no provider above and therefore no clock, which is
+ * the degraded render rather than a state the page reaches.
+ */
+export function resolveHour(
+  selected: number | null,
+  currentHour: number | null,
+): number | null {
+  return selected ?? currentHour;
+}


### PR DESCRIPTION
Closes #197. Blocks #193.

The chart held the chosen hour in its own `useState`, so nothing else could
answer for it — which is why the map's readout beside it shows a day aggregate.
This gives the hour to the page. The readout follows it in the next PR; the map
is unchanged here.

## What changed, by slice

**1 — the plan addendum.** The design in `docs/plans/map-weather-readout.md` was
grilled before the work started and did not survive it. It proposed a readout
with two modes — the day's figures on arrival, one hour's after a click — and
argued the wedge told them apart. It does not: with nothing selected the arrow
sits at the day's resultant, which is inside the wedge by construction, and with
3 PM selected it sits at 3 PM's bearing, also inside it. **The two modes draw the
same picture**, which is exactly the needle ADR-0027 refuses. The design agreed
instead has no day mode at all.

**2 — ADR-0035.** One decision, recorded whole even though it ships in two PRs:
the page has one selected hour, it starts at now, and the readout shows it.
Supersedes ADR-0027's clause "The compass may not follow the selected hour" —
whose four conditions are unchanged and each of which is met — and reverses
`ChosenDay`'s rule that a chosen hour does not survive a day change.

**3 — the lift.** `selectedHour.tsx` mirroring `selectedDay.ts`; `HourChart`
reads it; `DayPanel` mounts the provider and computes the current hour.

**4 — the sentence renders on the server.** The selection's guide and mark were
never hydration-gated, so after slice 3 a reader without a script arrived at a
marked point with no word about which hour it marked. The sentence that explains
it was mounted with the buttons, and that gate was in the wrong place: a dead
button is a lie about what the page can do, a printed fact is not.

## Decisions worth reviewing

- **It is an hour of the day, not an instant.** That is what makes the default
  expressible — six of the seven days have no "now", so the rule is the same
  clock hour on each — and it carries a chosen hour across a day change, which an
  instant cannot. `ChosenDay` recorded that clearing as a virtue; it was an
  accident of the representation, and a reader comparing 9 AM across the week had
  it taken away on every step.
- **The current hour is computed on the server.** `revalidate = 900` means a
  client reading its own clock would disagree with a fifteen-minute-old render
  across an hour boundary and hydrate wrong. Where the daylight read names no day
  today — unreachable, since `weekOfDays` builds from today outward — it selects
  nothing rather than midnight.
- **`hourOfDay` lives in `dayFrame.ts`, and the build found that.**
  `selectedHour.tsx` is `"use client"` and `DayPanel` is a server component, so
  the first arrangement failed to prerender. The packaging turned out to name a
  real seam: an hour's definition is day geometry, shared by the component that
  computes the default and the one that draws it; which hour a reader chose is
  not.

## A correction to ADR-0034, found while writing ADR-0035

ADR-0034 justifies drawing the readout on all 51 beaches partly on the cost of
withholding it: "nearly half the inventory printed no wind figure anywhere on the
picture — **the same figure the week grid above states for every one of those
beaches**." The week grid states no wind figure. `WeekPanel.tsx:91` declines it
deliberately and says why — wind comes from the air station, and moving it to a
forecast is the displacement ADR-0019 did not decide.

That matters for the next PR rather than this one: `peakInDaylight` feeding
`windFigure` is the page's **only** statement of the day's biggest wind, so an
hour instrument would have removed it silently. It moves into the provenance
line, where `WaveWeek`'s rule already puts the superlative. ADR-0034's own
decision is unaffected and stands more strongly without the clause.

## Test changes that are consequences, not churn

- **`HourChart.test.tsx` now mounts the chart inside its provider.** Rendering it
  bare exercises an arrangement the page never builds — one where the columns are
  drawn and the context's no-op `choose` swallows every press. `WeekGrid` has had
  that shape since `selectedDay.tsx` and answers it the same way, and this
  follows it rather than inventing a second mechanism. Asserted explicitly in
  `selectedHour.test.tsx` so it is a defined state rather than an accident.
- **Two `DayPanel` assertions counted every `circle` in a plot** to count CDIP's
  published estimates. The arriving selection is a circle too, so 8 became 9.
  They now scope to `[data-marks] circle` and say what they meant.
- **The no-script test asserted `data-hour-readout` was absent**, which is the
  half of the old rule slice 4 reverses. It now asserts the distinction: the
  sentence is there, and nothing pressable is.
- **One assertion I wrote and then had to fix.** The server-render test first
  read `expect(markup).toContain("2 PM")`, which passes on a chart with nothing
  selected at all, because `hourLabel` writes every axis label. It now reads the
  sentence out of the readout element.

## Verified on the built page, not only in fixtures

Driven with Playwright against `next dev` at 1536×639, on live feeds:

```
READOUT: "12 PM · 5.4 ft · 24% cloud · in daylight"
MARK PRESENT: true GUIDE PRESENT: true
AFTER Later:      "1 PM · 4.9 ft · 24% cloud · in daylight"
AFTER day change: "1 PM · 5.5 ft · 24% cloud · in daylight"
```

The figure changing from 4.9 ft to 5.5 ft across the day change is the point: the
hour carried and was resolved against the new day rather than a stale reading
being kept.

## Gates

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

```
 Test Files  96 passed (96)
      Tests  1514 passed (1514)

Statements   : 89.67% ( 2778/3098 )
Branches     : 89.33% ( 1818/2035 )
Functions    : 94.43% ( 645/683 )
Lines        : 89.36% ( 2505/2803 )
```

Coverage went under both floors partway through — the new module's
out-of-provider `choose` and `DayPanel`'s no-today branch were the two uncovered
things. Both are now asserted rather than having the floor lowered.

## Not done, and why

- **The readout still shows the day.** That is #193, and this PR is its blocker.
- **A DST defect is inherited rather than fixed** — filed as #196. `hourOfDay`
  returns an index into the day and `hourLabel` reads it as a clock hour; a
  Pacific day is 23 or 25 hours twice a year, so on 2026-11-01 index 24 renders
  "12 PM" and collides with noon. This work deliberately reuses that one
  convention rather than introducing a second, so the chart and the map stay
  wrong together rather than disagreeing, and the fix stays single-site.
- **No plan file was skipped**; the existing one gained a dated addendum, since
  the work was already in flight.

## One thing to look at

On **today**, at arrival, the selection guide and the now-line are near-parallel:
measured on the built page, x=360 against x=368.4 in a 720-unit plot, about 9px
apart on the rendered chart, and the gap slides from 0 to about 34px across the
hour. It is two vertical rules of different weight — solid ocean, dashed dark —
one of which is labelled NOW. On the other six days there is no now-line and the
guide stands alone, which reads cleanly.

I have left it as it is rather than suppressing one, because they mean different
things and the alternative is a rule that hides a mark under a condition a reader
cannot see. It is a look-at-the-page call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GwPvqm8B8iDYG7EKyPft1
