### PR TITLE
Close the sea wash on the frame, not on a normal off the coast

### DIFF
--- a/docs/adr/0041-the-wash-closes-on-the-frame.md
+++ b/docs/adr/0041-the-wash-closes-on-the-frame.md
@@ -1,0 +1,143 @@
+# 0041 — The sea wash closes on the frame, not on the coast
+
+Date: 2026-09-01. Status: accepted. Replaces the closure ADR-0033 introduced
+and ADR-0036 described; both of those decisions otherwise stand, and this
+changes nothing about what is drawn — only about where the drawing stops.
+
+## Context
+
+ADR-0033 replaced ADR-0030's gradient with one flat tint and made the water's
+edge the drawn line. The polygon that carried the tint was closed from a single
+normal taken across the drawn run's two ends, extended off the frame in both
+directions. `ShoreMap` recorded the reason:
+
+> Taken from the run's two ends rather than segment by segment: the polygon
+> only has to close on the right side of the frame, and a per-segment normal
+> would fold on itself at a bend.
+
+Both halves of that were true, and the conclusion no longer follows from them.
+A single normal is exact on a straight shore and approximate on a bent one, and
+what the shore is has changed twice since: ADR-0037 traced a real shoreline,
+and ADR-0039 stopped withholding it from the bays. **A bay shore turns through
+more than a right angle inside one frame.** The approximation was asked to
+describe both arms of a turn with one direction, and could not.
+
+Measured on the 50 beaches with a coast to draw, sampling each frame on a
+61-by-61 grid and comparing against the side the coastline itself gives:
+
+- **834 of 121,794 samples were shaded on the wrong side of their own shore**,
+  spread over ten beaches. Worst: `coronado-city-beaches` at 25.4 percent of
+  its frame, `coronado-cays-nr` at 11.3, `north-imperial-beach` at 5.0.
+- **Ten closing edges reached inside a frame**, across eight beaches —
+  `childrens-pool`, `south-casa-beach-s-d`, `mission-bay-crown-point-shores`,
+  `coronado-city-beaches`, `coronado-cays-nr`, `silver-strand-state-beach`,
+  `north-imperial-beach` and `border-field-state-park`. A straight edge between
+  water and land, inside the picture, at an angle to the shore beside it.
+- Asked one segment at a time — is the point a hair to this segment's left
+  shaded, and the point a hair to its right not? — **32 drawn segments failed**,
+  on `coronado-city-beaches` and `north-imperial-beach`.
+
+The closing edges are the part that was not predicted. The old construction
+offsets its two closing corners from the _coast's_ two ends, and a coast can be
+drawn well outside the box it is framed in — `windowAround` returns a point past
+each end on purpose, and on a bay run that point is a long way off. Offset from
+a point that is already off the picture, the closure comes back onto it.
+
+## Decision
+
+**The wash is closed by walking the frame's own edges, and reads which side is
+water from the walk rather than from a direction.**
+
+- **A box that holds the frame and everything drawn**, with a tenth of its
+  larger span to spare. The frame is in that arithmetic as well as the coast,
+  which is what the old closure was missing.
+- **The shore is carried straight off both ends to that box**, along the line
+  its own end segment was on.
+- **The box's edge is then walked whichever way holds the water**, decided by
+  the sign of the closed ring's area. The coast divides the box in two and the
+  two ways round give those two halves, so the sign is what tells them apart.
+- **Nothing in it approximates the coast by a line.** The coast _is_ the
+  boundary; the only invented geometry is off the picture. Exact for any shape
+  the shore takes, including one that turns back on itself.
+
+`seaWash` lives in `src/components/conditions/wash.ts`, beside its component
+the way `needles.ts` sits beside `Compass.tsx`: plot-space geometry, handed a
+projected coast and a box, knowing nothing about latitude or beaches.
+
+**The map now derives no seaward direction at all.** `shoreViewFor` still
+computes one, because `squareToward` has to know which way to grow the box, and
+that is a different question — which way the frame should lean overall, not
+which side of a bend a pixel is on. The two can no longer disagree because only
+one of them exists.
+
+## What the check is, and what it cannot be
+
+#200 proposed the verification directly: sample each frame on a grid and
+compare against `sideOf`, the ground truth the `sea-side` gate row already
+uses, so the two rows check one rule at two scales. **That check fails on
+correct output, and the reason is worth writing down.**
+
+`sideOf` takes the side of the single _nearest segment_. Far from shore that
+choice is decided by millimetres between segments pointing opposite ways. At
+`torrey-pines-state-beach` a 20 m reversed spur in the county's linework beats
+its own neighbour by 0.01 m from 5.9 km away, and flips the verdict for a
+quarter of the frame. The wash is right there and the ground truth is wrong.
+
+So the sweep asks only what this geometry can answer:
+
+- **within 500 m of the drawn shore**, and
+- **only where every segment within one percent of the nearest agrees.**
+
+That leaves 121,794 of 185,928 samples, spread over all 50 beaches, and under
+it the new construction is wrong on none of them. The per-segment sweep beside
+it declines a probe the segment does not own, for the same reason and by the
+same rule: 593 of 5,533 probes are declined, and the 4,940 that stand pass.
+
+**A tolerance was the alternative and was rejected.** The ten beaches the old
+construction fails under this sweep fail at 0.1, 0.4, 0.5, 1.0, 1.0, 1.2, 5.0,
+11.3 and 25.4 percent of their samples — there is no gap for a threshold to sit
+in, so any figure loose enough to absorb the near-misses also absorbs a quarter
+of a frame. And the construction is exact, so zero is reachable: a tolerance
+would be a constant standing in for an understanding, which is the thing the
+two filters above are instead.
+
+## Alternatives considered
+
+**Share one seaward direction between the frame and the wash.** #200's own
+smaller option: `shoreViewFor` already decides which way the sea lies for
+`squareToward`, so pass it through `ShoreView` instead of re-deriving it. It is
+smaller, and **measured, it makes the picture worse**: 1,670 drawn segments
+wash the wrong side against the old construction's 32, on eight beaches rather
+than two. The run it is taken over is longer than the drawn window and bends
+more, so as a half-plane it is a worse fit than the chord's normal — and the
+inconsistency it was meant to remove is a symptom of using a direction at all.
+
+**Keep the normal and take it per segment.** The objection ADR-0033 recorded
+still holds: per-segment half-planes fold on themselves at a bend, and the
+union of them is not the region wanted.
+
+**Clip the polygon to the frame instead of closing outside it.** Would put the
+frame's edges in the emitted path and give the same picture. Rejected: the
+outer `<svg>` already clips to its viewport, so the clipping is free and the
+path stays readable as "the shore, then off the edge".
+
+## Consequences
+
+- **`ShoreMap` gets smaller and stops doing geometry.** `seaPath` goes, along
+  with `OFF_FRAME` and the two fields it returned that nothing had read since
+  ADR-0038 took the readout off the picture.
+- **The wash covers the bays properly for the first time.** `silver-strand-state-beach`
+  is the clearest: it is a sand spit with the ocean on one side and San Diego
+  Bay on the other, and the bay was white. Swept without the two filters above —
+  every in-frame sample counted, so a looser reading than the one the check
+  makes — 15.7 percent of that frame was shaded on the wrong side, against 0.1
+  percent now.
+- **`border-field-state-park` is the one beach where the wash draws a boundary
+  inside the frame that the source did not give.** The committed shoreline
+  begins there, at the Mexican border, so the shore runs out mid-picture and the
+  wash continues along the line it was on. The alternative is a wedge of
+  unshaded water, which is the defect this replaces.
+- **The `sea-side` gate row is unchanged and still needed.** It proves the
+  premise this construction reads — that walked south to north, this coast has
+  the sea on its left — against the wave buoys. Nothing here re-proves it; the
+  sweeps in `wash.test.ts` assume it and check the drawing.

--- a/docs/adr/0041-the-wash-closes-on-the-frame.md
+++ b/docs/adr/0041-the-wash-closes-on-the-frame.md
@@ -124,8 +124,10 @@ path stays readable as "the shore, then off the edge".
 ## Consequences
 
 - **`ShoreMap` gets smaller and stops doing geometry.** `seaPath` goes, along
-  with `OFF_FRAME` and the two fields it returned that nothing had read since
-  ADR-0038 took the readout off the picture.
+  with `OFF_FRAME` and the `from` and `unit` it returned. Those two were the
+  gradient's anchor and axis under ADR-0030, and ADR-0033 replaced the fade with
+  a flat tint without removing them — so they have been computed and unread
+  since 2026-08-30.
 - **The wash covers the bays properly for the first time.** `silver-strand-state-beach`
   is the clearest: it is a sand spit with the ocean on one side and San Diego
   Bay on the other, and the bay was white. Swept without the two filters above —

--- a/src/components/conditions/ShoreMap.test.tsx
+++ b/src/components/conditions/ShoreMap.test.tsx
@@ -105,17 +105,18 @@ test("the shaded side is the seaward one", () => {
   const sea = container.querySelector("[data-sea]")!.getAttribute("d")!;
   const xs = [...sea.matchAll(/[ML](-?[\d.]+) /g)].map((m) => Number(m[1]));
 
-  // The polygon closes on two points pushed off-frame to the seaward side.
-  const closing = xs.slice(-2);
-  const coastXs = xs.slice(0, -2);
+  // The wash runs off the western edge of the picture and stops short of the
+  // eastern one. Where exactly its corners fall is `wash.ts`'s business and is
+  // checked there, against every committed beach rather than one fixture.
+  expect(Math.min(...xs)).toBeLessThan(0);
+  expect(Math.max(...xs)).toBeLessThan(100);
+  expect(sea.endsWith("Z")).toBe(true);
 
-  expect(Math.max(...closing)).toBeLessThan(Math.min(...coastXs));
-
-  // And a point known to be out at sea falls west of every drawn coast point,
-  // which is the direction the closing corners went.
+  // And the drawn coast is well inside the frame, so "runs off the west edge"
+  // is a claim about the wash rather than about where the window happens to be.
   const project = projectionFor(BOUNDS, { width: 100, height: 100 });
-  const offshore = project(32.865, -117.272);
-  expect(offshore.x).toBeLessThan(Math.min(...coastXs));
+  const coastXs = COAST.map((point) => project(point.lat, point.lon).x);
+  expect(Math.min(...coastXs)).toBeGreaterThan(0);
 });
 
 test("the water is one solid wash, not a gradient", () => {

--- a/src/components/conditions/ShoreMap.tsx
+++ b/src/components/conditions/ShoreMap.tsx
@@ -45,6 +45,7 @@
 import type { ReactNode } from "react";
 import type { Bounds, Position, ShorePoint } from "@/lib/coastline";
 import { projectionFor } from "@/lib/coastline";
+import { seaWash } from "./wash";
 
 export type ShoreMapProps = {
   /** The windowed coast in walk order. Empty draws no shoreline and says so. */
@@ -143,71 +144,6 @@ export type ShoreMapProps = {
 const WIDTH = 100;
 const HEIGHT = 100;
 
-/**
- * Far enough that the sea polygon always leaves the frame.
- *
- * Twice the diagonal, so no window shape can leave a corner unshaded. The outer
- * `<svg>` clips to its own viewport, so the overshoot costs nothing.
- */
-const OFF_FRAME = 2 * Math.hypot(WIDTH, HEIGHT);
-
-/**
- * The sea, as a polygon closed off the edge of the frame.
- *
- * **Which side is seaward.** `sideOf` in `lib/coastline.ts` answers that
- * geographically and the `sea-side` gate row proves the answer is "left of the
- * walk" for every beach that can be asked. Converting to plot coordinates is
- * the one place the flip matters: `projectionFor` puts north at the top, so y
- * grows southward and the geographic left of a walk appears on the other hand
- * on screen. Left of geographic (dx, dy) is (-dy, dx); with y flipped, a plot
- * direction (px, py) has its seaward normal at (py, -px).
- *
- * **The polygon also runs on past both ends, and that is not decoration.**
- * Closing straight from the last point to seaward and back to the first leaves
- * a wedge of frame unshaded wherever the coast is not perpendicular to that
- * normal — a diagonal edge of missing sea in a corner, which reads as a drawing
- * error because it is one. Extending along the walk as well as out to sea puts
- * both closing corners outside the frame in both directions, so the whole
- * seaward half is covered whatever angle the shore runs at.
- *
- * Taken from the run's two ends rather than segment by segment: the polygon
- * only has to close on the right side of the frame, and a per-segment normal
- * would fold on itself at a bend.
- */
-function seaPath(
-  path: string,
-  drawn: readonly { x: number; y: number }[],
-): {
-  d: string;
-  from: { x: number; y: number };
-  unit: { x: number; y: number };
-} {
-  const first = drawn[0];
-  const last = drawn[drawn.length - 1];
-
-  const px = last.x - first.x;
-  const py = last.y - first.y;
-  const length = Math.hypot(px, py) || 1;
-
-  const unit = { x: py / length, y: -px / length };
-  const walk = { x: (px / length) * OFF_FRAME, y: (py / length) * OFF_FRAME };
-  const sea = { x: unit.x * OFF_FRAME, y: unit.y * OFF_FRAME };
-
-  const beyondEnd = { x: last.x + walk.x + sea.x, y: last.y + walk.y + sea.y };
-  const beforeStart = {
-    x: first.x - walk.x + sea.x,
-    y: first.y - walk.y + sea.y,
-  };
-
-  return {
-    d:
-      `${path} L${beyondEnd.x.toFixed(2)} ${beyondEnd.y.toFixed(2)}` +
-      ` L${beforeStart.x.toFixed(2)} ${beforeStart.y.toFixed(2)} Z`,
-    from: drawn[Math.floor(drawn.length / 2)],
-    unit,
-  };
-}
-
 export function ShoreMap({
   coast,
   bounds,
@@ -234,7 +170,17 @@ export function ShoreMap({
     )
     .join(" ");
 
-  const sea = hasCoast ? seaPath(path, drawn) : null;
+  /*
+    The wash is built from the drawn coast and the frame, and from nothing else.
+
+    It used to be closed on a normal taken across the run's two ends, which is
+    exact on a straight shore and approximate on a bent one -- and ADR-0039 gave
+    the bays a shoreline that turns through more than a right angle inside one
+    frame. `seaWash` closes on the frame's own edges instead, so which side is
+    water is read from the walk rather than from a direction anything here has
+    to get right. ADR-0041.
+  */
+  const sea = seaWash(drawn, { width: WIDTH, height: HEIGHT });
 
   const drawnSegment =
     segment === null || segment.length < 2
@@ -281,7 +227,12 @@ export function ShoreMap({
           */}
         {sea !== null && (
           <path
-            d={sea.d}
+            d={`${sea
+              .map(
+                (at, index) =>
+                  `${index === 0 ? "M" : "L"}${at.x.toFixed(2)} ${at.y.toFixed(2)}`,
+              )
+              .join(" ")} Z`}
             className="fill-ocean"
             fillOpacity={0.16}
             data-sea=""

--- a/src/components/conditions/shore.ts
+++ b/src/components/conditions/shore.ts
@@ -243,10 +243,17 @@ export function coastRunFor(beach: Beach): CoastRun | null {
  * is the gate that holds it, for every beach, against the wave buoy as ground
  * truth — so this reads a fact that is checked rather than assuming one.
  *
- * Taken from the run's two ends rather than segment by segment, which is
- * `seaPath`'s choice one step earlier and made for the same reason: a
- * per-segment normal turns at every bend, and what is wanted is which side of
- * the whole run the ocean is.
+ * Taken from the run's two ends rather than segment by segment, because the
+ * only caller is `squareToward` and a box grows in one direction: the question
+ * being asked is which way the frame should lean overall, not which side of any
+ * particular bend the water is on.
+ *
+ * **The wash used to ask the second question with this answer, and stopped.**
+ * `ShoreMap` closed its polygon on a normal built the same way, which is exact
+ * on a straight shore and wrong wherever one turns — so ADR-0041 gave the wash
+ * a construction that reads the side from the walk itself and needs no
+ * direction at all. Nothing here is shared with it now, which is why the two
+ * can no longer disagree.
  *
  * Null on a run too short to have a direction, which is a beach with no traced
  * coast.

--- a/src/components/conditions/wash.test.ts
+++ b/src/components/conditions/wash.test.ts
@@ -1,0 +1,461 @@
+import { expect, test } from "vitest";
+import { allBeaches } from "@/lib/beaches";
+import type { PlotPoint, ShorePoint } from "@/lib/coastline";
+import { projectionFor } from "@/lib/coastline";
+import { shoreViewFor } from "./shore";
+import { seaWash } from "./wash";
+
+/** The drawing space `ShoreMap` uses, so these read against the real picture. */
+const SIZE = { width: 100, height: 100 };
+
+const inFrame = (at: PlotPoint) =>
+  at.x >= 0 && at.x <= SIZE.width && at.y >= 0 && at.y <= SIZE.height;
+
+/**
+ * Whether a point falls inside a polygon, by ray crossing.
+ *
+ * The same question the browser answers when it fills the path, asked here so a
+ * test can put a point where it knows the water is and read back whether it
+ * would be shaded.
+ */
+function shaded(polygon: readonly PlotPoint[], at: PlotPoint): boolean {
+  let hit = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i, i += 1) {
+    const a = polygon[i];
+    const b = polygon[j];
+    if (
+      a.y > at.y !== b.y > at.y &&
+      at.x < ((b.x - a.x) * (at.y - a.y)) / (b.y - a.y) + a.x
+    ) {
+      hit = !hit;
+    }
+  }
+  return hit;
+}
+
+/** How far a point sits from a run of segments, and which one is nearest. */
+function nearestOn(run: readonly PlotPoint[], at: PlotPoint) {
+  let distance = Infinity;
+  let index = -1;
+  for (let i = 0; i < run.length - 1; i += 1) {
+    const from = run[i];
+    const to = run[i + 1];
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const span = dx * dx + dy * dy;
+    if (span === 0) continue;
+    const px = at.x - from.x;
+    const py = at.y - from.y;
+    const along = Math.min(1, Math.max(0, (px * dx + py * dy) / span));
+    const offX = px - along * dx;
+    const offY = py - along * dy;
+    const off = Math.hypot(offX, offY);
+    if (off < distance) {
+      distance = off;
+      index = i;
+    }
+  }
+  return { distance, index };
+}
+
+/**
+ * The parts of a wash that are not the drawn shore: what closes it, and the two
+ * straight continuations that carry the shore off the edge of the picture.
+ *
+ * Found by locating the coast inside the returned ring rather than by counting
+ * from either end, so the test says what it means instead of restating the
+ * order `seaWash` happens to build in.
+ */
+function closureOf(wash: readonly PlotPoint[], coast: readonly PlotPoint[]) {
+  const same = (a: PlotPoint, b: PlotPoint) => a.x === b.x && a.y === b.y;
+  const at = wash.findIndex((point) => same(point, coast[0]));
+  expect(at).toBeGreaterThanOrEqual(0);
+  coast.forEach((point, step) => {
+    expect(same(wash[at + step], point)).toBe(true);
+  });
+
+  const before = wash[at - 1];
+  const after = wash[at + coast.length];
+  expect(before).toBeDefined();
+  expect(after).toBeDefined();
+
+  // Everything from the far continuation round to the near one, which is the
+  // part that has to stay off the picture.
+  const rest: PlotPoint[] = [];
+  for (let step = at + coast.length; step <= wash.length + at - 1; step += 1) {
+    rest.push(wash[step % wash.length]);
+  }
+
+  return { before, after, rest };
+}
+
+/** A direction, so two runs can be compared without their lengths mattering. */
+function heading(from: PlotPoint, to: PlotPoint) {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const length = Math.hypot(dx, dy);
+  return { x: dx / length, y: dy / length };
+}
+
+/**
+ * A short run down a west-facing coast, walked south to north.
+ *
+ * Plot space, so north is up and y runs the other way to latitude. The sea is
+ * to the west of it, which on this picture is smaller x.
+ */
+const STRAIGHT: PlotPoint[] = [
+  { x: 60, y: 95 },
+  { x: 60, y: 60 },
+  { x: 60, y: 20 },
+  { x: 60, y: 5 },
+];
+
+/**
+ * The same walk, turning a right angle partway.
+ *
+ * This is the shape the old construction could not draw: north up the first
+ * arm, then east along the second, so the water is west of one and north of the
+ * other and no single normal describes both. A bay mouth is this shape.
+ */
+const BENT: PlotPoint[] = [
+  { x: 50, y: 95 },
+  { x: 50, y: 60 },
+  { x: 50, y: 50 },
+  { x: 70, y: 50 },
+  { x: 95, y: 50 },
+];
+
+test("a run with nothing to give it a direction has no wash", () => {
+  // Both are unreachable through `ShoreMap`, which draws no sea without a
+  // coast, and both are the kind of guard that stops being unreachable when
+  // someone changes the caller.
+  expect(seaWash([], SIZE)).toBeNull();
+  expect(seaWash([{ x: 10, y: 10 }], SIZE)).toBeNull();
+  expect(
+    seaWash(
+      [
+        { x: 10, y: 10 },
+        { x: 10, y: 10 },
+      ],
+      SIZE,
+    ),
+  ).toBeNull();
+});
+
+test("the sea is shaded and the land is not, on a straight shore", () => {
+  const wash = seaWash(STRAIGHT, SIZE)!;
+
+  // West of the line is the Pacific; east of it is the county.
+  expect(shaded(wash, { x: 20, y: 50 })).toBe(true);
+  expect(shaded(wash, { x: 90, y: 50 })).toBe(false);
+});
+
+test("a shore that turns a corner keeps the sea on its left the whole way", () => {
+  // The defect in #200, at its smallest. One normal taken across the run's two
+  // ends points north-west here, which covers the water off neither arm
+  // properly: it leaves a corner of the frame unshaded and washes a corner of
+  // the land instead.
+  const wash = seaWash(BENT, SIZE)!;
+
+  // West of the first arm, which is water.
+  expect(shaded(wash, { x: 20, y: 80 })).toBe(true);
+  // North of the second arm, which is also water.
+  expect(shaded(wash, { x: 85, y: 25 })).toBe(true);
+  // And the wedge the two arms enclose is land, all the way into the corner.
+  expect(shaded(wash, { x: 80, y: 80 })).toBe(false);
+  expect(shaded(wash, { x: 95, y: 95 })).toBe(false);
+});
+
+test("walked the other way, the same shore washes the other side", () => {
+  // The sea is left of the walk rather than a fixed compass direction, which is
+  // the one convention here that is easy to get exactly backwards -- and
+  // getting it backwards would put every map's water over the land while still
+  // looking deliberate.
+  const wash = seaWash([...STRAIGHT].reverse(), SIZE)!;
+
+  expect(shaded(wash, { x: 20, y: 50 })).toBe(false);
+  expect(shaded(wash, { x: 90, y: 50 })).toBe(true);
+});
+
+test("the wash closes outside the picture, never across it", () => {
+  // The complaint #200 opens with. What closes the polygon is a walk round the
+  // corners of a box that already holds the whole frame, so none of it can
+  // appear as a straight edge inside the picture.
+  const wash = seaWash(BENT, SIZE)!;
+  const { rest } = closureOf(wash, BENT);
+
+  for (let i = 0; i < rest.length - 1; i += 1) {
+    for (let step = 0; step <= 40; step += 1) {
+      const at = {
+        x: rest[i].x + ((rest[i + 1].x - rest[i].x) * step) / 40,
+        y: rest[i].y + ((rest[i + 1].y - rest[i].y) * step) / 40,
+      };
+      expect(inFrame(at)).toBe(false);
+    }
+  }
+});
+
+test("where the shore leaves the picture the wash leaves it along the same line", () => {
+  // The two edges that do reach inside the frame are the shore's own
+  // continuations, so the only boundary a reader sees between water and land is
+  // the drawn line or the line it was heading along when it ran out.
+  const wash = seaWash(BENT, SIZE)!;
+  const { before, after } = closureOf(wash, BENT);
+
+  const back = heading(BENT[1], BENT[0]);
+  const on = heading(BENT[BENT.length - 2], BENT[BENT.length - 1]);
+
+  expect(heading(BENT[0], before).x).toBeCloseTo(back.x, 10);
+  expect(heading(BENT[0], before).y).toBeCloseTo(back.y, 10);
+  expect(heading(BENT[BENT.length - 1], after).x).toBeCloseTo(on.x, 10);
+  expect(heading(BENT[BENT.length - 1], after).y).toBeCloseTo(on.y, 10);
+});
+
+/** Every beach that has a coast to draw, as `ShoreMap` would receive it. */
+function drawnCounty() {
+  const drawn: { slug: string; coast: PlotPoint[] }[] = [];
+
+  for (const beach of allBeaches()) {
+    const view = shoreViewFor(beach);
+    if (view.bounds === null || view.coast.length < 2) continue;
+    const project = projectionFor(view.bounds, SIZE);
+    drawn.push({
+      slug: beach.slug,
+      coast: view.coast.map((point) => project(point.lat, point.lon)),
+    });
+  }
+
+  return drawn;
+}
+
+test("the whole county has a coast to wash, and it is drawn", () => {
+  // The denominator the three sweeps below run over, pinned here so a data
+  // change that halves it fails as a change rather than as three checks that
+  // quietly got easier.
+  expect(drawnCounty()).toHaveLength(50);
+});
+
+test("no beach's wash leaves the seaward side of its own drawn shore", () => {
+  // The property the picture has to have, asserted where it is well posed: at
+  // each drawn segment, against that segment's own normal.
+  //
+  // **A probe the segment does not own is skipped, and that is not a loophole.**
+  // A point a hair to the left of a 20 m spur in the county's linework is
+  // nearer to the piece of shore on the other side of the spur, so it says
+  // nothing about the spur. 593 of 5,533 probes are declined that way; the
+  // 4,940 that stand cover every beach.
+  const strayed: string[] = [];
+
+  for (const { slug, coast } of drawnCounty()) {
+    for (let i = 0; i < coast.length - 1; i += 1) {
+      const from = coast[i];
+      const to = coast[i + 1];
+      const dx = to.x - from.x;
+      const dy = to.y - from.y;
+      const length = Math.hypot(dx, dy);
+      if (length === 0) continue;
+
+      const mid = { x: (from.x + to.x) / 2, y: (from.y + to.y) / 2 };
+      if (!inFrame(mid)) continue;
+
+      // Plot space puts north at the top, so y grows southward and the
+      // geographic left of the walk appears on the other hand: for a walk
+      // (dx, dy) the seaward normal is (dy, -dx).
+      const reach = Math.min(0.2, length / 2);
+      const sea = {
+        x: mid.x + (dy / length) * reach,
+        y: mid.y - (dx / length) * reach,
+      };
+      const land = {
+        x: mid.x - (dy / length) * reach,
+        y: mid.y + (dx / length) * reach,
+      };
+      if (nearestOn(coast, sea).index !== i) continue;
+      if (nearestOn(coast, land).index !== i) continue;
+
+      const wash = seaWash(coast, SIZE)!;
+      if (!shaded(wash, sea)) strayed.push(`${slug}: segment ${i} left dry`);
+      if (shaded(wash, land)) strayed.push(`${slug}: segment ${i} washed land`);
+    }
+  }
+
+  expect(strayed).toEqual([]);
+});
+
+test("no beach's wash closes inside its own picture", () => {
+  // Measured before the change: ten closing edges reached inside a frame,
+  // across eight beaches, because a coast can be drawn well outside the box it
+  // is framed in and the old closure was offset from *it* rather than from the
+  // frame.
+  const crossed: string[] = [];
+
+  for (const { slug, coast } of drawnCounty()) {
+    const { rest } = closureOf(seaWash(coast, SIZE)!, coast);
+
+    for (let i = 0; i < rest.length - 1; i += 1) {
+      for (let step = 0; step <= 40; step += 1) {
+        const at = {
+          x: rest[i].x + ((rest[i + 1].x - rest[i].x) * step) / 40,
+          y: rest[i].y + ((rest[i + 1].y - rest[i].y) * step) / 40,
+        };
+        if (inFrame(at)) {
+          crossed.push(`${slug}: closing edge ${i} reaches the picture`);
+          break;
+        }
+      }
+    }
+  }
+
+  expect(crossed).toEqual([]);
+});
+
+/**
+ * How near a point is to a run of segments, squared, and which way it lies off
+ * the nearest of them.
+ *
+ * Squared and in plot units because it is called on every sample of every
+ * frame: no square root, no allocation, and no second spelling of the cosine
+ * correction, which the projection has already applied. The projection is a
+ * uniform scale with north at the top, so a side in plot space is the same side
+ * on the ground -- read with the flip the rest of this file uses, where the
+ * seaward normal of a walk (dx, dy) is (dy, -dx).
+ */
+function agreedSide(
+  coast: readonly PlotPoint[],
+  at: PlotPoint,
+  reach: number,
+  slack: number,
+  off: Float64Array,
+  toward: Float64Array,
+): "sea" | "land" | null {
+  let nearest = Infinity;
+
+  // Written out rather than called through a helper, and filling two buffers
+  // the caller owns rather than returning a pair. This runs 121,794 times over
+  // runs of up to 856 segments, so a closure and an object per segment is the
+  // difference between a sweep and a slow one.
+  for (let index = 0; index < coast.length - 1; index += 1) {
+    const from = coast[index];
+    const to = coast[index + 1];
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+    const span = dx * dx + dy * dy;
+    if (span === 0) {
+      off[index] = Infinity;
+      continue;
+    }
+
+    const px = at.x - from.x;
+    const py = at.y - from.y;
+    const along = Math.min(1, Math.max(0, (px * dx + py * dy) / span));
+    const offX = px - along * dx;
+    const offY = py - along * dy;
+
+    off[index] = offX * offX + offY * offY;
+    toward[index] = px * dy - py * dx;
+    if (off[index] < nearest) nearest = off[index];
+  }
+  if (nearest > reach * reach) return null;
+
+  // Every segment that could plausibly be the nearest has to agree, or the
+  // question has no answer here. Squared, so the one percent is applied twice.
+  const plausible = nearest * (1 + slack) * (1 + slack);
+  let sea = false;
+  let land = false;
+
+  for (let index = 0; index < coast.length - 1; index += 1) {
+    if (off[index] > plausible) continue;
+    if (toward[index] > 0) sea = true;
+    if (toward[index] < 0) land = true;
+    if (toward[index] === 0) return null;
+  }
+
+  if (sea === land) return null;
+  return sea ? "sea" : "land";
+}
+
+// The budget is raised because the work is the assertion, which is the
+// distinction `gate-scope.test.mjs` draws when it declines to raise one: there
+// the seconds were a cold resolver being warmed inside a test, and moving them
+// to a hook was the repair. Here they are 121,794 point-in-polygon tests
+// against runs of up to 856 segments, and there is nowhere else for that to
+// happen. It costs 2.5s under v8's coverage instrumentation on an idle machine
+// -- 4.8s before the buffers below -- and 5s has no room left for a loaded run.
+test(
+  "every beach's wash agrees with the shore it is drawn from",
+  { timeout: 60_000 },
+  () => {
+    // #200's own verification: sampled on a grid over every frame and compared
+    // against the side the coastline itself gives, which is the ground truth
+    // `scripts/sea-side.mjs` already uses one scale up.
+    //
+    // **Asked only where that ground truth has an answer**, which is the
+    // correction the issue's own wording needs. The side of a coast is decided by
+    // the nearest segment, and far from shore that is decided by millimetres
+    // between segments pointing opposite ways: at `torrey-pines-state-beach` a
+    // 20 m reversed spur in the county's linework wins by 0.01 m from 5.9 km
+    // away, and flips the verdict for a quarter of the frame. So a sample counts
+    // only within 500 m of the drawn shore, and only where every segment within
+    // one percent of the nearest agrees on the answer. That leaves 121,794 of
+    // 185,928 samples, spread over all 50 beaches.
+    //
+    // Measured before the change: 834 of those were shaded on the wrong side,
+    // across ten beaches, worst `coronado-city-beaches` at 25.4 percent of its
+    // frame. See docs/adr/0041.
+    const REACH_M = 500;
+    const SLACK = 0.01;
+    const METRES_PER_DEGREE = 111_320;
+    const STEPS = 60;
+
+    const wrong: string[] = [];
+
+    for (const beach of allBeaches()) {
+      const view = shoreViewFor(beach);
+      if (view.bounds === null || view.coast.length < 2) continue;
+
+      const bounds = view.bounds;
+      const project = projectionFor(bounds, SIZE);
+      const coast = view.coast.map((point) => project(point.lat, point.lon));
+      const wash = seaWash(coast, SIZE)!;
+
+      // One metre, in this frame's own plot units, taken off the projection
+      // rather than rebuilt from its scale factors.
+      const metre = Math.abs(
+        project(bounds.south + 1 / METRES_PER_DEGREE, bounds.west).y -
+          project(bounds.south, bounds.west).y,
+      );
+      // Two buffers per beach, reused by every sample of its frame. See
+      // `agreedSide`.
+      const off = new Float64Array(coast.length);
+      const toward = new Float64Array(coast.length);
+      let missed = 0;
+
+      for (let row = 0; row <= STEPS; row += 1) {
+        for (let column = 0; column <= STEPS; column += 1) {
+          const at = project(
+            bounds.south + ((bounds.north - bounds.south) * row) / STEPS,
+            bounds.west + ((bounds.east - bounds.west) * column) / STEPS,
+          );
+          if (!inFrame(at)) continue;
+
+          const side = agreedSide(
+            coast,
+            at,
+            REACH_M * metre,
+            SLACK,
+            off,
+            toward,
+          );
+          if (side === null) continue;
+          if (shaded(wash, at) !== (side === "sea")) missed += 1;
+        }
+      }
+
+      if (missed > 0) {
+        wrong.push(`${beach.slug}: ${missed} samples washed wrongly`);
+      }
+    }
+
+    expect(wrong).toEqual([]);
+  },
+);

--- a/src/components/conditions/wash.ts
+++ b/src/components/conditions/wash.ts
@@ -1,0 +1,241 @@
+/**
+ * The sea, as a polygon that closes on the frame rather than on the coast.
+ *
+ * **`ShoreMap` shades one side of the drawn shore, and this decides which side
+ * and how far.** It is plot-space geometry only: it is handed the coast already
+ * projected and the box it is being drawn into, and it knows nothing about
+ * latitude, beaches or the county. `needles.ts` sits beside `Compass.tsx` for
+ * the same reason — the part with a rule in it is separable from the part that
+ * renders, and only one of the two can be wrong in an interesting way.
+ *
+ * **Which side is seaward is read from the walk, not from a direction.** The
+ * proven property is that this coast, walked south to north, has the sea on its
+ * left; `scripts/sea-side.mjs` holds it against every committed wave buoy. So
+ * the wash needs no seaward vector of its own: it takes the side the walk
+ * itself gives, which is exactly what "left of the walk" means. `shore.ts`
+ * still computes one, because `squareToward` has to know which way to grow the
+ * box, and that is the only thing left that needs an answer as a direction.
+ *
+ * **It used to close on a normal taken across the run's two ends**, which was
+ * exact on a straight shore and approximate on a bent one. The approximation
+ * was asked to do more once ADR-0039 gave the bays their own shoreline, because
+ * a bay shore turns through more than a right angle inside one frame and no
+ * single normal describes both arms. Measured over the 50 beaches with a coast,
+ * on a 61-by-61 grid per frame: 834 of 121,794 samples were shaded on the wrong
+ * side of their own shore, across ten beaches, worst `coronado-city-beaches` at
+ * 25.4 percent of its frame. Ten closing edges reached inside a frame, across
+ * eight beaches. Both are zero here. See ADR-0041.
+ */
+
+import type { PlotPoint, PlotSize } from "@/lib/coastline";
+
+/**
+ * How far outside everything drawn the closing box sits, as a fraction of its
+ * larger span.
+ *
+ * It only has to be more than nothing: the box has to *contain* the frame and
+ * every drawn point strictly, so that a run continued from either end leaves it
+ * through exactly one edge. A tenth is far enough to be clear of rounding and
+ * near enough that the numbers in the emitted path stay readable.
+ */
+const CLEARANCE = 0.1;
+
+/** A box in plot space, which is the only shape this file closes against. */
+type Box = {
+  readonly minX: number;
+  readonly minY: number;
+  readonly maxX: number;
+  readonly maxY: number;
+};
+
+/**
+ * A box holding the frame and every drawn point, with room to spare.
+ *
+ * **The frame is in the arithmetic as well as the coast**, which is the whole
+ * of this file's correction. The coast can be drawn well outside the box it is
+ * framed in — `windowAround` returns a point past each end on purpose, and on a
+ * bay run that point can be a long way off — so a closure measured only against
+ * the coast can still fall across the picture. Measured before this changed, it
+ * did, on eight beaches.
+ */
+function boxAround(coast: readonly PlotPoint[], size: PlotSize): Box {
+  const xs = [0, size.width, ...coast.map((point) => point.x)];
+  const ys = [0, size.height, ...coast.map((point) => point.y)];
+
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const minY = Math.min(...ys);
+  const maxY = Math.max(...ys);
+  const room = CLEARANCE * Math.max(maxX - minX, maxY - minY);
+
+  return {
+    minX: minX - room,
+    minY: minY - room,
+    maxX: maxX + room,
+    maxY: maxY + room,
+  };
+}
+
+/** Where a ray from inside the box crosses its edge. */
+function leavingAt(box: Box, from: PlotPoint, along: PlotPoint): PlotPoint {
+  const toX =
+    along.x > 0
+      ? (box.maxX - from.x) / along.x
+      : along.x < 0
+        ? (box.minX - from.x) / along.x
+        : Infinity;
+  const toY =
+    along.y > 0
+      ? (box.maxY - from.y) / along.y
+      : along.y < 0
+        ? (box.minY - from.y) / along.y
+        : Infinity;
+
+  const reach = Math.min(toX, toY);
+  return { x: from.x + along.x * reach, y: from.y + along.y * reach };
+}
+
+/**
+ * How far round the box's edge a point on it sits, in corners.
+ *
+ * Zero at the top-left corner and rising clockwise, so a whole number is a
+ * corner and the walk between two points is a difference. It is the only thing
+ * that makes "follow the edge from here to there" expressible without four
+ * cases.
+ */
+function wayRound(box: Box, at: PlotPoint): number {
+  const across = box.maxX - box.minX;
+  const down = box.maxY - box.minY;
+  const touching = 1e-9 * Math.max(across, down);
+
+  if (Math.abs(at.y - box.minY) <= touching) return (at.x - box.minX) / across;
+  if (Math.abs(at.x - box.maxX) <= touching)
+    return 1 + (at.y - box.minY) / down;
+  if (Math.abs(at.y - box.maxY) <= touching)
+    return 2 + (box.maxX - at.x) / across;
+  return 3 + (box.maxY - at.y) / down;
+}
+
+/** The box's four corners, in the order `wayRound` counts them. */
+function cornersOf(box: Box): readonly PlotPoint[] {
+  return [
+    { x: box.minX, y: box.minY },
+    { x: box.maxX, y: box.minY },
+    { x: box.maxX, y: box.maxY },
+    { x: box.minX, y: box.maxY },
+  ];
+}
+
+const round = (turns: number): number => ((turns % 4) + 4) % 4;
+
+/** The corners passed walking the box's edge from one place to another. */
+function cornersFrom(
+  box: Box,
+  from: number,
+  to: number,
+  way: 1 | -1,
+): readonly PlotPoint[] {
+  const span = way > 0 ? round(to - from) : round(from - to);
+
+  return cornersOf(box)
+    .map((corner, index) => ({
+      corner,
+      passed: way > 0 ? round(index - from) : round(from - index),
+    }))
+    .filter((each) => each.passed > 0 && each.passed < span)
+    .sort((a, b) => a.passed - b.passed)
+    .map((each) => each.corner);
+}
+
+/**
+ * Whether a closed ring holds the ground to the left of its own walk.
+ *
+ * Twice the signed area, by the shoelace sum. The sign is the whole point: the
+ * coast divides the box in two and the two ways round the edge give those two
+ * halves, so this is what tells them apart — no probe point, no seaward vector,
+ * and nothing that has to be right about San Diego in particular.
+ *
+ * **Negative is left, because y grows downward here.** `projectionFor` puts
+ * north at the top, so the plot is a mirror of the usual orientation and the
+ * sign of the usual test flips with it. For a walk (dx, dy) the seaward side is
+ * (dy, -dx), and a ring holding that side sums negative.
+ */
+function holdsTheLeft(ring: readonly PlotPoint[]): boolean {
+  let sum = 0;
+  for (let index = 0; index < ring.length; index += 1) {
+    const from = ring[index];
+    const to = ring[(index + 1) % ring.length];
+    sum += from.x * to.y - to.x * from.y;
+  }
+  return sum < 0;
+}
+
+/**
+ * Which way the shore was heading when it reached one of its ends.
+ *
+ * Reads outward from the end until two points differ, so a repeated point
+ * cannot hand back a direction of zero length. Null when every point is the
+ * same place, which is a run with no direction at all.
+ */
+function headingOut(
+  coast: readonly PlotPoint[],
+  from: number,
+  step: 1 | -1,
+): PlotPoint | null {
+  const end = coast[from];
+
+  for (
+    let index = from + step;
+    index >= 0 && index < coast.length;
+    index += step
+  ) {
+    const dx = end.x - coast[index].x;
+    const dy = end.y - coast[index].y;
+    if (dx === 0 && dy === 0) continue;
+
+    const length = Math.hypot(dx, dy);
+    return { x: dx / length, y: dy / length };
+  }
+
+  return null;
+}
+
+/**
+ * The sea as a ring of points, or null when the coast gives no direction.
+ *
+ * The shore is carried straight off both ends to the closing box, and the box's
+ * edge is then walked whichever way holds the water. Exact for any shape the
+ * shore takes, including one that turns back on itself, because nothing in it
+ * approximates the coast by a line: the coast *is* the boundary, and the only
+ * invented geometry is off the picture.
+ *
+ * **The two continuations are the one thing drawn that the source does not
+ * say.** Where the traced shore runs out inside the frame — which is
+ * `border-field-state-park`, at the Mexican border, where the committed ring
+ * begins — the wash has to reach the edge somehow, and it does it along the
+ * line the shore was on. Stopping instead would leave a wedge of unshaded
+ * water, which is the defect this file exists to remove.
+ */
+export function seaWash(
+  coast: readonly PlotPoint[],
+  size: PlotSize,
+): readonly PlotPoint[] | null {
+  if (coast.length < 2) return null;
+
+  const back = headingOut(coast, 0, 1);
+  const on = headingOut(coast, coast.length - 1, -1);
+  if (back === null || on === null) return null;
+
+  const box = boxAround(coast, size);
+  const from = leavingAt(box, coast[0], back);
+  const to = leavingAt(box, coast[coast.length - 1], on);
+
+  const shore = [from, ...coast, to];
+  const start = wayRound(box, to);
+  const finish = wayRound(box, from);
+
+  const clockwise = [...shore, ...cornersFrom(box, start, finish, 1)];
+  return holdsTheLeft(clockwise)
+    ? clockwise
+    : [...shore, ...cornersFrom(box, start, finish, -1)];
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -473,10 +473,33 @@ export default defineConfig({
         // Functions rose because `unlistedCellFault` and its two arrow
         // callbacks are covered, which is the same event seen from the other
         // side.
-        statements: 89.21,
-        branches: 88.88,
-        functions: 94.11,
-        lines: 88.87,
+        // RAISED 2026-09-01, all four, by the sea wash closing on the frame
+        // (#200). The ordinary direction, and about as clean as this file gets:
+        //
+        //   statements 3072/3437  89.21 -> 89.38
+        //   branches   1952/2191  88.88 -> 89.09
+        //   functions   703/746   94.11 -> 94.23
+        //   lines      2763/3103  88.87 -> 89.04
+        //
+        // **Three of the four moved by the same amount top and bottom** --
+        // statements +54/+54, functions +15/+15, lines +46/+46 -- which says
+        // every statement, function and line `wash.ts` brought is covered. It
+        // arrives at 100% on all four and does not appear in the report's table
+        // at all.
+        //
+        // Branches are the interesting one: +33 numerator against +32
+        // denominator, so the numerator grew by more than the denominator did.
+        // That is not a rounding artefact and it is not a new test. `seaPath`
+        // took `Math.hypot(px, py) || 1` to guard a drawn run whose two ends
+        // project to the same point, and that arm was the one uncovered branch
+        // this file named against `ShoreMap.tsx` in the #192 note above. The
+        // guard is gone rather than covered: `seaWash` asks whether the run has
+        // a direction at all and returns null when it has not, which is a state
+        // a test can put it in. So `ShoreMap.tsx` leaves the table too.
+        statements: 89.38,
+        branches: 89.09,
+        functions: 94.23,
+        lines: 89.04,
       },
     },
   },


### PR DESCRIPTION
Closes #200.

## What changed

The polygon carrying the sea tint was closed from a single normal taken across
the drawn run's two ends. That is exact on a straight shore and approximate on
a bent one, and what the shore is has changed twice since ADR-0033 chose it:
ADR-0037 traced a real shoreline, ADR-0039 stopped withholding it from the
bays, and **a bay shore turns through more than a right angle inside one
frame**.

`seaWash` in the new `src/components/conditions/wash.ts` closes on a box that
holds the frame as well as the coast, carries the shore straight off both ends
to it, and walks that box's edge whichever way the sign of the closed ring's
area says holds the water. Nothing in it approximates the coast by a line, so
it is exact for any shape the shore takes.

**The map now derives no seaward direction at all**, which is how the
inconsistency #200 opens on is resolved: `shoreViewFor` still computes one for
`squareToward`, and there is no longer a second answer for it to disagree with.

One commit, because this repo's ADRs ship with the code they justify
(e6d3c65, 13d0f54, 2988a5c). **No plan file**: one sitting, and the rejected
alternatives are in ADR-0041, which is the document that stays current.

## The issue was stale, and every figure in it was re-derived

#200 was filed at 2026-08-31 21:13Z. ADR-0037 landed six hours later and
ADR-0039 seven. Three of its specifics no longer held:

- **`coronado-north-beach` is not where it shows.** It has zero wrongly-shaded
  samples on `main`. The 2,967 m bay-mouth gap it was about was a
  `mop-lines.json` artefact; the traced shore has no gap over 970 m. The worst
  beach is `coronado-city-beaches`, at 25.4 percent of its frame.
- **The sentence it quotes is not in ADR-0033.** It is `ShoreMap.tsx`'s own
  `seaPath` docstring. ADR-0033 decides the flat tint and the water's edge, and
  those stand.
- **Its three direction-disagreeing beaches now agree** — `sunset-cliffs-park`,
  `coronado-north-beach` and `imperial-beach-municipal-beach-other` differ by
  0.7°, 12.9° and 4.6°. Nine *other* beaches differ, up to 127.6°.

Its direction survived all of that: the defect is real and wider than one beach.

## Measured, on `main` and on this branch

50 beaches with a coast, each sampled on a 61-by-61 grid over its own frame:

| | main | this branch |
|---|---|---|
| samples shaded on the wrong side | **834 / 121,794**, on 10 beaches | **0 / 121,794** |
| worst beach | `coronado-city-beaches` 25.4% | — |
| drawn segments with the wash on the wrong side | **32**, on 2 beaches | **0 / 4,940** |
| closing edges reaching inside a frame | **10**, on 8 beaches | **0** |

The closing edges are the part #200's title names and the part I did not expect
to find: the old closure offsets from the *coast's* ends, and `windowAround`
returns a point past each end on purpose, so on a bay run it offsets from a
point that is already off the picture and comes back onto it. Affected:
`childrens-pool`, `south-casa-beach-s-d`, `mission-bay-crown-point-shores`,
`coronado-city-beaches`, `coronado-cays-nr`, `silver-strand-state-beach`,
`north-imperial-beach`, `border-field-state-park`.

## Two things in #200 I did not do

**Its "smaller and composable" option makes the picture worse.** Sharing
`seawardFrom` through `ShoreView` was measured before being rejected: **1,670**
drawn segments wash the wrong side against the old construction's 32, on eight
beaches rather than two. The run it is taken over is longer than the drawn
window and bends more, so as a half-plane it fits worse than the chord's normal.

**Its proposed verification fails on correct output.** `sideOf` takes the side
of the single nearest *segment*, and far from shore that is decided by
millimetres between segments pointing opposite ways: at
`torrey-pines-state-beach` a 20 m reversed spur in the county linework beats its
own neighbour by 0.01 m from 5.9 km away and flips the verdict for a quarter of
the frame. So the sweep counts a sample only within 500 m of the drawn shore and
only where every segment within one percent of the nearest agrees — 121,794 of
185,928 samples, over all 50 beaches — and the per-segment sweep declines a
probe the segment does not own, 593 of 5,533. Both then assert **zero**, with no
tolerance. ADR-0041 records why a percentage threshold was the wrong repair:
the ten failing beaches sit at 0.1, 0.4, 0.5, 1.0, 1.0, 1.2, 5.0, 11.3 and 25.4
percent, so there is no gap for one to sit in.

## Verification

Six of the ten tests in `wash.test.ts` fail against the old construction — run
before replacing it, with `seaWash` holding `seaPath`'s body verbatim:

```
   × a run with nothing to give it a direction has no wash
   × the wash closes outside the picture, never across it
   × where the shore leaves the picture the wash leaves it along the same line
   × no beach's wash leaves the seaward side of its own drawn shore
   × no beach's wash closes inside its own picture
   × every beach's wash agrees with the shore it is drawn from

AssertionError: expected [ …(32) ] to deeply equal []
+   "coronado-city-beaches: segment 222 left dry",
+   "coronado-city-beaches: segment 222 washed land",
+   ...

AssertionError: expected [ …(10) ] to deeply equal []
+   "childrens-pool: 13 samples washed wrongly",
+   "south-casa-beach-s-d: 15 samples washed wrongly",
+   "whispering-sands-nicholson-pt: 7 samples washed wrongly",
+   "mission-bay-crown-point-shores: 37 samples washed wrongly",
+   "mission-bay-bahia-point: 2 samples washed wrongly",
+   "coronado-city-beaches: 415 samples washed wrongly",
+   "coronado-cays-nr: 270 samples washed wrongly",
+   "silver-strand-state-beach: 12 samples washed wrongly",
+   "north-imperial-beach: 51 samples washed wrongly",
+   "border-field-state-park: 12 samples washed wrongly",
```

`npm run gate` on this branch's HEAD:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

…  format
…  lint
…  typecheck
…  adr-numbers
…  sea-side
…  test
…  build
…  stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

The coverage floor is **raised**, all four, and the note in `vitest.config.mts`
records the arithmetic. Statements, functions and lines moved by the same amount
top and bottom — `wash.ts` arrives at 100% on all four. Branches gained one more
numerator than denominator because `seaPath`'s `|| 1` divide-by-zero guard is
gone rather than covered: `seaWash` asks whether the run has a direction at all,
which is a state a test can put it in. `ShoreMap.tsx` leaves the report's table.

## Needs a human

The `needs-human` label is right — the geometry is asserted, but whether it
*reads* correctly is not something a gate can say. A before-and-after of six
beaches is rendered at:

`C:/Users/coled/AppData/Local/Temp/claude/C--Projects-lena-projects-wild-coast-kids/c92e13d1-ef43-4677-ae2f-99221fd4fc6b/scratchpad/wash-before-after.html`

The white wedge cutting diagonally across `coronado-city-beaches`,
`silver-strand-state-beach` and `coronado-cays-nr` on the left is the defect;
`torrey-pines-state-beach` is included as a beach that should look identical,
and does.

## Noticed, not fixed

`CONTEXT.md`'s **Shore map** entry still says the drawn line "is CDIP's model
line rather than a shoreline" (ADR-0037 replaced it) and its **Readout** entry
still says the block is "laid over a corner of the shore map" (ADR-0038 moved it
below). Both predate this branch and neither is touched by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

