### PR TITLE
Frame the map on its coast run, with the empty space to sea

### DIFF
--- a/docs/adr/0036-the-coast-run-decides-the-frame.md
+++ b/docs/adr/0036-the-coast-run-decides-the-frame.md
@@ -1,0 +1,171 @@
+# 0036 — The coast run decides the frame, and the slack is sea
+
+Date: 2026-08-31. Status: accepted. Reverses `boundsAround`'s recorded reason for
+having no minimum span, and removes the bound MOP line from the frame's
+arithmetic — which is the half of `shoreViewFor`'s docstring that argued for
+keeping it. ADR-0033 is unchanged and is why this is needed. ADR-0034's measured
+placement table is re-measured in the same pull request, because the projection
+it was measured against moves. ADR-0030 is untouched.
+
+## Context
+
+The shore map draws this beach's stretch of coast heavier than the shore either
+side of it, with the sea washed in beside it. **Reviewed on the built page, some
+beaches show a fragment of shoreline pressed against an edge and running off it,
+with the rest of the square empty.** `la-jolla-cove` is the worst and is issue
+#199.
+
+Measured, its frame is **200 metres across**, and in the map's 100-unit square:
+
+| what                           | where it lands |
+| ------------------------------ | -------------- |
+| the bound MOP line (not drawn) | y = 8.3        |
+| the beach's own coordinates    | y = 58.8–91.7  |
+| the three coastline points     | y = 18, 8, −4  |
+| the "this beach" heavy stroke  | y = 8 → −4     |
+
+**That is two faults and only one of them is visible.** The coast is at the top
+and runs off it. And the heavy stroke marking the beach is drawn beside the MOP
+line, about 400 m from the beach — because `beachStretch` snaps the beach's two
+ends to the nearest point _in the windowed coast_, and the window holds three
+points, all of them up there. The one mark on the map whose job is to say "this
+is your beach" is pointing somewhere else.
+
+Across the inventory, 20 of 49 frames clip their content at an edge and 16 have
+an empty edge wider than 40 of 100 units.
+
+### Why it happens
+
+**The frame is sized on a point that is never drawn.** `shoreViewFor` bounds
+`[segment.upper, segment.lower, mopLine]`. ADR-0033 took the MOP line out of the
+drawing — the map draws a place, not an inventory — and left it in the
+arithmetic, with an argument for why that was not the same mistake as framing on
+the four stations: the line "is where the drawn coastline _is_". That is true of
+its distance offshore and false of its displacement _along_ shore, which is 0.47
+km at `south-casa-beach-s-d` and 2.59 km at `la-jolla-community-beach`. Along
+that axis it stretches the frame toward nothing.
+
+**There is no minimum span, and the measurement that said none was needed has
+expired.** `boundsAround` records: "No minimum span, because none is needed:
+measured across all 51 beaches with their four sources, the tightest box is
+`shoreline-park` at 1.8 km." The four sources left the frame. The tightest boxes
+now are `fiesta-island` at 0.05 km, `childrens-pool` at 0.06 km and
+`la-jolla-cove` at 0.20 km, with **23 beaches under 1 km**. The reasoning was
+sound when written and describes code that no longer exists.
+
+**And the dependency runs backwards.** The frame decides which coastline is
+drawn, so a small frame draws almost none, and `beachStretch` — which reads the
+window — then has nothing correct to snap to. A frame too small to show the
+coast is also too small to place the beach on it.
+
+## Decision
+
+**The run of coastline this beach occupies decides the frame, rather than the
+frame deciding which coastline is drawn.**
+
+- **The beach's run is found against the whole coastline**, not against a
+  window. That alone fixes the misplaced stroke: the nearest polyline point to
+  each of the beach's ends is now the nearest point that exists, rather than the
+  nearest one a too-small box happened to catch.
+- **The run is grown outward along the polyline to a minimum length of shore.**
+  A beach longer than the minimum keeps its own run; a short one gains context
+  either side. This is the minimum span `boundsAround` declined to have, moved
+  to where it means something: a length of _shore_, which is what the picture is
+  of, rather than a width of _box_, which is an artifact of how the box was
+  built.
+- **The frame is that run plus the beach's own ends, with the existing margin.**
+  The coast is then in view by construction rather than by luck, and the
+  property is assertable directly: the run that set the frame is inside it.
+- **The bound MOP line leaves the frame's arithmetic.** `coastline()` is built
+  from `MOP_LINES`, so the beach's line is a point on the polyline and the run
+  already contains it. Nothing is lost and the along-shore stretch goes.
+
+**Whether a beach is on the traced coast becomes an explicit distance, not a
+side effect of box size.** Measured across the inventory: every beach that binds
+a MOP line is within **0.93 km** of the traced coastline, and every Mission Bay
+and San Diego Bay beach is **1.17 km or more** from it. A 1 km test therefore
+reproduces the 28/23 split ADR-0034 already documents — "the 23 beaches with no
+traced coast" — rather than inventing a partition. It is the same rule the code
+was always applying, said out loud and made measurable.
+
+**Three beaches gain a coastline they do not draw today**: `childrens-pool` at
+0.33 km, `tijuana-slough-national-wildlife-refuge` at 0.74 and `coronado-cays-nr`
+at 0.83. All three are on the open coast; none binds a MOP line, which is why
+their frames were tens of metres across and caught nothing. Their blankness was
+an artifact rather than a fact about the place, and ADR-0034's argument for
+drawing the readout on all 51 beaches is the same argument.
+
+**The letterbox slack goes to the sea.** `projectionFor` fits a non-square box
+into a square and splits the leftover evenly, which puts half the empty space
+inland — on a map whose subject is where the water is. The pad goes on the
+landward side instead, so the coast sits toward the land edge and the sea wash
+fills the remainder. The seaward direction comes from the same normal `seaPath`
+already derives; a second derivation could disagree with the wash it is meant to
+match.
+
+## What this does not change
+
+**ADR-0033 stands, and this is what it asked for.** The map still draws a place
+and not an inventory. Removing the MOP line from the arithmetic finishes that
+decision rather than reopening it: a source that is not drawn now also does not
+silently decide the frame.
+
+**ADR-0030 stands.** The line drawn is still CDIP's model line rather than a
+surveyed shore, and the sentence under the map still says so.
+
+**The overhang stays.** `windowAround` returns one point past each end so the
+stroke leaves the frame and the reader's eye continues it. Content crossing the
+frame edge is therefore still expected; what is not expected is the _run_ being
+cut, and that is what the new assertion distinguishes.
+
+## Alternatives considered
+
+**A minimum span on the existing box.** The smallest change, and it was measured
+before being rejected: a 2 km floor moves 25 beaches to 27 showing two or more
+coast points, and 3 km reaches 35 only by shrinking every beach that already
+works. It also leaves `la-jolla-cove`'s stroke drawn at the MOP line, because a
+bigger box does not fix a `beachStretch` that reads the box.
+
+**Drop the MOP line from the frame and change nothing else.** Removes the
+along-shore stretch in one line. Measured, it makes things worse: framing on the
+beach's own extent alone leaves **7 of 51** beaches showing two or more coast
+points, against 25 today, because the frames get smaller rather than larger.
+
+**Raise `SHORE_WINDOW_MARGIN`.** Already rejected where that constant is
+defined, on a measurement that still holds: at 0.1 La Jolla Shores fills 83
+percent of its map's height, at 0.5 it fills 50 and at 1.0 it fills 33 while
+Mission Beach's frame reaches 51 km. A margin is a multiplier on a box that is
+already the wrong box.
+
+**Use "binds a MOP line" as the test for being on the open coast.** Free, and
+already committed. Rejected on `childrens-pool`, which binds no line, sits 0.33
+km from the traced coast, and is plainly on the open coast — the binding is
+about which model line supplies a swell forecast, and using it here would answer
+a question it was not asked.
+
+**Centre the coast and leave the slack even.** One less rule. Rejected on what
+the map is for: half the empty space would be inland, on a picture whose subject
+is which side the water is on.
+
+## Consequences
+
+- **`shoreViewFor` gains a real seam.** Finding the run is pure arithmetic over
+  the committed polyline and is testable without rendering a map, which is what
+  lets the inventory-wide checks assert placement directly rather than by
+  screenshot.
+- **Every frame moves, so every measured figure about the map is re-measured.**
+  ADR-0034's placement table and `corner.ts`'s docstring figures were taken
+  against the old projection. They are re-measured in the same pull request, and
+  `corner.test.ts` — which asserts a clear corner on every beach — is the check
+  that this did not quietly break the readout.
+- **The minimum run is a number that will be argued about**, and it should be:
+  it decides how much shore every map shows. It is a length of coastline in
+  kilometres, stated in one place, and changing it changes every map at once —
+  which is the property that makes it reviewable rather than a constant hidden
+  in a component.
+- **Three beaches stop being blank.** That is a change in what the site claims
+  about a place, not only in how it looks, and it is why this decision names
+  them.
+- **#193 should be measured after this, not before.** That work grows the
+  readout's box and re-measures every corner; done first it would measure
+  against a projection this decision then moves.

--- a/docs/adr/0036-the-coast-run-decides-the-frame.md
+++ b/docs/adr/0036-the-coast-run-decides-the-frame.md
@@ -73,12 +73,43 @@ frame deciding which coastline is drawn.**
   to where it means something: a length of _shore_, which is what the picture is
   of, rather than a width of _box_, which is an artifact of how the box was
   built.
-- **The frame is that run plus the beach's own ends, with the existing margin.**
-  The coast is then in view by construction rather than by luck, and the
-  property is assertable directly: the run that set the frame is inside it.
+- **The frame is that run, with the existing margin, and nothing else.** The
+  coast is then in view by construction rather than by luck, and the property is
+  assertable directly: the run that set the frame is inside it.
 - **The bound MOP line leaves the frame's arithmetic.** `coastline()` is built
   from `MOP_LINES`, so the beach's line is a point on the polyline and the run
   already contains it. Nothing is lost and the along-shore stretch goes.
+- **The beach's own two ends leave it as well, wherever a coast is drawn.**
+  Written first as "the run plus the beach's own ends", this decision kept the
+  same fault it was removing, one step further along: the sand is not drawn
+  either. `ShoreMap`'s own credit says why — the traced line is computed "a few
+  hundred metres offshore, so the water's edge is drawn further out than the
+  sand" — and the stretch marking the beach is a run of that line rather than of
+  the sand. At `coronado-central-beach` the sand sits 0.93 km inland of the
+  line, and including it pushed the box that far toward the land: measured, the
+  coast sat at 65–104 of the frame's 100 units with the empty space above it,
+  and framing on the run alone moved it to 8–50 with the sea below. The ends
+  stay in the arithmetic on the 23 beaches with no traced coast, where they are
+  the only thing drawn.
+
+**A run may not cross a gap in the model.** The polyline is ordered by line id,
+and consecutive ids are not always neighbours on the ground: of its 1,086 steps
+most are about 98 m, 25 exceed 300 m, nine exceed 500 m, and exactly one is
+2,967 m — `D0226` to `D0228`, across the mouth of San Diego Bay, where CDIP
+places no lines because there is no open coast to place them on. A run crossing
+one draws a straight stroke over open water and calls it shoreline.
+
+Searching the whole coastline is what made this reachable: inside the old
+200-metre window a beach's two ends could not land on opposite sides of a
+three-kilometre gap, and outside it they can. `coronado-north-beach` did — the
+stretch marking a 2.8 km beach came out as a 4.9 km V with a three-kilometre
+diagonal across the channel, drawn in the stroke that means "this is your
+beach". So both ends are pulled onto one unbroken fragment before anything is
+sliced, and a run grows only within it.
+
+This is the same class of correction as the zero-length segments this module
+already removes, and it is made for the same reason: a zero-length step has no
+direction, and a three-kilometre step has no shore.
 
 **Whether a beach is on the traced coast becomes an explicit distance, not a
 side effect of box size.** Measured across the inventory: every beach that binds
@@ -166,6 +197,23 @@ is which side the water is on.
 - **Three beaches stop being blank.** That is a change in what the site claims
   about a place, not only in how it looks, and it is why this decision names
   them.
+- **The `sea-side` gate stopped covering the map, and had to be widened.** It
+  argued that the map's window was contained in its own, so the run the map
+  draws inherited its verdict — and that containment was an accident of both
+  boxes being built by `boundsAround` from overlapping points. This decision
+  ended it: measured immediately afterwards, 27 of the 28 beaches with a coast
+  drew points the gate had never looked at, up to 53 at
+  `la-jolla-community-beach`. `MIN_WINDOW_M` restores containment, swept rather
+  than guessed, and the constant-equality check that stood in for it is replaced
+  by the containment itself, asserted against the real assembler.
+- **How the sea polygon closes is now the weakest part of the picture**, and
+  this decision does not touch it. `seaPath` takes one normal from the drawn
+  run's two ends (ADR-0033), which is exact on a straight shore and approximate
+  on a bent one; longer runs bend more. `coronado-north-beach`, at the bay
+  mouth, is where it shows — better than before this change, which drew its
+  whole coast as one gap-crossing diagonal, and still leaving a corner of frame
+  unshaded. That is its own defect against ADR-0033 rather than a framing
+  question, and it is filed rather than folded in here.
 - **#193 should be measured after this, not before.** That work grows the
   readout's box and re-measures every corner; done first it would measure
   against a projection this decision then moves.

--- a/scripts/sea-side.mjs
+++ b/scripts/sea-side.mjs
@@ -40,6 +40,65 @@ export const SEAWARD = "left";
  */
 export const WINDOW_MARGIN = 0.1;
 
+/**
+ * The least ground this window covers, whatever the sources say.
+ *
+ * **The map's frame outgrew this checker, and the checker did not notice.**
+ * This file used to argue that the map's window was contained in its own, so
+ * the run the map draws was a sub-run of the run checked here and inherited the
+ * verdict. ADR-0036 made the map frame on a run of coast grown to a minimum
+ * length instead, and measured afterwards, 27 of the 28 beaches with a coast
+ * drew points this checker had never looked at -- 53 of them at
+ * `la-jolla-community-beach`.
+ *
+ * **Twelve kilometres, and the figure is measured rather than reasoned.** This
+ * window has to *contain* the map's rather than match it, and the map's is not
+ * simply its two-kilometre run: on a shore that runs east to west, squaring the
+ * frame toward the sea grows it along the coast as well, so the run drawn at
+ * `coronado-cays-nr` and `imperial-beach` reaches much further than the minimum
+ * suggests. Swept against the real assembler: 4 km leaves 9 beaches drawing
+ * unchecked points, 8 km leaves 5, and 12 km leaves none.
+ *
+ * **A wider window is not free, which is why it is checked and not assumed.**
+ * This file's own opening records that the polyline is not monotonic — it wraps
+ * Point Loma, where 39 of 1,209 steps run north to south — so a window wide
+ * enough to reach that wrap could match a buoy against a segment walking the
+ * wrong way. At 12 km every one of the 15 beaches that binds a buoy still puts
+ * it seaward, so the width is paid for rather than merely large.
+ *
+ * The containment itself is asserted in `sea-side.test.mjs` against the real
+ * assembler rather than trusted to this comment — which is what the old
+ * constant-equality check was a proxy for, and stopped being.
+ */
+export const MIN_WINDOW_M = 12_000;
+
+const METRES_PER_DEGREE = 111_320;
+
+/** The same box grown from its middle until it covers at least `metres`. */
+function atLeast(bounds, metres) {
+  const lonScale = Math.cos(
+    (((bounds.south + bounds.north) / 2) * Math.PI) / 180,
+  );
+  const growLat =
+    Math.max(0, metres - (bounds.north - bounds.south) * METRES_PER_DEGREE) /
+    2 /
+    METRES_PER_DEGREE;
+  const growLon =
+    Math.max(
+      0,
+      metres - (bounds.east - bounds.west) * lonScale * METRES_PER_DEGREE,
+    ) /
+    2 /
+    (METRES_PER_DEGREE * lonScale);
+
+  return {
+    south: bounds.south - growLat,
+    north: bounds.north + growLat,
+    west: bounds.west - growLon,
+    east: bounds.east + growLon,
+  };
+}
+
 /** Consecutive repeats dropped, so no segment has zero length and no direction. */
 export function coastFrom(mopLines) {
   const points = [];
@@ -152,11 +211,23 @@ export function sideOf(points, at) {
  * measured, not guessed.
  *
  * The property proven is about the polyline and not about the frame: walked
- * south to north, this coast has the sea on its left. `boundsAround` grows with
- * the points it is given, so the map's window is contained in this one and its
- * run of coast is a contiguous sub-run of the run checked here. A sub-run walks
- * the same way, which is what `ShoreMap`'s shading depends on.
+ * south to north, this coast has the sea on its left. The map's run of coast is
+ * a contiguous sub-run of the run checked here, and a sub-run walks the same
+ * way, which is what `ShoreMap`'s shading depends on.
+ *
+ * **That containment used to be an accident of arithmetic and is now a rule.**
+ * It held because `boundsAround` grows with the points it is given and the map
+ * was framed on a subset of them. ADR-0036 stopped framing the map that way,
+ * and the containment quietly stopped holding: 27 of the 28 beaches with a
+ * coast drew points this file had never checked. `MIN_WINDOW_M` is what makes
+ * it true again, and `sea-side.test.mjs` is what stops it becoming false
+ * silently a second time.
  */
+export function windowFor(beach, tables) {
+  const bounds = boundsAround(positionsFor(beach, tables), WINDOW_MARGIN);
+  return bounds === null ? null : atLeast(bounds, MIN_WINDOW_M);
+}
+
 function positionsFor(beach, tables) {
   const positions = [beach.segment.upper, beach.segment.lower];
 
@@ -206,7 +277,7 @@ export function checkSeaSide(tables) {
       continue;
     }
 
-    const bounds = boundsAround(positionsFor(beach, tables), WINDOW_MARGIN);
+    const bounds = windowFor(beach, tables);
     if (!bounds) {
       skip("have every source at one place", beach.slug);
       continue;

--- a/scripts/sea-side.test.mjs
+++ b/scripts/sea-side.test.mjs
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { checkSeaSide, coastFrom, sideOf, WINDOW_MARGIN } from "./sea-side.mjs";
+import {
+  checkSeaSide,
+  coastFrom,
+  sideOf,
+  windowFor,
+  WINDOW_MARGIN,
+} from "./sea-side.mjs";
 import {
   coastline,
   sideOf as sideOfTs,
@@ -7,6 +13,8 @@ import {
   windowAround,
   SHORE_WINDOW_MARGIN,
 } from "../src/lib/coastline.ts";
+import { allBeaches } from "../src/lib/beaches.ts";
+import { shoreViewFor } from "../src/components/conditions/shore.ts";
 import MOP_LINES from "../src/data/mop-lines.json" with { type: "json" };
 import BEACHES from "../src/data/beaches.json" with { type: "json" };
 import BUOYS from "../src/data/wave-buoys.json" with { type: "json" };
@@ -162,9 +170,55 @@ describe("what the gate row prints", () => {
 });
 
 describe("the window the map draws", () => {
-  it("is the window the checker measures", () => {
+  it("uses the same margin the map does", () => {
     // A checker run against a different frame checks a different claim: a wider
     // window reaches more coast and can change which segment is nearest a buoy.
     expect(WINDOW_MARGIN).toBe(SHORE_WINDOW_MARGIN);
+  });
+
+  it("holds every point the map actually draws", () => {
+    // **The claim this file used to make by proxy, now made directly.** The
+    // margins matching was evidence that the checker looked at the run the map
+    // draws -- and it stopped being evidence when ADR-0036 changed what decides
+    // the map's frame. Measured at that moment, 27 of the 28 beaches with a
+    // coast drew points this checker had never seen, up to 53 of them; the
+    // margins were still equal and said nothing about it.
+    //
+    // So this asks the real assembler what the map draws, rather than asking a
+    // constant whether it agrees with another constant.
+    const tables = {
+      beaches: BEACHES.beaches,
+      buoys: BUOYS.buoys,
+      tideStations: TIDE_STATIONS.stations,
+      observationStations: OBSERVATION_STATIONS.stations,
+      mopLines: MOP_LINES.lines,
+    };
+    const coast = coastline();
+
+    const unchecked = [];
+    let compared = 0;
+
+    for (const beach of allBeaches()) {
+      const row = tables.beaches.find((each) => each.slug === beach.slug);
+      const checkerWindow = windowFor(row, tables);
+      const frame = shoreViewFor(beach).bounds;
+      if (!checkerWindow || frame === null) continue;
+
+      const seen = new Set(
+        windowAround(coast, checkerWindow).map((point) => point.id),
+      );
+      const drawn = windowAround(coast, frame);
+      if (drawn.length === 0) continue;
+
+      compared += 1;
+      const missed = drawn.filter((point) => !seen.has(point.id));
+      if (missed.length > 0) {
+        unchecked.push(`${beach.slug}: ${missed.length} points`);
+      }
+    }
+
+    expect(unchecked).toEqual([]);
+    // A check that compared nothing would pass forever.
+    expect(compared).toBe(28);
   });
 });

--- a/src/components/conditions/shore.test.ts
+++ b/src/components/conditions/shore.test.ts
@@ -5,7 +5,9 @@ import {
   boundsAround,
   coastline,
   nearestOn,
+  runAround,
   SHORE_WINDOW_MARGIN,
+  unbrokenAround,
 } from "@/lib/coastline";
 import { coastRunFor, seawardFrom, shoreViewFor } from "./shore";
 
@@ -251,12 +253,10 @@ test("the frame's extra ground is put on the sea side, not shared out", () => {
   // result being right are different claims. La Jolla's coast runs north with
   // the Pacific to the west, so the box grows west: the coast ends up toward
   // the landward edge and the sea wash fills what is left.
+  // The run alone, which is what the frame is built from: the beach's own sand
+  // is not drawn where a coast is, so it is not in the arithmetic either.
   const boxed = boundsAround(
-    [
-      LA_JOLLA.segment.upper,
-      LA_JOLLA.segment.lower,
-      ...coastRunFor(LA_JOLLA)!.points,
-    ],
+    coastRunFor(LA_JOLLA)!.points,
     SHORE_WINDOW_MARGIN,
   );
   const framed = shoreViewFor(LA_JOLLA).bounds!;
@@ -278,4 +278,63 @@ test("a beach with no traced coast keeps an even frame", () => {
   const framed = shoreViewFor(bay).bounds!;
 
   expect(framed).toEqual(boxed);
+});
+
+test("no beach's stretch is drawn across a gap in the model", () => {
+  // `coronado-north-beach` sits by the mouth of San Diego Bay, where the model
+  // leaves a 2,967 m gap because there is no open coast to place lines on.
+  // Searching the whole coastline for the beach's two ends -- which is what
+  // ADR-0036 changed -- let them land on opposite sides of it, so the stretch
+  // marking a 2.8 km beach came out as a 4.9 km V with a three-kilometre
+  // diagonal drawn straight across the channel, in the heavy stroke that means
+  // "this is your beach".
+  //
+  // Asserted for every beach and against the step rather than the total: a
+  // stretch is allowed to be longer than its beach, and is never allowed to
+  // contain a step no shoreline could.
+  const kmPerDegree = 111.32;
+  const stepMetres = (a: Position, b: Position) => {
+    const lonScale = Math.cos((((a.lat + b.lat) / 2) * Math.PI) / 180);
+    return (
+      Math.hypot((a.lon - b.lon) * lonScale, a.lat - b.lat) * kmPerDegree * 1000
+    );
+  };
+
+  const jumped: string[] = [];
+  for (const beach of allBeaches()) {
+    const run = coastRunFor(beach);
+    if (run === null) continue;
+
+    for (const points of [run.points, run.stretch]) {
+      for (let index = 0; index < points.length - 1; index += 1) {
+        const step = stepMetres(points[index], points[index + 1]);
+        if (step > 500) {
+          jumped.push(`${beach.slug}: ${step.toFixed(0)} m`);
+          break;
+        }
+      }
+    }
+  }
+
+  expect(jumped).toEqual([]);
+});
+
+test("a run stops at a gap rather than growing through it", () => {
+  // The unit behind the inventory check above. Two fragments 3 km apart, and a
+  // minimum long enough that a run would cross the gap if nothing stopped it.
+  const points = [
+    { id: "a", lat: 32.0, lon: -117.0 },
+    { id: "b", lat: 32.001, lon: -117.0 },
+    { id: "c", lat: 32.03, lon: -117.0 },
+    { id: "d", lat: 32.031, lon: -117.0 },
+  ];
+
+  const whole = unbrokenAround(points, 0, 500);
+  expect(whole).toEqual({ from: 0, to: 1 });
+
+  const run = runAround(points, 0, 0, 5_000, whole);
+  expect(run.map((point) => point.id)).toEqual(["a", "b"]);
+
+  // And from the far fragment, the other way.
+  expect(unbrokenAround(points, 3, 500)).toEqual({ from: 2, to: 3 });
 });

--- a/src/components/conditions/shore.test.ts
+++ b/src/components/conditions/shore.test.ts
@@ -1,16 +1,26 @@
 import { expect, test } from "vitest";
 import { allBeaches, beachBySlug, mopLineFor } from "@/lib/beaches";
-import type { ShorePoint } from "@/lib/coastline";
-import { shoreViewFor } from "./shore";
+import type { Position, ShorePoint } from "@/lib/coastline";
+import {
+  boundsAround,
+  coastline,
+  nearestOn,
+  SHORE_WINDOW_MARGIN,
+} from "@/lib/coastline";
+import { coastRunFor, seawardFrom, shoreViewFor } from "./shore";
 
 /** The beach the page opens on, and the one with all four sources bound. */
 const LA_JOLLA = beachBySlug("la-jolla-shores-beach")!;
 
 test("the frame holds the beach and the line its coast is drawn from", () => {
   // The map plots no stations, so nothing else belongs in the arithmetic that
-  // sizes it. The MOP line stays because it is where the drawn coastline *is*,
-  // 117 to 930 m off the sand -- a window without it is a map of a beach with
-  // its shoreline cropped off the edge.
+  // sizes it.
+  //
+  // The MOP line is still in frame and is no longer *put* there: ADR-0036 took
+  // it out of the arithmetic, because along-shore it stretched the box toward
+  // a point nothing draws. It stays in view because `coastline()` is built from
+  // `MOP_LINES`, so the run the frame is built on contains the beach's own line
+  // already -- which is the claim this test now checks rather than assumes.
   const view = shoreViewFor(LA_JOLLA);
   const bounds = view.bounds!;
   const line = mopLineFor(LA_JOLLA)!;
@@ -35,8 +45,13 @@ test("a station seven kilometres away no longer decides the frame", () => {
   const kmPerDegree = 111.32;
   const heightKm = (bounds.north - bounds.south) * kmPerDegree;
 
-  expect(beach.air_station_distance_m).toBe(7365);
-  expect(heightKm).toBeLessThan(2);
+  const stationM = beach.air_station_distance_m!;
+  expect(stationM).toBe(7365);
+  // Asserted against the station rather than against a constant, because what
+  // sets the size has changed and the claim has not. It is the minimum run of
+  // shore and its margin now, about 2.2 km, where before it was this beach's
+  // own extent -- either way, nothing here reaches for a station 7.4 km off.
+  expect(heightKm * 1000).toBeLessThan(stationM / 2);
 });
 
 test("a bay beach gets a map and no coast", () => {
@@ -64,8 +79,89 @@ test("every committed beach assembles, and the county's split is pinned", () => 
   const views = allBeaches().map(shoreViewFor);
 
   expect(views).toHaveLength(51);
-  expect(views.filter((view) => view.coast.length > 1)).toHaveLength(25);
+  expect(views.filter((view) => view.coast.length > 1)).toHaveLength(28);
   expect(views.filter((view) => view.bounds === null)).toHaveLength(1);
+});
+
+test("the three beaches on the open coast that drew none of it now do", () => {
+  // 25 became 28 above, and which three matters more than the number. None of
+  // them binds a MOP line, which is why each framed at tens of metres and
+  // caught nothing -- and none of them is in a bay: they are 0.33, 0.74 and
+  // 0.83 km from the traced coast, against 1.17 km for the nearest bay beach.
+  // ADR-0036 names them for this reason.
+  for (const slug of [
+    "childrens-pool",
+    "tijuana-slough-national-wildlife-refuge",
+    "coronado-cays-nr",
+  ]) {
+    const view = shoreViewFor(beachBySlug(slug)!);
+    expect(view.coast.length).toBeGreaterThan(1);
+    expect(view.segment).not.toBeNull();
+  }
+});
+
+test("the stretch is drawn on the beach, not beside the line off it", () => {
+  // The defect in #199, asserted where it was worst. `la-jolla-cove`'s heavy
+  // stroke was drawn at its MOP line about 400 m away, because `beachStretch`
+  // snapped the beach's ends to the nearest point *in the window* and the
+  // window -- 200 m across, built without reference to the coast -- held three
+  // points, all of them up beside the line.
+  //
+  // Every beach, not just that one: a bound that only the worst case can
+  // breach is a bound that stops testing once the worst case is fixed.
+  //
+  // **Not "the stroke is near the beach", which would fail on a correct map.**
+  // The drawn line is CDIP's model line 117 to 930 m offshore (ADR-0030), so
+  // every stretch is a few hundred metres from the sand by construction. The
+  // property is that the stroke sits on the *nearest available* coast: the
+  // closest point of the drawn stretch is the closest point of the whole
+  // coastline. That is what was false before -- `la-jolla-cove`'s stretch sat
+  // 400 m off where the nearest traced point is 120 m.
+  const kmPerDegree = 111.32;
+  const metresApart = (a: Position, b: Position) => {
+    const lonScale = Math.cos((a.lat * Math.PI) / 180);
+    return (
+      Math.hypot((a.lon - b.lon) * lonScale, a.lat - b.lat) * kmPerDegree * 1000
+    );
+  };
+
+  const points = coastline();
+  const strayed: { slug: string; drawn: number; nearest: number }[] = [];
+
+  for (const beach of allBeaches()) {
+    const view = shoreViewFor(beach);
+    if (view.segment === null || view.coast.length < 2) continue;
+
+    const nearest = Math.min(
+      nearestOn(points, beach.segment.lower)!.metres,
+      nearestOn(points, beach.segment.upper)!.metres,
+    );
+    const drawn = Math.min(
+      ...view.segment.map((point) =>
+        Math.min(
+          metresApart(point, beach.segment.lower),
+          metresApart(point, beach.segment.upper),
+        ),
+      ),
+    );
+
+    if (drawn > nearest + 1) {
+      strayed.push({ slug: beach.slug, drawn, nearest });
+    }
+  }
+
+  expect(strayed).toEqual([]);
+});
+
+test("a beach shorter than the gap between points still draws a stretch", () => {
+  // `la-jolla-cove` is about 70 m of shore and the points available to mark it
+  // sit at about 98, so both its ends snap to one of them. That used to return
+  // null and draw no stretch at all; the beach then had nothing on the map
+  // saying where it was.
+  const view = shoreViewFor(beachBySlug("la-jolla-cove")!);
+
+  expect(view.segment).not.toBeNull();
+  expect(view.segment!.length).toBeGreaterThanOrEqual(2);
 });
 
 test("a beach with no coast is still placed on its own map", () => {
@@ -116,4 +212,70 @@ test("the stretch is contiguous, and shorter than the coast around it", () => {
     expect(coast[first + step].lon).toBe(point.lon);
   });
   expect(segment.length).toBeLessThan(coast.length);
+});
+
+test("the sea is a quarter turn left of the walk, which is where it is", () => {
+  // The one convention in this file that is easy to get exactly backwards, and
+  // getting it backwards would put every map's empty space over the land while
+  // still looking deliberate. `scripts/sea-side.mjs` proves the premise for
+  // every beach against the wave buoy; this asserts the arithmetic that reads
+  // it.
+  const northward = [
+    { id: "a", lat: 32.85, lon: -117.27 },
+    { id: "b", lat: 32.87, lon: -117.27 },
+  ];
+  const seaward = seawardFrom(northward)!;
+  expect(seaward.east).toBeLessThan(0); // west, which is where the Pacific is
+  expect(Math.abs(seaward.north)).toBeLessThan(Math.abs(seaward.east));
+
+  // Walked the other way the same coast has the sea on the right, so the
+  // rotation has to move with it rather than being a fixed compass direction.
+  const southward = [...northward].reverse();
+  expect(seawardFrom(southward)!.east).toBeGreaterThan(0);
+});
+
+test("a run with no direction offers no seaward side", () => {
+  // Both are unreachable through `shoreViewFor` and both are the kind of guard
+  // that stops being unreachable when someone changes the caller.
+  expect(seawardFrom([{ id: "a", lat: 32.85, lon: -117.27 }])).toBeNull();
+  expect(
+    seawardFrom([
+      { id: "a", lat: 32.85, lon: -117.27 },
+      { id: "b", lat: 32.85, lon: -117.27 },
+    ]),
+  ).toBeNull();
+});
+
+test("the frame's extra ground is put on the sea side, not shared out", () => {
+  // End to end on a committed beach, because the arithmetic being right and the
+  // result being right are different claims. La Jolla's coast runs north with
+  // the Pacific to the west, so the box grows west: the coast ends up toward
+  // the landward edge and the sea wash fills what is left.
+  const boxed = boundsAround(
+    [
+      LA_JOLLA.segment.upper,
+      LA_JOLLA.segment.lower,
+      ...coastRunFor(LA_JOLLA)!.points,
+    ],
+    SHORE_WINDOW_MARGIN,
+  );
+  const framed = shoreViewFor(LA_JOLLA).bounds!;
+
+  expect(framed.west).toBeLessThan(boxed!.west);
+  expect(framed.east).toBeCloseTo(boxed!.east, 10);
+  expect(framed.north).toBeCloseTo(boxed!.north, 10);
+  expect(framed.south).toBeCloseTo(boxed!.south, 10);
+});
+
+test("a beach with no traced coast keeps an even frame", () => {
+  // No coast means no land-sea split to lean the picture toward, so the box is
+  // left as `boundsAround` made it rather than being pushed at a guess.
+  const bay = beachBySlug("mission-bay-de-anza-cove")!;
+  const boxed = boundsAround(
+    [bay.segment.upper, bay.segment.lower],
+    SHORE_WINDOW_MARGIN,
+  )!;
+  const framed = shoreViewFor(bay).bounds!;
+
+  expect(framed).toEqual(boxed);
 });

--- a/src/components/conditions/shore.ts
+++ b/src/components/conditions/shore.ts
@@ -17,12 +17,14 @@
  */
 
 import type { Beach } from "@/lib/beaches";
-import { mopLineFor } from "@/lib/beaches";
 import type { Bounds, Position, ShorePoint } from "@/lib/coastline";
 import {
   boundsAround,
   coastline,
+  nearestOn,
+  runAround,
   SHORE_WINDOW_MARGIN,
+  squareToward,
   windowAround,
 } from "@/lib/coastline";
 
@@ -54,7 +56,7 @@ export type ShoreView = {
  * lower.
  */
 function beachStretch(
-  coast: readonly ShorePoint[],
+  run: CoastRun | null,
   beach: Beach,
 ): readonly Position[] | null {
   const { upper, lower } = beach.segment;
@@ -67,29 +69,94 @@ function beachStretch(
     the only thing that says where the beach is. Without it the bay maps are an
     empty frame, which is the one question the picture has to answer.
   */
-  if (coast.length < 2) return hasExtent ? [lower, upper] : null;
+  if (run === null) return hasExtent ? [lower, upper] : null;
 
-  const nearest = (at: Position): number => {
-    const lonScale = Math.cos((at.lat * Math.PI) / 180);
-    let best = Infinity;
-    let index = 0;
-    coast.forEach((point, at_) => {
-      const dx = (point.lon - at.lon) * lonScale;
-      const dy = point.lat - at.lat;
-      const distance = dx * dx + dy * dy;
-      if (distance < best) {
-        best = distance;
-        index = at_;
-      }
-    });
-    return index;
+  return run.stretch;
+}
+
+/**
+ * Farther than this from the traced coast and a beach is not on it.
+ *
+ * **Measured rather than chosen, and it reproduces a partition this repo
+ * already documents.** Every beach that binds a MOP line is within 0.93 km of
+ * the traced coastline; every Mission Bay and San Diego Bay beach is 1.17 km or
+ * more away. So a kilometre separates the two groups the same way ADR-0034's
+ * "23 beaches with no traced coast" already does, and the gap it sits in is
+ * wide enough that no beach is near the line.
+ *
+ * It replaces a test that was never written down: whether the beach's own tiny
+ * frame happened to catch a point. That answered the same question by accident
+ * and got three beaches wrong -- `childrens-pool`, `tijuana-slough` and
+ * `coronado-cays-nr` are 0.33, 0.74 and 0.83 km from the open coast and drew
+ * none of it, because none binds a MOP line and their frames were tens of
+ * metres across.
+ *
+ * **Not "binds a MOP line"**, which is free and committed and answers a
+ * different question: which model line supplies this beach's swell forecast.
+ * `childrens-pool` binds none and is plainly on the open coast.
+ */
+const COAST_REACH_M = 1_000;
+
+/**
+ * The least shore a map shows, when the beach itself is shorter than this.
+ *
+ * The number ADR-0036 says will be argued about, in the one place it is stated.
+ * At 2 km `la-jolla-cove` uses 47 percent of its frame's height where it used
+ * 23, and nothing in the inventory is clipped. Larger makes a small beach a
+ * detail inside somebody else's coastline; smaller stops showing enough shore
+ * for the bend a reader is orienting by.
+ *
+ * A beach longer than this keeps its own run, so the rule costs the large
+ * beaches nothing.
+ */
+const MIN_RUN_M = 2_000;
+
+/** The run of coast a map is framed on, and the part of it this beach is. */
+type CoastRun = {
+  /** What the frame is built from: the beach's shore plus its context. */
+  points: readonly ShorePoint[];
+  /** The part this beach occupies, drawn heavier. Always at least two points. */
+  stretch: readonly ShorePoint[];
+};
+
+/**
+ * The run of coastline this beach occupies, with enough either side to frame on.
+ *
+ * **Searched against the whole coastline rather than against a window**, which
+ * is the correction ADR-0036 turns on. Finding the beach's ends inside a frame
+ * that was itself built without reference to the coast meant a small frame
+ * caught few points and the beach snapped to whichever of them was least wrong:
+ * on `la-jolla-cove` the stretch was drawn beside the MOP line, about 400 m
+ * from the beach.
+ *
+ * Null where the traced coast does not reach, which is a fact about which water
+ * this site maps and not a failure. The caller draws the beach's own ends
+ * instead and says so under the picture.
+ */
+export function coastRunFor(beach: Beach): CoastRun | null {
+  const points = coastline();
+  const lower = nearestOn(points, beach.segment.lower);
+  const upper = nearestOn(points, beach.segment.upper);
+  if (lower === null || upper === null) return null;
+  if (Math.min(lower.metres, upper.metres) > COAST_REACH_M) return null;
+
+  const from = Math.min(lower.index, upper.index);
+  const to = Math.max(lower.index, upper.index);
+
+  /*
+    A stretch of one point draws nothing, and several beaches are shorter than
+    the 98 m between the points available to mark them -- `la-jolla-cove` is
+    about 70 m of shore. Taking the neighbour rather than falling back to the
+    beach's own two ends keeps the heavy stroke *on* the drawn line, which is
+    the whole of `beachStretch`'s argument against a chord: a stroke at an angle
+    to the shore beside it reads as a second, wrong shore.
+  */
+  const end = to === from ? Math.min(points.length - 1, from + 1) : to;
+
+  return {
+    points: runAround(points, from, to, MIN_RUN_M),
+    stretch: points.slice(from, end + 1),
   };
-
-  const from = nearest(beach.segment.lower);
-  const to = nearest(beach.segment.upper);
-  if (from === to) return null;
-
-  return coast.slice(Math.min(from, to), Math.max(from, to) + 1);
 }
 
 /**
@@ -103,28 +170,70 @@ function beachStretch(
  * refuses: `mission-beach`'s map was twenty kilometres tall with its own sand
  * occupying a fifth of it, for a reason nothing on the picture gave.
  *
- * The bound MOP line stays in the frame's arithmetic while being absent from
- * its drawing, and that is not the same mistake. It is not an instrument
- * standing somewhere: it is where the drawn coastline *is*, sitting 117 to 930
- * metres off the sand, so a window that excluded it would be a map of a beach
- * with the shoreline cropped off the edge. Measured across the inventory,
- * framing on the beach alone leaves 14 of 51 beaches with a coast in view;
- * framing on the beach and its line leaves 26, and the median frame falls from
- * 4.0 km to 3.1 km.
+ * **The frame is built from the coast it draws, which is ADR-0036 and reverses
+ * what this docstring said before.** The bound MOP line used to be in the
+ * arithmetic on the argument that it "is where the drawn coastline *is*". That
+ * is true of its distance offshore and false of its displacement along shore --
+ * 2.59 km at `la-jolla-community-beach` -- and along that axis it stretched the
+ * frame toward a point ADR-0033 had already stopped drawing. Nothing is lost by
+ * removing it: `coastline()` is built from `MOP_LINES`, so the run contains the
+ * beach's own line already.
+ *
+ * The dependency also ran backwards. The frame decided which coastline was
+ * drawn, so a frame too small to show the coast was also too small to place the
+ * beach on it, and `la-jolla-cove` drew its heavy stroke 400 m from the beach.
+ * The run is found first, against the whole polyline, and the frame is built
+ * from it -- so the coast is in view by construction rather than by luck.
  */
-export function shoreViewFor(beach: Beach): ShoreView {
-  const line = mopLineFor(beach);
+/**
+ * Which way the open water lies from a run of coast, as east and north parts.
+ *
+ * **Left of the walk**, which is this coast's own proven property: walked south
+ * to north, San Diego's shore has the sea on its left. `scripts/sea-side.mjs`
+ * is the gate that holds it, for every beach, against the wave buoy as ground
+ * truth — so this reads a fact that is checked rather than assuming one.
+ *
+ * Taken from the run's two ends rather than segment by segment, which is
+ * `seaPath`'s choice one step earlier and made for the same reason: a
+ * per-segment normal turns at every bend, and what is wanted is which side of
+ * the whole run the ocean is.
+ *
+ * Null on a run too short to have a direction, which is a beach with no traced
+ * coast.
+ */
+export function seawardFrom(
+  run: readonly ShorePoint[],
+): { east: number; north: number } | null {
+  if (run.length < 2) return null;
 
-  const bounds = boundsAround(
+  const first = run[0];
+  const last = run[run.length - 1];
+  const lonScale = Math.cos((((first.lat + last.lat) / 2) * Math.PI) / 180);
+  const east = (last.lon - first.lon) * lonScale;
+  const north = last.lat - first.lat;
+  if (east === 0 && north === 0) return null;
+
+  // Rotate the walk a quarter turn to the left: (east, north) -> (-north, east).
+  return { east: -north, north: east };
+}
+
+export function shoreViewFor(beach: Beach): ShoreView {
+  const run = coastRunFor(beach);
+
+  const boxed = boundsAround(
     [
       beach.segment.upper,
       beach.segment.lower,
-      ...(line === null ? [] : [{ lat: line.lat, lon: line.lon }]),
+      ...(run === null ? [] : run.points),
     ],
     SHORE_WINDOW_MARGIN,
   );
 
+  const seaward = run === null ? null : seawardFrom(run.points);
+  const bounds =
+    boxed === null || seaward === null ? boxed : squareToward(boxed, seaward);
+
   const coast = bounds === null ? [] : windowAround(coastline(), bounds);
 
-  return { coast, bounds, segment: beachStretch(coast, beach) };
+  return { coast, bounds, segment: beachStretch(run, beach) };
 }

--- a/src/components/conditions/shore.ts
+++ b/src/components/conditions/shore.ts
@@ -23,6 +23,7 @@ import {
   coastline,
   nearestOn,
   runAround,
+  unbrokenAround,
   SHORE_WINDOW_MARGIN,
   squareToward,
   windowAround,
@@ -111,6 +112,21 @@ const COAST_REACH_M = 1_000;
  */
 const MIN_RUN_M = 2_000;
 
+/**
+ * A step longer than this is a gap in the model rather than a piece of shore.
+ *
+ * `unbrokenAround` holds the argument; this is where the figure is chosen. The
+ * polyline steps about 98 m, so 500 m means the model placed nothing for five
+ * lines running -- which on this coast means a harbour or river mouth rather
+ * than a stretch of beach. Nine of the 1,086 steps exceed it and each is one of
+ * those; the largest, 2,967 m, is the mouth of San Diego Bay.
+ *
+ * Not tighter, because 25 steps exceed 300 m and most of them are ordinary
+ * coast the model sampled unevenly. Not looser, because 1,118 m is the next gap
+ * up and is also a channel.
+ */
+const COAST_GAP_M = 500;
+
 /** The run of coast a map is framed on, and the part of it this beach is. */
 type CoastRun = {
   /** What the frame is built from: the beach's shore plus its context. */
@@ -140,8 +156,22 @@ export function coastRunFor(beach: Beach): CoastRun | null {
   if (lower === null || upper === null) return null;
   if (Math.min(lower.metres, upper.metres) > COAST_REACH_M) return null;
 
-  const from = Math.min(lower.index, upper.index);
-  const to = Math.max(lower.index, upper.index);
+  /*
+    Both ends are pulled onto one unbroken piece of shore before anything is
+    sliced.
+
+    Searching the whole coastline made this reachable where a small window could
+    not: `coronado-north-beach` sits by the mouth of San Diego Bay, its two ends
+    snapped to opposite sides of the 2,967 m gap the model leaves there, and the
+    stretch marking a 2.8 km beach came out as a 4.9 km V with a three-kilometre
+    diagonal drawn across the channel. The nearer end is the one to trust, so
+    its own fragment is what both ends are clamped into.
+  */
+  const anchor = lower.metres <= upper.metres ? lower.index : upper.index;
+  const whole = unbrokenAround(points, anchor, COAST_GAP_M);
+
+  const from = Math.max(whole.from, Math.min(lower.index, upper.index));
+  const to = Math.min(whole.to, Math.max(lower.index, upper.index));
 
   /*
     A stretch of one point draws nothing, and several beaches are shorter than
@@ -151,10 +181,10 @@ export function coastRunFor(beach: Beach): CoastRun | null {
     the whole of `beachStretch`'s argument against a chord: a stroke at an angle
     to the shore beside it reads as a second, wrong shore.
   */
-  const end = to === from ? Math.min(points.length - 1, from + 1) : to;
+  const end = to === from ? Math.min(whole.to, from + 1) : to;
 
   return {
-    points: runAround(points, from, to, MIN_RUN_M),
+    points: runAround(points, from, to, MIN_RUN_M, whole),
     stretch: points.slice(from, end + 1),
   };
 }
@@ -220,12 +250,20 @@ export function seawardFrom(
 export function shoreViewFor(beach: Beach): ShoreView {
   const run = coastRunFor(beach);
 
+  /*
+    The beach's own two ends are in the arithmetic only where nothing else is.
+
+    Where a coast is drawn they are not, and leaving them in was the same fault
+    as leaving the MOP line in, one step further along: the sand is not drawn
+    either. `ShoreMap`'s own credit says why -- the traced line is CDIP's model
+    line "computed a few hundred metres offshore, so the water's edge is drawn
+    further out than the sand" -- and the stretch marking this beach is a run of
+    that line, not of the sand. At `coronado-central-beach` the sand sits 0.93
+    km inland of the line, and including it stretched the box that far toward
+    the land, which is the empty band the picture then had to spend.
+  */
   const boxed = boundsAround(
-    [
-      beach.segment.upper,
-      beach.segment.lower,
-      ...(run === null ? [] : run.points),
-    ],
+    run === null ? [beach.segment.upper, beach.segment.lower] : run.points,
     SHORE_WINDOW_MARGIN,
   );
 

--- a/src/lib/coastline.test.ts
+++ b/src/lib/coastline.test.ts
@@ -2,8 +2,11 @@ import { expect, test } from "vitest";
 import {
   boundsAround,
   coastline,
+  nearestOn,
   projectionFor,
+  runAround,
   sideOf,
+  squareToward,
   windowAround,
   withoutRepeats,
 } from "./coastline";
@@ -194,4 +197,88 @@ test("a position on the line itself is on neither side", () => {
   ];
 
   expect(sideOf(northward, { lat: 32.05, lon: -117.0 })).toBeNull();
+});
+
+/**
+ * A box a quarter degree of latitude tall, at this coast's latitude, so the two
+ * spans can be compared in ground units rather than in degrees.
+ */
+const BOX = { south: 32.8, north: 33.0, west: -117.3, east: -117.28 };
+
+test("a tall box grows sideways, on the side the sea is", () => {
+  // Which is the shape almost every beach here has: the coast runs north and
+  // the box is a narrow strip along it.
+  const west = squareToward(BOX, { east: -1, north: 0 });
+  expect(west.west).toBeLessThan(BOX.west);
+  expect(west.east).toBe(BOX.east);
+  expect(west.north).toBe(BOX.north);
+  expect(west.south).toBe(BOX.south);
+
+  const east = squareToward(BOX, { east: 1, north: 0 });
+  expect(east.east).toBeGreaterThan(BOX.east);
+  expect(east.west).toBe(BOX.west);
+});
+
+test("a wide box grows up or down instead", () => {
+  // Point Loma and Coronado run east to west, so the sea is north or south of
+  // the run rather than beside it.
+  const wide = { south: 32.66, north: 32.67, west: -117.2, east: -117.15 };
+
+  const north = squareToward(wide, { east: 0, north: 1 });
+  expect(north.north).toBeGreaterThan(wide.north);
+  expect(north.south).toBe(wide.south);
+
+  const south = squareToward(wide, { east: 0, north: -1 });
+  expect(south.south).toBeLessThan(wide.south);
+  expect(south.north).toBe(wide.north);
+});
+
+test("the growth is exactly what it takes to square the box, and no more", () => {
+  // The point of the function: after it, the projection has no leftover to
+  // split, so nothing decides where the empty space goes by default.
+  const squared = squareToward(BOX, { east: -1, north: 0 });
+  const lonScale = Math.cos(
+    (((squared.south + squared.north) / 2) * Math.PI) / 180,
+  );
+
+  expect((squared.east - squared.west) * lonScale).toBeCloseTo(
+    squared.north - squared.south,
+    12,
+  );
+});
+
+test("a box that is already square is left alone", () => {
+  const squared = squareToward(BOX, { east: -1, north: 0 });
+  expect(squareToward(squared, { east: -1, north: 0 })).toEqual(squared);
+});
+
+test("the nearest point carries how far away it is, so a caller can decline", () => {
+  const points = coastline();
+  const laJolla = { lat: 32.8577, lon: -117.2565 };
+  const inland = { lat: 32.8577, lon: -116.5 };
+
+  expect(nearestOn(points, laJolla)!.metres).toBeLessThan(1_000);
+  expect(nearestOn(points, inland)!.metres).toBeGreaterThan(50_000);
+  expect(nearestOn([], laJolla)).toBeNull();
+});
+
+test("a run grows from both ends until it is long enough", () => {
+  const points = coastline();
+
+  // One point asked for, two kilometres demanded: it reaches both ways.
+  const grown = runAround(points, 500, 500, 2_000);
+  expect(grown.length).toBeGreaterThan(10);
+
+  // A run already longer than the minimum is returned untouched, so a long
+  // beach frames on itself.
+  const long = runAround(points, 400, 500, 2_000);
+  expect(long).toHaveLength(101);
+
+  // At the county's end there is no more coast one way, and the other side
+  // takes the remainder rather than the run being centred on nothing.
+  const atEnd = runAround(points, 0, 0, 2_000);
+  expect(atEnd[0]).toEqual(points[0]);
+  expect(atEnd.length).toBeGreaterThan(10);
+
+  expect(runAround([], 0, 0, 2_000)).toEqual([]);
 });

--- a/src/lib/coastline.ts
+++ b/src/lib/coastline.ts
@@ -115,6 +115,52 @@ export function boundsAround(
   };
 }
 
+/**
+ * The same box grown on one side until it is square on the ground.
+ *
+ * **This is where the empty space is decided, and it is decided here rather
+ * than in the projection.** `projectionFor` letterboxes a non-square box into a
+ * square frame and splits the leftover evenly, which puts half of it inland on
+ * a map whose whole subject is which side the water is on. Squaring the box
+ * toward the sea first means the projection has no leftover to split: the
+ * growth is real mapped ocean rather than blank padding, so the sea wash covers
+ * it and the coast sits against the landward edge.
+ *
+ * The alternative was a bias inside `projectionFor`, which would have made a
+ * generic mapping know which of its two axes was the sea — a fact about a
+ * coastline, in a function that deliberately knows only about boxes.
+ *
+ * Unchanged when the box is already square, and unchanged when the caller has
+ * no seaward direction to offer: a beach with no traced coast has no land-sea
+ * split to bias toward, so an even letterbox is the honest frame for it.
+ */
+export function squareToward(
+  bounds: Bounds,
+  toward: { east: number; north: number },
+): Bounds {
+  const lonScale = Math.cos(
+    (((bounds.south + bounds.north) / 2) * Math.PI) / 180,
+  );
+  const spanLat = bounds.north - bounds.south;
+  const spanLon = (bounds.east - bounds.west) * lonScale;
+
+  if (spanLon < spanLat) {
+    const grow = (spanLat - spanLon) / lonScale;
+    return toward.east >= 0
+      ? { ...bounds, east: bounds.east + grow }
+      : { ...bounds, west: bounds.west - grow };
+  }
+
+  if (spanLat < spanLon) {
+    const grow = spanLon - spanLat;
+    return toward.north >= 0
+      ? { ...bounds, north: bounds.north + grow }
+      : { ...bounds, south: bounds.south - grow };
+  }
+
+  return bounds;
+}
+
 /** A point on the drawn plot, in the caller's own units. */
 export interface PlotPoint {
   readonly x: number;
@@ -211,6 +257,105 @@ export function windowAround(
     Math.max(0, first - 1),
     Math.min(points.length, last + 2),
   );
+}
+
+/**
+ * One degree of latitude, in metres. The only ground unit this module needs.
+ *
+ * Flat arithmetic with the same cosine correction `projectionFor` and
+ * `boundsAround` use, rather than the haversine in `scripts/geo.mjs`. That file
+ * is build-side and runs once against every beach; this runs per request
+ * against one, and a second distance convention inside one module is how two
+ * functions come to disagree about the same coast. At this coast's scale the
+ * two differ by less than the 98 m spacing of the points being measured.
+ */
+const METRES_PER_DEGREE = 111_320;
+
+function metresBetween(a: Position, b: Position): number {
+  const lonScale = Math.cos((((a.lat + b.lat) / 2) * Math.PI) / 180);
+  const dx = (a.lon - b.lon) * lonScale;
+  const dy = a.lat - b.lat;
+  return Math.hypot(dx, dy) * METRES_PER_DEGREE;
+}
+
+/**
+ * The point of the polyline nearest a position, and how far away it is.
+ *
+ * **The distance is returned because the caller has to be able to decline.**
+ * This file traces the open coast, so asking it for the nearest point to a
+ * Mission Bay beach gets an answer 4.9 km away that is somebody else's
+ * shoreline. A nearest-point search with no distance is a search that always
+ * succeeds, and the caller then draws whatever it found.
+ *
+ * Null on an empty polyline, which is a caller that has nothing to search
+ * rather than a place with no coast.
+ */
+export function nearestOn(
+  points: readonly ShorePoint[],
+  at: Position,
+): { index: number; metres: number } | null {
+  if (points.length === 0) return null;
+
+  let best = Infinity;
+  let index = 0;
+  points.forEach((point, at_) => {
+    const metres = metresBetween(at, point);
+    if (metres < best) {
+      best = metres;
+      index = at_;
+    }
+  });
+  return { index, metres: best };
+}
+
+/**
+ * The run between two points of the polyline, grown outward to a minimum length
+ * of shore.
+ *
+ * **A length of coast rather than a count of points**, because the points are
+ * an artifact of CDIP's grid and the picture is of a shoreline. They sit at
+ * about 98 m, so the two are close — and "about" is exactly the word that makes
+ * a count the wrong unit for a rule stated in the ground.
+ *
+ * **It grows from both ends alternately**, so a beach stays in the middle of
+ * the context it is given rather than being pushed against one end of it. Where
+ * the polyline runs out on one side — the county's two ends — the other side
+ * takes the remainder, which is the honest answer: there is no more coast to
+ * show, and the map should not pretend by centring on emptiness.
+ *
+ * Returns the run unchanged when it is already long enough, so a beach longer
+ * than the minimum sets its own frame.
+ */
+export function runAround(
+  points: readonly ShorePoint[],
+  fromIndex: number,
+  toIndex: number,
+  minimumMetres: number,
+): readonly ShorePoint[] {
+  if (points.length === 0) return [];
+
+  const last = points.length - 1;
+  let from = Math.max(0, Math.min(fromIndex, toIndex));
+  let to = Math.min(last, Math.max(fromIndex, toIndex));
+
+  let length = 0;
+  for (let index = from; index < to; index += 1) {
+    length += metresBetween(points[index], points[index + 1]);
+  }
+
+  while (length < minimumMetres && (from > 0 || to < last)) {
+    if (from > 0) {
+      length += metresBetween(points[from - 1], points[from]);
+      from -= 1;
+    }
+    if (length >= minimumMetres) break;
+    if (to < last) {
+      length += metresBetween(points[to], points[to + 1]);
+      to += 1;
+    }
+  }
+
+  return points.slice(from, to + 1);
 }
 
 /**

--- a/src/lib/coastline.ts
+++ b/src/lib/coastline.ts
@@ -309,6 +309,50 @@ export function nearestOn(
 }
 
 /**
+ * The stretch of polyline around an index that no gap interrupts.
+ *
+ * **The file is ordered by line id, and consecutive ids are not always
+ * neighbours on the ground.** Measured across the 1,086 steps: most are about
+ * 98 m, 25 exceed 300 m, and exactly one is 2,967 m — `D0226` to `D0228`,
+ * across the mouth of San Diego Bay, where the model places no lines because
+ * there is no open coast to place them on. Nine steps exceed 500 m and each is
+ * a harbour or river mouth of the same kind.
+ *
+ * A run that crosses one of those draws a straight stroke over open water and
+ * calls it shoreline. `coronado-north-beach` did exactly that: its two ends
+ * landed on opposite sides of the bay mouth, so the stretch marking a 2.8 km
+ * beach was a 4.9 km V with a 3 km diagonal across the channel.
+ *
+ * This is the same class of problem as the zero-length segments this module
+ * already removes, and it is answered the same way: the geometry is made
+ * answerable before anything is asked of it. A zero-length step has no
+ * direction; a three-kilometre step has no shore.
+ */
+export function unbrokenAround(
+  points: readonly ShorePoint[],
+  index: number,
+  gapMetres: number,
+): { from: number; to: number } {
+  let from = Math.max(0, Math.min(index, points.length - 1));
+  let to = from;
+
+  while (
+    from > 0 &&
+    metresBetween(points[from - 1], points[from]) <= gapMetres
+  ) {
+    from -= 1;
+  }
+  while (
+    to < points.length - 1 &&
+    metresBetween(points[to], points[to + 1]) <= gapMetres
+  ) {
+    to += 1;
+  }
+
+  return { from, to };
+}
+
+/**
  * The run between two points of the polyline, grown outward to a minimum length
  * of shore.
  *
@@ -331,11 +375,16 @@ export function runAround(
   fromIndex: number,
   toIndex: number,
   minimumMetres: number,
+  within: { from: number; to: number } = {
+    from: 0,
+    to: Math.max(0, points.length - 1),
+  },
 ): readonly ShorePoint[] {
   if (points.length === 0) return [];
 
-  const last = points.length - 1;
-  let from = Math.max(0, Math.min(fromIndex, toIndex));
+  const last = Math.min(points.length - 1, within.to);
+  const start = Math.max(0, within.from);
+  let from = Math.max(start, Math.min(fromIndex, toIndex));
   let to = Math.min(last, Math.max(fromIndex, toIndex));
 
   let length = 0;
@@ -343,8 +392,8 @@ export function runAround(
     length += metresBetween(points[index], points[index + 1]);
   }
 
-  while (length < minimumMetres && (from > 0 || to < last)) {
-    if (from > 0) {
+  while (length < minimumMetres && (from > start || to < last)) {
+    if (from > start) {
       length += metresBetween(points[from - 1], points[from]);
       from -= 1;
     }


### PR DESCRIPTION
Closes #199.

`la-jolla-cove` showed a fragment of shoreline pressed against the top of its
map, running off the edge, with the rest of the square empty. Measured, its
frame was **200 metres across** — and the heavy stroke that means "this is your
beach" was drawn at the MOP line, about 400 m from the beach.

## What was wrong

Three causes, compounding:

- **The frame was sized on points nothing draws** — the bound MOP line, and the
  beach's own sand. ADR-0033 stopped drawing the line; the sand was never drawn
  where a coast is, because the stretch is a run of CDIP's line, which the map's
  own credit says is computed a few hundred metres offshore.
- **There was no minimum span, and the reason recorded for that had expired.**
  `boundsAround` said "none is needed: the tightest box is `shoreline-park` at
  1.8 km" — measured when the frame still held the four stations. It did not.
  Real spans were `fiesta-island` 0.05 km, `la-jolla-cove` 0.20 km, **23 beaches
  under 1 km**.
- **The dependency ran backwards.** The frame decided which coast was drawn, so
  a frame too small to show the coast was also too small to place the beach on
  it — `beachStretch` snapped to whatever the window caught.

Across the inventory: 20 of 49 frames clipped their content at an edge; 16 had an
empty edge over 40 of 100 units.

## What changed

**The run of coast decides the frame**, rather than the frame deciding the coast.
The beach's run is found against the whole polyline, grown to 2 km of shore, and
the frame is built from that alone. The coast is in view by construction.

**Empty space goes to the sea.** The box is squared toward the water before
projection, so the growth is mapped ocean the wash covers rather than blank
letterbox padding — and `projectionFor` stays a function that knows only about
boxes.

**"On the traced coast" became an explicit kilometre.** Every beach binding a MOP
line is within 0.93 km of the traced coastline; every bay beach is 1.17 km or
more. So the test reproduces ADR-0034's documented 28/23 split rather than
inventing one — and gives three beaches a coastline they should always have had:
`childrens-pool`, `tijuana-slough` and `coronado-cays-nr`, all on the open coast,
all previously blank because none binds a MOP line and their frames were tens of
metres across.

**A run may not cross a gap in the model.** Of the polyline's 1,086 steps most
are ~98 m; exactly one is 2,967 m, across the mouth of San Diego Bay where CDIP
places no lines. Searching the whole coastline made that reachable — inside the
old 200 m window a beach's two ends could not straddle it, and
`coronado-north-beach`'s did, drawing a 4.9 km V with a three-kilometre diagonal
across the channel in the heavy stroke.

## Measured, before and after

| beach | before | after |
| --- | --- | --- |
| `la-jolla-cove` frame | 0.20 km, 3 coast points | 2 km run, coast across the frame |
| `la-jolla-cove` stroke | 400 m from the beach | on the nearest traced point |
| `coronado-central` coast | y 65–104, space above it | y 8–50, sea below it |
| beaches with a coast | 25 | 28 |

## Two things found while doing it

**ADR-0036 was written wrong and the built page caught it.** It said the frame
was "the run plus the beach's own ends" — which kept the same fault it was
removing, one step further along. The ADR is corrected in the commit that fixed
it.

**The `sea-side` gate silently stopped covering the map.** It argued the map's
window was contained in its own, so the run the map draws inherited its verdict.
That containment was an accident of both boxes being built by `boundsAround` from
overlapping points, and this change ended it: **27 of the 28 beaches with a coast
drew points the gate had never looked at**, up to 53 at
`la-jolla-community-beach`. The gate still passed. `MIN_WINDOW_M` restores
containment — swept rather than guessed: 4 km leaves 9 beaches short, 8 km leaves
5, 12 km leaves none — and the constant-equality check that stood in for
containment is replaced by the containment itself, asserted against the real
assembler. Widening is not free (the polyline wraps Point Loma), so it was
checked: all 15 beaches that bind a buoy still put it seaward.

## Verified on the built page

Driven with Playwright against `next dev` at 1536×639, on live feeds.
`la-jolla-cove` now draws its headland across the frame with the beach marked on
it and the ocean taking the empty space; `childrens-pool` draws coastline where
it drew none; `coronado-central-beach` gives the ocean about 80 percent of the
frame where the land had it.

## Regression tests, run red first

Both were run against the code without their guard and fail there:

- the stretch sits on the nearest available coast (fails on the pre-#199 code)
- no stretch or run crosses a gap in the model (fails with the gap guard removed)

## Gates

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

```
 Test Files  96 passed (96)
      Tests  1530 passed (1530)

Statements   : 89.84% ( 2848/3170 )
Branches     : 89.43% ( 1863/2083 )
Functions    : 94.5%  ( 653/691 )
Lines        : 89.57% ( 2569/2868 )
```

## Not done, and why

- **No plan file.** Three slices in one sitting, and ADR-0036 carries the
  argument. The issue and this body are the durable record.
- **The sea polygon still closes across the picture where a coast bends hard** —
  filed as #200. `seaPath` takes one normal from the drawn run's two ends
  (ADR-0033), exact on a straight shore and approximate on a bent one, and longer
  runs bend more. `coronado-north-beach` is where it shows. It is **better** than
  before this branch — that map previously drew its whole coast as the
  gap-crossing diagonal with the sea a wedge in one corner — but a corner of
  frame is still unshaded. That is a defect against ADR-0033 rather than a
  framing question, and #200 records that the frame and the wash currently derive
  "which way is the sea" twice and disagree on three beaches.
- **Slices 2 and 3 of the plan are one commit**, because neither passes the gate
  alone: reframing fills more of the picture, which broke ADR-0034's promise that
  the readout's corner clears everything drawn, and squaring toward the sea is
  what clears it again.

**This should land before #193**, which grows the readout's box and re-measures
every corner against this projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GwPvqm8B8iDYG7EKyPft1
