### PR TITLE
Correct the beach the taller readout box moves

### DIFF
--- a/docs/adr/0035-the-page-has-one-selected-hour.md
+++ b/docs/adr/0035-the-page-has-one-selected-hour.md
@@ -5,7 +5,9 @@ compass may not follow the selected hour"**; the rest of that decision, includin
 all four of its conditions, is unchanged and still binds. Reverses `ChosenDay`'s
 rule that a chosen hour does not survive a day change. Adds the `Selected hour`
 entry to `CONTEXT.md`, updated in the same pull request. Corrects one sentence of
-ADR-0034, below. ADR-0032 and ADR-0034 are otherwise untouched.
+ADR-0034, below. ADR-0032 and ADR-0034 are otherwise untouched. Amended
+2026-08-31, after the box grew in #203, to correct one beach name in the last
+consequence; the decision is unchanged.
 
 ## Context
 
@@ -237,7 +239,15 @@ selection guide — and it would need a rule for the other three tabs.
   the condition ADR-0010 and ADR-0029 set rather than an exception to them.
 - **`READOUT_BOX` grows from 35 to 40 units** to hold the caption, which
   `corner.ts` measured as moving three beaches to a different corner:
-  `pacific-beach`, `mission-bay-de-anza-cove` and `mission-bay-sea-world`.
+  `south-casa-beach-s-d`, `mission-bay-de-anza-cove` and
+  `mission-bay-sea-world`. **This said `pacific-beach` rather than the first of
+  those**, from a measurement taken before ADR-0036 reframed every map. By the
+  time the box actually grew, `pacific-beach` stood in the bottom-left at 30, 35
+  and 40 alike — it moves at no height now — and `south-casa-beach-s-d` moved in
+  its place. One name; the same count; no consequence for the decision. It is
+  corrected here rather than left to be believed, and the figure is kept in
+  `corner.ts` with `corner.test.ts` pinning the width ceiling it is budgeted
+  against, so the next reframing fails a gate instead of ageing a sentence.
 - **This decision ships in two pull requests.** The context, the lift and the
   chart's arrival state land with this document; the readout's caption, its
   per-hour rows, the box growing and `periodS` land in the next one, and #194's

--- a/src/components/conditions/corner.ts
+++ b/src/components/conditions/corner.ts
@@ -104,11 +104,12 @@ export interface PlotPoint {
  * Across the inventory, 35 chooses the same corner as 30 on all 50 beaches that
  * draw one, and 40 moves three of them -- `south-casa-beach-s-d` to the
  * bottom-right, `mission-bay-de-anza-cove` and `mission-bay-sea-world` to the
- * top-right. **Two of those three are not the beaches ADR-0035 named**: that
- * measurement was taken before ADR-0036 reframed every map, and `pacific-beach`
- * has stopped moving while `south-casa-beach-s-d` has started. The count is the
- * same and so is the shape of the answer, which is the half of a measurement
- * that survives a reframing.
+ * top-right. **One of those three is not the beach ADR-0035 named**, because
+ * that list was measured before ADR-0036 reframed every map: it said
+ * `pacific-beach`, which now stands in the bottom-left at 30, 35 and 40 alike
+ * and so moves at no height at all, and `south-casa-beach-s-d` moves in its
+ * place. The count is the same and so is the shape of the answer, which is the
+ * half of a measurement that survives a reframing.
  */
 export const READOUT_BOX: Box = { width: 50, height: 40 };
 


### PR DESCRIPTION
Small lane: prose only, in `docs/adr/0035-the-page-has-one-selected-hour.md` and `corner.ts`'s docstring. No logic, no data shape, no contract, and nothing here contradicts a recorded decision — the decision the ADR records is unaffected.

## What was wrong

ADR-0035's last consequence named `pacific-beach` as one of three beaches that change corner when `READOUT_BOX` grows from 35 to 40. That list was measured before ADR-0036 reframed every map in #201 and #202. Re-measured now that the box has actually grown (#203):

| beach | 30 | 35 | 40 |
| --- | --- | --- | --- |
| `south-casa-beach-s-d` | top-left | top-left | **bottom-right** |
| `mission-bay-de-anza-cove` | top-left | top-left | **top-right** |
| `mission-bay-sea-world` | top-left | top-left | **top-right** |
| `pacific-beach` | bottom-left | bottom-left | bottom-left |

`pacific-beach` does not move at any height any more — the reframing took it out of the top-left entirely — and `south-casa-beach-s-d` moves in its place. One name; the same count of three.

**And `corner.ts` carried the same correction with its own error**, introduced in #203: it said *two* of the three names had changed when only one had. That is fixed in the same commit rather than left as the tidier-looking half of a wrong pair.

The ADR is amended in place, with the old name and the reason it was wrong kept visible, which is how ADR-0035 itself treats ADR-0034's error. Its header records the amendment.

## What I did not do

- **No addendum to `docs/plans/map-weather-readout.md`**, whose 2026-08-31 addendum carries the same stale list. It is a dated record of what was decided; the binding decision lives in the ADR, which is the document CLAUDE.md keeps current, and a third copy of one beach name is a third thing that can go stale on its own.
- **No test naming these three beaches.** `corner.test.ts` deliberately asserts "at least one beach" rather than naming `childrens-pool`, so it survives the inventory moving and fails only if the reason goes away. A test pinning three slugs would fail on the next reframing for the right reason and the wrong one indistinguishably. What holds the figure that matters is the 50.5-unit ceiling check, which already runs at every height from 14 to 50.

## Verification

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… sea-side
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GwPvqm8B8iDYG7EKyPft1