### PR TITLE
Name the day chart's hours from their instants, and stand its axis on them

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -191,9 +191,13 @@ is what redraws.
 _Avoid_: day view, detail panel, today panel (it is any of seven days)
 
 **Hour chart**:
-The large plot inside the day panel: twenty-four hours across, night shaded,
-cloud as a band above, one of four series drawn at a time behind four tabs.
-_Avoid_: graph, the plot, day chart, timeline
+The large plot inside the day panel: one whole day across, midnight to
+midnight, night shaded, cloud as a band above, one of four series drawn at a
+time behind four tabs. Twice a year that day is twenty-three or twenty-five
+hours rather than twenty-four, and the axis shows it — the named hours stay
+12 AM, 3 AM, 6 AM and so on, each over the moment it names, so the gap holding
+the transition is wider or narrower than the rest (ADR-0040).
+_Avoid_: graph, the plot, day chart, timeline, twenty-four hours across
 
 **Selected hour**:
 The one hour of the chosen day the day panel is showing. The hour chart marks

--- a/docs/adr/0040-the-page-speaks-instants-and-counts-positions.md
+++ b/docs/adr/0040-the-page-speaks-instants-and-counts-positions.md
@@ -1,0 +1,202 @@
+# 0040 — The page speaks instants and counts positions
+
+Date: 2026-09-01. Status: accepted. Discharges the last consequence of
+ADR-0035, which recorded this defect as inherited rather than fixed; that
+document is a dated record and is not amended. Nothing in ADR-0027, ADR-0034 or
+ADR-0035 changes. Corrects the **Hour chart** entry in `CONTEXT.md`, updated in
+the same pull request.
+
+## Context
+
+`hourOfDay` derives an hour as `Math.round((atMs - startMs) / HOUR_MS)`. That is
+a position in the day, not a reading of a clock, and `localMidnightOf` resolves
+the zone offset twice — so `startMs` and `endMs` are true local midnights and a
+Pacific day is genuinely twenty-three or twenty-five hours long twice a year.
+Four places on the day panel then said that position out loud as though it were
+a clock hour, and one placed a tick by dividing it by twenty-four.
+
+This is issue #196, and it is two defects rather than one.
+
+### The name
+
+On the fall-back day, 2026-11-01, the day holds twenty-five hours:
+
+| position | real instant | printed |
+| -------- | ------------ | ------- |
+| 3        | 2:00 AM      | "3 AM"  |
+| 12       | 11:00 AM     | "12 PM" |
+| 13       | 12:00 PM     | "1 PM"  |
+| 24       | 11:00 PM     | "12 PM" |
+
+So the axis printed "12 PM" twice — once over 11 AM and once at eleven at night
+— and **never named noon at all**. #196's own text says the two collide "at noon
+and at 11 PM"; the first half of that is not right, and the correction matters
+because it is the reading that makes the fault visible. On the spring-forward
+day, 2027-03-14, the day holds twenty-three hours and every hour from position 2
+was named an hour early.
+
+The chart's readout, its hidden column labels and the map's caption all carried
+the same wrong number. `hourLabel(25)` would have returned "13 PM", but position
+25 is the next day's midnight and the series bucket by local date, so it was
+unreachable.
+
+### The position, which #196 does not mention
+
+The axis placed each label at `(hour / 24) * 100%` while the curve above it is
+mapped by `x()` against the day's **real** span. Measured on both days:
+
+| tick, at `hour / 24` | 2026-11-01 sits over | 2027-03-14 sits over |
+| -------------------- | -------------------- | -------------------- |
+| 3 AM @ 12.50%        | 2:07 AM (−53 min)    | 3:52 AM (+52 min)    |
+| 6 AM @ 25%           | 5:15 AM (−45)        | 6:45 AM (+45)        |
+| 9 AM @ 37.5%         | 8:22 AM (−38)        | 9:37 AM (+37)        |
+| 12 PM @ 50%          | 11:30 AM (−30)       | 12:30 PM (+30)       |
+| 9 PM @ 87.5%         | 8:52 PM (−8)         | 9:07 PM (+7)         |
+
+**The error is largest just after the transition and shrinks through the day**,
+because the position stretch and the offset partly cancel, which is part of why
+it was never noticed. Fixing only the label would have left a correctly-named
+tick over the wrong part of the curve — a fault a reader is _less_ likely to
+catch than the first one, because the words would now look right.
+
+## Decision
+
+**Every hour this page speaks is named from its instant; the position stays a
+position and is never spoken.**
+
+- **`hourOfDay` is unchanged and keeps its meaning.** It is a legitimate plot
+  coordinate, and the hour columns, `cloudByHour`, `needles.ts` and the selected
+  hour all key on it. A clock hour cannot replace it: a fall-back day holds two
+  1 AMs, and keying a selection on one of them would make two hours
+  indistinguishable. This is #196's own recommendation and it is taken.
+
+- **`localHourOf` and `hourLabelAt` live in `pacific-time.ts`**, beside
+  `localTimeOf`. Naming an instant in a named zone is what that module is;
+  `hourLabel` sat in `dayFrame.ts` only while it took `hourOfDay`'s output, on
+  the argument that one definition of an hour and one definition of what to call
+  it belong together. Naming from the instant dissolves that pairing.
+
+- **The words are built here rather than asked of `Intl`.** An hour-only format
+  returns "3 PM" with an ordinary space and "12 AM" at midnight on Node 22.18.0
+  / ICU 77 — checked rather than assumed — but which space character ICU picks
+  has moved before and CI runs a different build of it, so a label asserted as
+  `toBe("3 PM")` could fail there and nowhere else. `localHourOf` reads a
+  _number_ out of `Intl`, where no such question arises.
+
+- **The label function is renamed rather than kept.** Its argument went from a
+  0-to-23 index to epoch milliseconds and both are `number`, so a missed call
+  site would have compiled and returned plausible nonsense — `hourLabel(12)`
+  gave "12 PM". This defect exists because an index was silently readable as a
+  clock hour; shipping the fix under a signature that stays silently readable
+  both ways would leave the same trap one layer down.
+
+- **The map's caption is fixed with the chart, and that is not optional.** It is
+  not in #196. ADR-0035 arranged for the chart and the readout to name one hour
+  the same way; fixing only the chart would make the two regions disagree on
+  exactly the two days that decision was written to make them agree on.
+
+- **The axis names the same eight hours on all 365 days, each at its true
+  instant.** `axisTicks` returns a clock hour and the instant it happened at,
+  and `HourChart` positions each tick with the same `x` it draws the curve with.
+  So a 25-hour day's ticks sit at 0, 16, 28, 40, 52, 64, 76 and 88 per cent
+  rather than every 12.5, and a 23-hour day's at 0, 8.7, 21.74 and so on.
+
+- **The one uneven gap is the first, which is where the transition is.** On a
+  fall-back day midnight to 3 AM is 16% against 12% elsewhere, because that span
+  really did hold four hours; on a spring-forward day it is 8.7% against 13.04%.
+  The curve is already drawn on real elapsed time, so this is a true statement
+  about the day rather than a distortion introduced to make one.
+
+- **An hour the day does not hold is dropped; a repeated hour takes the earlier
+  of the two.** `LABELLED_HOURS` reaches neither case — the repeated hour is
+  1 AM and the skipped one is 2 AM — but that is a property of the current list
+  and not a guarantee, so both are defined and both are asserted.
+
+- **A repeated hour is named twice rather than disambiguated.** On 2026-11-01
+  the readout and the caption both say "1 AM" for two different hours. They stay
+  distinct selections because the position keys them, and neither is ever an
+  axis tick.
+
+### What was measured, and where
+
+The narrowest spacing this rule produces is midnight to 3 AM on a spring-forward
+day. Measured on the built page, 2026-09-01, at five viewport widths:
+
+| viewport | plot width | "3 AM" would start at | "12 AM" ends at | clearance |
+| -------- | ---------- | --------------------- | --------------- | --------- |
+| 375      | 237px      | not shown             | 28.6px          | —         |
+| 640      | 502px      | 31.2px                | 28.6px          | **2.5px** |
+| 768      | 582px      | 38.1px                | 28.6px          | 9.5px     |
+| 1024     | 806px      | 57.6px                | 28.6px          | 29.0px    |
+| 1536     | 854px      | 61.8px                | 28.6px          | 33.1px    |
+
+`sm` is the binding width: it is the narrowest at which all eight labels show,
+and at 375 only the quarter-day four do, so no narrow screen meets this pair at
+all. **It clears, so no per-day degrade ships.** The same run reproduced the
+237px plot at 375 that `LABELLED_HOURS` already cites, which is what says the
+rig agrees with the page those figures came from.
+
+## Alternatives considered
+
+**Even spacing, names from instants.** Ticks stay at positions 0, 3, 6 … 21,
+evenly spaced, each named from its own instant — so a fall-back day would read
+12 AM, 2 AM, 5 AM, 8 AM, 11 AM, 2 PM, 5 PM, 8 PM. Correct, and rejected. It does
+not remove the day's irregularity, it moves it: the ticks are even and the day
+then runs 16% past the last one instead of 12%, so the anomaly lands in the tail
+where nothing happened rather than in the span that actually holds the extra
+hour. It pays for that with the words, which are the half a reader reads, and it
+would leave `data-axis-hour` carrying a position — the very thing this decision
+stops anything reading as a clock hour.
+
+**Make the hour a clock hour throughout and derive the position.** #196's second
+candidate. Rejected there and here: a repeated 1 AM stops being a unique key,
+and the columns, `cloudByHour` and the selection all need one.
+
+**Ask `Intl` for the hour-only string.** Shorter, and it produces identical text
+on this toolchain. Rejected above: it puts a rendering decision outside the repo
+and into an ICU version that CI does not share.
+
+**Keep the name `hourLabel`.** Smaller diff, and the name still reads well.
+Rejected: `number` to `number` means the type system cannot catch a stale call
+site, and a stale one returns a plausible string rather than an error.
+
+**Fix the label and leave the tick positions.** What #196 describes, and it is
+half the defect. Rejected because it is the worse half to fix alone: a
+correctly-named tick sitting 53 minutes off the curve is harder for a reader to
+catch than a wrongly-named one, since the words now look right.
+
+**Amend ADR-0035's last consequence.** This repo does amend ADRs in place —
+0035 amended itself and corrected 0034 inline — so leaving it is a choice.
+Rejected: that consequence was _correct_. It recorded a defect as deliberately
+inherited so that the chart and the map would stay wrong together rather than
+disagree, and said the fix would be a single-site one. It was, and it is
+discharged here. An ADR whose prediction came true does not need editing.
+
+**Correct `CONTEXT.md`'s Day sparkline entry too**, which calls that plot "the
+24-hour shape" and has the same fault. Rejected as out of scope: `DaySpark` is
+untouched by this work and has no hour axis, so nothing here makes that sentence
+newly wrong. It is named in the pull request rather than filed.
+
+## Consequences
+
+- **`dayFrame.ts` is no longer a leaf**: it imports `localHourOf` from
+  `pacific-time.ts`. Geometry depending on the clock is the right direction and
+  there is no cycle — `needles.ts → dayFrame` already existed.
+- **`dayFrame.ts` gains a test file.** It had none while it held `nightBands`
+  and a one-line `hourOfDay`; a rule whose whole value is being right on
+  2026-11-01 and 2027-03-14 should not cost a jsdom render to assert.
+- **`data-axis-hour` now carries a clock hour.** Four existing tests already
+  read it as one, so this makes an existing reading true rather than adding a
+  convention. Anything reading it as a position would now be wrong — nothing
+  does.
+- **`DayPanel`'s readout rows come back through `instantOfHour` to be named**,
+  because `needles.ts` buckets by position and keeps no instant. That inverse is
+  exact across a transition, which is asserted rather than argued.
+- **`selectedHour.tsx` needed no change**, and its docstring now says why: the
+  hour it holds was always a position, and nothing about a position was ever
+  shown to a reader once the naming moved.
+- **The gate's `mustFail` mechanism cannot express "commit the regression test
+  first" for this kind of defect.** It is a per-gate-row flag and the `test` row
+  runs the whole suite, so a failing test fails that row too. The failing-first
+  evidence is in the pull request instead: the new tests run against the
+  pre-fix call sites, with their output.

--- a/src/components/conditions/DayCompass.tsx
+++ b/src/components/conditions/DayCompass.tsx
@@ -49,9 +49,13 @@ import { resolveHour, useSelectedHour } from "./selectedHour";
  * is a fact about the forecast rather than about this component.
  */
 export type CompassHour = {
-  /** The hour's index into its own day, which is `hourOfDay`'s convention. */
+  /** The hour's position in its own day, which is `hourOfDay`'s convention. */
   hour: number;
-  /** What to call it, worded by `hourLabel` so the chart's axis agrees. */
+  /**
+   * What to call it, worded by `hourLabelAt` from the position's own instant so
+   * the chart's readout agrees. Not derived from `hour` above: on a fall-back
+   * day two positions are both 1 AM and one is 11 PM (ADR-0040).
+   */
   caption: string;
   /** Empty on an hour no feed gave a bearing for, which renders no readout. */
   needles: readonly CompassNeedle[];

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -75,7 +75,17 @@ function daylight(dates: string[], atMs = NOW) {
   });
 }
 
-/** A day of hourly heights that rises and falls, so a curve has somewhere to go. */
+/**
+ * A day of hourly heights that rises and falls, so a curve has somewhere to go.
+ *
+ * **These helpers assume a 24-hour day and every date they are used with is
+ * one.** `endMs` is a literal `+ 24 * HOUR` where production takes the next
+ * day's local midnight, and the hour arrays are `{ length: 24 }`. Dating a test
+ * on 2026-11-01 or 2027-03-14 through here would build a 24-hour fixture for a
+ * 25- or 23-hour day, and any assertion about the transition would pass without
+ * ever meeting one. The DST tests at the foot of this file build their own days
+ * for that reason -- see `dstWeek`.
+ */
 function hoursOn(localDate: string, offset = 0) {
   return {
     localDate,
@@ -1460,4 +1470,185 @@ test("the attribution survives choosing an hour", async () => {
   fireEvent.click(container.querySelector('[data-hour-column="9"]')!);
 
   expect(provenance(container)).toContain("NOAA Tides & Currents");
+});
+
+/**
+ * The map's caption on the two days a year a position is not a clock hour.
+ *
+ * **Its own fixture rather than the shared helpers above**, which hardcode a
+ * 24-hour day: fed a DST date they would build 24 hours for a 25-hour span, and
+ * a test asserting the transition would pass without a transition in it. This
+ * one takes the day's length from `localMidnightOf` at both ends, which is what
+ * `DayPanel` itself does, so the span is 25 or 23 because the zone says so.
+ *
+ * The caption is the site issue #196 does not mention and the one ADR-0035
+ * makes non-optional: if the chart names hours from instants while the caption
+ * counts positions, the two regions disagree on exactly the days that decision
+ * arranged for them to agree on.
+ */
+function dstWeek(localDate: string, nextDate: string, atMs: number) {
+  const startMs = localMidnightOf(localDate);
+  const count = Math.round((localMidnightOf(nextDate) - startMs) / HOUR);
+  const day = {
+    localDate,
+    dayLabel: "Sun, Nov 1",
+    dateLabel: "Sun, Nov 1",
+    isToday: true,
+  };
+  const hourly = <T,>(build: (hour: number) => T) =>
+    Array.from({ length: count }, (_, hour) => build(hour));
+
+  readDaylightWeek.mockReturnValue({
+    beachName: BINDING.beachName,
+    atMs,
+    days: [
+      {
+        ...day,
+        sunriseLabel: "6:14 AM",
+        sunsetLabel: "4:55 PM",
+        sunriseMs: startMs + 6 * HOUR + 14 * 60_000,
+        sunsetMs: startMs + 17 * HOUR + 55 * 60_000,
+      },
+    ],
+  });
+
+  readHourlyTide.mockResolvedValue({
+    ...BINDING,
+    state: {
+      kind: "week",
+      days: [
+        {
+          ...day,
+          startMs,
+          endMs: localMidnightOf(nextDate),
+          hours: hourly((hour) => ({
+            atMs: startMs + hour * HOUR,
+            feet: 2.5 + 2 * Math.sin((hour / count) * 2 * Math.PI),
+          })),
+        },
+      ],
+    },
+  });
+
+  readWaveWeek.mockResolvedValue({
+    beachName: BINDING.beachName,
+    line: { id: "D0481", distanceM: 117 },
+    state: {
+      kind: "week",
+      days: [
+        {
+          ...day,
+          daylight: { timeLabel: "11:00 AM", heightFt: 1.8, periodS: 15 },
+          allDay: null,
+          hours: hourly((hour) => ({
+            atMs: startMs + hour * HOUR,
+            heightFt: 1.5,
+            published: hour % 3 === 2,
+            periodS: hour % 3 === 2 ? 15 : null,
+            directionDegT: hour % 3 === 2 ? 315 : null,
+          })),
+        },
+      ],
+    },
+  });
+
+  const published = (value: number) => ({
+    kind: "published" as const,
+    hours: hourly((hour) => ({
+      atMs: startMs + hour * HOUR,
+      value,
+      published: true,
+    })),
+  });
+
+  readGridpointWeek.mockResolvedValue({
+    beachName: BINDING.beachName,
+    cell: CELL,
+    state: {
+      kind: "week",
+      days: [
+        {
+          ...day,
+          windMph: published(8),
+          windDirDegT: published(180),
+          airTempF: published(64),
+        },
+      ],
+    },
+  });
+
+  readSkyWeek.mockResolvedValue({
+    beachName: BINDING.beachName,
+    cell: CELL,
+    state: {
+      kind: "week",
+      days: [
+        {
+          ...day,
+          thirds: { am: 40, mid: 40, eve: 40 },
+          hours: hourly((hour) => ({
+            atMs: startMs + hour * HOUR,
+            percent: 40,
+          })),
+          phenomenon: null,
+        },
+      ],
+    },
+  });
+
+  wordingWeek([{ localDate, periodName: "Today", words: "Patchy Fog" }]);
+  return { startMs, count };
+}
+
+test("the map's caption names the last hour of a fall-back day 11 PM", async () => {
+  // Position 24 of a 25-hour day. Read as a clock hour it fell through to
+  // `${hour - 12} PM` and the caption said "12 PM" -- noon, printed at eleven
+  // at night, over a wind arrow for the wrong hour.
+  const { startMs, count } = dstWeek(
+    "2026-11-01",
+    "2026-11-02",
+    localMidnightOf("2026-11-01") + 24 * HOUR,
+  );
+  expect(count).toBe(25);
+
+  const { container } = render(
+    <SelectedDayProvider>
+      {await DayPanel({ slug: "la-jolla-shores-beach" })}
+    </SelectedDayProvider>,
+  );
+
+  expect(container.querySelector("[data-readout-caption]")!.textContent).toBe(
+    "11 PM",
+  );
+  // And the chart's readout says the same words about the same hour, which is
+  // the property ADR-0035 exists for and the one that would break first if
+  // only one region were fixed.
+  expect(container.querySelector("[data-hour-readout]")!.textContent).toContain(
+    "11 PM",
+  );
+  expect(startMs + 24 * HOUR).toBeGreaterThan(startMs);
+});
+
+test("the map's caption names a spring-forward hour ahead, not behind", async () => {
+  // The mirror. Position 2 of a 23-hour day is 3 AM: a fix that subtracted an
+  // hour would pass the test above and fail this one.
+  const { count } = dstWeek(
+    "2027-03-14",
+    "2027-03-15",
+    localMidnightOf("2027-03-14") + 2 * HOUR,
+  );
+  expect(count).toBe(23);
+
+  const { container } = render(
+    <SelectedDayProvider>
+      {await DayPanel({ slug: "la-jolla-shores-beach" })}
+    </SelectedDayProvider>,
+  );
+
+  expect(container.querySelector("[data-readout-caption]")!.textContent).toBe(
+    "3 AM",
+  );
+  expect(container.querySelector("[data-hour-readout]")!.textContent).toContain(
+    "3 AM",
+  );
 });

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -61,7 +61,12 @@ import {
   type WaveWeekView,
 } from "@/lib/conditions";
 import { beachBySlug } from "@/lib/beaches";
-import { localMidnightOf, addLocalDays, localTimeOf } from "@/lib/pacific-time";
+import {
+  localMidnightOf,
+  addLocalDays,
+  localTimeOf,
+  hourLabelAt,
+} from "@/lib/pacific-time";
 import { ChosenDay, type DayView } from "./ChosenDay";
 import type { HourSeries } from "./HourChart";
 import { MeasuredPanel } from "./MeasuredPanel";
@@ -74,7 +79,7 @@ import {
   type CompassDay,
   type CompassHour,
 } from "./DayCompass";
-import { hourLabel, hourOfDay } from "./dayFrame";
+import { hourOfDay, instantOfHour } from "./dayFrame";
 import { SelectedHourProvider } from "./selectedHour";
 import {
   GRID_MODEL_NOTE,
@@ -816,13 +821,21 @@ export async function DayPanel({ slug }: { slug: string }) {
         if (swellRow !== undefined) needles.push(swellRow);
 
         /*
-          The caption, worded through the same `hourLabel` the chart's axis
-          uses. One hour named twice on one screen has to be named the same way,
-          and the defect the two share on a DST day is better than the
-          disagreement they would have if each counted its own -- `dayFrame.ts`
-          says why it is inherited rather than forked.
+          The caption, worded through the same `hourLabelAt` the chart's readout
+          and axis use. One hour named twice on one screen has to be named the
+          same way, which is what ADR-0035 arranged and what would break first
+          if only the chart were fixed: the two regions would disagree on
+          exactly the two days that decision was written to make them agree on.
+
+          `instantOfHour` because the rows are keyed by position -- `needles.ts`
+          buckets by `hourOfDay` and keeps no instant -- and a position is the
+          one thing this must not name itself from.
         */
-        return { hour, caption: hourLabel(hour), needles };
+        return {
+          hour,
+          caption: hourLabelAt(instantOfHour(hour, dayStartMs)),
+          needles,
+        };
       });
 
     return { localDate: day.localDate, hours };

--- a/src/components/conditions/HourChart.test.tsx
+++ b/src/components/conditions/HourChart.test.tsx
@@ -1170,3 +1170,155 @@ describe("the frame on a phone", () => {
     expect(container.querySelectorAll("circle")).toHaveLength(24);
   });
 });
+
+/**
+ * The two days a year a position in the day is not a clock hour.
+ *
+ * A 24-hour fixture cannot exercise this, so these build their own days from
+ * `localMidnightOf` at both ends -- which is what production does
+ * (`DayPanel.tsx`) and what makes the span really 25 or 23 hours rather than a
+ * literal that agrees with the zone by luck.
+ */
+describe("a day the clocks change on", () => {
+  /** Falls back: 25 positions, 0 through 24. */
+  const FALL_START = localMidnightOf("2026-11-01");
+  const FALL_END = localMidnightOf("2026-11-02");
+  /** Springs forward: 23 positions, 0 through 22. */
+  const SPRING_START = localMidnightOf("2027-03-14");
+  const SPRING_END = localMidnightOf("2027-03-15");
+
+  /** A day of readings across whatever span it is really given. */
+  function dayOf(startMs: number, endMs: number) {
+    const count = Math.round((endMs - startMs) / HOUR);
+    return {
+      ...PROPS,
+      startMs,
+      endMs,
+      sunriseMs: startMs + 6 * HOUR + 14 * 60_000,
+      sunsetMs: startMs + 17 * HOUR + 55 * 60_000,
+      series: [
+        {
+          ...TIDE,
+          points: Array.from({ length: count }, (_, hour) => ({
+            atMs: startMs + hour * HOUR,
+            value: 2 + Math.sin(hour / 4),
+            published: true,
+          })) as readonly SparkPoint[],
+        },
+      ],
+    };
+  }
+
+  test("the fall-back day really is twenty-five positions long", () => {
+    // The premise every assertion below rests on. Without it these tests could
+    // pass against a 24-hour fixture and prove nothing -- which is exactly what
+    // `DayPanel.test.tsx`'s shared helper would have done.
+    expect(FALL_END - FALL_START).toBe(25 * HOUR);
+    expect(SPRING_END - SPRING_START).toBe(23 * HOUR);
+  });
+
+  test("every axis label is the true name of its own tick", () => {
+    // The ticks are still *positions* in this commit -- 0, 3, 6 ... 21 -- and
+    // what changes is that each is named from the instant it falls on rather
+    // than read as a clock hour. So on a 25-hour day the axis reads 12 AM,
+    // 2 AM, 5 AM ... which is odd-looking and true, where before it read 12 AM,
+    // 3 AM, 6 AM ... which is tidy and false.
+    //
+    // **Noon is absent here and that is not a defect of this commit**: no
+    // position on this day is 12 PM. The next commit stands the ticks on clock
+    // hours, which is what brings noon back and what moves them to the right
+    // part of the curve.
+    const { container } = render(
+      <HourChart {...dayOf(FALL_START, FALL_END)} />,
+    );
+
+    const labels = [...container.querySelectorAll("[data-axis-hour]")].map(
+      (label) => label.textContent,
+    );
+    expect(labels).toEqual([
+      "12 AM",
+      "2 AM",
+      "5 AM",
+      "8 AM",
+      "11 AM",
+      "2 PM",
+      "5 PM",
+      "8 PM",
+    ]);
+    // The half of #196 that is already gone: no hour is named twice, and no
+    // label reads "12 PM" anywhere but at noon.
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  test("the chart's readout names the hour a reader is on, not its position", () => {
+    // Position 15 on this day is 2 PM. The readout used to say "3 PM", and a
+    // reader has no way to detect that from the page.
+    const { container } = render(
+      <HourChart {...dayOf(FALL_START, FALL_END)} />,
+    );
+
+    const columns = container.querySelectorAll("[data-hour-column]");
+    fireEvent.click(columns[15]);
+    expect(
+      container.querySelector("[data-hour-readout]")?.textContent,
+    ).toContain("2 PM");
+  });
+
+  test("the last hour of a fall-back day reads 11 PM", () => {
+    const { container } = render(
+      <HourChart {...dayOf(FALL_START, FALL_END)} />,
+    );
+
+    const columns = container.querySelectorAll("[data-hour-column]");
+    expect(columns).toHaveLength(25);
+    fireEvent.click(columns[24]);
+    expect(
+      container.querySelector("[data-hour-readout]")?.textContent,
+    ).toContain("11 PM");
+  });
+
+  test("a spring-forward day names its hours forward, not back", () => {
+    // The mirror, and it matters that it is a mirror: a fix that subtracted an
+    // hour would pass the fall-back tests above and fail here.
+    const { container } = render(
+      <HourChart {...dayOf(SPRING_START, SPRING_END)} />,
+    );
+
+    const columns = container.querySelectorAll("[data-hour-column]");
+    expect(columns).toHaveLength(23);
+    fireEvent.click(columns[2]);
+    expect(
+      container.querySelector("[data-hour-readout]")?.textContent,
+    ).toContain("3 AM");
+  });
+
+  test("the hidden column label names the same hour the readout does", () => {
+    // A screen reader landing on a column gets the hour without moving to the
+    // readout, so the two have to be one hour named once.
+    const { container } = render(
+      <HourChart {...dayOf(FALL_START, FALL_END)} />,
+    );
+
+    expect(
+      container.querySelectorAll("[data-hour-column]")[24]?.textContent,
+    ).toContain("11 PM");
+  });
+
+  test("an ordinary day is unchanged, so the fix is about the transition", () => {
+    const { container } = render(<HourChart {...PROPS} />);
+
+    const labels = [...container.querySelectorAll("[data-axis-hour]")].map(
+      (label) => label.textContent,
+    );
+    expect(labels).toEqual([
+      "12 AM",
+      "3 AM",
+      "6 AM",
+      "9 AM",
+      "12 PM",
+      "3 PM",
+      "6 PM",
+      "9 PM",
+    ]);
+  });
+});

--- a/src/components/conditions/HourChart.test.tsx
+++ b/src/components/conditions/HourChart.test.tsx
@@ -1217,17 +1217,11 @@ describe("a day the clocks change on", () => {
     expect(SPRING_END - SPRING_START).toBe(23 * HOUR);
   });
 
-  test("every axis label is the true name of its own tick", () => {
-    // The ticks are still *positions* in this commit -- 0, 3, 6 ... 21 -- and
-    // what changes is that each is named from the instant it falls on rather
-    // than read as a clock hour. So on a 25-hour day the axis reads 12 AM,
-    // 2 AM, 5 AM ... which is odd-looking and true, where before it read 12 AM,
-    // 3 AM, 6 AM ... which is tidy and false.
-    //
-    // **Noon is absent here and that is not a defect of this commit**: no
-    // position on this day is 12 PM. The next commit stands the ticks on clock
-    // hours, which is what brings noon back and what moves them to the right
-    // part of the curve.
+  test("the axis names the same eight hours it names on every other day", () => {
+    // ADR-0040's choice, on the page: the names stay regular and the spacing
+    // bends. The axis reads 12 AM, 3 AM, 6 AM on a 25-hour day exactly as it
+    // does on a 24-hour one -- and, unlike before, each of those is over the
+    // moment it names.
     const { container } = render(
       <HourChart {...dayOf(FALL_START, FALL_END)} />,
     );
@@ -1237,17 +1231,67 @@ describe("a day the clocks change on", () => {
     );
     expect(labels).toEqual([
       "12 AM",
-      "2 AM",
-      "5 AM",
-      "8 AM",
-      "11 AM",
-      "2 PM",
-      "5 PM",
-      "8 PM",
+      "3 AM",
+      "6 AM",
+      "9 AM",
+      "12 PM",
+      "3 PM",
+      "6 PM",
+      "9 PM",
     ]);
-    // The half of #196 that is already gone: no hour is named twice, and no
-    // label reads "12 PM" anywhere but at noon.
+    // #196's first symptom, gone: noon is named once, at noon, and no hour is
+    // named twice.
+    expect(labels.filter((label) => label === "12 PM")).toHaveLength(1);
     expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  test("data-axis-hour carries a clock hour, so nothing inherits the bug", () => {
+    // The attribute is unrenamed and now true. Every test in this file already
+    // read it as a clock hour -- `[data-axis-hour="6"]` meaning the 6 AM label
+    // -- and on a DST day it used to be a position wearing that name.
+    const { container } = render(
+      <HourChart {...dayOf(FALL_START, FALL_END)} />,
+    );
+
+    expect(container.querySelector('[data-axis-hour="12"]')?.textContent).toBe(
+      "12 PM",
+    );
+    expect(container.querySelector('[data-axis-hour="24"]')).toBeNull();
+  });
+
+  test("each tick sits where the curve puts its own instant", () => {
+    // The second defect, and the one #196 does not mention. `left` was
+    // `hour / 24` while the curve is mapped against the day's real span, so on
+    // this day the "3 AM" tick sat over 2:07 AM. The expected figures are the
+    // day's own: 3 hours of 25 is 12%, not 12.5%, and the wide first gap is the
+    // span that really held four hours.
+    const { container } = render(
+      <HourChart {...dayOf(FALL_START, FALL_END)} />,
+    );
+
+    const lefts = [...container.querySelectorAll("[data-axis-hour]")].map(
+      (label) =>
+        Number(
+          Number((label as HTMLElement).style.left.replace("%", "")).toFixed(2),
+        ),
+    );
+    expect(lefts).toEqual([0, 16, 28, 40, 52, 64, 76, 88]);
+  });
+
+  test("a spring-forward day is displaced the other way", () => {
+    // A fix that stretched in one direction only would pass every assertion
+    // above and fail here: the first gap is *narrower* on this day, not wider.
+    const { container } = render(
+      <HourChart {...dayOf(SPRING_START, SPRING_END)} />,
+    );
+
+    const lefts = [...container.querySelectorAll("[data-axis-hour]")].map(
+      (label) =>
+        Number(
+          Number((label as HTMLElement).style.left.replace("%", "")).toFixed(2),
+        ),
+    );
+    expect(lefts).toEqual([0, 8.7, 21.74, 34.78, 47.83, 60.87, 73.91, 86.96]);
   });
 
   test("the chart's readout names the hour a reader is on, not its position", () => {

--- a/src/components/conditions/HourChart.tsx
+++ b/src/components/conditions/HourChart.tsx
@@ -1,7 +1,14 @@
 /**
- * One day at reading size: twenty-four hours across in the site's own tile,
- * night shaded, cloud in a band above the frame, and the model's own published
- * points marked.
+ * One day at reading size: midnight to midnight in the site's own tile, night
+ * shaded, cloud in a band above the frame, and the model's own published points
+ * marked.
+ *
+ * **A whole day rather than twenty-four hours, which is not pedantry twice a
+ * year.** This coast changes offset on two days and they are twenty-three and
+ * twenty-five hours long; the axis names its hours from the instants they fall
+ * on and stands them where the curve puts them, so on those days the gap
+ * holding the transition is wider or narrower than the rest. See ADR-0040 and
+ * `axisTicks`.
  *
  * **The same instrument as `DaySpark`, at the other zoom level.** It takes the
  * same `SparkPoint` series and draws the same night band from the same shared
@@ -115,7 +122,7 @@
 
 import { useId, useState } from "react";
 import { hourLabelAt } from "@/lib/pacific-time";
-import { hourOfDay, instantOfHour, nightBands } from "./dayFrame";
+import { axisTicks, hourOfDay, nightBands } from "./dayFrame";
 import { useHydrated } from "./hydrated";
 import { resolveHour, useSelectedHour } from "./selectedHour";
 import type { SparkPoint } from "./DaySpark";
@@ -373,7 +380,7 @@ const MARKS_FIT_NARROW = 12;
 const HOUR_MS = 3_600_000;
 
 /**
- * Hours the axis names, and which of them survive a narrow screen.
+ * Clock hours the axis names, and which of them survive a narrow screen.
  *
  * Every three hours is right at 1536 and collides at 375: eight labels at 10px
  * need about 35px each and a 283px plot gives them 35px exactly, so "12 PM"
@@ -381,6 +388,31 @@ const HOUR_MS = 3_600_000;
  * quarter-day hours are kept at every width and the rest appear from `sm`,
  * which is the same degrade-before-you-lie rule the sparkline follows when its
  * cell gets too narrow to read.
+ *
+ * **These are clock hours, and were positions until #196.** The distinction is
+ * invisible on 363 days and decides the axis on the other two -- see
+ * `axisTicks`. It is also why the spacing figures above describe a 24-hour day
+ * only: on a 25-hour day these sit 16% then 12% apart, and on a 23-hour day
+ * 8.7% then 13%.
+ *
+ * **The tightest pair that produces is midnight and 3 AM on a spring-forward
+ * day at `sm`, and it clears by 2.5px.** Measured on the built page 2026-09-01
+ * at five widths, because 8.7% of a plot is the one figure this rule could have
+ * broken and an argument about it is worth less than a number. `sm` is the
+ * binding width -- it is the narrowest at which all eight labels show, and at
+ * 375 only the quarter-day four do, so no narrow screen can meet this pair at
+ * all. At 640 the plot is 502px: "3 AM" is 25.0px centred on 8.7%, so it starts
+ * at 31.2px, and "12 AM" is 28.6px left-aligned at 0, so it ends at 28.6px.
+ * Every wider viewport has more room -- 9.5px at 768, 29.0px at 1024, 33.1px at
+ * 1536 -- and every other gap on both DST days is wider than a 24-hour day's.
+ * The same run re-measured the 237px plot at 375 this docstring already cites,
+ * which is what says the rig agrees with the page these figures came from.
+ *
+ * **Neither transition's ambiguous hour is in this list**, which is what makes
+ * `axisTicks`' two refusals unreachable from here: the hour a fall-back day
+ * repeats is 1 AM and the one a spring-forward day skips is 2 AM. That is a
+ * property of this list rather than a guarantee, so `axisTicks` defines both
+ * cases and `dayFrame.test.ts` asserts them.
  */
 const LABELLED_HOURS = [0, 3, 6, 9, 12, 15, 18, 21];
 const QUARTER_DAY_HOURS = new Set([0, 6, 12, 18]);
@@ -1109,32 +1141,30 @@ export function HourChart({
         cloud, value and hour -- all line up on the same left edge.
       */}
         <div className="relative mt-1 ml-14 h-4">
-          {LABELLED_HOURS.map((hour) => (
-            <span
-              key={hour}
-              className={`text-2xs absolute text-fog ${
-                hour === 0 ? "" : "-translate-x-1/2"
-              } ${QUARTER_DAY_HOURS.has(hour) ? "" : "hidden sm:inline"}`}
-              style={{ left: `${(hour / 24) * 100}%` }}
-              data-axis-hour={hour}
-            >
-              {/*
-                Named from the instant at this position rather than by reading
-                the position as a clock hour. On a fall-back day position 12 is
-                11 AM and position 24 is 11 PM, so the old reading printed
-                "12 PM" twice and never printed noon at all.
-
-                **The positions themselves are still wrong here**, and are put
-                right in the next commit: `left` divides by 24 while the curve
-                above is mapped against the day's real span, so on a 25-hour day
-                this tick sits up to 53 minutes off the instant it now names.
-                Naming and placing are separate defects and this commit fixes
-                only the first -- but the label is true of the tick it is on,
-                which is more than could be said before it.
-              */}
-              {hourLabelAt(instantOfHour(hour, startMs))}
-            </span>
-          ))}
+          {axisTicks(LABELLED_HOURS, { startMs, endMs }).map(
+            ({ clockHour, atMs }) => (
+              <span
+                key={clockHour}
+                className={`text-2xs absolute text-fog ${
+                  clockHour === 0 ? "" : "-translate-x-1/2"
+                } ${QUARTER_DAY_HOURS.has(clockHour) ? "" : "hidden sm:inline"}`}
+                /*
+                  Positioned with the same `x` the curve is drawn with, divided
+                  by the frame's own width to get back to a fraction. That is
+                  the point of `axisTicks` returning an instant rather than a
+                  percentage: there is one mapping from time to position in this
+                  file, so a tick cannot sit anywhere but over its own moment on
+                  the curve. It used to be `hour / 24`, a second mapping that
+                  agreed with this one on 363 days and was up to 53 minutes out
+                  on the other two.
+                */
+                style={{ left: `${(x(atMs) / WIDTH) * 100}%` }}
+                data-axis-hour={clockHour}
+              >
+                {hourLabelAt(atMs)}
+              </span>
+            ),
+          )}
         </div>
 
         {/*

--- a/src/components/conditions/HourChart.tsx
+++ b/src/components/conditions/HourChart.tsx
@@ -114,7 +114,8 @@
 "use client";
 
 import { useId, useState } from "react";
-import { hourLabel, hourOfDay, nightBands } from "./dayFrame";
+import { hourLabelAt } from "@/lib/pacific-time";
+import { hourOfDay, instantOfHour, nightBands } from "./dayFrame";
 import { useHydrated } from "./hydrated";
 import { resolveHour, useSelectedHour } from "./selectedHour";
 import type { SparkPoint } from "./DaySpark";
@@ -705,7 +706,10 @@ export function HourChart({
     const dark =
       selectedPoint.atMs < sunriseMs || selectedPoint.atMs > sunsetMs;
     return [
-      hourLabel(selectedHour),
+      // Named from the point's own instant rather than from `selectedHour`,
+      // which is the position that found it. On a fall-back day those are
+      // different hours from position 3 onward -- see ADR-0040.
+      hourLabelAt(selectedPoint.atMs),
       `${selectedPoint.value.toFixed(1)} ${unitLabel}`,
       cloudAt === undefined ? "no cloud forecast" : `${cloudAt}% cloud`,
       dark ? "before sunrise or after sunset" : "in daylight",
@@ -1080,7 +1084,8 @@ export function HourChart({
                       has just selected.
                     */}
                       <span className="absolute -m-px h-px w-px overflow-hidden">
-                        {hourLabel(hour)}, {point.value.toFixed(1)} {unitLabel}
+                        {hourLabelAt(point.atMs)}, {point.value.toFixed(1)}{" "}
+                        {unitLabel}
                         {cloudAt === undefined ? "" : `, ${cloudAt}% cloud`}
                       </span>
                     </button>
@@ -1113,7 +1118,21 @@ export function HourChart({
               style={{ left: `${(hour / 24) * 100}%` }}
               data-axis-hour={hour}
             >
-              {hourLabel(hour)}
+              {/*
+                Named from the instant at this position rather than by reading
+                the position as a clock hour. On a fall-back day position 12 is
+                11 AM and position 24 is 11 PM, so the old reading printed
+                "12 PM" twice and never printed noon at all.
+
+                **The positions themselves are still wrong here**, and are put
+                right in the next commit: `left` divides by 24 while the curve
+                above is mapped against the day's real span, so on a 25-hour day
+                this tick sits up to 53 minutes off the instant it now names.
+                Naming and placing are separate defects and this commit fixes
+                only the first -- but the label is true of the tick it is on,
+                which is more than could be said before it.
+              */}
+              {hourLabelAt(instantOfHour(hour, startMs))}
             </span>
           ))}
         </div>

--- a/src/components/conditions/dayFrame.test.ts
+++ b/src/components/conditions/dayFrame.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The day's geometry, called directly.
+ *
+ * These functions were reached through `HourChart.test.tsx` and one direct
+ * import in `selectedHour.test.tsx` while this module held only `nightBands`
+ * and a one-line `hourOfDay`. ADR-0040 gave it rules whose whole value is being
+ * right on two specific dates, and a rule about 2027-03-14 should not cost a
+ * jsdom render to assert.
+ */
+
+import { describe, expect, test } from "vitest";
+import { localMidnightOf, localTimeOf } from "@/lib/pacific-time";
+import { hourOfDay, instantOfHour, nightBands } from "./dayFrame";
+
+const HOUR = 3_600_000;
+
+/** California falls back here: 25 hours. */
+const FALL_BACK = "2026-11-01";
+/** And springs forward here: 23. */
+const SPRING_FORWARD = "2027-03-14";
+/** An ordinary Monday, so a failure says which kind of day broke. */
+const ORDINARY = "2026-08-17";
+
+describe("hourOfDay", () => {
+  test("counts positions from the day's own midnight", () => {
+    const start = localMidnightOf(ORDINARY);
+    expect(hourOfDay(start, start)).toBe(0);
+    expect(hourOfDay(start + 14 * HOUR, start)).toBe(14);
+  });
+
+  test("rounds to the nearest position rather than truncating", () => {
+    // A published point at 2:20 belongs to the hour it is in, not to the one
+    // before it. The series this feeds are hourly, so the offsets are minutes.
+    const start = localMidnightOf(ORDINARY);
+    expect(hourOfDay(start + 14 * HOUR + 20 * 60_000, start)).toBe(14);
+    expect(hourOfDay(start + 14 * HOUR + 40 * 60_000, start)).toBe(15);
+  });
+
+  test("a fall-back day has twenty-five positions", () => {
+    // The property that makes this a position and not a clock hour, and the
+    // reason ADR-0040 stopped anything speaking it. Position 24 exists and its
+    // clock reads 11 PM.
+    const start = localMidnightOf(FALL_BACK);
+    const end = localMidnightOf("2026-11-02");
+    expect(hourOfDay(end, start)).toBe(25);
+    expect(localTimeOf(instantOfHour(24, start))).toBe("11:00 PM");
+  });
+
+  test("a spring-forward day has twenty-three", () => {
+    const start = localMidnightOf(SPRING_FORWARD);
+    expect(hourOfDay(localMidnightOf("2027-03-15"), start)).toBe(23);
+  });
+});
+
+describe("instantOfHour", () => {
+  test("is the exact inverse of hourOfDay on an ordinary day", () => {
+    const start = localMidnightOf(ORDINARY);
+    for (let hour = 0; hour <= 24; hour += 1) {
+      expect(hourOfDay(instantOfHour(hour, start), start)).toBe(hour);
+    }
+  });
+
+  test("is the exact inverse across a fall-back transition too", () => {
+    // The claim in its docstring, asserted rather than argued: elapsed time
+    // does not repeat even where the wall clock does, so adding hours to a
+    // midnight is right for *this* question and wrong for a clock reading.
+    const start = localMidnightOf(FALL_BACK);
+    for (let hour = 0; hour <= 25; hour += 1) {
+      expect(hourOfDay(instantOfHour(hour, start), start)).toBe(hour);
+    }
+  });
+
+  test("is the exact inverse across a spring-forward transition", () => {
+    const start = localMidnightOf(SPRING_FORWARD);
+    for (let hour = 0; hour <= 23; hour += 1) {
+      expect(hourOfDay(instantOfHour(hour, start), start)).toBe(hour);
+    }
+  });
+
+  test("the instant it returns is a real instant, not a clock reading", () => {
+    // Position 3 on a fall-back day is 2 AM, which is the whole point: the two
+    // numbers diverge and this function answers the geometry's question.
+    const start = localMidnightOf(FALL_BACK);
+    expect(localTimeOf(instantOfHour(3, start))).toBe("2:00 AM");
+    expect(localTimeOf(instantOfHour(3, localMidnightOf(SPRING_FORWARD)))).toBe(
+      "4:00 AM",
+    );
+  });
+});
+
+describe("nightBands", () => {
+  const bounds = {
+    startMs: localMidnightOf(ORDINARY),
+    endMs: localMidnightOf("2026-08-18"),
+    sunriseMs: localMidnightOf(ORDINARY) + 6 * HOUR,
+    sunsetMs: localMidnightOf(ORDINARY) + 19 * HOUR,
+  };
+  const x = (atMs: number) => ((atMs - bounds.startMs) / (24 * HOUR)) * 240;
+
+  test("draws the two dark ends of a day, not one band across its middle", () => {
+    const bands = nightBands(bounds, x, 240);
+    expect(bands.map((band) => band.side)).toEqual([
+      "before-dawn",
+      "after-dusk",
+    ]);
+    expect(bands[0]).toMatchObject({ x: 0, width: 60 });
+    expect(bands[1]).toMatchObject({ x: 190, width: 50 });
+  });
+
+  test("a band with no width is dropped rather than drawn at zero", () => {
+    // A polar summer, which this coast does not have -- and a caller handing in
+    // a sunrise before its own day start, which is a bug rather than a place.
+    const bands = nightBands(
+      { ...bounds, sunriseMs: bounds.startMs, sunsetMs: bounds.endMs },
+      x,
+      240,
+    );
+    expect(bands).toEqual([]);
+  });
+});

--- a/src/components/conditions/dayFrame.test.ts
+++ b/src/components/conditions/dayFrame.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, test } from "vitest";
 import { localMidnightOf, localTimeOf } from "@/lib/pacific-time";
-import { hourOfDay, instantOfHour, nightBands } from "./dayFrame";
+import { axisTicks, hourOfDay, instantOfHour, nightBands } from "./dayFrame";
 
 const HOUR = 3_600_000;
 
@@ -116,5 +116,107 @@ describe("nightBands", () => {
       240,
     );
     expect(bands).toEqual([]);
+  });
+});
+
+describe("axisTicks", () => {
+  const LABELLED = [0, 3, 6, 9, 12, 15, 18, 21];
+  const bounds = (localDate: string, nextDate: string) => ({
+    startMs: localMidnightOf(localDate),
+    endMs: localMidnightOf(nextDate),
+  });
+
+  /**
+   * Where a tick sits, as the percentage `HourChart` positions it by.
+   *
+   * Rounded to two places because 28% of a 25-hour day comes back as
+   * 28.000000000000004 in binary floating point. The browser is laying out a
+   * few hundred pixels, so the hundredth of a percent this drops is a
+   * ten-thousandth of one of them.
+   */
+  const at = (ticks: { atMs: number }[], startMs: number, spanMs: number) =>
+    ticks.map((tick) =>
+      Number((((tick.atMs - startMs) / spanMs) * 100).toFixed(2)),
+    );
+
+  test("an ordinary day is eight ticks, evenly spaced, named the usual way", () => {
+    const day = bounds(ORDINARY, "2026-08-18");
+    const ticks = axisTicks(LABELLED, day);
+
+    expect(ticks.map((tick) => tick.clockHour)).toEqual(LABELLED);
+    expect(at(ticks, day.startMs, 24 * HOUR)).toEqual([
+      0, 12.5, 25, 37.5, 50, 62.5, 75, 87.5,
+    ]);
+  });
+
+  test("a fall-back day keeps the names and bends the spacing", () => {
+    // ADR-0040's choice, in numbers. The wide gap is the first one -- midnight
+    // to 3 AM -- which is the span that really did hold four hours. The old
+    // axis put all eight at 12.5% and named the fifth "12 PM" while it sat over
+    // 11:30 AM.
+    const day = bounds(FALL_BACK, "2026-11-02");
+    const ticks = axisTicks(LABELLED, day);
+
+    expect(ticks.map((tick) => tick.clockHour)).toEqual(LABELLED);
+    expect(at(ticks, day.startMs, 25 * HOUR)).toEqual([
+      0, 16, 28, 40, 52, 64, 76, 88,
+    ]);
+    // Each tick is over the moment it names, which is the whole of the second
+    // defect: the old "3 AM" sat over 2:07 AM.
+    expect(ticks.map((tick) => localTimeOf(tick.atMs))).toEqual([
+      "12:00 AM",
+      "3:00 AM",
+      "6:00 AM",
+      "9:00 AM",
+      "12:00 PM",
+      "3:00 PM",
+      "6:00 PM",
+      "9:00 PM",
+    ]);
+  });
+
+  test("a spring-forward day bends it the other way", () => {
+    // The mirror, and the narrow gap is in the same place: the span the missing
+    // hour was taken out of.
+    const day = bounds(SPRING_FORWARD, "2027-03-15");
+    const ticks = axisTicks(LABELLED, day);
+
+    expect(at(ticks, day.startMs, 23 * HOUR)).toEqual([
+      0, 8.7, 21.74, 34.78, 47.83, 60.87, 73.91, 86.96,
+    ]);
+    expect(ticks.map((tick) => localTimeOf(tick.atMs))[1]).toBe("3:00 AM");
+  });
+
+  test("an hour the day does not hold is dropped rather than placed", () => {
+    // 2 AM never happens on a spring-forward day, so there is nowhere honest to
+    // put it. Unreachable from `LABELLED_HOURS`, which is exactly why the
+    // contract is asserted here rather than left to be discovered.
+    const day = bounds(SPRING_FORWARD, "2027-03-15");
+
+    expect(axisTicks([2], day)).toEqual([]);
+    expect(axisTicks([1, 2, 3], day).map((tick) => tick.clockHour)).toEqual([
+      1, 3,
+    ]);
+  });
+
+  test("a repeated hour takes the earlier of the two", () => {
+    // A fall-back day holds two 1 AMs and only one tick can be drawn. Also
+    // unreachable from `LABELLED_HOURS`, and asserted for the same reason.
+    const day = bounds(FALL_BACK, "2026-11-02");
+    const [tick] = axisTicks([1], day);
+
+    expect(tick.atMs).toBe(day.startMs + 1 * HOUR);
+    expect(hourOfDay(tick.atMs, day.startMs)).toBe(1);
+  });
+
+  test("the last hour of a day is reachable, and the next day's is not", () => {
+    // 11 PM on a fall-back day is position 24, which a loop bounded at 24 would
+    // miss -- and midnight resolves to this day's own, not tomorrow's.
+    const day = bounds(FALL_BACK, "2026-11-02");
+    const [eleven] = axisTicks([23], day);
+    const [midnight] = axisTicks([0], day);
+
+    expect(hourOfDay(eleven.atMs, day.startMs)).toBe(24);
+    expect(midnight.atMs).toBe(day.startMs);
   });
 });

--- a/src/components/conditions/dayFrame.ts
+++ b/src/components/conditions/dayFrame.ts
@@ -56,39 +56,37 @@ const HOUR_MS = 3_600_000;
  * module is `"use client"`, and the default is computed on the server. The
  * hour's definition is day geometry; which hour a reader chose is not.
  *
- * **It is an index into the day rather than a clock hour**, and on the two days
- * a year this coast changes offset the two diverge: `localMidnightOf` resolves
- * the zone offset twice, so a fall-back day is twenty-five hours long. The
- * chart's `hourLabel` reads this index as a clock hour and is wrong for it on
- * those days. That defect predates the sharing and is inherited here rather
- * than forked, so the two regions stay wrong together rather than
- * disagreeing -- see ADR-0035's last consequence.
+ * **It is a position in the day and is never spoken**, which is the whole of
+ * ADR-0040. On the two days a year this coast changes offset it is not a clock
+ * hour: `localMidnightOf` resolves the zone offset twice, so a fall-back day is
+ * twenty-five hours long and its twelfth position is 11 AM. That is not a
+ * defect in this function -- an index is exactly what the geometry needs, and
+ * the columns, `cloudByHour`, `needles.ts` and the selection all key on it,
+ * where a repeated 1 AM would not be a unique key. The defect was that four
+ * places *said* it out loud. They now name their hours from instants through
+ * `hourLabelAt`, and this stays a coordinate.
  */
 export function hourOfDay(atMs: number, dayStartMs: number): number {
   return Math.round((atMs - dayStartMs) / HOUR_MS);
 }
 
 /**
- * `0` to "12 AM", `13` to "1 PM". The axis speaks the reader's clock.
+ * The instant a position in the day falls on. The inverse of `hourOfDay`.
  *
- * **Here rather than in the chart, because the readout on the map names the
- * same hour.** `hourOfDay` is the one definition of which hour an instant falls
- * in and this is the one definition of what to call it, and the pair belongs
- * together for that function's own reason: the caption over the readout and the
- * label under the plot are how a reader sees that two regions are showing one
- * hour, and they can only be that if the words come from one place. `HourChart`
- * is `"use client"` and the caption is worded on the server, so a module both
- * can reach was the only place this could go in any case.
+ * **Exact rather than approximate, and that is worth saying because it looks
+ * like the arithmetic this module was just corrected for.** `hourOfDay` rounds
+ * `(atMs - dayStartMs) / HOUR_MS`, so position `i` is by construction the
+ * instant `dayStartMs + i` hours -- including across a transition, where the
+ * wall clock repeats or skips an hour but elapsed time does not. Adding hours
+ * to a local midnight is wrong when the answer wanted is *a clock reading*, and
+ * right when the answer wanted is *the instant at a position*, which is this.
  *
- * **It reads its argument as a clock hour, which an index is not on the two
- * days a year this coast changes offset** -- see `hourOfDay` above. Inherited
- * rather than forked: the chart and the map are wrong together rather than
- * disagreeing, and the fix stays a single-site one.
+ * For the one caller that holds a position and no instant: `DayPanel` keys its
+ * readout rows by `hourOfDay` and has to name them, so it comes back here for
+ * the instant rather than adding hours to a midnight itself.
  */
-export function hourLabel(hour: number): string {
-  if (hour === 0) return "12 AM";
-  if (hour === 12) return "12 PM";
-  return hour < 12 ? `${hour} AM` : `${hour - 12} PM`;
+export function instantOfHour(hour: number, dayStartMs: number): number {
+  return dayStartMs + hour * HOUR_MS;
 }
 
 /**

--- a/src/components/conditions/dayFrame.ts
+++ b/src/components/conditions/dayFrame.ts
@@ -23,6 +23,8 @@
  * every test counting bands would then have to know about.
  */
 
+import { localHourOf } from "@/lib/pacific-time";
+
 /** One stretch of a day that is dark, already mapped into plot units. */
 export interface NightBand {
   x: number;
@@ -87,6 +89,62 @@ export function hourOfDay(atMs: number, dayStartMs: number): number {
  */
 export function instantOfHour(hour: number, dayStartMs: number): number {
   return dayStartMs + hour * HOUR_MS;
+}
+
+/** One hour the axis names, and the instant in this day it happened at. */
+export interface AxisTick {
+  /** The clock hour a reader sees: `0` for midnight, `15` for 3 PM. */
+  clockHour: number;
+  /** When that was, which is where the tick belongs on the curve. */
+  atMs: number;
+}
+
+/**
+ * Where each of a day's named hours actually falls.
+ *
+ * **The axis stands on instants rather than on positions**, which is ADR-0040
+ * and the second half of #196. A tick placed at `hour / 24` of the plot while
+ * the curve above it is mapped against the day's real span is displaced by up
+ * to 53 minutes on a fall-back day and 52 on a spring-forward one, in opposite
+ * directions -- so a correctly *named* tick still sat over the wrong part of
+ * the curve. Returning the instant is what fixes that structurally: the caller
+ * positions a tick with the same `x` it draws the curve with, so there is one
+ * mapping in the file and the two cannot drift apart even in principle.
+ *
+ * **The names stay regular and the spacing bends**, which is the choice
+ * ADR-0040 records. A 25-hour day's ticks are 16% then 12% apart rather than
+ * 12.5% throughout, and the wide gap sits between midnight and 3 AM -- the span
+ * that really did hold four hours. The alternative kept the spacing even by
+ * moving the irregularity into the words, where a reader would meet it.
+ *
+ * **An hour the day does not hold is dropped rather than placed.** On a
+ * spring-forward day 2 AM never happens, so there is nowhere honest to put it.
+ * No caller asks for 2 AM today, which is why this is a contract worth writing
+ * down rather than a case worth discovering later.
+ *
+ * **A repeated hour takes the earlier of the two.** A fall-back day holds two
+ * 1 AMs and only one tick can be drawn; the first is the one a reader reaches
+ * first. No caller asks for 1 AM either, and both facts are asserted rather
+ * than left as a property of the current tick list.
+ */
+export function axisTicks(
+  clockHours: readonly number[],
+  bounds: { startMs: number; endMs: number },
+): AxisTick[] {
+  const count = Math.round((bounds.endMs - bounds.startMs) / HOUR_MS);
+
+  // Backwards, so that where an hour repeats the earlier position is the one
+  // left standing. Written as a sweep rather than a search per tick because the
+  // day has to be walked once either way to know which hours it holds at all.
+  const instants = new Map<number, number>();
+  for (let hour = count - 1; hour >= 0; hour -= 1) {
+    const atMs = instantOfHour(hour, bounds.startMs);
+    instants.set(localHourOf(atMs), atMs);
+  }
+
+  return clockHours
+    .map((clockHour) => ({ clockHour, atMs: instants.get(clockHour) }))
+    .filter((tick): tick is AxisTick => tick.atMs !== undefined);
 }
 
 /**

--- a/src/components/conditions/selectedHour.test.tsx
+++ b/src/components/conditions/selectedHour.test.tsx
@@ -270,7 +270,7 @@ test("the server render carries the hour, and still carries no control", () => {
   // printed fact. The mark is the fact and it is not gated on hydration, so a
   // reader without a script arrives on an hour like everyone else.
   //
-  // Asserted on the mark rather than on the hour's words: `hourLabel` writes
+  // Asserted on the mark rather than on the hour's words: `hourLabelAt` writes
   // every axis label, so `toContain("2 PM")` is true of a chart with nothing
   // selected at all and would pass without this feature existing.
   const markup = renderToStaticMarkup(
@@ -288,7 +288,7 @@ test("the server render carries the hour, and still carries no control", () => {
 
   // And the sentence that says which hour the mark is, which is gated with the
   // facts rather than with the buttons. Read out of the readout element rather
-  // than off the whole markup: `hourLabel` writes every axis label, so a bare
+  // than off the whole markup: `hourLabelAt` writes every axis label, so a bare
   // search for "2 PM" would pass on a chart with nothing selected at all.
   const sentence = markup
     .split("data-hour-readout")[1]
@@ -394,7 +394,7 @@ test("the map's readout shows the hour the chart marks, before and after a click
   // about one day, a few centimetres apart, which is issue #193.
   //
   // Both name the hour in the same words, because both print through
-  // `hourLabel`. That is what a reader has to see it with: the caption over the
+  // `hourLabelAt`. That is what a reader has to see it with: the caption over the
   // block and the sentence under the plot are the only visible statement that
   // the two regions are showing one hour.
   const { container } = renderPage(

--- a/src/components/conditions/selectedHour.tsx
+++ b/src/components/conditions/selectedHour.tsx
@@ -30,15 +30,13 @@
  * therefore supplied by the server read that already knows which day is today,
  * and the server render and the first client render agree by construction.
  *
- * **The hour is an index into the day, which is `HourChart`'s convention rather
- * than a new one.** That component derives an hour as
- * `Math.round((atMs - startMs) / HOUR_MS)` and prints it through `hourLabel`,
- * which reads an index as a clock hour -- and `localMidnightOf` resolves the
- * zone offset twice, so a fall-back day is twenty-five hours long and the two
- * diverge. That defect predates this file and is not fixed here; what this file
- * owes it is not to introduce a second, disagreeing convention, so that the
- * chart and the readout can never call one hour by two names and the fix stays
- * a single-site one. See ADR-0035's last consequence.
+ * **The hour is a position in the day, which is `hourOfDay`'s convention rather
+ * than a new one**, and it is deliberately not a clock hour. A position is
+ * unique on all 365 days; a clock hour is not, because a fall-back day holds
+ * two 1 AMs and keying a selection on one of them would make the two
+ * indistinguishable. Nothing here is ever shown to a reader: the words come
+ * from `hourLabelAt`, against the instant the position falls on, which is
+ * ADR-0040's split and the reason this file needed no change to survive it.
  */
 
 "use client";

--- a/src/lib/pacific-time.test.ts
+++ b/src/lib/pacific-time.test.ts
@@ -4,6 +4,8 @@ import {
   localDateOf,
   localDayLabel,
   localDayOf,
+  hourLabelAt,
+  localHourOf,
   localMidnightOf,
   localTimeOf,
   SITE_TIME_ZONE,
@@ -126,5 +128,100 @@ describe("localDayLabel", () => {
     // formatting it in a zone behind UTC yields New Year's Eve. A local date
     // carries no zone, so it is named in the only one that cannot shift it.
     expect(localDayLabel("2026-01-01")).toBe("Thu, Jan 1");
+  });
+});
+
+/**
+ * The two days a year a position in the day is not a clock hour.
+ *
+ * California falls back on 2026-11-01 and springs forward on 2027-03-14, so
+ * those days hold 25 and 23 hours. Every figure below was taken by running
+ * these helpers over both days rather than reasoned about.
+ */
+const FALL_BACK = "2026-11-01";
+const SPRING_FORWARD = "2027-03-14";
+const HOUR = 3_600_000;
+
+describe("localHourOf", () => {
+  test("reads the clock rather than counting from midnight", () => {
+    const midnight = localMidnightOf("2026-08-17");
+    expect(localHourOf(midnight)).toBe(0);
+    expect(localHourOf(midnight + 15 * HOUR)).toBe(15);
+  });
+
+  test("midnight is 0 and not 24", () => {
+    // `hour12: false` yields "24" for midnight on some ICU builds, which would
+    // make the guard in this function the difference between 0 and a number no
+    // clock has. Asserted rather than trusted for the reason `zoneOffsetMs`
+    // carries the same guard.
+    expect(localHourOf(localMidnightOf("2026-01-15"))).toBe(0);
+    expect(localHourOf(localMidnightOf(FALL_BACK))).toBe(0);
+  });
+
+  test("a fall-back day repeats an hour, so two positions read the same", () => {
+    const start = localMidnightOf(FALL_BACK);
+    expect(localHourOf(start + 1 * HOUR)).toBe(1);
+    expect(localHourOf(start + 2 * HOUR)).toBe(1);
+    // And from there the position runs an hour ahead of the clock for the rest
+    // of the day: 25 positions, 24 clock hours.
+    expect(localHourOf(start + 12 * HOUR)).toBe(11);
+    expect(localHourOf(start + 24 * HOUR)).toBe(23);
+  });
+
+  test("a spring-forward day skips one, so 2 AM never reads at all", () => {
+    const start = localMidnightOf(SPRING_FORWARD);
+    expect(localHourOf(start + 1 * HOUR)).toBe(1);
+    expect(localHourOf(start + 2 * HOUR)).toBe(3);
+    expect(localHourOf(start + 22 * HOUR)).toBe(23);
+  });
+
+  test("the zone is a parameter, so the rule can be tested rather than trusted", () => {
+    expect(localHourOf(SUMMER_INSTANT, "UTC")).toBe(13);
+  });
+});
+
+describe("hourLabelAt", () => {
+  test("names the hour in the reader's own clock", () => {
+    const start = localMidnightOf("2026-08-17");
+    expect(hourLabelAt(start)).toBe("12 AM");
+    expect(hourLabelAt(start + 3 * HOUR)).toBe("3 AM");
+    expect(hourLabelAt(start + 12 * HOUR)).toBe("12 PM");
+    expect(hourLabelAt(start + 15 * HOUR)).toBe("3 PM");
+    expect(hourLabelAt(start + 23 * HOUR)).toBe("11 PM");
+  });
+
+  test("the words are the repo's own, with an ordinary space", () => {
+    // Not `Intl`'s hour-only format, which returns the same string on ICU 77
+    // and is free to choose a narrow no-break space on another build. A test
+    // reading `toBe("3 PM")` would then fail on CI and nowhere else.
+    expect([...hourLabelAt(localMidnightOf("2026-08-17") + 15 * HOUR)]).toEqual(
+      ["3", " ", "P", "M"],
+    );
+  });
+
+  test("the twenty-fifth hour of a fall-back day is 11 PM, not a second noon", () => {
+    // The defect this replaces, in one line: reading position 24 as a clock
+    // hour fell through to `${hour - 12} PM` and printed "12 PM" -- a second
+    // noon, at eleven at night. Position 12 is 11 AM on this day, so the old
+    // reading also never named noon at all.
+    const start = localMidnightOf(FALL_BACK);
+    expect(hourLabelAt(start + 24 * HOUR)).toBe("11 PM");
+    expect(hourLabelAt(start + 12 * HOUR)).toBe("11 AM");
+    expect(hourLabelAt(start + 13 * HOUR)).toBe("12 PM");
+  });
+
+  test("a repeated hour is named twice rather than disambiguated", () => {
+    // ADR-0040: two hours honestly share a name on the one day they genuinely
+    // do. They stay distinct selections because the position keys them, and
+    // neither is ever an axis tick.
+    const start = localMidnightOf(FALL_BACK);
+    expect(hourLabelAt(start + 1 * HOUR)).toBe("1 AM");
+    expect(hourLabelAt(start + 2 * HOUR)).toBe("1 AM");
+  });
+
+  test("a spring-forward day names its hours an hour ahead of its positions", () => {
+    const start = localMidnightOf(SPRING_FORWARD);
+    expect(hourLabelAt(start + 2 * HOUR)).toBe("3 AM");
+    expect(hourLabelAt(start + 22 * HOUR)).toBe("11 PM");
   });
 });

--- a/src/lib/pacific-time.ts
+++ b/src/lib/pacific-time.ts
@@ -53,6 +53,68 @@ export function localTimeOf(
 }
 
 /**
+ * The clock hour an instant falls in, in `timeZone`, as `0` to `23`.
+ *
+ * **The hour a reader would say, which is not the same as the hour a plot
+ * counts.** `hourOfDay` in `dayFrame.ts` divides a day's span by an hour and
+ * gets a position; this reads the clock. They agree on 363 days a year and
+ * disagree on the two this coast changes offset, which is issue #196: a
+ * fall-back day is twenty-five hours long, so its twelfth position is 11 AM
+ * and its twenty-fourth is 11 PM. Anything the page *says* out loud is named
+ * from here; the position stays a position.
+ *
+ * `hour12: false` yields "24" for midnight on some ICU versions rather than
+ * "00", which `zoneOffsetMs` below guards against for the same reason. The
+ * modulo is that guard and not a rounding.
+ */
+export function localHourOf(
+  atMs: number,
+  timeZone: string = SITE_TIME_ZONE,
+): number {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    hour: "2-digit",
+    hour12: false,
+  }).formatToParts(new Date(atMs));
+  return Number(parts.find((part) => part.type === "hour")!.value) % 24;
+}
+
+/**
+ * The hour an instant falls in, named for a reader: `12 AM`, `3 PM`.
+ *
+ * **Here rather than in `dayFrame.ts`, because it names an instant rather than
+ * a position.** It sat beside `hourOfDay` while it took that function's output,
+ * on the argument that one definition of an hour and one definition of what to
+ * call it belong together. Naming from the instant dissolves that pairing: this
+ * is a wall clock read in a named zone, which is what this module is, and it is
+ * reachable from both a server component and a `"use client"` one either way.
+ *
+ * **The words are built here rather than asked of `Intl`**, which would be the
+ * shorter implementation and is deliberately not taken. An hour-only format
+ * returns "3 PM" with an ordinary space on Node 22.18.0 / ICU 77 and "12 AM" at
+ * midnight -- checked, not assumed -- but which space character ICU chooses has
+ * moved before, and CI runs a different build of it. `localHourOf` above reads
+ * a *number* out of `Intl`, where no such question arises, and the wording is
+ * the repo's own.
+ *
+ * **`At` is not decoration.** This took a `0`-to-`23` index until #196 and now
+ * takes epoch milliseconds; both are `number`, so a call site missed in that
+ * change would compile and return plausible nonsense -- `hourLabel(12)` gave
+ * "12 PM". The defect being fixed here is an index being silently readable as a
+ * clock hour, and shipping the fix under the old name would leave that same
+ * trap one layer down.
+ */
+export function hourLabelAt(
+  atMs: number,
+  timeZone: string = SITE_TIME_ZONE,
+): string {
+  const hour = localHourOf(atMs, timeZone);
+  if (hour === 0) return "12 AM";
+  if (hour === 12) return "12 PM";
+  return hour < 12 ? `${hour} AM` : `${hour - 12} PM`;
+}
+
+/**
  * The calendar day an instant falls on, in `timeZone`, as `Tue, Sep 8`.
  *
  * Weekday included because the co-op's whole identity is which day of the week

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -431,10 +431,24 @@ export default defineConfig({
         //
         // Nothing new is excluded. The same 0% entry-plumbing files named above
         // still drag all four down in plain sight.
-        statements: 89.24,
+        // RAISED again 2026-09-01, three of four, by the axis standing on its
+        // instants (#196, second slice). Same ordinary direction:
+        //
+        //   statements 3012/3374  89.24 -> 89.27
+        //   functions   685/728   94.06 -> 94.09
+        //   lines      2712/3050  88.88 -> 88.91
+        //
+        // **Branches did not move at all -- 1917/2155 on both sides -- and that
+        // is the expected shape rather than an untested arm.** `axisTicks` has
+        // one conditional in it, the `filter` that drops an hour the day does
+        // not hold, and both of its arms are covered: 2 AM on 2027-03-14 goes
+        // one way and every ordinary hour the other. What the slice mostly did
+        // was replace one expression with another, and the tests it added are
+        // assertions about values rather than new paths through code.
+        statements: 89.27,
         branches: 88.95,
-        functions: 94.06,
-        lines: 88.88,
+        functions: 94.09,
+        lines: 88.91,
       },
     },
   },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -407,10 +407,34 @@ export default defineConfig({
         // readout left the picture, then modelLine() when the open-coast test
         // it existed for stopped existing. No test stopped running in any of
         // them, and every deletion is a decision with an ADR.
-        statements: 89.22,
-        branches: 88.89,
-        functions: 94.04,
-        lines: 88.87,
+        // RAISED 2026-09-01, all four, by the day chart naming its hours from
+        // instants (#196, first slice). The ordinary direction and the easy
+        // case -- both halves of every ratio grew and the numerators grew
+        // faster:
+        //
+        //   statements 3003/3365  89.22 -> 89.24
+        //   branches   1917/2155  88.89 -> 88.95
+        //   functions   682/725   94.04 -> 94.06
+        //   lines      2704/3042  88.87 -> 88.88
+        //
+        // Hundredths, and they are recorded rather than absorbed for the reason
+        // the entries above give in both directions: the ratchet only means
+        // something if it is moved every time it can be. The slice is small in
+        // code -- `localHourOf` and `hourLabelAt` in pacific-time.ts,
+        // `instantOfHour` in dayFrame.ts, four call sites following them -- and
+        // large in tests, because a rule about 2026-11-01 and 2027-03-14 is
+        // worth nothing unless both dates are asserted. `dayFrame.ts` gained a
+        // test file of its own and reached 100% on all four; its one previously
+        // uncovered branch, `nightBands` dropping a band with no width, is
+        // covered now by calling it directly rather than by widening the floor
+        // around it.
+        //
+        // Nothing new is excluded. The same 0% entry-plumbing files named above
+        // still drag all four down in plain sight.
+        statements: 89.24,
+        branches: 88.95,
+        functions: 94.06,
+        lines: 88.88,
       },
     },
   },


### PR DESCRIPTION
Closes #196.

The day chart derived an hour as a **position** in the day, and four places said
that number out loud as a **clock hour**. They agree on 363 days and diverge on
the two this coast changes offset. This separates the two ideas: the position
stays a plot coordinate and is never spoken, and every hour the page names comes
from its instant.

## There are two defects, and the issue describes one

Re-derived before starting, with a scratch vitest run over `localMidnightOf`,
`localTimeOf` and `hourLabel` on 2026-11-01 (25 h), 2027-03-14 (23 h) and
2026-08-17 (24 h, the control).

**The name.** On 2026-11-01: position 3 is 2:00 AM printed "3 AM", position 12
is 11:00 AM printed "12 PM", position 24 is 11:00 PM printed "12 PM".

> Two corrections to #196's own text. It says the axis prints "12 PM" "once at
> noon and once at 11 PM". The second half is right; the first is not — the
> first "12 PM" sits over **11 AM**, and on that day the axis **never names noon
> at all**. Also, `hourLabel(25)` would give "13 PM", but position 25 is the next
> day's midnight and the series bucket by local date, so it was unreachable —
> not a third defect.

**The position, which #196 does not mention.** Ticks were placed at
`(hour / 24) * 100%` while the curve is mapped against the day's real span:

| tick | 2026-11-01 sits over | 2027-03-14 sits over |
| --- | --- | --- |
| 3 AM @ 12.50% | 2:07 AM (−53 min) | 3:52 AM (+52 min) |
| 6 AM @ 25% | 5:15 AM (−45) | 6:45 AM (+45) |
| 12 PM @ 50% | 11:30 AM (−30) | 12:30 PM (+30) |
| 9 PM @ 87.5% | 8:52 PM (−8) | 9:07 PM (+7) |

The error is **largest just after the transition and shrinks through the day**,
because the position stretch and the offset partly cancel — part of why it was
never noticed. Fixing only the label is the worse half to fix alone: a
correctly-named tick 53 minutes off the curve is harder for a reader to catch
than a wrongly-named one, because the words now look right.

## The slices

**1 — Name an hour from its instant, not from its position.** `localHourOf` and
`hourLabelAt` join `localTimeOf` in `pacific-time.ts`; `instantOfHour` joins
`hourOfDay` in `dayFrame.ts`; the chart's readout, its hidden column labels and
**the map's caption** follow. That last one is not in the issue and is not
optional: ADR-0035 arranged for the chart and the readout to name one hour the
same way, so fixing only the chart would make them disagree on exactly the days
that decision exists for.

**2 — Stand the axis on its instants.** `axisTicks` returns a clock hour and the
**instant** it happened at; `HourChart` positions each tick with the same `x` it
draws the curve with. Returning a percentage would have left two pieces of
arithmetic that agree today — the same species of thing this issue is about.

**3 — ADR-0040.** Which axis rule was taken and why, the rule not taken, and the
two things the code cannot say. Written *after* slice 2, because the measurement
below could have changed the rule.

## The axis rule, which was a real choice

Both options were correct. The one taken keeps **regular names and bends the
spacing**; the one rejected keeps even spacing and bends the names (a fall-back
day would read 12 AM, 2 AM, 5 AM, 8 AM, 11 AM…).

The deciding argument is that option 2 does not *remove* the day's irregularity,
it moves it: its ticks are even and the day then runs 16% past the last one
instead of 12%, so the anomaly lands in the tail where nothing happened rather
than in the span that actually holds the extra hour — and it pays for that in
the words, which are the half a reader reads. It would also leave
`data-axis-hour` carrying a position.

## Failing-first evidence

`mustFail` is a per-gate-row flag and the `test` row runs the whole suite, so a
failing regression test fails that row too — "commit the test as MUST FAIL
first" cannot be expressed for this kind of defect. Flagging that because
CLAUDE.md's clause reads as though it can. Instead, the new tests were run
against the pre-fix call sites, restored verbatim:

**Slice 1** — 7 failures, exactly the defect:

```
 × every axis label is the true name of its own tick
 × the chart's readout names the hour a reader is on, not its position
 × the last hour of a fall-back day reads 11 PM
 × a spring-forward day names its hours forward, not back
 × the hidden column label names the same hour the readout does
 × the map's caption names the last hour of a fall-back day 11 PM
 × the map's caption names a spring-forward hour ahead, not behind

AssertionError: expected '12 PM' to be '11 PM'          (map caption)
AssertionError: expected '2 AM' to be '3 AM'            (map caption, spring)
AssertionError: expected '3 PM · 1.4 ft …' to contain '2 PM'
AssertionError: expected '12 PM · 1.7 ft …' to contain '11 PM'
AssertionError: expected '12 PM, 1.7 ft' to contain '11 PM'
      Tests  7 failed | 117 passed (124)
```

**Slice 2** — restoring `left: (clockHour / 24) * 100%` and keeping the names:

```
 × each tick sits where the curve puts its own instant
 × a spring-forward day is displaced the other way

AssertionError: expected [ +0, 12.5, 25, 37.5, 50, 62.5, …(2) ]
             to deeply equal [ +0, 16, 28, 40, 52, 64, 76, 88 ]
AssertionError: expected [ +0, 12.5, 25, 37.5, 50, 62.5, …(2) ]
             to deeply equal [ +0, 8.7, 21.74, 34.78, 47.83, …(3) ]
      Tests  2 failed | 73 passed (75)
```

One of my own tests also failed correctly mid-slice-1, and was wrong rather than
the code: I had asserted the axis "names noon once" in the commit where ticks are
still positions, and no position on a 25-hour day is noon. The assertion moved to
slice 2, where it is true.

## The measurement

The one number this rule could have failed on: the narrowest gap it produces is
midnight → 3 AM on a spring-forward day, 8.7% instead of 12.5%. Measured on the
**built page** with Playwright at five widths:

| viewport | plot | "3 AM" starts | "12 AM" ends | clearance |
| --- | --- | --- | --- | --- |
| 375 | 237px | not shown | 28.6px | — |
| **640 (`sm`)** | **502px** | **31.2px** | **28.6px** | **2.5px** |
| 768 | 582px | 38.1px | 28.6px | 9.5px |
| 1024 | 806px | 57.6px | 28.6px | 29.0px |
| 1536 | 854px | 61.8px | 28.6px | 33.1px |

`sm` is the binding width — the narrowest showing all eight labels; at 375 only
the quarter-day four do. **It clears, so the per-day degrade agreed as a
contingency does not ship.** The same run reproduced the 237px plot at 375 that
`LABELLED_HOURS` already cites, which is what says the rig agrees with the page
those figures came from.

My pre-measurement estimate had predicted ~1px of *overlap*. It was wrong in two
directions that cancelled: the plot is 502px rather than the ~548px I inferred,
and the labels are ~25px rather than the 35px the old docstring budgeted.

## Gate

Run before each of the three commits. Final run on the pushed HEAD:

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

Coverage floors raised twice, with notes in `vitest.config.mts`'s own style:
89.22/88.89/94.04/88.87 → 89.24/88.95/94.06/88.88 (slice 1) →
89.27/88.95/94.09/88.91 (slice 2). Branches did not move in slice 2, and the note
says why rather than absorbing it: `axisTicks` has one conditional and both its
arms are covered.

## Not done, and why

- **No plan file.** Three slices on one branch, and the decision that outlives
  the task is ADR-0040. A plan file would be a third copy of this body and that
  document, able to go stale on its own — which is what `docs/plans/README.md`
  already says it costs.
- **`docs/plans/map-weather-readout.md`'s "Noticed, not fixed" section is
  untouched**, as a dated record.
- **ADR-0035 is not amended.** Its last consequence was *correct*: it recorded
  this defect as deliberately inherited so the two regions would stay wrong
  together rather than disagree, and predicted a single-site fix. It was one.
- **`CONTEXT.md`'s Day sparkline entry still says "the 24-hour shape"**, which
  has the same fault as the Hour chart entry this fixes. `DaySpark` has no hour
  axis and is untouched here, so nothing in this branch makes that sentence newly
  wrong. Noticed, not filed.
- **`DayPanel.test.tsx`'s shared fixture helpers still assume a 24-hour day**
  (`endMs: localMidnightOf(localDate) + 24 * HOUR`, `{ length: 24 }`). The DST
  tests build their own day for that reason, and the helper now carries a comment
  saying so — dating a test on a DST date through those helpers would produce a
  regression test that passes without ever meeting a transition.
- **#200, #194, #191 and the selection/keying are out of scope.** The position
  stays the key.
