### PR TITLE
Correct the horizon the surf zone slot promises

### DIFF
--- a/src/components/conditions/WeekPanel.test.tsx
+++ b/src/components/conditions/WeekPanel.test.tsx
@@ -263,6 +263,38 @@ test("the forecasts that are not built yet are named, and waves are no longer am
 });
 
 /**
+ * The horizon the slot promises, held still.
+ *
+ * It said "about three days ahead" until 2026-09-02, when all fourteen
+ * issuances NWS SGX still held — seven days of them — were read and every one
+ * carried exactly two periods for `CAZ043`. This asserts the sentence rather
+ * than the ocean: nothing in CI reaches the National Weather Service, so a
+ * change in what SGX issues is invisible here. The measurement is the
+ * evidence; the test only stops the claim reverting silently, which is the
+ * same division `inventoryCaveats()` is tested under.
+ *
+ * "three days" is asserted absent by name because that is the specific wrong
+ * figure, and it still stands in `docs/plans/conditions-tool.md`'s source
+ * table — permanently, since that plan is historical and never corrected. So
+ * the phrase remains copyable out of a document this repo keeps and reads,
+ * which is exactly the reverting this test exists to catch.
+ */
+test("the surf zone slot states the reach the product actually has", async () => {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
+  });
+
+  render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
+
+  const detail = screen.getByText(/Rip current risk/i).textContent ?? "";
+  expect(detail).toMatch(/about two days ahead/i);
+  expect(detail).not.toMatch(/three days/i);
+  // The cadence is the half a reader can act on, so it is in the copy too.
+  expect(detail).toMatch(/twice a day/i);
+});
+
+/**
  * The row that replaced the promise. Until 2026-08-27 this slot said a gridded
  * forecast was coming and, briefly, over-promised temperature and wind with it.
  * A slot and the row it stood in for must never both be on the page: that is

--- a/src/components/conditions/WeekPanel.tsx
+++ b/src/components/conditions/WeekPanel.tsx
@@ -95,8 +95,24 @@ import { WeekGrid, type ReservedRow, type WeekRow } from "./WeekGrid";
  * to a forecast is the displacement ADR-0019 declined to decide, and this row
  * previously promised it.
  *
- * The surf zone forecast is zone-level and reaches about three days
- * out; it is the product the tide heights on this page were checked against.
+ * The surf zone forecast is zone-level; it is the product the tide heights on
+ * this page were checked against.
+ *
+ * **It reaches about two days, not three, and the slot said three until now.**
+ * Measured 2026-09-02 against all fourteen issuances NWS SGX still held —
+ * seven days of them — every one carried exactly two periods for `CAZ043`.
+ * A morning issuance reads `TODAY` then a weekday; an afternoon one reads
+ * `THIS AFTERNOON THROUGH <weekday>` then the day after, which is why the
+ * reach is worth stating as "about" rather than as a number of days. The
+ * three-day figure came from `docs/plans/conditions-tool.md`'s source table,
+ * recorded from a 2026-08-17 measurement. It stays wrong there: that plan is
+ * historical, and `docs/plans/README.md` is explicit that a shipped plan is a
+ * dated record which is never corrected. What is still binding lives in
+ * `docs/adr/`, which is why the measurement above is here and not there.
+ *
+ * The cadence is in the copy because it is the part a reader can act on: a
+ * product reissued twice a day is one they should look at again, and a horizon
+ * alone does not say that.
  *
  * No issue numbers in the copy. A reader is owed what is coming, not our
  * backlog — the sighting map's slot set that precedent.
@@ -106,7 +122,7 @@ const RESERVED: readonly ReservedRow[] = [
     emoji: "🏖️",
     headline: "The surf zone forecast is coming.",
     detail:
-      "Rip current risk, surf height and water temperature, issued for this stretch of coast about three days ahead.",
+      "Rip current risk, surf height and water temperature, issued for this stretch of coast twice a day and reaching about two days ahead.",
   },
 ];
 


### PR DESCRIPTION
Closes #215

## What changed

`WeekPanel`'s reserved slot told readers the surf zone forecast is "issued for
this stretch of coast about three days ahead". It is not, and the false promise
was live at all 51 beaches.

Measured 2026-09-02 against every SRF issuance NWS SGX still held — 14 of them,
covering seven days, San Diego County Coastal (`CAZ043`):

- **Exactly two periods, 14 of 14.** Never three.
- Morning (~1 AM PDT): `TODAY` / `<weekday>` — today and tomorrow.
- Afternoon (~1 PM PDT): `THIS AFTERNOON THROUGH <weekday>` / `<weekday>` —
  today's remainder merged with tomorrow, then the day after.

So the reach is about two days and the number of calendar days covered varies
with the issuance. The copy now says "twice a day and reaching about two days
ahead": "about" because the reach genuinely varies, and the cadence because it
is the half a reader can act on — a product reissued twice a day is one worth
checking again, which a horizon alone does not say.

One slice, one commit. Small lane per `CLAUDE.md`: page copy, no logic, no data
shape, no contract, and it contradicts nothing in `docs/adr/` or `CONTEXT.md`.
No plan file, for the same reason — but see below, this is slice 1 of a plan
that will get one.

## Verification

The regression test was confirmed to fail before the fix rather than assumed to:

```
 × the surf zone slot states the reach the product actually has 27ms
 FAIL  src/components/conditions/WeekPanel.test.tsx > the surf zone slot states the reach the product actually has
AssertionError: expected 'The surf zone forecast is coming.Rip …' to match /about two days ahead/i
      Tests  1 failed | 36 passed (37)
```

With the fix in place, `npm run gate`:

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

## What I did not do

- **`docs/plans/conditions-tool.md` still says `~3 d`, and stays that way.** It
  carries the Historical note, and `docs/plans/README.md` is explicit: a shipped
  plan is never corrected, and its drift is not a defect. The measurement lands
  in the docstring here instead. The test asserts `three days` absent by name
  precisely because the phrase remains copyable out of a document this repo keeps.
- **The slot still promises the forecast at the 25 bay, lagoon and inlet
  beaches, where it will never arrive** — a *surf zone* forecast for open-coast
  areas does not describe Sail Bay. Noticed, not fixed here: it is the same
  class of defect but a different decision, and it is resolved by removing the
  slot in the slice that fills it. Not filed as an issue; that slice already
  owns it.
- **The 🏖️ glyph is still wrong** (ADR-0015 files it as such). It goes with the
  slot, in the same slice.

## Next

Slice 1 of five, from a grilling session on 2026-09-02. Slices 2–5 build the
forecast itself and land under a plan file at `docs/plans/surf-zone-forecast.md`
with two ADRs — the zone binding to the inventory rather than the beach, and the
two-period product resolved onto calendar days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)