### PR TITLE
Record that EW3619 Santee stopped answering, and assert a bound air station still does

### DIFF
--- a/src/data/observation-stations.json
+++ b/src/data/observation-stations.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
-  "generated": "2026-08-18",
+  "generated": "2026-09-01",
   "_provenance": "Measured by scripts/probe-observation-stations.mjs; re-runnable and diffable with --check. National Weather Service candidates are the union of https://api.weather.gov/gridpoints/<grid>/stations over every distinct gridpoint the beaches in beaches.json resolve to, filtered to 32.4-33.6N and -117.7 to -116.8E: 56 stations. The state-wide listing at /stations?state=CA is NOT the source; it is capped at 500 results and truncates before reaching either KSAN or KNKX. NDBC candidates are https://www.ndbc.noaa.gov/activestations.xml filtered to the wave corridor box 32.4-33.5N and -118.2 to -117E AND to type \"fixed\": 6 stations. That type filter is the criterion that lost both Scripps Pier stations from wave-buoys.json, so it is stated here rather than applied silently -- NDBC's buoys are that table's subject, eleven of the thirteen in the box publish no air temperature or wind at all, and the one that publishes both, 46086, is twenty-seven nautical miles offshore and out of every beach's reach. Capability was then measured one station at a time against the endpoints this site reads -- /stations/<id>/observations for NWS, https://www.ndbc.noaa.gov/data/realtime2/<id>.txt for NDBC -- rather than inferred from either listing.",
-  "_what_was_measured": "6 observations per station; a field counts as published if it appears on at least one of them. Of 62 candidates, 60 deliver, 56 publish air temperature and wind together, and 10 publish sky. So the pool an air join ranks over is 56 stations and not the thirteen a visibility-shaped probe recorded. Sky and visibility are one capability: both were measured, and they select exactly the same stations -- every one an airport METAR -- with sky the scarcer of the two per observation. Only publishes_sky is stored, because two flags for one capability are two things that can drift apart while naming one. Counts of how many of the six observations carried a field are deliberately absent from this file: they move on every probe, and a --check that fails from noise stops being read.",
+  "_what_was_measured": "6 observations per station; a field counts as published if it appears on at least one of them. Of 62 candidates, 59 deliver, 55 publish air temperature and wind together, and 10 publish sky. So the pool an air join ranks over is 55 stations and not the thirteen a visibility-shaped probe recorded. Sky and visibility are one capability: both were measured, and they select exactly the same stations -- every one an airport METAR -- with sky the scarcer of the two per observation. Only publishes_sky is stored, because two flags for one capability are two things that can drift apart while naming one. Counts of how many of the six observations carried a field are deliberately absent from this file: they move on every probe, and a --check that fails from noise stops being read.",
   "_schema": {
     "name": "The station name, reproduced as its network serves it, run of spaces and trailing 'CA US' included. A record of what upstream said, and what a later probe compares against. NOT what is shown to a reader -- see display_name.",
     "display_name": "What the page calls this station. Hand-written, like `shore` and like tide-stations.json's `water`, because the published name is an identifier rather than prose for most of these: the mesonet publishes callsigns, the tide network publishes station numbers, and the reserve network publishes instrument sites. The rule is the shortest name someone looking at a map of this county would recognise, saying nothing the sentence around it already says. See #87.",
@@ -559,10 +559,11 @@
       "lon": -117,
       "elevation_m": 126.1872,
       "shore": false,
-      "delivers": true,
-      "publishes_air_temp": true,
-      "publishes_wind": true,
-      "publishes_sky": false
+      "delivers": false,
+      "publishes_air_temp": false,
+      "publishes_wind": false,
+      "publishes_sky": false,
+      "dead_note": "Listed for a gridpoint and answers with no observations at all."
     },
     "E9965": {
       "name": "EW9965 Lakeside",

--- a/src/lib/beaches.test.ts
+++ b/src/lib/beaches.test.ts
@@ -7,6 +7,7 @@ import {
   defaultBeach,
   inventoryCaveats,
   inventoryReach,
+  airStationFor,
   mopLineFor,
   tideStationFor,
   waveBuoyFor,
@@ -510,6 +511,57 @@ describe("the forecast cell binding", () => {
       "coronado-city-beaches",
     ]) {
       expect(beachBySlug(slug)!.grid_cell_elevation_m).toBe(0);
+    }
+  });
+});
+
+describe("the air station binding", () => {
+  test("never binds a station that does not deliver", () => {
+    // THE ASSERTION AIR WAS THE ONLY ONE OF THE FOUR MISSING. The tide station,
+    // the MOP line and the wave buoy all have it; this table did not, and a
+    // station dying is not hypothetical -- EW3619 Santee stopped answering
+    // between 2026-08-18 and 2026-09-01, which is what re-measured the table in
+    // the commit before this one.
+    //
+    // `air-join.mjs` filters on `delivers` when it binds, so a re-seed cannot
+    // produce this state. What it cannot rule out is the gap that cost six
+    // beaches their forecast in #167: a table re-measured and committed while
+    // beaches.json still points at what it used to say. The join runs at seed
+    // time; this runs in the gate.
+    for (const beach of allBeaches()) {
+      const station = airStationFor(beach);
+      if (station === null) continue;
+      expect(
+        station.delivers,
+        `${beach.slug} reads ${station.id}, which no longer delivers`,
+      ).toBe(true);
+    }
+  });
+
+  test("every bound station publishes both the figures the card states", () => {
+    // The air card prints a temperature and a wind, so a station delivering
+    // neither is bound and still useless. Two flags rather than `delivers`
+    // alone, because `delivers` only says the station answered at all.
+    for (const beach of allBeaches()) {
+      const station = airStationFor(beach);
+      if (station === null) continue;
+      expect(station.publishes_air_temp).toBe(true);
+      expect(station.publishes_wind).toBe(true);
+    }
+  });
+
+  test("no beach in the inventory is missing one", () => {
+    // Every beach binds an air station today, at 0.73 to 7.37 km, all inside
+    // SERVICE_TOLERANCE_M. Asserted for the reason #167 gave: the forecast-cell
+    // table was complete too, until an inventory grew past it and nothing
+    // asked. A null here would be a real state -- `air_station_null_reason`
+    // exists -- so this is a check that the inventory and the table still
+    // agree, not a claim that they must.
+    for (const beach of allBeaches()) {
+      expect(
+        beach.air_station,
+        `${beach.slug}: ${beach.air_station_null_reason}`,
+      ).not.toBeNull();
     }
   });
 });


### PR DESCRIPTION
Closes #168.

**Unlike #167, this one really was upstream.** A station died. The probe was
accurate, its report was proportionate, and re-measuring shows the whole of what
moved is one row.

## What moved

```
E3619  EW3619 Santee   delivers            true -> false
                       publishes_air_temp  true -> false
                       publishes_wind      true -> false
                       dead_note           "Listed for a gridpoint and answers
                                            with no observations at all."
```

No station added or removed. No coordinate, elevation or `shore` flag changed.
`unresolved` untouched. The summary follows it: 60 delivering becomes 59, and
the pool an air join ranks over is 55 stations rather than 56.

## Nothing downstream moves, and that is measured

E3619 is inland — 126 m up at `32.854, -117.0`, `shore: false` — and **no beach
binds it**. Nor does any beach bind `NPQC1` or `TIQC1`, the two Tijuana River
reserve stations already recorded as not delivering.

Re-running `seed-beaches.mjs` against the new table produces a **byte-identical
`beaches.json`**. So the first commit is a measurement record and carries no
test: what would have needed one is a binding moving, and none did.

## The invariant air was the only one missing

Checking why nothing would have caught it *if* a bound station had died turned
up a real hole. Three of the four bindings assert their source is alive:

| binding | asserts `delivers` |
| --- | --- |
| tide station | [beaches.test.ts:198](../blob/main/src/lib/beaches.test.ts#L198) |
| MOP line | [beaches.test.ts:330](../blob/main/src/lib/beaches.test.ts#L330) |
| wave buoy | [beaches.test.ts:390](../blob/main/src/lib/beaches.test.ts#L390) |
| **air station** | **nothing — no `air_station` assertion of any kind** |

`air-join.mjs` filters on `delivers` at bind time, so a re-seed cannot produce a
beach reading a dead station. What that cannot rule out is exactly the state
that cost six beaches their forecast in #167: **a table re-measured and
committed while `beaches.json` still points at what it used to say.** The join
runs at seed time; this runs in the gate. Between them the gap closes.

Three assertions, matching the shape of the three that already existed:

- no bound station has `delivers: false`
- every bound station publishes air temperature **and** wind, since the card
  states both and `delivers` alone only says the station answered at all
- every beach in the inventory binds one — #167's completeness check applied to
  the table next door

**Verified rather than assumed**, by pointing `ocean-beach` at the station that
just died:

```
 × never binds a station that does not deliver
 × every bound station publishes both the figures the card states

AssertionError: ocean-beach reads E3619, which no longer delivers:
  expected false to be true
      Tests  2 failed | 43 passed (45)
```

## Gate

Run before both commits. Final run on the pushed HEAD:

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

Coverage unchanged at `89.21/88.88/94.11/88.87` — data and tests only, no source
touched. Floors stay where PR #208 left them.

## Not done, and why

- **No ADR and no plan file.** Nothing here decides anything; it records a
  measurement and fills a hole in an established pattern.
- **The probe is unchanged.** It did its job: it reported a real change, weekly,
  until someone read it.
- **E3619 is left in the table rather than removed.** It is a candidate that
  answered once and does not now, which is what `delivers: false` and
  `dead_note` are for — the same treatment `NPQC1` and `TIQC1` already have.
  Dropping it would lose the record that it was measured.
