### PR TITLE
Grow the day control to its cell's width and 32px above md

### DIFF
--- a/src/components/conditions/DaySpark.tsx
+++ b/src/components/conditions/DaySpark.tsx
@@ -124,14 +124,25 @@ export type DaySparkProps = {
  * -- which, with a full day chart coming below the grid, is a duplication the
  * brief's first principle exists to avoid. 8:1 renders 21px there and reads as
  * an annotation on the row instead: the same information, at the weight a
- * sparkline is supposed to carry. Measured 2026-08-28 against the built page:
+ * sparkline is supposed to carry. Shape measured 2026-08-28 against the built
+ * page and unchanged since; grid height re-measured 2026-09-02:
  *
  * | viewport | cell | shape        | grid height |
  * | -------- | ---- | ------------ | ----------- |
- * | 1536     | 168  | 169 x 21.2   | 275.0       |
- * | 1280     | 132  | 133 x 16.6   | 270.4       |
- * | 1024     | 196  | 197 x 24.6   | 568.9       |
- * | 375      | 300  | 301 x 37.6   | 1753.1      |
+ * | 1536     | 168  | 169 x 21.2   | 292.0       |
+ * | 1280     | 132  | 133 x 16.6   | 287.4       |
+ * | 1024     | 196  | 197 x 24.6   | 602.9       |
+ * | 375      | 300  | 301 x 37.6   | 1956.1      |
+ *
+ * **The grid height column is context, not the measurement this docstring
+ * turns on**, which is the shape's own height -- and it is the column that
+ * goes stale, because anything in a day block moves it. Two things moved it
+ * since it was written. The day control grew to 32px above `md` (#183), which
+ * is +17 on every cell and nothing at 375, where the touch floor already made
+ * it 44px -- so +17 at 1536 and 1280, where the week is one row, and +34 at
+ * 1024, where four columns make it two. And the 375 figure was already 203px
+ * out before that, from work between 2026-08-28 and now that nobody
+ * re-measured here.
  *
  * The vertical range costs real resolution -- 24 user units of swing where
  * there were 42 -- and that is the trade, not an oversight. What a reader takes

--- a/src/components/conditions/WeekGrid.test.tsx
+++ b/src/components/conditions/WeekGrid.test.tsx
@@ -1,6 +1,7 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { REGION_HEADING } from "../ui/headingRank";
+import { TOUCH_TARGET } from "../ui/touchTarget";
 import {
   MIN_SPARK_BLOCK_PX,
   NARROWEST_CELL_CLEARS_FLOOR,
@@ -93,9 +94,13 @@ test("names every day it was given, in the order it was given them", () => {
   // Today's column reads its date without a weekday, because the chip beside
   // it already says which day this is -- and dropping that token is what lets
   // the chip sit on the date's line instead of reserving a line above it in all
-  // seven columns. The space before "Today" is a real text node: two elements
-  // with nothing between them read aloud as "Aug 17Today", the concatenation
-  // `ReadingCard` records hitting in the accessible-name algorithm.
+  // seven columns. The space before "Today" is a real text node, and this is
+  // the assertion that keeps it there: without it these headings read
+  // "Aug 17Today". It was recorded as protecting the *accessible* name against
+  // the concatenation `ReadingCard` describes; measured in Chrome on
+  // 2026-09-02 that is no longer what it buys, because the chip and the
+  // control are separated whether or not a text node sits between them. What
+  // it still buys is this string, which is the surface jsdom can see at all.
   expect(headings).toEqual(["Aug 17 Today", "Tue, Aug 18", "Wed, Aug 19"]);
 });
 
@@ -378,6 +383,54 @@ test("the chip follows the date rather than sitting above it", () => {
     chip.compareDocumentPosition(heading.firstChild!) &
       Node.DOCUMENT_POSITION_PRECEDING,
   ).toBeTruthy();
+});
+
+/**
+ * The control was a 15px strip in a 195.4x275 cell — 38.8px wide on today and
+ * 74.8px on a named day, measured at 1536 on 2026-09-02. It is the heading's
+ * date and nothing more, because a `<button>` around the cell would take its
+ * figures as presentational children and hide the week's whole text equivalent
+ * from the accessibility tree. So the target grows *within* the cell instead:
+ * the row's full width and 32px, measured 169.4x32 after this change.
+ *
+ * jsdom applies no stylesheets (ADR-0001), so what is assertable here is the
+ * composition. `TOUCH_TARGET` and the height above `md`, both rather than
+ * either: 32px is additive, and a `md:` rule that replaced the floor instead of
+ * adding above it would read identically in the markup while quietly removing
+ * ADR-0004's guarantee on a phone.
+ */
+test("the day control fills its row and keeps the touch floor under it", () => {
+  const { container } = renderGrid();
+
+  const controls = [...container.querySelectorAll("[data-day-choice]")];
+  expect(controls).toHaveLength(3);
+  for (const control of controls) {
+    expect(control.className).toContain(TOUCH_TARGET);
+    expect(control.className).toContain("md:min-h-8");
+    expect(control.className).toContain("flex-1");
+  }
+
+  // The button grows because its heading is the flex row it grows inside. On
+  // today that row also holds the chip, which is what `flex-1` pushes to the
+  // far end rather than off a second line.
+  for (const heading of container.querySelectorAll("ol > li h3")) {
+    expect(heading.className).toContain("flex");
+  }
+});
+
+/**
+ * Asserted by name, not by tag, because the name is what growing the control
+ * could have cost. The chip stays a sibling of the button: moving it inside to
+ * simplify the row would have renamed today's control from "Aug 17" to
+ * "Aug 17 Today", which is a different thing for a screen reader to announce
+ * and would read here as a failure rather than a layout choice.
+ */
+test("growing the control does not rename it", () => {
+  renderGrid();
+
+  for (const name of ["Aug 17", "Tue, Aug 18", "Wed, Aug 19"]) {
+    expect(screen.getByRole("button", { name })).toBeTruthy();
+  }
 });
 
 /**

--- a/src/components/conditions/WeekGrid.tsx
+++ b/src/components/conditions/WeekGrid.tsx
@@ -376,8 +376,11 @@ export function WeekGrid({
                 `inline-size` containment only, which is what `@container`
                 sets. The block's width already comes from the grid track and
                 its height still comes from its contents, so nothing here sizes
-                differently for it -- measured before and after: 195.4 x 275.0
-                at 1536, unchanged.
+                differently for it -- measured with the containment and with it
+                switched off: 195.4 x 292.0 at 1536 either way. Re-measured
+                2026-09-02, when the day control's height moved the second
+                figure from 275.0; the claim is that the two columns match, so
+                it is checked again whenever one of them moves.
               */
               className={`@container overflow-hidden rounded-tile border-[1.5px] bg-white/60 ${
                 day.localDate === showing ? "border-ocean" : "border-lavender"
@@ -391,7 +394,15 @@ export function WeekGrid({
                 }`}
               >
                 <h3
-                  className={`text-2xs font-extrabold tracking-widest uppercase ${
+                  /*
+                    A flex row, so the control inside it can grow to the row's
+                    full width while the chip stays a sibling of the button
+                    rather than a child of it. `gap-1` is 4px, which is what
+                    the space text node below rendered as at 4.9px and stops
+                    rendering as here: a whitespace-only text node between two
+                    flex items generates no box.
+                  */
+                  className={`flex items-center gap-1 text-2xs font-extrabold tracking-widest uppercase ${
                     day.localDate === showing ? "text-white" : "text-ocean"
                   }`}
                 >
@@ -417,18 +428,28 @@ export function WeekGrid({
                     over mid-week, which was the objection to shortening this
                     heading the first time.
 
-                    `leading-none` on the chip, so its padding fits inside the
-                    heading's own line box. Without it the chip is 16px against
-                    the other columns' 15px, and today's band renders a pixel
-                    taller than the six beside it -- which is the same
-                    misalignment in miniature that the reserved line was
-                    introduced to prevent.
+                    `leading-none` on the chip keeps it tight -- 59.1x14
+                    against 59.1x17 without it. **It no longer holds the row's
+                    alignment**, which is what it was introduced for: it was
+                    the chip that set the band's height when the heading was
+                    one inline line, and the control's 32px sets it now.
+                    Measured both ways at 1536, the band is 67.7 either way.
+                    So this is a look, and the misalignment it used to prevent
+                    can no longer happen.
 
-                    Inline rather than a flex row, and with a real space text
-                    node before the chip. Two flex items with nothing between
-                    them read aloud as "Aug 28Today", which is the
-                    concatenation `ReadingCard` records hitting in the
-                    accessible-name algorithm.
+                    **The space text node before the chip stays, and the
+                    reason it stays has changed.** It was recorded here as what
+                    keeps the accessible name from reading "Aug 28Today". That
+                    is no longer what it buys: measured in Chrome on the built
+                    page with the heading as a flex row, today's heading is
+                    named "SEP 2 TODAY" with the text node and without it,
+                    because the two elements are separated whether or not
+                    anything sits between them. What
+                    it still buys is the DOM text -- `heading.textContent` is
+                    "Aug 17 Today" with it and "Aug 17Today" without -- and
+                    that is the surface this repo can assert, because jsdom
+                    applies no stylesheets (ADR-0001) and computes no layout.
+                    A rendered separator is `gap-1` on the heading above.
                   */}
                   {/*
                     The date is the control, and only the date.
@@ -453,6 +474,22 @@ export function WeekGrid({
                     the current item of a set of dates, which is the token's
                     own definition, where a pressed button is a toggle that
                     stays down.
+
+                    **So the target grows inside the cell rather than becoming
+                    it.** It was the width of its own text: 38.8x15 on today
+                    and 74.8x15 on a named day, in a 195.4x275 cell at 1536.
+                    `flex-1` takes the heading's full row and `md:min-h-8`
+                    takes 32px of it, measured 169.4x32, which costs the band
+                    50.7 -> 67.7 and every cell 275 -> 292 -- the same 17px in
+                    all seven, so no column moves against its neighbours.
+
+                    On today the same `flex-1` is what carries the chip to the
+                    far end of the row instead of wrapping it to a second line.
+                    That is the one visible change to the header band, and it
+                    is why the chip could not simply move inside the button:
+                    the control would be renamed from "Aug 17" to
+                    "Aug 17 Today", which `WeekGrid.test.tsx` asserts against
+                    by name rather than by tag.
                   */}
                   {hydrated ? (
                     <button
@@ -475,7 +512,20 @@ export function WeekGrid({
                         already knows means "this one", it needs no legend, and
                         it leaves the header's text exactly what it was.
                       */
-                      className={`${TOUCH_TARGET} md:min-h-0 inline-flex cursor-pointer items-center text-left ${
+                      /*
+                        `md:min-h-8` rather than the `md:min-h-0` most callers
+                        of `TOUCH_TARGET` take. Both compose the floor rather
+                        than replacing it, so ADR-0004 still holds below `md`
+                        and the button is 44px on a phone either way; the
+                        difference is that this one is a pointer target above
+                        `md` too, where `min-h-0` lets an element fall back to
+                        the height of its own text. 15px of it, here.
+
+                        `flex` rather than `inline-flex`: a flex item's
+                        `inline-flex` computes to `flex`, so the inline form
+                        would describe a layout that is not there.
+                      */
+                      className={`${TOUCH_TARGET} md:min-h-8 flex flex-1 cursor-pointer items-center text-left ${
                         day.localDate === showing
                           ? "text-white underline decoration-2 underline-offset-4"
                           : "text-ocean"
@@ -492,7 +542,7 @@ export function WeekGrid({
                   {day.isToday && (
                     <>
                       {" "}
-                      <span className="leading-none rounded-pill bg-yellow px-1.5 py-0.5 align-[0.1em] text-dark">
+                      <span className="leading-none rounded-pill bg-yellow px-1.5 py-0.5 text-dark">
                         Today
                       </span>
                     </>


### PR DESCRIPTION
Closes #183

The control was the width of its own text. It now takes the heading's full row
and 32px of height above `md`, without the cell becoming a `<button>` and
without `TOUCH_TARGET`'s floor being traded away to get there.

## What changed

One slice, one commit.

**`WeekGrid.tsx`** — the `<h3>` becomes the flex row (`flex items-center
gap-1`); the control takes `flex-1` and `md:min-h-8` in place of `md:min-h-0`,
and `flex` in place of `inline-flex` (a flex item's `inline-flex` computes to
`flex`, so the inline form described a layout that was not there). The chip
stays a **sibling** of the button. `align-[0.1em]` on the chip is deleted —
measured inert under flex.

**`WeekGrid.test.tsx`** — two tests, in the same commit. The first failed
before the change (`expected 'min-h-11 md:min-h-0 inline-flex…' to contain
'md:min-h-8'`).

**`DaySpark.tsx`** — its docstring's `grid height` column, re-measured. See
_What I did not do_.

## Measured, on the built page at `pacific-beach`

| viewport | control before | control after | cell before | cell after |
| --- | --- | --- | --- | --- |
| 1536 | 38.8×15 / 74.8×15 | 106.3×**32** / **169.4**×32 | 195.4×275 | 195.4×**292** |
| 1280 | 38.8×15 / 74.8×15 | 69.7×32 / 132.9×32 | 158.8×270.4 | 158.8×287.4 |
| 1024 | 38.8×15 / 74.8×15 | 133.9×32 / 197×32 | 223×278.4 | 223×295.4 |
| 375 | 38.8×**44** / 74.8×44 | 237.9×**44** / **301**×44 | 327×260.8 | 327×260.8 |

Two figures per cell: today's control, then a named day's. Against the issue's
verification list:

- **the control's box is the row's width and a comfortable height above `md`** —
  169.4×32, up from 74.8×15. Not literally "the header band's height": the band
  also holds the daylight line, which is figures and cannot go inside a button
  for the same reason the `<dl>` cannot;
- **at 375 it still clears 44px** — 301×44. `TOUCH_TARGET` is untouched and
  `md:min-h-8` is additive. A `md:` rule that *replaced* the floor would read
  identically in the markup, which is why the test asserts both;
- **the accessible name is unchanged, asserted by name and not by tag** —
  `getByRole("button", { name: "Tue, Aug 18" })`;
- **`aria-current="date"` still moves with selection and the chip is still
  independent** — verified by clicking Fri Sep 4 on the built page: the ocean
  band and the underline moved, today's chip did not;
- **looked at at 1536×639 and 375×812**, both with a control keyboard-focused.

## Three things I measured rather than assumed

**The accessible-name objection to option 1 does not hold.** The issue and the
code both warned that a flex `<h3>` would read "Aug 28Today". Read back out of
Chrome's AX tree, today's heading is named `"Sep 2 TODAY"` inline, as a flex
row, and as a flex row with the whitespace text node deleted. The text node
stays anyway — it is what keeps `heading.textContent` `"Aug 17 Today"`, which
is the surface jsdom can see at all — but the comment saying *why* was wrong
and is corrected rather than restated.

**`leading-none` on the chip no longer holds the row's alignment.** It was
recorded as preventing today's band rendering a pixel taller than the six
beside it. The control's 32px sets the band now: measured 67.7 with
`leading-none` and 67.7 without. It is kept, because dropping it takes the chip
from 59.1×14 to 59.1×17, but it is a look now and the comment says so.

**Option 3 was tried and rejected on evidence.** Moving the band's padding into
the control gets 181.4×31 with *no* cell growth at all, which is strictly
better on paper. It puts the control flush to the cell's edge, and the focus
ring is `outline-offset: 2px` inside a cell with `overflow-hidden` — so 2px
outside a flush edge is outside the clip. Screenshotted focused: the ring's top
and left are gone. The 17px is what buys a visible focus ring.

## What I did not do

**No plan file.** One sitting, one branch, one slice; the decision that needed
recording was which of the issue's three shapes to take, and it is recorded
here and in the code. No ADR: nothing here outlives the call site.

**`DaySpark.tsx`'s 375 figure was already wrong before this branch.** Its table
said `1753.1`; `main` measures `1956.1`, a 203px drift from work between
2026-08-28 and now. I re-measured all four rows rather than update three and
leave a known-wrong fourth in a table I was already editing, and labelled the
column as the context it is — the docstring turns on the shape's height, not on
this. Not filed as an issue: it is now correct, and the note explains why the
column drifts.

**Nothing else from the design review** — finding 4's ragged edge and the chart
card are untouched. The review's two stale figures noted in #183's comment are
still stale; that document is a dated record.

## Gate

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… sea-side
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

Run on `5b1d75d`, from a cleared `.next/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
