### PR TITLE
Re-measure the readout's corner figures and pin the ceiling

### DIFF
--- a/docs/adr/0036-the-coast-run-decides-the-frame.md
+++ b/docs/adr/0036-the-coast-run-decides-the-frame.md
@@ -4,8 +4,16 @@ Date: 2026-08-31. Status: accepted. Reverses `boundsAround`'s recorded reason fo
 having no minimum span, and removes the bound MOP line from the frame's
 arithmetic — which is the half of `shoreViewFor`'s docstring that argued for
 keeping it. ADR-0033 is unchanged and is why this is needed. ADR-0034's measured
-placement table is re-measured in the same pull request, because the projection
-it was measured against moves. ADR-0030 is untouched.
+placement table has to be re-measured, because the projection it was measured
+against moves. ADR-0030 is untouched.
+
+**Correction, 2026-08-31.** This document said twice that the re-measurement
+happened "in the same pull request". It did not: PR #201 left `corner.ts` and
+ADR-0034 untouched, and the claim was false the moment it merged. The figures
+were re-measured immediately afterwards and the outcome is below. That this
+document — whose own subject is a measurement that expired unnoticed — shipped
+with a stale claim of its own is the most direct evidence it could have offered
+for its own argument.
 
 ## Context
 
@@ -184,11 +192,15 @@ is which side the water is on.
   the committed polyline and is testable without rendering a map, which is what
   lets the inventory-wide checks assert placement directly rather than by
   screenshot.
-- **Every frame moves, so every measured figure about the map is re-measured.**
-  ADR-0034's placement table and `corner.ts`'s docstring figures were taken
-  against the old projection. They are re-measured in the same pull request, and
-  `corner.test.ts` — which asserts a clear corner on every beach — is the check
-  that this did not quietly break the readout.
+- **Every frame moves, so every measured figure about the map had to be
+  re-measured.** Done in the follow-up named in the correction above, not here.
+  Two of the three figures in `corner.ts`'s table had gone stale: a fixed
+  top-left survives 1.0 unit rather than 8.3, and the flip rule 43.3 at a
+  14-unit height rather than 19.0. **The one that decides anything did not
+  move** — the adaptive corner's 50.5-unit ceiling holds at every height from 14
+  to 50, because the beach that sets it binds no coast and so was not one of the
+  frames this decision moved. It is now asserted in `corner.test.ts` rather than
+  stated in a docstring, which is what should have held it in the first place.
 - **The minimum run is a number that will be argued about**, and it should be:
   it decides how much shore every map shows. It is a length of coastline in
   kilometres, stated in one place, and changing it changes every map at once —

--- a/src/components/conditions/corner.test.ts
+++ b/src/components/conditions/corner.test.ts
@@ -188,3 +188,45 @@ test("the footprint stays inside what the inventory can hold", () => {
   // vertical room to spend and none to spare across.
   expect(READOUT_BOX.width).toBeLessThanOrEqual(50);
 });
+
+test("the inventory's ceiling on the readout's width is 50.5 units", () => {
+  // **The figure `READOUT_BOX` is budgeted against, held by the gate instead of
+  // by the docstring that used to hold it.**
+  //
+  // ADR-0036 reframed every map, and two of the three figures in this module's
+  // table went stale without anything noticing -- a fixed top-left fell from 8.3
+  // units to 1.0. This one did not move, and the reason it did not is worth
+  // asserting rather than trusting: the beach that sets the ceiling binds no
+  // coast, so its frame was not one of the frames that moved. A later change
+  // that does move it should fail here.
+  //
+  // Measured at several heights because "the height is free and the width is
+  // not" is the claim the rows are laid out against, and it is the half most
+  // likely to stop being true.
+  for (const height of [14, 20, 30, 35, 40, 50]) {
+    const probe: Box = { width: 0, height };
+
+    let worst = Infinity;
+    let worstBeach = "";
+    for (const beach of allBeaches()) {
+      const points = drawnPoints(beach);
+      if (points.length === 0) continue;
+      const roomiest = Math.max(
+        ...(
+          ["top-left", "top-right", "bottom-left", "bottom-right"] as const
+        ).map((corner) => clearanceAt(corner, points, probe, FRAME)),
+      );
+      if (roomiest < worst) {
+        worst = roomiest;
+        worstBeach = beach.slug;
+      }
+    }
+
+    expect(worst).toBeCloseTo(50.5, 1);
+    expect(worstBeach).toBe("mission-bay-visitor-s-center");
+  }
+
+  // And the box actually declared stays inside it, which is the point of
+  // knowing the number at all.
+  expect(READOUT_BOX.width).toBeLessThanOrEqual(50);
+});

--- a/src/components/conditions/corner.ts
+++ b/src/components/conditions/corner.ts
@@ -10,21 +10,30 @@
  * that test says the fixed corner has nowhere to stand.
  *
  * Measured across the inventory, as the widest readout each rule survives on its
- * worst beach — and the three figures do not move at any readout height from 12
- * units to 40:
+ * worst beach. **Re-measured after ADR-0036 moved every frame** — the first
+ * three figures were taken against the old projection and two of them had gone
+ * stale, which is what `MEASURED.md` would say if this repo kept one:
  *
- * | placement                | widest readout | worst beach                  |
- * | ------------------------ | ------------ | ------------------------------ |
- * | fixed top-left           | 8.3 units    | `childrens-pool`               |
- * | top, side flips          | 19.0 units   | `la-jolla-cove`                |
- * | any of the four corners  | 50.5 units   | `mission-bay-visitor-s-center` |
+ * | placement               | widest readout | worst beach                    |
+ * | ----------------------- | -------------- | ------------------------------ |
+ * | fixed top-left          | 1.0 unit       | `tijuana-slough…`              |
+ * | top, side flips         | 43.3 at h=14   | `coronado-central-beach`       |
+ * | any of the four corners | 50.5 units     | `mission-bay-visitor-s-center` |
  *
- * 8.3 units is about 27px on the 328px map a phone draws, against the 150px two
- * rows of four fields need. **The cause is structural rather than unlucky**: on
- * the beaches with no traced coast, `beachStretch` draws the beach's own two
- * ends, so the segment is a chord between the frame's margin corners and always
- * blocks one diagonal pair. `childrens-pool` reads 8 units clear at the
- * top-left, 8 at the bottom-right, 92 at each of the others.
+ * **The one that decides anything did not move**, and that is not luck: the
+ * worst beach for the adaptive rule binds no coast, so ADR-0036's reframing
+ * never touched it. 50.5 units still holds at every height from 14 to 50, which
+ * is the "height is free and width is not" the readout's rows are budgeted
+ * against. `corner.test.ts` now pins it rather than leaving it here to rot.
+ *
+ * The two that did move describe rejected alternatives, and both moved *away*
+ * from viability: a fixed top-left now survives one unit rather than 8.3.
+ * **The cause is structural rather than unlucky**: on the beaches with no
+ * traced coast, `beachStretch` draws the beach's own two ends, so the segment
+ * is a chord between the frame's margin corners and always blocks one diagonal
+ * pair. The flip rule's figure now falls with height — 43.3 at 14, 16.0 at 35,
+ * 8.3 at 40 — where the adaptive rule's does not, which is the clearest
+ * statement of why the fourth corner is worth having.
  *
  * **The half of the plan's rejection that was wrong is the reason this file
  * exists.** It said an adaptive corner "becomes untestable in the useful
@@ -64,10 +73,14 @@ export interface PlotPoint {
  *
  * **The height is free and the width is not**, which is the measurement that
  * decides what the rows may say. The widest readout any corner allows is 50.5
- * units at a band 14 units deep, and *still* 50.5 at 20, 25, 30, 35 and 40 --
- * it only moves at 50, where it drops to 50.0. What blocks a corner is a stroke
- * crossing it diagonally, and a deeper band meets the same stroke at nearly the
- * same place.
+ * units at a band 14 units deep, and *still* 50.5 at 20, 30, 35, 40 and 50.
+ * What blocks a corner is a stroke crossing it diagonally, and a deeper band
+ * meets the same stroke at nearly the same place.
+ *
+ * Re-measured after ADR-0036 reframed every map, and unchanged: the beach that
+ * sets this ceiling binds no coast, so it was not one of the frames that moved.
+ * `corner.test.ts` asserts the figure, so the next reframing says so here
+ * rather than leaving a stale number to be believed.
  *
  * So the rows have vertical room to spend and none at all to spare across, and
  * that is why a row wraps rather than running on: at 10px, `SWELL south-west


### PR DESCRIPTION
Small lane: prose and one assertion, no logic and no contract.

ADR-0036 states twice that ADR-0034's placement table was re-measured "in the
same pull request". **It was not** — #201 left `corner.ts` and ADR-0034
untouched, so the claim was false the moment it merged. In the document whose
own subject is a measurement that expired without anything noticing.

## Re-measured

| placement               | said           | actual                   | worst beach                    |
| ----------------------- | -------------- | ------------------------ | ------------------------------ |
| fixed top-left          | 8.3 units      | **1.0 unit**             | `tijuana-slough…`              |
| top, side flips         | 19.0 units     | **43.3 at h=14**         | `coronado-central-beach`       |
| any of the four corners | 50.5 units     | **50.5 units** unchanged | `mission-bay-visitor-s-center` |

Both stale figures describe **rejected** alternatives, and both moved further
from viability rather than toward it, so nothing decided on them is disturbed.

**The figure that decides anything did not move**, and not by luck: the beach
that sets the ceiling binds no coast, so its frame was not one of the frames
ADR-0036 moved. 50.5 units holds at every height from 14 to 50 — which is the
"height is free and width is not" the readout's rows are budgeted against, and
what #193 is about to spend.

## Pinned rather than written down

`corner.test.ts` now walks the inventory at six heights and asserts both the
ceiling and the beach that sets it. That is what should have held it before: a
docstring cannot fail when the code it measured moves, and this one did not.

ADR-0036 carries a dated correction naming what it got wrong, rather than being
quietly edited to look right.

## Gates

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

`corner.test.ts` 11 passed.

## Not done

No new issue filed. This is a correction to #199's own work, caught in the same
session, and the durable record is the ADR correction plus the assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GwPvqm8B8iDYG7EKyPft1
