### PR TITLE
Rank the measured cards below the region that contains them

### DIFF
--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, expect, test, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { localMidnightOf } from "@/lib/pacific-time";
+import { MeasuredToday, type MeasuredReadings } from "./MeasuredToday";
 import { SelectedDayProvider, useSelectedDay } from "./selectedDay";
 
 const readSkyWording = vi.fn();
@@ -792,6 +793,105 @@ test("today carries the measured block, and it is asked for this beach", async (
   expect(measuredPanel).toHaveBeenCalledWith({
     slug: "la-jolla-shores-beach",
   });
+});
+
+/**
+ * Both instruments, as `MeasuredPanel` would hand them over once its reads
+ * land. Every other test here stands the panel down to a paragraph, which is
+ * all they need; the outline needs the real cards, because a stub's heading is
+ * whatever the stub says.
+ */
+const MEASURED: MeasuredReadings = {
+  waves: {
+    beachName: BINDING.beachName,
+    buoy: { name: "Scripps Nearshore", distanceM: 1400 },
+    state: {
+      kind: "reading",
+      heightFt: 2.62,
+      periodS: 5,
+      directionDegT: 278,
+      waterTempF: 69.98,
+    },
+  },
+  air: {
+    beachName: BINDING.beachName,
+    airStation: { name: "Scripps Pier", distanceM: 1381 },
+    air: {
+      kind: "reading",
+      airTempF: 71.42,
+      windMph: 8.05,
+      gustMph: null,
+      windDirDegT: 320,
+    },
+  },
+};
+
+/**
+ * The outline, asserted where the containment it turns on is real. See #181.
+ *
+ * The cards were page-level regions and their `<h2>` was right; #176 moved them
+ * inside this one and left the rank behind, so "Waves and water" and "Air"
+ * became siblings-in-outline of the heading that contains them. ADR-0014 was
+ * written against the arrangement where cards are siblings of regions, and that
+ * arrangement no longer holds.
+ *
+ * The rank is asserted **inside the region** rather than by counting `<h3>`s: a
+ * test that only says the card renders a level 3 would pass with the card
+ * outside the day region entirely, which is the half of the defect that is
+ * about placement rather than about a tag. The real `MeasuredToday` stands in
+ * for the mocked panel for the same reason -- the substitution replaces the
+ * fetch, not the render.
+ */
+test("the cards inside the day region rank below the heading that names it", async () => {
+  measuredPanel.mockImplementation(() => (
+    <MeasuredToday when="today" readings={MEASURED} />
+  ));
+
+  const { container } = render(
+    await DayPanel({ slug: "la-jolla-shores-beach" }),
+  );
+
+  const region = container.querySelector<HTMLElement>(
+    'section[aria-labelledby="day-panel-heading"]',
+  )!;
+
+  // One level 2 in the region, and it is the region's own name. Two cards
+  // sitting at that rank is exactly what this test exists to catch.
+  expect(
+    within(region)
+      .getAllByRole("heading", { level: 2 })
+      .map((heading) => heading.textContent),
+  ).toEqual(["Today, hour by hour"]);
+
+  // And both cards one level under it, inside it.
+  const inside = within(region)
+    .getAllByRole("heading", { level: 3 })
+    .map((heading) => heading.textContent);
+  expect(inside).toContain("Waves and water");
+  expect(inside).toContain("Air");
+});
+
+/**
+ * The rank moved and the name did not. The accessible name is composed on the
+ * `<section>` from the title and the beach -- `ReadingCard` records why it is
+ * an `aria-label` rather than a hidden span -- so it is reachable from the tag
+ * and must survive a change to it.
+ */
+test("a card is still called what it was called, at its new rank", async () => {
+  measuredPanel.mockImplementation(() => (
+    <MeasuredToday when="today" readings={MEASURED} />
+  ));
+
+  render(await DayPanel({ slug: "la-jolla-shores-beach" }));
+
+  expect(
+    screen.getByRole("region", {
+      name: `Waves and water · ${BINDING.beachName}`,
+    }),
+  ).toBeDefined();
+  expect(screen.getByRole("heading", { name: "Waves and water" }).id).toBe(
+    "waves-today-heading",
+  );
 });
 
 test("a day that has not happened says so rather than showing nothing", async () => {

--- a/src/components/conditions/MeasuredToday.tsx
+++ b/src/components/conditions/MeasuredToday.tsx
@@ -133,6 +133,7 @@ function SeaCard({ beachName, buoy, state }: WavesView) {
   return (
     <ReadingCard
       emoji="🏄"
+      headingLevel="h3"
       headingId="waves-today-heading"
       title="Waves and water"
       context={beachName}
@@ -406,6 +407,7 @@ function AirCard({ beachName, airStation, air }: AirView) {
   return (
     <ReadingCard
       emoji="💨"
+      headingLevel="h3"
       headingId="wind-today-heading"
       title="Air"
       context={beachName}

--- a/src/components/conditions/ReadingCard.test.tsx
+++ b/src/components/conditions/ReadingCard.test.tsx
@@ -6,6 +6,7 @@ function card(figure?: string | null) {
   return (
     <ReadingCard
       emoji="🐚"
+      headingLevel="h3"
       headingId="test-heading"
       title="Lowest tide today"
       context="La Jolla Shores Beach"
@@ -64,7 +65,7 @@ test("a card with no figure has no empty slot where one would go", () => {
 
 test("a card given no figure at all behaves the same as one given null", () => {
   const { container } = render(
-    <ReadingCard emoji="🌊" headingId="h" title="Waves">
+    <ReadingCard emoji="🌊" headingLevel="h3" headingId="h" title="Waves">
       <p>body</p>
     </ReadingCard>,
   );
@@ -111,7 +112,7 @@ test("the beach reaches the accessible name without being printed three times", 
 
 test("a card given no context is named by its title alone", () => {
   const { container } = render(
-    <ReadingCard emoji="🌊" headingId="h" title="Waves">
+    <ReadingCard emoji="🌊" headingLevel="h3" headingId="h" title="Waves">
       <p>body</p>
     </ReadingCard>,
   );

--- a/src/components/conditions/ReadingCard.tsx
+++ b/src/components/conditions/ReadingCard.tsx
@@ -56,6 +56,22 @@ import type { ReactNode } from "react";
 type ReadingCardProps = {
   /** Sets the subject at a glance; hidden from assistive tech, which reads the heading. */
   emoji: string;
+  /**
+   * The heading's rank. Callers own it, because they own where the card sits,
+   * and rank is a fact about placement rather than about a card.
+   *
+   * It was hardcoded `h2`, which was right while these were page-level
+   * regions. #176 moved both inside the day region and the rank stayed, so two
+   * card headings became siblings-in-outline of the heading that contains
+   * them — the arrangement ADR-0014 was written against, reached from the
+   * other direction. Required rather than defaulted for that reason: the next
+   * component to move a card has to answer the question rather than inherit an
+   * answer taken for somewhere else.
+   *
+   * Only the outline moves. The visual register is `text-2xs` at either rank,
+   * which is what ADR-0014 decided and what a level says nothing about.
+   */
+  headingLevel: "h2" | "h3";
   /** The heading's own id. Callers own it, because they own the anchor. */
   headingId: string;
   /** What this reading is. Short: these sit side by side. */
@@ -90,12 +106,17 @@ type ReadingCardProps = {
 
 export function ReadingCard({
   emoji,
+  headingLevel,
   headingId,
   title,
   context = null,
   figure = null,
   children,
 }: ReadingCardProps) {
+  // The tag itself, not a branch on it: one rendered path, so there is no arm
+  // of this component that only one rank exercises.
+  const Heading = headingLevel;
+
   return (
     // flex-col so a card fills the height of its row in the measured block.
     // Cards of unequal content otherwise leave a ragged surface beside the
@@ -104,12 +125,12 @@ export function ReadingCard({
       aria-label={context !== null ? `${title} · ${context}` : title}
       className="rounded-card flex h-full flex-col bg-dark px-6 py-4"
     >
-      <h2
+      <Heading
         id={headingId}
         className="text-2xs mb-3 font-extrabold tracking-widest text-yellow uppercase"
       >
         {title}
-      </h2>
+      </Heading>
 
       {/*
         One row for the glyph and the figure, and the row renders whether or not

--- a/src/components/conditions/WeekGrid.test.tsx
+++ b/src/components/conditions/WeekGrid.test.tsx
@@ -284,6 +284,17 @@ test("the week's heading outranks the day headings inside it", () => {
   const day = container.querySelector("h3");
   expect(day?.className).toContain("text-2xs");
   expect(day?.className).not.toContain("text-quote");
+
+  // And the outline the register is drawn over, stated rather than implied.
+  // #181 moves the measured cards to level 3, which is the rank these day
+  // headings already hold: the two sets share it, so a change to one of them
+  // that reached the other would go unnoticed here otherwise.
+  expect(
+    screen
+      .getAllByRole("heading", { level: 3 })
+      .map((each) => each.textContent),
+  ).toEqual(["Aug 17 Today", "Tue, Aug 18", "Wed, Aug 19"]);
+  expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(1);
 });
 
 /**


### PR DESCRIPTION
Closes #181

## What changed

One slice, one commit.

**`ReadingCard` takes its heading rank from the caller, and `MeasuredToday`
passes `h3`.** The card hardcoded `<h2>`, which was right while the two cards
were page-level regions. #176 moved both inside the day region and left the rank
behind, so `Waves and water` and `Air` render as siblings-in-outline of
`Today, hour by hour` — the heading that contains them. ADR-0014 was written
against the arrangement where a card `<h2>` sits beside a region; that
arrangement stopped holding, so the page reached the state the decision exists
to prevent, from the other direction.

The prop is **required rather than defaulted**, because #176 is exactly what a
default costs: the card moved and the rank silently stayed. It is the tag itself
(`const Heading = headingLevel`) rather than a branch on it, so there is no arm
of the component that only one rank exercises.

Nothing visual moves. The heading keeps `text-2xs` in the label register, which
is what ADR-0014 decided and what a level says nothing about, and the card keeps
its `headingId` and the `aria-label` composing its accessible name — asserted by
a second test, which is a guard rather than a regression test and passed before
this change too.

## The issue's cited precedent does not exist

#181 (and finding 3 behind it) justified the prop shape with "`WeekGrid` already
effectively has one for its `<h3>` day headings". It does not: `WeekGrid` takes
only `headingId`, and its `<h3>` is hardcoded exactly the way `ReadingCard`'s
`<h2>` was. The direction of the fix survives that; the argument for its shape
had to be made again rather than transcribed, and was — the rank follows
placement, and placement is the caller's. Flagged and decided before
implementing.

## Verifying it

The regression test asserts **the outline inside the region**, not the tag. A
test that only saw an `<h3>` render would pass with the card outside the day
region entirely, which is the half of the defect that is about placement. It
renders the real `MeasuredToday` in place of the mocked `MeasuredPanel` —
substituting the fetch, not the render — so the assertion runs against the real
`<section aria-labelledby="day-panel-heading">`.

It failed before the change, for the right reason:

```
 FAIL  src/components/conditions/DayPanel.test.tsx > the cards inside the day region rank below the heading that names it
AssertionError: expected [ 'Today, hour by hour', …(2) ] to deeply equal [ 'Today, hour by hour' ]

- Expected
+ Received

  [
    "Today, hour by hour",
+   "Waves and water",
+   "Air",
  ]
```

The week's day headings — the other level-3s on the page, which share this
outline — get an explicit assertion added to `WeekGrid.test.tsx`'s existing rank
test, where they previously rode on an incidental `querySelector("h3")`.

## Gate

`npm run gate` at `6e5f0b1`:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… sea-side
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

## What I did not do

- **No plan file.** The work is one slice finished in one sitting and turns on
  no choice a plan file would hold; the issue and this body are the durable
  record. Recorded here so the omission is a decision rather than a lapse.
- **No ADR change.** ADR-0014 decides which *register* each heading is written
  in, and this changes only the semantic rank. Its Context sentence about cards
  being siblings of regions is now a description of a superseded arrangement,
  but the decision it supports is untouched.
- **Noticed, not filed:** ADR-0014 locates `REGION_HEADING` at
  `src/components/headingRank.ts`; it is at
  `src/components/conditions/headingRank.ts`. A stale path in a historical
  document, not a defect in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
