### PR TITLE
Relay the surf zone forecast's rip current risk in the day panel

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -220,6 +220,27 @@ than a shoreline, which the sentence under it says. It reads no feed — every
 position on it is committed.
 _Avoid_: locator, mini map, station map, chart (that word is the plot's)
 
+**Surf zone forecast**:
+The National Weather Service's twice-daily bulletin for San Diego County
+Coastal Areas — the only **judgement** on this site rather than a reading or a
+model, quoted verbatim and attributed (ADR-0009). Its rip current risk is the
+one thing on `/conditions` that answers whether to put children in the water;
+everything else is a figure a reader interprets. It appears as a block in the
+day panel, below the hour chart and above what was measured.
+
+It is the publisher's product and keeps the publisher's name, so "forecast"
+here is theirs rather than ours — the `Conditions` entry's _Avoid_ list still
+governs how this site describes **itself**. Its three levels and the sentence
+explaining each are the bulletin's own, and nothing here rewords them.
+
+It reaches **26 of the 51 beaches**. A surf zone forecast for coastal areas does
+not describe a bay, lagoon or inlet, so the other 25 are told so in the same
+voice their missing wave buoy is (ADR-0043). It reaches two calendar days from a
+morning bulletin and three from an afternoon one, because its periods are named
+and never dated (ADR-0044).
+_Avoid_: surf report (banned outright), rip current forecast, safety rating,
+hazard level, SRF (the product code is not a word for a reader)
+
 **Readout**:
 The wind and swell block laid over a corner of the shore map: one row per
 source, each an arrow pointing the way the weather travels with a faint wedge

--- a/docs/adr/0043-the-surf-zone-forecast-binds-to-the-inventory.md
+++ b/docs/adr/0043-the-surf-zone-forecast-binds-to-the-inventory.md
@@ -1,0 +1,117 @@
+# 0043 — The surf zone forecast binds to the inventory, and only where there is a surf zone
+
+Date: 2026-09-02. Status: accepted. Narrows ADR-0011's rule that a binding is
+joined per beach, and declines to follow the readout precedent set in ADR-0034.
+
+## Context
+
+ADR-0009 decided the conditions tool is built here rather than embedded, and
+named the surf zone forecast as the product its "published judgements are
+relayed, inferred ones are not computed" rule was written about. The National
+Weather Service publishes rip current risk for San Diego County Coastal as a
+forecaster's judgement, and this site quotes it verbatim and attributes it.
+
+That decision also set a second rule, which this one narrows:
+
+> **Resolved values come from joins, never from typing.** Beach coordinates,
+> tide station, buoy, water-quality station and marine protected area are joined
+> against upstream authorities and committed with enough provenance to re-run,
+> with one re-join script per binding that exits nonzero when a match moves.
+
+Every binding in `beaches.json` follows it — `tide_station`, `wave_buoy`,
+`mop_line`, `grid_cell`, `air_station`, each with a distance and the segment end
+it was joined from. The obvious way to add the surf zone forecast was a `zone`
+column and a `srf-join.mjs` beside the other five.
+
+**It was tried and it does not work.** Resolving
+`api.weather.gov/zones?point=<lat>,<lon>&type=public` for both ends of all 51
+beaches on 2026-09-02:
+
+| Result                | Beaches |
+| --------------------- | ------- |
+| `CAZ043` at both ends | 27      |
+| `CAZ043` at one end   | 14      |
+| no zone at either end | 10      |
+
+The ten that resolve to nothing are every Coronado beach, Border Field State
+Park, Whispering Sands, Marine Street Beach and the inner-bay sites. **None of
+that is a fact about those beaches.** All 51 are inside San Diego County, which
+is the filter `beaches.json`'s `_inclusion` records the inventory being seeded
+under, and the product's own section is titled "San Diego County Coastal Areas".
+
+`CAZ043` is a **land** polygon. A beach coordinate on the water side of the
+mapped shoreline falls outside it, and this repo has met that edge before —
+ADR-0030 records the Scripps tide gauge and air station sitting _landward_ of
+CDIP's model line, both bolted to a pier over water. The difference is what the
+failure looks like: every other join here is **nearest-feature**, which degrades
+to a larger distance, and this one is **containment**, which degrades to an
+empty result indistinguishable from "not covered".
+
+A second question arrived with the first. The bulletin is issued for _coastal
+areas_, and 25 of the 51 beaches in this inventory are bays, lagoons and inlets.
+Two precedents point opposite ways:
+
+- **The wave join withholds.** Those same 25 beaches carry
+  `wave_buoy_null_reason`: "every wave buoy sits on the open coast, and ocean
+  swell does not reach into a bay or lagoon, so no buoy describes the water
+  here."
+- **The readout does not.** ADR-0034 draws it on all 51, including the 23 the
+  traced coast does not reach, because withholding "left nearly half the
+  inventory with no wind figure anywhere on the picture".
+
+## Decision
+
+**The zone binds to the inventory, not to the beach.** There is no `zone` column
+in `beaches.json` and no re-join script. `SURF_ZONE_ID` is a constant in
+`nws-surf-zone.ts` carrying the measurement above, and it follows from the
+inventory's own `County = 'San Diego'` definition rather than from any beach's
+coordinates. ADR-0009's rule is satisfied — the value is still derived from an
+upstream authority rather than typed off a map — but the join is county-to-zone,
+done once, rather than beach-to-zone with a distance beside it.
+
+**The forecast is withheld at the 25 sheltered beaches**, with a stated reason
+in the `wave_buoy_null_reason` voice, and the request is not made at all rather
+than made and discarded. The wave precedent governs and ADR-0034's does not: the
+readout is drawn everywhere because **wind blows on a bay**, so a wind figure
+there is true. A surf zone forecast describes water that does not exist at Sail
+Bay.
+
+**The classification is read off the tide station's water class**, not off the
+region. Both classify the inventory identically — 51 of 51, asserted in
+`beaches.test.ts` — but the region is a grouping for a dropdown while the water
+class is a joined fact the tide join already had to establish in order to bind
+an open-coast beach to an open-coast station.
+
+## Consequences
+
+The product reaches **26 of 51 beaches**. The other 25 get one sentence naming
+what is true of their water, which is what they already get for having no wave
+buoy.
+
+**A judgement printed at the wrong beach is worse than no judgement.** "Rip
+Current Risk: High" over Mission Bay would alarm about a hazard that is not
+there, and would teach a reader that this line is not about the beach they
+selected — which costs it on the 26 beaches where it is the most important thing
+on the page. That asymmetry is why this withholding is not the coin-flip the two
+precedents make it look like.
+
+**`docs/plans/conditions-tool.md` is wrong about this and stays wrong.** It says
+the sheltered beaches' missing water temperature "waits for the surf zone
+forecast's county-wide range in slice 9". The product cannot describe bay water,
+so it does not fill that gap and those beaches keep it. That plan is historical
+and `docs/plans/README.md` forbids correcting it; this ADR is where the
+correction lives, which is the division that README describes.
+
+**Nothing notices if NWS re-draws the zone.** A per-beach join with a re-join
+script would fail loudly when a match moved; a constant cannot. The compensating
+guard is in the parser rather than in the data: `CAZ043`'s absence from a
+bulletin is a failed read that says so, never a fall-through to the other county
+in the same text. That is a weaker signal than a nonzero exit from a join
+script, and it is the price of a binding that has nothing to re-join.
+
+**If the inventory ever leaves San Diego County, this decision expires.** The
+bulletin already carries `CAZ552` Orange County, and the parser already takes
+the zone as a parameter, so the code is ready — but the constant would become a
+lie and the binding would have to move to the beach after all. The measurement
+above would need re-running first, because it would still fail at the water's
+edge.

--- a/docs/adr/0044-a-two-period-product-is-resolved-onto-days.md
+++ b/docs/adr/0044-a-two-period-product-is-resolved-onto-days.md
@@ -1,0 +1,95 @@
+# 0044 — A two-period product is resolved onto calendar days, and an unknown period stops the read
+
+Date: 2026-09-02. Status: accepted. Extends ADR-0035's rule that the page is
+indexed by a chosen day, to a product that is not.
+
+## Context
+
+The conditions page is indexed by day. The week grid is the control, the day
+panel is what redraws, and ADR-0035 fixed that a reader's choice persists across
+products. Every feed behind it is addressable by day: NOAA's tide predictions,
+CDIP's three-hourly estimates, and the gridpoint's hours all carry instants.
+
+The surf zone forecast does not. It names its periods and never dates them.
+Measured across all 14 issuances NWS SGX held on 2026-09-02 — seven days —
+`CAZ043`:
+
+| Issuance         | First period                       | Second period |
+| ---------------- | ---------------------------------- | ------------- |
+| morning, ~1 AM   | `TODAY`                            | `<weekday>`   |
+| afternoon, ~1 PM | `THIS AFTERNOON THROUGH <weekday>` | `<weekday>`   |
+
+Every issuance carried exactly two periods, never three. But the two shapes do
+not cover the same ground: a morning bulletin describes **two** calendar days,
+while an afternoon one merges today's remainder with tomorrow into one period
+and pushes the second to the day after — **three**.
+
+`nws-forecast.ts` already records the neighbouring version of this hazard, that
+"the first period is not today's", and solved it by selecting on instants the
+publisher supplies. That solution is unavailable here: this product supplies no
+instants at all.
+
+Three options were considered.
+
+**Clamp to today.** Show the first period, ignore the second. Stable and simple,
+and throws away a forecast day the office published.
+
+**Show both periods on today's panel, in the publisher's own words.** Never
+asserts a mapping, so nothing can be wrong. But it puts a block about Sunday on
+Wednesday's panel, which fights the day selector the whole region is built
+around.
+
+**Resolve the labels onto dates.** `TODAY` becomes the issuance's local date;
+`THIS AFTERNOON THROUGH SATURDAY` becomes every date from the issuance through
+that weekday inclusive; a bare weekday becomes the next such day at or after
+where the previous period ended.
+
+## Decision
+
+**The labels are resolved onto calendar dates**, by `resolvePeriodDates`, and
+the day panel shows whichever period covers the day a reader picked.
+
+**A label the resolver does not know stops the read.** It throws
+`NwsSurfZoneDriftError` rather than dropping the period or resolving it to
+nothing. The measured vocabulary is one week of one summer, which is not the
+whole of what NWS period naming produces — `TONIGHT`, `REST OF TODAY` and
+holiday names all exist in the wider product family and none appeared in the
+capture window.
+
+**The publisher's own name for the period is printed beside the resolved day.**
+The dates are this repo's arithmetic; the name is the office's fact. Showing
+both is what keeps them apart, and it is how a reader can see that one period
+covers both Tuesday and Wednesday.
+
+**The headline is carried unreconciled with the days beneath it.** It is scoped
+to the bulletin, and on 2026-08-28 07:11 it read `HIGH RIP CURRENT RISK` over a
+`TODAY` that read Moderate — because `SATURDAY` was the High one. Both are
+correct at their own scope. Taking the worse of the two, or hiding the headline
+when it disagrees, would be this site editing a safety product.
+
+## Consequences
+
+**Coverage varies with the time of day.** A reader at 9 AM finds the block on
+two days; the same reader at 3 PM finds it on three. That is the publisher's
+cadence showing through rather than a defect, and the block states its issuance
+so the variation is legible rather than mysterious.
+
+**A vocabulary change takes the block down rather than moving it.** A new period
+label — likely, since the measured set is small — means every reader on all 26
+open-coast beaches sees the outage sentence until the resolver learns the word.
+That is the deliberate trade: the alternative failure is a period silently
+dropped, which shows a day as "beyond the horizon" when the office did forecast
+it. On a page whose only hazard signal this is, a loud absence beats a quiet
+wrong answer.
+
+**The resolver is the seam, and it is a pure function.** It takes a label and a
+date to search from, and returns dates. That is testable without a network, a
+clock or a fixture, which is what lets the unrecognised-label path be asserted
+at all — no capture would ever have produced one.
+
+**The `searchFrom` argument is load-bearing and easy to misread as a
+convenience.** A bare weekday is ambiguous on its own: `THURSDAY` read on a
+Thursday could mean today or a week away. Resolving each period from where the
+previous one ended is what disambiguates it, and a caller that passed the
+issuance date to every period would put the second period on the wrong day
+roughly once a week without raising.

--- a/docs/plans/surf-zone-forecast.md
+++ b/docs/plans/surf-zone-forecast.md
@@ -264,3 +264,65 @@ never as a competing surf reading, and never adjacent to the MOP swell.
 here. Rejected on the measurement above: the join is containment rather than
 proximity and fails at the water's edge for 10 of 51 beaches, and the zone is
 not per-beach data in the first place.
+
+## Addenda
+
+### 2026-09-02 — the product has a headline, and it outranks the day
+
+Capturing fixtures surfaced an element the design above does not account for.
+The `CAZ043` section may open with a headline in the National Weather Service's
+own emphasis markers, before the first period:
+
+```
+...HIGH RIP CURRENT RISK...
+```
+
+Read across all 14 issuances:
+
+| Issued (UTC) | First period's risk | Headline                                                   |
+| ------------ | ------------------- | ---------------------------------------------------------- |
+| 09-02 08:54  | Low                 | —                                                          |
+| 09-01 19:20  | Moderate            | `...MODERATE RIP CURRENT RISK...`                          |
+| 09-01 08:44  | Moderate            | —                                                          |
+| 08-31 20:15  | High                | `...HIGH RIP CURRENT RISK...`                              |
+| 08-31 08:20  | Moderate            | —                                                          |
+| 08-30 19:09  | High                | `...HIGH RIP CURRENT RISK...`                              |
+| 08-30 07:59  | High                | `...HIGH RIP CURRENT RISK...`                              |
+| 08-29 21:01  | High                | `...HIGH RIP CURRENT RISK...`                              |
+| 08-29 07:11  | High                | `...HIGH RIP CURRENT RISK...`                              |
+| 08-28 19:44  | High                | `...HIGH RIP CURRENT RISK...`                              |
+| 08-28 07:11  | **Moderate**        | **`...HIGH RIP CURRENT RISK...`**                          |
+| 08-27 20:39  | High                | `...BEACH HAZARDS STATEMENT THROUGH 11 PM THIS EVENING...` |
+| 08-27 08:17  | High                | `...BEACH HAZARDS STATEMENT THROUGH 11 PM THIS EVENING...` |
+| 08-26 19:10  | High                | `...BEACH HAZARDS STATEMENT THROUGH 11 PM THURSDAY...`     |
+
+Three facts, and the third is why this changes the plan.
+
+**It is optional** — absent on 3 of 14. A parser that requires it fails on a
+quiet day.
+
+**It is scoped to the product, not to a period.** On 2026-08-28 07:11 the
+headline read `HIGH RIP CURRENT RISK` while `TODAY` read Moderate; the second
+period, `SATURDAY`, read High. Verified in the product text rather than
+inferred. So the headline and the per-day field can differ, legitimately, and
+neither is wrong.
+
+**It sometimes announces an active Beach Hazards Statement** — 3 of 14. That is
+the event-driven signal measured above as the thing this page has none of, and
+it arrives inside a read this slice already makes.
+
+**Decision: the headline is relayed**, as a product-level line above the
+per-day risk, worded so that its scope is the issuance rather than the chosen
+day. Omitting it would let the page print "Moderate" on a day the forecaster
+headlined `HIGH RIP CURRENT RISK`, and stay silent while a Beach Hazards
+Statement is running — which is the same failure of omission the whole feature
+exists to correct.
+
+**What this costs**: two risk words on screen that can differ, one above the
+other. That is the product being honest about scope rather than a
+contradiction, but it only reads that way if the wording carries the scope, and
+no gate can check that it does. It is why #217 is `needs-human`.
+
+**What it does not do**: deliver active alerts. The headline is the SGX
+forecaster's announcement text, not the alert product, and it appears only when
+that office chooses to lead with it. `Active alerts` stays out of scope above.

--- a/docs/plans/surf-zone-forecast.md
+++ b/docs/plans/surf-zone-forecast.md
@@ -1,0 +1,266 @@
+# The surf zone forecast on the conditions page (issue #217)
+
+Date: 2026-09-02.
+
+## Problem, from the reader's point of view
+
+A parent deciding whether to put children in the water opens `/conditions` and
+finds tide times, a modelled swell height, cloud cover, wind and air
+temperature. Every one of those is a number they have to interpret themselves.
+Nothing on the page answers the question they actually came with.
+
+Between 2026-08-26 and 2026-08-31 the National Weather Service said rip current
+risk on this coast was **High** — its own words: _"Life threatening rip currents
+are likely"_ — for six consecutive days. Through all six, this page showed a
+sub-foot swell figure and no hazard signal of any kind.
+
+## What was measured, and when
+
+Everything below was read from the live products on **2026-09-02**, not
+inherited from `docs/plans/conditions-tool.md`, whose figures for this product
+are wrong in two places. That plan is historical and is not corrected; see
+`docs/plans/README.md`.
+
+### Rip current risk moves
+
+All 14 SRF issuances NWS SGX still held — seven days — first period, `CAZ043`
+San Diego County Coastal:
+
+| Issued (PDT)   | Rip current risk | Surf height                   | Water temperature |
+| -------------- | ---------------- | ----------------------------- | ----------------- |
+| 09-02 01:54 AM | Low              | 1 to 3 feet. Sets to 4 feet.  | 70 to 74 degrees  |
+| 09-01 12:20 PM | Moderate         | 2 to 4 feet.                  | 70 to 76 degrees  |
+| 09-01 01:44 AM | Moderate         | 2 to 4 feet.                  | 70 to 76 degrees  |
+| 08-31 01:15 PM | High             | 3 to 5 feet. Sets to 6 feet.  | 70 to 77 degrees  |
+| 08-31 01:20 AM | Moderate         | 2 to 4 feet. Sets to 5 feet.  | 73 to 77 degrees  |
+| 08-30 12:09 PM | High             | 3 to 5 feet.                  | 70 to 77 degrees  |
+| 08-30 12:59 AM | High             | 3 to 5 feet, local sets to 6. | 70 to 77 degrees  |
+| 08-29 02:01 PM | High             | 3 to 5 feet, local sets to 6. | 68 to 78 degrees  |
+| 08-29 12:11 AM | High             | 3 to 5 feet.                  | 68 to 78 degrees  |
+| 08-28 12:44 PM | High             | 3 to 5 feet.                  | 73 to 77 degrees  |
+| 08-28 12:11 AM | Moderate         | 2 to 4 feet.                  | 72 to 77 degrees  |
+| 08-27 01:39 PM | High             | 3 to 5 feet.                  | 70 to 77 degrees  |
+| 08-27 01:17 AM | High             | 3 to 5 feet.                  | 70 to 77 degrees  |
+| 08-26 12:10 PM | High             | 3 to 5 feet with sets to 6.   | 70 to 76 degrees  |
+
+High on 8, Moderate on 4, Low on 2; the value changed on five of seven days.
+**It is not a constant that renders the same all summer**, which was the main
+reason to suspect this feature was not worth building.
+
+It also changes **within a calendar day**: 08-31 read Moderate at 01:20 AM and
+High at 01:15 PM, both for "today". So the value is an as-of-issuance judgement,
+not a property of a day — which is what rules out a week-grid cell, whose whole
+register is a fact about one day.
+
+### Alerts are not a substitute
+
+`/alerts/active?zone=CAZ043` was empty on 2026-09-02, and the whole of
+2026-06-01 to 2026-09-02 carried only 6 Beach Hazards Statements (plus 10 Heat
+Advisories). The statement fires rarely; the risk was elevated most of last
+week. An alerts-only safety layer would have been silent through all six High
+days.
+
+### The product's shape
+
+Fixed-width dot-leader fields, not forecaster prose:
+
+```
+Rip Current Risk*.............High.
+Surf Height...................3 to 5 feet. Sets to 6 feet.
+Thunderstorm Potential........None expected.
+Water Temperature.............70 to 77 degrees.
+```
+
+Contract facts, each 14 of 14:
+
+- **Exactly two periods.** Never three. `docs/plans/conditions-tool.md` records
+  `~3 d` and is wrong.
+- **Period labels are not calendar days.** A morning issuance (~1 AM PDT) reads
+  `TODAY` then a weekday. An afternoon issuance (~1 PM PDT) reads
+  `THIS AFTERNOON THROUGH <weekday>` — today's remainder merged with tomorrow —
+  then the day _after_. So a morning issuance reaches two calendar days and an
+  afternoon one reaches three.
+- **`Water Temperature` appears in the first period only.** The last day covered
+  never has one.
+- **The full field set** is `Rip Current Risk`, `Surf Height`,
+  `Thunderstorm Potential`, `Water Temperature`, `Tides`, `Remarks`.
+- **One text carries both zones.** `CAZ552` Orange County sits in the same
+  product with different figures (71 to 78 degrees on 2026-09-02, against 70 to
+  74 for San Diego) and tides quoted at Newport Beach rather than La Jolla.
+- **The product ships its own glossary** — the three risk levels and their
+  meanings — so even the explanatory text is the publisher's, not ours.
+
+### The zone cannot be joined per beach
+
+`api.weather.gov/zones?point=<lat>,<lon>&type=public`, both segment ends, all 51
+beaches:
+
+| Result                | Beaches |
+| --------------------- | ------- |
+| `CAZ043` at both ends | 27      |
+| `CAZ043` at one end   | 14      |
+| no zone at either end | 10      |
+
+The ten include every Coronado beach, Border Field State Park and the inner-bay
+sites. **That is not a fact about those beaches** — all 51 are unambiguously
+inside San Diego County Coastal. `CAZ043` is a _land_ polygon, and a beach
+coordinate on the water side of the mapped shoreline falls outside it. A
+containment join fails at the water's edge where this repo's other joins, which
+are all nearest-feature, degrade gracefully.
+
+## Solution
+
+A **surf zone forecast** block in the day panel, below the hour chart and above
+the measured block, carrying the National Weather Service's published judgement
+for the days it covers, quoted and attributed, on the 26 open-coast beaches.
+
+ADR-0009 already fixed the posture: a published judgement is relayed, never
+recomputed. This site does not say whether conditions are safe. It says what the
+forecaster said, and when they said it.
+
+## Implementation decisions
+
+**The zone binds to the inventory, not to the beach.** No `zone` column in
+`beaches.json`, no `srf-join.mjs`. The zone follows from the `County = 'San
+Diego'` filter already recorded in `_inclusion`, and it is asserted once. This
+contradicts the pattern of every other binding here, which is exactly why it
+gets an ADR — someone will try to add the column.
+
+**The parser gets no fallbacks.** Select `CAZ043` by name; its absence is a
+failed read. An unrecognised period label is a failed read. Every fallback
+available here renders either another county's forecast or the wrong day's, and
+both fail silently and plausibly.
+
+**Periods resolve to sets of local dates.** `TODAY` → today;
+`THIS AFTERNOON THROUGH SATURDAY` → today and Saturday; `SUNDAY` → Sunday. The
+panel shows, for the day a reader picked, whichever period covers it. Coverage
+therefore varies with the time of day — two days from a morning issuance, three
+from an afternoon one — so the block names its issuance, and that reads as the
+publisher's cadence rather than as a defect.
+
+**It is withheld at the 25 bay, lagoon and inlet beaches**, with a stated
+reason in the `wave_buoy_null_reason` voice. A _surf zone_ forecast for
+open-coast areas does not describe Sail Bay, by the same logic those beaches
+already carry for having no wave buoy. Region and tide-station water
+classification agree 51/51 on the split, so it is twice-recorded already.
+
+The failure mode this avoids is unusually bad: "Rip Current Risk: High" printed
+on a lagoon alarms about a hazard that is not there, and teaches a reader that
+this line is not about the beach they selected — which destroys it on the 26
+beaches where it is the most important thing on the page.
+
+**Three of the six fields are dropped**, and the reasons are recorded so they
+are not re-litigated:
+
+- **Tides** — quoted at La Jolla for the whole county, so wrong at 50 of 51
+  beaches, and the page already holds per-beach NOAA predictions.
+- **Remarks** — swell direction, which the shore map readout already carries per
+  beach from CDIP at finer resolution.
+- **Thunderstorm potential** — "None expected" on 14 of 14. A field that reads
+  the same every day trains a reader to skip the block, and the block's standing
+  risk is already that "Low" is common.
+
+**No glyph.** ADR-0015's vocabulary is 🐚 tide, 🏄 waves and water, 💨 air, and
+it is explicitly scoped to the three reading cards. This block is not one.
+Borrowing 🏄 would put "waves and water" over a rip current risk. Removing the
+slot discharges ADR-0015's open note that 🏖️ marks this product wrongly.
+
+**1800s revalidate**, against a product issued strictly twice daily with no
+off-cycle reissue in the sampled week. Its own Suspense boundary, failing apart
+from the other four agencies, per the page's standing rule.
+
+**The loading line must not contain "forecast".** `ConditionsSection` and
+`DayPanel` both assert loading copy against `CONTEXT.md`'s
+`_Avoid_: weather, forecast, surf report`. The assertion is scoped to loading
+lines, so the block's own heading may use the publisher's name for the product;
+the loading line may not. "Reading the rip current risk…".
+
+## Test seams
+
+Existing seams, preferred to new ones:
+
+- **`lib/upstream.ts`** — the fetch policy, tested by stubbing `fetch`, as the
+  other five reads are. What a 404 means, what a missing `CAZ043` means, what an
+  issuance older than a cycle means.
+- **A pure parser over committed fixtures**, the `ndbc-realtime2` pattern:
+  real product text in `src/lib/__fixtures__/`, offline, no network in any gate.
+  Fixtures must include **both period-label shapes** — one morning issuance and
+  one afternoon — plus a text whose `CAZ043` section is absent, which is the
+  fail-loud path and the one a fallback would have rendered wrongly.
+- **`lib/conditions.ts`** — the read that composes what the component gets,
+  where the bay withholding is decided and stated.
+- **The component's own tests**, on `MeasuredToday`'s precedent: what a covered
+  day renders, what an uncovered day says instead, and what a bay beach says.
+
+The label→date resolution is a pure function and is the highest seam the
+mapping can sit at. It must be tested for the unrecognised label, because that
+path is the one no fixture will discover naturally.
+
+## Out of scope
+
+- **Surf height and water temperature** — slice 4. The block ships with rip
+  current risk first because that is the product's reason to exist and the rest
+  is additive.
+- **Staleness** — slice 5. A missed issuance cycle saying so rather than
+  presenting an 18-hour-old risk as current.
+- **Active alerts.** The other half of `conditions-tool.md`'s slice 9. Measured
+  above as a poor substitute for this product, and it is not made redundant by
+  it either — both is right eventually, this first.
+- **The bay beaches' missing water temperature.** `conditions-tool.md` says it
+  "waits for the surf zone forecast's county-wide range". It does not: the
+  product does not describe bay water. Those 25 beaches keep the gap, and the
+  correction lives here rather than in that historical plan.
+- **The landing-page teaser.** Outside this brief; ADR-0015 records why the
+  first screen wants its own branch.
+
+## Considered and rejected
+
+**A week-grid row.** The obvious and cheapest answer — the reserved slot already
+sits there, `WaveWeek` already handles a row that does not reach all seven days,
+and both earlier slots became rows. Rejected on two counts: a grid cell states a
+fact about a day, and this value changed _within_ 2026-08-31; and a row of five
+empty cells out of seven, sitting fifth below tide, wave and sky in a 159×148
+cell, inverts the importance of the one thing on this page that answers the
+question the site exists for.
+
+**A standing block above the week.** The highest-prominence option and the right
+register — it would sit directly under the standing notice, which disclaims
+_our_ judgement where this relays _theirs_. Rejected because anything above the
+readings is paid for out of a first screen with about two pixels of slack, and
+the trade was not worth making before the block has been seen. If the day panel
+proves too deep, this is what to reconsider — not a different position inside
+the panel.
+
+**Above the hour chart, joined to the sky wording.** Conceptually tidy: both are
+NWS's relayed words for the chosen day. Rejected because a five-line block
+collapsing to a one-line absence would move the plot up and down the page as a
+reader steps across the week, which is the constraint `ChosenDay` already pays
+for by putting the measured block below. Noted that the chart already drifts a
+little, since the publisher's sky wording varies in length — so this is a
+difference of degree, and the degree is large.
+
+**Clamping to today only.** Stable, simple, and throws away a real forecast day
+the publisher gave us.
+
+**Showing both periods on today's panel in the publisher's words.** Never
+asserts a mapping, which is honest — but it puts a block about Sunday on
+Wednesday's panel, fighting the whole point of the day selector.
+
+**Drawing it at all 51 beaches.** The `Readout` precedent: it is drawn on all
+51, including the 23 the traced coast does not reach, because withholding left
+nearly half the inventory with no wind figure anywhere. Rejected because the
+analogy fails — wind blows on a bay, so a wind figure there is true; a surf zone
+forecast describes water that does not exist at Sail Bay.
+
+**Dropping surf height entirely.** Argued first, on the grounds that the page
+already has two better surf numbers — CDIP's per-beach modelled swell and the
+buoy's measured height — and a coarse county range would be a third that
+disagrees. Reversed: the measured table shows risk and surf height moving
+together, and "High — 3 to 5 feet, sets to 6" is one coherent statement where
+"High" alone is a bare word. It ships in slice 4 as the evidence for the risk,
+never as a competing surf reading, and never adjacent to the MOP swell.
+
+**A `zone` column and a re-join script**, by analogy with every other binding
+here. Rejected on the measurement above: the join is containment rather than
+proximity and fails at the water's edge for 10 of 51 beaches, and the zone is
+not per-beach data in the first place.

--- a/src/components/conditions/ChosenDay.tsx
+++ b/src/components/conditions/ChosenDay.tsx
@@ -84,6 +84,19 @@ export type DayView = {
    * with the daylight read that knows which day is today, not here.
    */
   measured: ReactNode;
+  /**
+   * The National Weather Service's relayed judgement for this day, already
+   * rendered: the risk on the days the bulletin reaches, a sentence on the
+   * days it does not, and on a sheltered beach a sentence saying the product
+   * is not about this water at all.
+   *
+   * A finished node for the reason `measured` is one -- a server read handed
+   * to a client component -- and present on all seven days rather than only on
+   * the ones the forecast reaches, so that stepping across the week never
+   * leaves a reader wondering whether the block failed or the day is simply
+   * beyond the horizon.
+   */
+  surfZone: ReactNode;
 };
 
 export function ChosenDay({
@@ -168,6 +181,21 @@ export function ChosenDay({
           {map}
         </div>
       </div>
+
+      {/*
+        Between the chart and the measured block, which is reading order rather
+        than layout convenience: the sky, then the day's shape, then what the
+        forecaster judges, then what the instruments read. The relayed
+        judgement comes before the instrument readings because the standing
+        notice at the top of the page says in as many words that the numbers
+        are not a safety assessment and that the authority is someone else's.
+
+        Below the chart and not above it, for the same reason the measured block
+        is: this is several lines on the days the bulletin reaches and one line
+        on the days it does not, so putting it above would move the plot up and
+        down the page as a reader steps across the week.
+      */}
+      <div className="mt-6">{day.surfZone}</div>
 
       {/*
         Under the chart, which is the order the brief lists this region in:

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -5,6 +5,7 @@ import { MeasuredToday, type MeasuredReadings } from "./MeasuredToday";
 import { SelectedDayProvider, useSelectedDay } from "./selectedDay";
 
 const readSkyWording = vi.fn();
+const readSurfZone = vi.fn();
 const readDaylightWeek = vi.fn();
 const readHourlyTide = vi.fn();
 const readSkyWeek = vi.fn();
@@ -12,6 +13,7 @@ const readWaveWeek = vi.fn();
 const readGridpointWeek = vi.fn();
 vi.mock("@/lib/conditions", () => ({
   readSkyWording,
+  readSurfZone,
   readDaylightWeek,
   readHourlyTide,
   readSkyWeek,
@@ -277,8 +279,34 @@ function curve(container: HTMLElement): Element | null {
   return container.querySelector('svg[aria-label^="Tide today"] [data-curve]');
 }
 
+/**
+ * The surf zone bulletin, defaulted so that every test in this file gets a
+ * block rather than a crash. What it says is asserted in `SurfZone.test.tsx`
+ * and in `conditions.test.ts`; here it only has to exist, because this panel's
+ * job is to hand one node per day to `ChosenDay`.
+ */
+function surfZoneWeek(
+  days: { localDate: string; level: "Low" | "Moderate" | "High" }[],
+) {
+  readSurfZone.mockResolvedValue({
+    beachName: "La Jolla Shores Beach",
+    state: {
+      kind: "forecast",
+      issuedMs: localMidnightOf(TODAY) + 3_600_000,
+      headline: null,
+      days: days.map((day) => ({
+        ...day,
+        periodName: "TODAY",
+        meaning: "Life threatening rip currents are possible.",
+      })),
+    },
+  });
+}
+
 beforeEach(() => {
   readSkyWording.mockReset();
+  readSurfZone.mockReset();
+  surfZoneWeek([{ localDate: TODAY, level: "Moderate" }]);
   readDaylightWeek.mockReset();
   readHourlyTide.mockReset();
   readSkyWeek.mockReset();
@@ -311,6 +339,7 @@ test("asks every read for the slug it was given", async () => {
     readSkyWeek,
     readWaveWeek,
     readGridpointWeek,
+    readSurfZone,
   ]) {
     expect(read).toHaveBeenCalledWith("la-jolla-shores-beach");
   }

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -29,12 +29,19 @@
  * the chart's "now" line is drawn at. `WeekPanel` takes its columns from the
  * same read, so the two regions cannot disagree about which day is which.
  *
- * **Five reads, made concurrently and failing apart.** The hourly heights come
+ * **Six reads, made concurrently and failing apart.** The hourly heights come
  * from NOAA, the swell from CDIP, the cloud from the National Weather Service's
- * numbers and the wording from its sentences -- five products, five outages. A
- * quiet cloud feed costs the band and not the curve; a quiet NOAA costs the
- * tide tab and not the swell tab; and each tab that is quiet says which
- * publisher went quiet rather than saying only that something is missing.
+ * numbers, the wording from its sentences and the rip current risk from its
+ * surf zone bulletin -- six products, six outages. A quiet cloud feed costs the
+ * band and not the curve; a quiet NOAA costs the tide tab and not the swell
+ * tab; and each tab that is quiet says which publisher went quiet rather than
+ * saying only that something is missing.
+ *
+ * The surf zone read is the odd one of the six twice over. It is the only
+ * relayed *judgement* here rather than a measurement or a model, which is what
+ * ADR-0009 permits and constrains; and it is the only one that reaches no
+ * publisher at all on 25 of the 51 beaches, because a bay, lagoon or inlet has
+ * no surf zone to forecast.
  *
  * **And, on today alone, what was measured.** Every read above is a model or a
  * prediction; the buoy and the shore station are the only instruments this
@@ -52,6 +59,7 @@ import {
   readHourlyTide,
   readSkyWeek,
   readSkyWording,
+  readSurfZone,
   readWaveWeek,
   type GridDaySeries,
   type GridpointWeekView,
@@ -110,6 +118,7 @@ import {
 } from "./needles";
 import type { ProvenanceFacts } from "./ProvenanceLine";
 import { ShoreMap } from "./ShoreMap";
+import { SurfZone } from "./SurfZone";
 import { shoreViewFor } from "./shore";
 import { SkyWording } from "./SkyWording";
 import { gridPoints, swellPoints, tidePoints } from "./series";
@@ -378,12 +387,18 @@ function mapDescription(beachName: string): string {
 
 export async function DayPanel({ slug }: { slug: string }) {
   const daylight = readDaylightWeek(slug);
-  const [hourly, waves, sky, grid, wording] = await Promise.all([
+  const [hourly, waves, sky, grid, wording, surfZone] = await Promise.all([
     readHourlyTide(slug),
     readWaveWeek(slug),
     readSkyWeek(slug),
     readGridpointWeek(slug),
     readSkyWording(slug),
+    // A sixth read and a third publisher's product, joining the others for the
+    // reason they are all here: five agencies go quiet independently, and the
+    // surf zone bulletin failing must cost its own block and nothing else. It
+    // is the only one of the six that reaches no network at all on 25 of the
+    // 51 beaches, because a bay has no surf zone to forecast.
+    readSurfZone(slug),
   ]);
 
   /*
@@ -666,6 +681,27 @@ export async function DayPanel({ slug }: { slug: string }) {
         </Suspense>
       ) : (
         <MeasuredToday when={when} readings={null} />
+      ),
+      /*
+        Rendered here and handed over finished, the precedent `wording` and
+        `measured` both set: the read is the server's and `ChosenDay` is a
+        client component.
+
+        Not behind a Suspense boundary of its own, unlike the measured block.
+        That block suspends because it is a second wave of reads taken inside
+        `MeasuredPanel`; this one is already resolved by the `Promise.all`
+        above, so a boundary here would render a loading line that never shows.
+
+        The same `state` on all seven days and only `localDate` varying, which
+        is what lets one bulletin answer for every day it reaches without being
+        read seven times.
+      */
+      surfZone: (
+        <SurfZone
+          state={surfZone.state}
+          localDate={day.localDate}
+          when={when}
+        />
       ),
     };
   });

--- a/src/components/conditions/SurfZone.test.tsx
+++ b/src/components/conditions/SurfZone.test.tsx
@@ -233,3 +233,49 @@ test("the three levels are rendered with the same emphasis", () => {
 
   expect(new Set(classNames).size).toBe(1);
 });
+
+/**
+ * The block must never say the water is safe, in any of its four states.
+ *
+ * ADR-0009 forbids this site forming the judgement, and the risk here is not
+ * the obvious one -- nobody would write "safe for kids today". It is the
+ * absence copy: "none is forecast here" and "no rip current risk" both read as
+ * *there is no rip current risk here*, which is a claim about the water rather
+ * than about the product's coverage. That reading is worst at exactly the
+ * beaches that get it, because a lagoon is calm until the day it is not.
+ *
+ * The withheld sentence is worded about the forecast for that reason, and this
+ * holds every state to the same line.
+ */
+test("no state implies the water is safe", () => {
+  const states: SurfZoneView["state"][] = [
+    forecast([{ localDate: "2026-09-02", periodName: "TODAY", level: "Low" }]),
+    forecast([{ localDate: "2026-09-01", periodName: "TODAY", level: "Low" }]),
+    {
+      kind: "no-surf-zone",
+      reason:
+        "the National Weather Service issues this forecast for San Diego County's " +
+        "coastal areas, and a bay, lagoon or inlet has no surf zone, so it does not " +
+        "describe the water here",
+    },
+    { kind: "unavailable", detail: "HTTP 503.", drift: false },
+  ];
+
+  for (const state of states) {
+    const { container, unmount } = render(
+      <SurfZone state={state} localDate="2026-09-02" when="today" />,
+    );
+    const text = container.textContent ?? "";
+
+    expect(text).not.toMatch(/\bsafe\b/i);
+    expect(text).not.toMatch(/no rip current risk/i);
+    expect(text).not.toMatch(/none is forecast/i);
+    // The publisher is named once at most; twice in one sentence was shipped
+    // to the rendered page before this test existed.
+    expect((text.match(/National Weather Service/g) ?? []).length).toBeLessThan(
+      2,
+    );
+
+    unmount();
+  }
+});

--- a/src/components/conditions/SurfZone.test.tsx
+++ b/src/components/conditions/SurfZone.test.tsx
@@ -1,0 +1,235 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { localMidnightOf } from "@/lib/pacific-time";
+import type { SurfZoneView } from "@/lib/conditions";
+import { SurfZone } from "./SurfZone";
+
+/** 1:54 AM Pacific on Wednesday 2026-09-02, the morning bulletin's issuance. */
+const ISSUED = localMidnightOf("2026-09-02") + 3_600_000 + 54 * 60_000;
+
+const MEANING = {
+  Low: "Life threatening rip currents are unlikely but still could occur.",
+  Moderate: "Life threatening rip currents are possible.",
+  High: "Life threatening rip currents are likely.",
+} as const;
+
+function forecast(
+  days: {
+    localDate: string;
+    periodName: string;
+    level: "Low" | "Moderate" | "High";
+  }[],
+  headline: string | null = null,
+): SurfZoneView["state"] {
+  return {
+    kind: "forecast",
+    issuedMs: ISSUED,
+    headline,
+    days: days.map((day) => ({ ...day, meaning: MEANING[day.level] })),
+  };
+}
+
+test("states the level and the publisher's own sentence for it", () => {
+  render(
+    <SurfZone
+      state={forecast([
+        { localDate: "2026-09-02", periodName: "TODAY", level: "High" },
+      ])}
+      localDate="2026-09-02"
+      when="today"
+    />,
+  );
+
+  expect(screen.getByText("High")).toBeDefined();
+  // ADR-0009 forbids this site forming the judgement, and writing the words
+  // that explain it would be forming it one step removed. This sentence is the
+  // bulletin's own, so its presence is what makes the level word safe to print.
+  expect(screen.getByText(MEANING.High)).toBeDefined();
+});
+
+/**
+ * The period's own name, printed beside the day.
+ *
+ * The bulletin names its periods and never dates them; working out which days a
+ * period covers is this repo's arithmetic. Showing the office's name for it is
+ * what keeps ours and theirs apart -- and on an afternoon bulletin it is how a
+ * reader can tell that one period covers both Tuesday and Wednesday.
+ */
+test("names the period the office issued, not just the day we resolved it to", () => {
+  render(
+    <SurfZone
+      state={forecast([
+        {
+          localDate: "2026-09-02",
+          periodName: "THIS AFTERNOON THROUGH WEDNESDAY",
+          level: "Moderate",
+        },
+      ])}
+      localDate="2026-09-02"
+      when="Wednesday"
+    />,
+  );
+
+  expect(screen.getByText(/THIS AFTERNOON THROUGH WEDNESDAY/)).toBeDefined();
+});
+
+/**
+ * Measured 2026-08-28: the office headlined `HIGH RIP CURRENT RISK` over a
+ * `TODAY` that read Moderate, because Saturday was the High one. Both are
+ * correct at their own scope. Reconciling them -- taking the worse, or hiding
+ * the headline when it disagrees -- would be this site editing a safety
+ * product, so both are shown and the copy says which is which.
+ */
+test("shows a headline that names a level the day does not, and scopes it", () => {
+  render(
+    <SurfZone
+      state={forecast(
+        [{ localDate: "2026-09-02", periodName: "TODAY", level: "Moderate" }],
+        "HIGH RIP CURRENT RISK",
+      )}
+      localDate="2026-09-02"
+      when="today"
+    />,
+  );
+
+  expect(screen.getByText("HIGH RIP CURRENT RISK")).toBeDefined();
+  expect(screen.getByText("Moderate")).toBeDefined();
+  // Without this the pair reads as a contradiction rather than as two scopes.
+  expect(
+    screen.getByText(/covers the whole bulletin rather than one day/i),
+  ).toBeDefined();
+});
+
+test("carries no headline line when the office published none", () => {
+  render(
+    <SurfZone
+      state={forecast([
+        { localDate: "2026-09-02", periodName: "TODAY", level: "Low" },
+      ])}
+      localDate="2026-09-02"
+      when="today"
+    />,
+  );
+
+  expect(screen.queryByText(/headlined this bulletin/i)).toBeNull();
+});
+
+/**
+ * The horizon, met as a reader meets it: by stepping to a day past it.
+ *
+ * The bulletin reaches two or three days depending on when it was issued, and
+ * the week grid offers seven. So this sentence is what four or five of the
+ * seven days show, and it says why rather than leaving a blank that reads as a
+ * failure.
+ */
+test("says the forecast does not reach a day beyond its horizon", () => {
+  render(
+    <SurfZone
+      state={forecast([
+        { localDate: "2026-09-02", periodName: "TODAY", level: "Low" },
+      ])}
+      localDate="2026-09-06"
+      when="Sunday"
+    />,
+  );
+
+  expect(screen.getByText(/does not reach Sunday/i)).toBeDefined();
+  expect(screen.getByText(/twice a day/i)).toBeDefined();
+  expect(screen.queryByText("Low")).toBeNull();
+});
+
+/**
+ * Half the inventory. The sentence names the water rather than reporting that a
+ * lookup came back empty, which is the voice `wave_buoy_null_reason` already
+ * uses at these same 25 beaches.
+ */
+test("a sheltered beach is told why the product is not about it", () => {
+  render(
+    <SurfZone
+      state={{
+        kind: "no-surf-zone",
+        reason:
+          "the National Weather Service issues this forecast for San Diego County's " +
+          "coastal areas, and a bay, lagoon or inlet has no surf zone, so it does not " +
+          "describe the water here",
+      }}
+      localDate="2026-09-02"
+      when="today"
+    />,
+  );
+
+  expect(screen.getByText(/no surf zone/i)).toBeDefined();
+  // Not an outage and not a horizon: a permanent fact about this water.
+  expect(screen.queryByText(/could not be read/i)).toBeNull();
+  expect(screen.queryByText(/does not reach/i)).toBeNull();
+});
+
+test("a quiet office is reported with the upstream reason, not summarised", () => {
+  render(
+    <SurfZone
+      state={{
+        kind: "unavailable",
+        detail:
+          "The National Weather Service returned HTTP 503 for SGX's surf zone bulletins.",
+        drift: false,
+      }}
+      localDate="2026-09-02"
+      when="today"
+    />,
+  );
+
+  expect(screen.getByText(/HTTP 503/)).toBeDefined();
+});
+
+/**
+ * A judgement reissued twice a day is one whose age a reader can act on, and
+ * this block is the only place the page says when it was made.
+ */
+test("attributes the bulletin and states when it was issued", () => {
+  render(
+    <SurfZone
+      state={forecast([
+        { localDate: "2026-09-02", periodName: "TODAY", level: "Low" },
+      ])}
+      localDate="2026-09-02"
+      when="today"
+    />,
+  );
+
+  expect(
+    screen.getByText(/Surf zone forecast, San Diego County Coastal Areas/),
+  ).toBeDefined();
+  expect(screen.getByText(/issued 1:54 AM/)).toBeDefined();
+});
+
+/**
+ * ADR-0015 records that a surface on this page is decoration and never a
+ * verdict, because ADR-0009 forbids the verdict. A three-step severity palette
+ * would be this site choosing what red means on top of a scale the office
+ * already publishes in words, so the level is emphasised identically at all
+ * three levels.
+ *
+ * Asserted as sameness rather than by naming a class, so the rule survives a
+ * change of type scale. jsdom applies no stylesheets (ADR-0001), so what this
+ * proves is that one code path renders all three -- a human confirms the
+ * emphasis reads.
+ */
+test("the three levels are rendered with the same emphasis", () => {
+  const classNames = (["Low", "Moderate", "High"] as const).map((level) => {
+    const { container, unmount } = render(
+      <SurfZone
+        state={forecast([
+          { localDate: "2026-09-02", periodName: "TODAY", level },
+        ])}
+        localDate="2026-09-02"
+        when="today"
+      />,
+    );
+    const found = screen.getByText(level).className;
+    unmount();
+    void container;
+    return found;
+  });
+
+  expect(new Set(classNames).size).toBe(1);
+});

--- a/src/components/conditions/SurfZone.tsx
+++ b/src/components/conditions/SurfZone.tsx
@@ -1,0 +1,179 @@
+/**
+ * The National Weather Service's surf zone forecast for one day.
+ *
+ * The page's only relayed judgement, and the only thing on it that answers
+ * "should my kid go in the water today" rather than handing a reader a number
+ * to interpret. Everything else here is an instrument reading or a model.
+ *
+ * **The words are the publisher's, including the ones that explain the words.**
+ * ADR-0009 forbids this site forming a forecaster's judgement, and authoring
+ * the sentence that says what "Moderate" means would be forming it one step
+ * removed. The bulletin carries its own glossary, so the gloss under the level
+ * is quoted from it. Nothing here rewords either.
+ *
+ * **The headline is scoped to the bulletin and the level is scoped to the
+ * day, and they can differ.** Measured 2026-08-28: the office headlined `HIGH
+ * RIP CURRENT RISK` over a `TODAY` that read Moderate, because Saturday was the
+ * High one. Both are correct, so both are shown and the copy says which is
+ * which. Reconciling them here -- taking the worse, or hiding the headline when
+ * it disagrees -- would be this site editing a safety product.
+ *
+ * **The period's own name is printed beside the day.** The bulletin names its
+ * periods and never dates them; `resolvePeriodDates` works out which days a
+ * period covers, and that is our arithmetic rather than the office's. Showing
+ * the name is what keeps the two apart: on an afternoon bulletin a reader sees
+ * "THIS AFTERNOON THROUGH WEDNESDAY" against a Wednesday and can tell that one
+ * period covers both days.
+ *
+ * **No colour by level, and that is deliberate rather than unfinished.**
+ * ADR-0015 records that a surface on this page is decoration and not a verdict,
+ * because ADR-0009 forbids the verdict. A three-step severity palette would be
+ * this site choosing what red means, on top of a scale the office already
+ * publishes in words. The level is emphasised by size and weight, identically
+ * at all three. Whether that is enough emphasis for `High` is a question for a
+ * human looking at the page, which is why #217 is `needs-human`.
+ */
+
+import type { SurfZoneDay, SurfZoneView } from "@/lib/conditions";
+import { localTimeOf } from "@/lib/pacific-time";
+import { PAGE_MUTED } from "./cardText";
+import { ProvenanceLine } from "./ProvenanceLine";
+
+/**
+ * The label register, on the page ground rather than on a card.
+ *
+ * A card heading rather than a region one: this block sits inside the day
+ * panel, whose `<h2>` is the region. ADR-0014 is what makes that distinction
+ * load-bearing -- a region, a card inside it and a day inside that were all
+ * rendering at the same 10px before it. `text-ocean` because this is the page's
+ * ground, where the cards' yellow is measured against `bg-dark` and nothing
+ * else.
+ */
+const BLOCK_HEADING =
+  "text-2xs mb-3 font-extrabold tracking-widest text-ocean uppercase";
+
+/** What the office calls this product, as the provenance line names it. */
+const SOURCE = "Surf zone forecast, San Diego County Coastal Areas";
+
+export type SurfZoneProps = {
+  /** The read's own state: a forecast, a quiet office, or water with no surf zone. */
+  state: SurfZoneView["state"];
+  /** The day being shown, `YYYY-MM-DD`. */
+  localDate: string;
+  /** That day, worded for a reader: `Thursday`. Matches the panel's heading. */
+  when: string;
+};
+
+/** The one sentence a reader gets when there is nothing to relay. */
+function Absence({ children }: { children: React.ReactNode }) {
+  /*
+    `PAGE_MUTED` rather than the card's colour, for the reason `MeasuredToday`
+    records: `CARD_MUTED` paints 1.03:1 on this ground and says nothing at all.
+    On the 25 sheltered beaches this sentence is what a reader always sees, so
+    it is not the rare path.
+  */
+  return (
+    <p className={`leading-relaxed text-base ${PAGE_MUTED}`}>{children}</p>
+  );
+}
+
+function Reading({ day, when }: { day: SurfZoneDay; when: string }) {
+  return (
+    <>
+      <p className="leading-display mb-1 text-2xl font-black italic">
+        {day.level}
+      </p>
+      {/*
+        The publisher's sentence, verbatim. It is the whole reason the level
+        word is safe to print at this size: "High" alone is a rating this site
+        would then owe a reader an explanation for, and the office already
+        wrote one.
+      */}
+      <p className="leading-relaxed mb-2 max-w-130 text-base">{day.meaning}</p>
+      <p className={`leading-relaxed text-sm ${PAGE_MUTED}`}>
+        For {when}, from the period the office called &ldquo;{day.periodName}
+        &rdquo;.
+      </p>
+    </>
+  );
+}
+
+export function SurfZone({ state, localDate, when }: SurfZoneProps) {
+  if (state.kind === "no-surf-zone") {
+    return (
+      <section>
+        <h3 className={BLOCK_HEADING}>Rip current risk</h3>
+        <Absence>
+          The National Weather Service does not forecast one here:{" "}
+          {state.reason}.
+        </Absence>
+      </section>
+    );
+  }
+
+  if (state.kind === "unavailable") {
+    return (
+      <section>
+        <h3 className={BLOCK_HEADING}>Rip current risk</h3>
+        {/*
+          The upstream reason is shown rather than summarised. It is the same
+          policy every other panel here follows: a reader owed an absence is
+          owed the reason, and "temporarily unavailable" is what a site says
+          when it has not looked.
+        */}
+        <Absence>
+          The National Weather Service&apos;s surf zone forecast could not be
+          read: {state.detail}
+        </Absence>
+      </section>
+    );
+  }
+
+  const day = state.days.find((entry) => entry.localDate === localDate) ?? null;
+
+  return (
+    <section>
+      <h3 className={BLOCK_HEADING}>Rip current risk</h3>
+
+      {state.headline !== null && (
+        /*
+          Above the day's level, because it is the office's own emphasis and
+          leading with it is what the office did. The scope is spelled out in
+          the same breath: this line covers the whole bulletin, so it can name a
+          level the day below does not, and a reader who is not told that reads
+          the pair as a contradiction.
+        */
+        <p className="leading-relaxed mb-3 max-w-130 text-base">
+          The forecast office headlined this bulletin{" "}
+          <strong className="font-black">{state.headline}</strong>. A headline
+          covers the whole bulletin rather than one day, so it can name a level
+          no single day below it does.
+        </p>
+      )}
+
+      {day === null ? (
+        <Absence>
+          This forecast does not reach {when}. It is issued twice a day and
+          reaches about two days ahead.
+        </Absence>
+      ) : (
+        <Reading day={day} when={when} />
+      )}
+
+      {/*
+        `surface="page"`, because this block renders on the page ground and not
+        on a card. The issuance is in the note rather than left off: a judgement
+        reissued twice a day is one whose age a reader can act on, and this is
+        the only place the page says when it was made.
+      */}
+      <div className="mt-3">
+        <ProvenanceLine
+          source={SOURCE}
+          network="NWS"
+          note={`issued ${localTimeOf(state.issuedMs)}`}
+          surface="page"
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/conditions/SurfZone.tsx
+++ b/src/components/conditions/SurfZone.tsx
@@ -103,9 +103,22 @@ export function SurfZone({ state, localDate, when }: SurfZoneProps) {
     return (
       <section>
         <h3 className={BLOCK_HEADING}>Rip current risk</h3>
+        {/*
+          "This forecast", not "no rip current risk". The obvious short lead-in
+          -- "none is forecast here" -- reads as *there is no rip current risk
+          here*, which is a safety judgement this site is forbidden from making
+          (ADR-0009) and which would be worst at exactly these beaches: a lagoon
+          is calm until the day it is not. The sentence is about the product's
+          coverage and never about the water.
+
+          It also does not repeat the publisher. The reason already names the
+          National Weather Service, and a lead-in naming it again put the
+          agency twice in one sentence -- caught on the rendered page rather
+          than in a fixture, which is why the absence path is worth looking at
+          rather than only asserting.
+        */}
         <Absence>
-          The National Weather Service does not forecast one here:{" "}
-          {state.reason}.
+          This forecast is not issued for this beach: {state.reason}.
         </Absence>
       </section>
     );

--- a/src/components/conditions/WeekPanel.test.tsx
+++ b/src/components/conditions/WeekPanel.test.tsx
@@ -246,40 +246,20 @@ test("asks for the slug it was given and renders both live rows", async () => {
   expect(daylightWindows()).toHaveLength(2);
 });
 
-test("the forecasts that are not built yet are named, and waves are no longer among them", async () => {
-  readWeekOfLowestLows.mockResolvedValue({
-    ...BINDING,
-    state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
-  });
-
-  render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
-
-  // The wave slot came out in the same change that filled its row: a slot left
-  // in beside a live row promises the same product twice.
-  expect(screen.queryByText(/A wave forecast is coming/i)).toBeNull();
-  // The gridded slot went the same way in the change that filled its row.
-  expect(screen.queryByText(/A gridded forecast is coming/i)).toBeNull();
-  expect(screen.getByText(/surf zone forecast/i)).toBeDefined();
-});
-
 /**
- * The horizon the slot promises, held still.
+ * Nothing is reserved here any more, and this is the test that says so.
  *
- * It said "about three days ahead" until 2026-09-02, when all fourteen
- * issuances NWS SGX still held — seven days of them — were read and every one
- * carried exactly two periods for `CAZ043`. This asserts the sentence rather
- * than the ocean: nothing in CI reaches the National Weather Service, so a
- * change in what SGX issues is invisible here. The measurement is the
- * evidence; the test only stops the claim reverting silently, which is the
- * same division `inventoryCaveats()` is tested under.
+ * Three slots stood under this grid. Each came out in the change that filled
+ * it, never before -- a slot removed early leaves the page promising less than
+ * it did, and a slot left beside its live row promises the same product twice.
+ * The surf zone forecast is the last of the three, and it is now a block in the
+ * day panel rather than a promise under the week.
  *
- * "three days" is asserted absent by name because that is the specific wrong
- * figure, and it still stands in `docs/plans/conditions-tool.md`'s source
- * table — permanently, since that plan is historical and never corrected. So
- * the phrase remains copyable out of a document this repo keeps and reads,
- * which is exactly the reverting this test exists to catch.
+ * The band's own sentence goes with them: "Each of these will join the week
+ * above as a row of its own" is a claim about a band that no longer has
+ * anything in it.
  */
-test("the surf zone slot states the reach the product actually has", async () => {
+test("every reserved forecast has been filled, and none is promised twice", async () => {
   readWeekOfLowestLows.mockResolvedValue({
     ...BINDING,
     state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
@@ -287,11 +267,11 @@ test("the surf zone slot states the reach the product actually has", async () =>
 
   render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
 
-  const detail = screen.getByText(/Rip current risk/i).textContent ?? "";
-  expect(detail).toMatch(/about two days ahead/i);
-  expect(detail).not.toMatch(/three days/i);
-  // The cadence is the half a reader can act on, so it is in the copy too.
-  expect(detail).toMatch(/twice a day/i);
+  expect(screen.queryByText(/A wave forecast is coming/i)).toBeNull();
+  expect(screen.queryByText(/A gridded forecast is coming/i)).toBeNull();
+  expect(screen.queryByText(/surf zone forecast is coming/i)).toBeNull();
+  // The band that introduced them is gone too, not left over an empty grid.
+  expect(screen.queryByText(/will join the week above/i)).toBeNull();
 });
 
 /**
@@ -486,18 +466,28 @@ test("a failure to resolve the beach is not swallowed into a rendered nothing", 
 });
 
 /**
- * ADR-0015 marked the gridded slot with the air card's glyph while it was a
- * promise about that card. The slot is gone, so the glyph question goes with
- * it: rows in this grid carry no glyph at all -- a full-colour emoji at 10px is
- * a smudge rather than a mark -- and the only glyph left in this band belongs
- * to the one slot still reserved.
+ * No glyph is left in this band at all, and that discharges ADR-0015's open
+ * note.
  *
- * The day headers now carry a decorative sun, which is why this counts *text*
+ * That decision closed the reading cards' vocabulary at 🐚 🏄 💨 and recorded
+ * one thing it had not fixed: "🏖️ still marks the surf-zone forecast, and that
+ * is still wrong" -- the product is rip-current risk and the glyph is a beach
+ * parasol. It was left because the mark sat on a reserved slot rather than on a
+ * card, which put it outside that decision's subject. The slot is now gone, and
+ * the block that replaced it in the day panel takes no glyph: the vocabulary is
+ * scoped to cards, that block is not one, and borrowing 🏄 would put "waves and
+ * water" over a rip current risk.
+ *
+ * So the wrong glyph was never corrected. It left with the thing it was wrong
+ * about, which is the outcome ADR-0015 said it was recording the omission
+ * against.
+ *
+ * The day headers carry a decorative sun, which is why this counts *text*
  * rather than every `aria-hidden` node. That mark is a stroked SVG on
  * `currentColor` and contributes no characters, so it cannot be the smudge the
  * rule is about; the assertion below is that it stays that way.
  */
-test("the filled row brings no glyph, and only the reserved slot still has one", async () => {
+test("no glyph is left in the week band, the parasol included", async () => {
   readWeekOfLowestLows.mockResolvedValue({
     beachName: "La Jolla Shores Beach",
     station: { name: "La Jolla (Scripps Institution Wharf)", distanceM: 1369 },
@@ -511,7 +501,7 @@ test("the filled row brings no glyph, and only the reserved slot still has one",
   const glyphs = [...container.querySelectorAll('[aria-hidden="true"]')]
     .map((node) => node.textContent)
     .filter((text) => text !== "");
-  expect(glyphs).toEqual(["🏖️"]);
+  expect(glyphs).toEqual([]);
 
   // The header's mark draws rather than spells, so a day block contributes no
   // glyph text of its own.

--- a/src/components/conditions/WeekPanel.tsx
+++ b/src/components/conditions/WeekPanel.tsx
@@ -68,63 +68,7 @@ import {
 } from "./tideStation";
 import { TideWeek, TIDE_WEEK_ROW } from "./TideWeek";
 import { WaveWeek, WAVE_WEEK_ROW } from "./WaveWeek";
-import { WeekGrid, type ReservedRow, type WeekRow } from "./WeekGrid";
-
-/**
- * The forecasts this grid is shaped for and does not yet carry.
- *
- * **The wave slot is gone**, because the row it stood in for exists. It came out
- * in the same change that filled it: a slot removed before its replacement
- * would leave the page promising less than it did, and a slot left in beside a
- * filled row would promise it twice.
- *
- * **The gridded slot is gone**, because the row it stood in for exists. Same
- * rule the wave slot came out under: a slot removed before its replacement
- * would leave the page promising less than it did, and a slot left in beside a
- * filled row would promise it twice.
- *
- * **It promises sky and nothing else, and both halves of that are measured.**
- * Visibility cannot follow: the gridpoint declares `visibility` and
- * `ceilingHeight` as keys and publishes no values for either -- measured
- * 2026-08-26, zero entries at every one of the 21 cells covering this
- * inventory, against 34-37 for `skyCover` -- so a row promising visibility
- * would promise a product that does not exist. Temperature and wind must not
- * follow: they come from the air
- * station rather than an airport, measured at p50 3.7 km and max 7.4 km, and
- * ADR-0012 records them as among the best-founded readings here. Moving those
- * to a forecast is the displacement ADR-0019 declined to decide, and this row
- * previously promised it.
- *
- * The surf zone forecast is zone-level; it is the product the tide heights on
- * this page were checked against.
- *
- * **It reaches about two days, not three, and the slot said three until now.**
- * Measured 2026-09-02 against all fourteen issuances NWS SGX still held —
- * seven days of them — every one carried exactly two periods for `CAZ043`.
- * A morning issuance reads `TODAY` then a weekday; an afternoon one reads
- * `THIS AFTERNOON THROUGH <weekday>` then the day after, which is why the
- * reach is worth stating as "about" rather than as a number of days. The
- * three-day figure came from `docs/plans/conditions-tool.md`'s source table,
- * recorded from a 2026-08-17 measurement. It stays wrong there: that plan is
- * historical, and `docs/plans/README.md` is explicit that a shipped plan is a
- * dated record which is never corrected. What is still binding lives in
- * `docs/adr/`, which is why the measurement above is here and not there.
- *
- * The cadence is in the copy because it is the part a reader can act on: a
- * product reissued twice a day is one they should look at again, and a horizon
- * alone does not say that.
- *
- * No issue numbers in the copy. A reader is owed what is coming, not our
- * backlog — the sighting map's slot set that precedent.
- */
-const RESERVED: readonly ReservedRow[] = [
-  {
-    emoji: "🏖️",
-    headline: "The surf zone forecast is coming.",
-    detail:
-      "Rip current risk, surf height and water temperature, issued for this stretch of coast twice a day and reaching about two days ahead.",
-  },
-];
+import { WeekGrid, type WeekRow } from "./WeekGrid";
 
 /** What a day says when the window this page asked NOAA for did not reach it. */
 const NO_SERIES = "No hourly prediction for this day.";
@@ -503,7 +447,6 @@ export async function WeekPanel({ slug }: { slug: string }) {
       days={days}
       rows={rows}
       notes={notes}
-      reserved={RESERVED}
     />
   );
 }

--- a/src/components/conditions/selectedDay.test.tsx
+++ b/src/components/conditions/selectedDay.test.tsx
@@ -101,6 +101,8 @@ function dayView(index: number): DayView {
       },
     ],
     wording: <p>Words for {localDate}</p>,
+    // A stand-in: what these tests assert is the day selection, not this block.
+    surfZone: <p>Rip current risk on {localDate}</p>,
     measured: <p>Measured on {localDate}</p>,
   };
 }

--- a/src/components/conditions/selectedHour.test.tsx
+++ b/src/components/conditions/selectedHour.test.tsx
@@ -92,6 +92,8 @@ function dayView(index: number, tideHours = 24): DayView {
       },
     ],
     wording: <p>Words for {localDate}</p>,
+    // A stand-in: what these tests assert is the day selection, not this block.
+    surfZone: <p>Rip current risk on {localDate}</p>,
     measured: <p>Measured on {localDate}</p>,
   };
 }

--- a/src/lib/__fixtures__/nws-srf-sgx-20260901-1920z.txt
+++ b/src/lib/__fixtures__/nws-srf-sgx-20260901-1920z.txt
@@ -1,0 +1,87 @@
+
+000
+FZUS56 KSGX 011920
+SRFSGX
+
+Surf Zone Forecast
+National Weather Service San Diego CA
+1220 PM PDT Tue Sep 1 2026
+
+CAZ552-021015-
+Orange County Coastal Areas-
+1220 PM PDT Tue Sep 1 2026
+
+...MODERATE RIP CURRENT RISK...
+
+.THIS AFTERNOON THROUGH WEDNESDAY...
+Rip Current Risk*.............Moderate.
+Surf Height...................2 to 4 feet. Sets to 5 feet.
+Thunderstorm Potential........None expected.
+Water Temperature.............74 to 78 degrees.
+Tides.........................
+        Newport Beach.........High 3.4 feet (MLLW) 01:02 AM PDT.
+                              Low 1.9 feet (MLLW) 06:04 AM PDT.
+                              High 5.4 feet (MLLW) 12:55 PM PDT.
+                              Low 1.0 feet (MLLW) 08:25 PM PDT.
+Remarks.......................Mixed south wind swell from 180 degrees and west swell from 280 degrees.
+
+.THURSDAY...
+Rip Current Risk*.............Moderate.
+Surf Height...................2 to 4 feet.
+Thunderstorm Potential........None expected.
+Tides.........................
+        Newport Beach.........High 2.9 feet (MLLW) 02:46 AM PDT.
+                              Low 2.4 feet (MLLW) 06:28 AM PDT.
+                              High 5.4 feet (MLLW) 01:54 PM PDT.
+                              Low 0.8 feet (MLLW) 10:13 PM PDT.
+Remarks.......................Mixed south wind swell from 190 degrees and west swell from 270 degrees.
+
+
+&&
+
+Rip Current Risks:
+* Low Risk - Life threatening rip currents are unlikely but still could occur.
+* Moderate Risk - Life threatening rip currents are possible.
+* High Risk - Life threatening rip currents are likely.
+
+$$
+
+
+CAZ043-021015-
+San Diego County Coastal Areas-
+1220 PM PDT Tue Sep 1 2026
+
+...MODERATE RIP CURRENT RISK...
+
+.THIS AFTERNOON THROUGH WEDNESDAY...
+Rip Current Risk*.............Moderate.
+Surf Height...................2 to 4 feet.
+Thunderstorm Potential........None expected.
+Water Temperature.............70 to 76 degrees.
+Tides.........................
+        La Jolla..............High 3.4 feet (MLLW) 12:57 AM PDT.
+                              Low 1.9 feet (MLLW) 06:01 AM PDT.
+                              High 5.4 feet (MLLW) 12:50 PM PDT.
+                              Low 1.0 feet (MLLW) 08:24 PM PDT.
+Remarks.......................Mixed west swell from 280 degrees and south swell from 210 degrees.
+
+.THURSDAY...
+Rip Current Risk*.............Moderate.
+Surf Height...................2 to 4 feet.
+Thunderstorm Potential........None expected.
+Tides.........................
+        La Jolla..............High 2.8 feet (MLLW) 02:44 AM PDT.
+                              Low 2.5 feet (MLLW) 06:24 AM PDT.
+                              High 5.4 feet (MLLW) 01:50 PM PDT.
+                              Low 0.8 feet (MLLW) 10:11 PM PDT.
+Remarks.......................Mixed south swell from 210 degrees and west swell from 280 degrees.
+
+
+&&
+
+Rip Current Risks:
+* Low Risk - Life threatening rip currents are unlikely but still could occur.
+* Moderate Risk - Life threatening rip currents are possible.
+* High Risk - Life threatening rip currents are likely.
+
+$$

--- a/src/lib/__fixtures__/nws-srf-sgx-20260902-0854z.txt
+++ b/src/lib/__fixtures__/nws-srf-sgx-20260902-0854z.txt
@@ -1,0 +1,85 @@
+
+000
+FZUS56 KSGX 020854
+SRFSGX
+
+Surf Zone Forecast
+National Weather Service San Diego CA
+154 AM PDT Wed Sep 2 2026
+
+CAZ552-022130-
+Orange County Coastal Areas-
+154 AM PDT Wed Sep 2 2026
+
+
+.TODAY...
+Rip Current Risk*.............Low.
+Surf Height...................1 to 3 feet. Sets to 4 feet.
+Thunderstorm Potential........None expected.
+Water Temperature.............71 to 78 degrees.
+Tides.........................
+        Newport Beach.........High 3.4 feet (MLLW) 01:02 AM PDT.
+                              Low 1.9 feet (MLLW) 06:04 AM PDT.
+                              High 5.4 feet (MLLW) 12:55 PM PDT.
+                              Low 1.0 feet (MLLW) 08:25 PM PDT.
+Remarks.......................Mixed swell from 180 and 280 degrees.
+
+.THURSDAY...
+Rip Current Risk*.............Low.
+Surf Height...................1 to 3 feet. Sets to 4 feet
+Thunderstorm Potential........None expected.
+Tides.........................
+        Newport Beach.........High 2.9 feet (MLLW) 02:46 AM PDT.
+                              Low 2.4 feet (MLLW) 06:28 AM PDT.
+                              High 5.4 feet (MLLW) 01:54 PM PDT.
+                              Low 0.8 feet (MLLW) 10:13 PM PDT.
+Remarks.......................Mixed swell from 190 and 270 degrees.
+
+
+&&
+
+Rip Current Risks:
+* Low Risk - Life threatening rip currents are unlikely but still could occur.
+* Moderate Risk - Life threatening rip currents are possible.
+* High Risk - Life threatening rip currents are likely.
+
+$$
+
+
+CAZ043-022130-
+San Diego County Coastal Areas-
+154 AM PDT Wed Sep 2 2026
+
+
+.TODAY...
+Rip Current Risk*.............Low.
+Surf Height...................1 to 3 feet. Sets to 4 feet.
+Thunderstorm Potential........None expected.
+Water Temperature.............70 to 74 degrees.
+Tides.........................
+        La Jolla..............High 3.4 feet (MLLW) 12:57 AM PDT.
+                              Low 1.9 feet (MLLW) 06:01 AM PDT.
+                              High 5.4 feet (MLLW) 12:50 PM PDT.
+                              Low 1.0 feet (MLLW) 08:24 PM PDT.
+Remarks.......................Mixed swell from 280 and 210 degrees.
+
+.THURSDAY...
+Rip Current Risk*.............Low.
+Surf Height...................1 to 3 feet. Sets to 4 feet.
+Thunderstorm Potential........None expected.
+Tides.........................
+        La Jolla..............High 2.8 feet (MLLW) 02:44 AM PDT.
+                              Low 2.5 feet (MLLW) 06:24 AM PDT.
+                              High 5.4 feet (MLLW) 01:50 PM PDT.
+                              Low 0.8 feet (MLLW) 10:11 PM PDT.
+Remarks.......................Mixed swell from 210 and 280 degrees.
+
+
+&&
+
+Rip Current Risks:
+* Low Risk - Life threatening rip currents are unlikely but still could occur.
+* Moderate Risk - Life threatening rip currents are possible.
+* High Risk - Life threatening rip currents are likely.
+
+$$

--- a/src/lib/__fixtures__/nws-srf-sgx-products-20260902.json
+++ b/src/lib/__fixtures__/nws-srf-sgx-products-20260902.json
@@ -1,0 +1,134 @@
+{
+  "@context": {
+    "@version": "1.1",
+    "@vocab": "https://api.weather.gov/ontology#"
+  },
+  "@graph": [
+    {
+      "@id": "https://api.weather.gov/products/36f48a5d-9b57-4fe2-9808-5f6a68ec4c64",
+      "id": "36f48a5d-9b57-4fe2-9808-5f6a68ec4c64",
+      "wmoCollectiveId": "FZUS56",
+      "issuingOffice": "KSGX",
+      "issuanceTime": "2026-09-02T08:54:00+00:00",
+      "productCode": "SRF",
+      "productName": "Surf Forecast"
+    },
+    {
+      "@id": "https://api.weather.gov/products/a62f8503-d094-4b25-ab00-28a318f1ee8d",
+      "id": "a62f8503-d094-4b25-ab00-28a318f1ee8d",
+      "wmoCollectiveId": "FZUS56",
+      "issuingOffice": "KSGX",
+      "issuanceTime": "2026-09-01T19:20:00+00:00",
+      "productCode": "SRF",
+      "productName": "Surf Forecast"
+    },
+    {
+      "@id": "https://api.weather.gov/products/4090affd-407f-4d0f-95f5-78c031f2643a",
+      "id": "4090affd-407f-4d0f-95f5-78c031f2643a",
+      "wmoCollectiveId": "FZUS56",
+      "issuingOffice": "KSGX",
+      "issuanceTime": "2026-09-01T08:44:00+00:00",
+      "productCode": "SRF",
+      "productName": "Surf Forecast"
+    },
+    {
+      "@id": "https://api.weather.gov/products/666a91b7-4cf1-416b-9908-548ce9ffd1d8",
+      "id": "666a91b7-4cf1-416b-9908-548ce9ffd1d8",
+      "wmoCollectiveId": "FZUS56",
+      "issuingOffice": "KSGX",
+      "issuanceTime": "2026-08-31T20:15:00+00:00",
+      "productCode": "SRF",
+      "productName": "Surf Forecast"
+    },
+    {
+      "@id": "https://api.weather.gov/products/d839a5af-c85f-4b7a-9565-ea0f791b2a75",
+      "id": "d839a5af-c85f-4b7a-9565-ea0f791b2a75",
+      "wmoCollectiveId": "FZUS56",
+      "issuingOffice": "KSGX",
+      "issuanceTime": "2026-08-31T08:20:00+00:00",
+      "productCode": "SRF",
+      "productName": "Surf Forecast"
+    },
+    {
+      "@id": "https://api.weather.gov/products/ceb53aaf-cf93-47f4-b94d-e64a51a811bd",
+      "id": "ceb53aaf-cf93-47f4-b94d-e64a51a811bd",
+      "wmoCollectiveId": "FZUS56",
+      "issuingOffice": "KSGX",
+      "issuanceTime": "2026-08-30T19:09:00+00:00",
+      "productCode": "SRF",
+      "productName": "Surf Forecast"
+    },
+    {
+      "@id": "https://api.weather.gov/products/7508a2e0-a01b-4c19-b006-cdb6c99d12a2",
+      "id": "7508a2e0-a01b-4c19-b006-cdb6c99d12a2",
+      "wmoCollectiveId": "FZUS56",
+      "issuingOffice": "KSGX",
+      "issuanceTime": "2026-08-30T07:59:00+00:00",
+      "productCode": "SRF",
+      "productName": "Surf Forecast"
+    },
+    {
+      "@id": "https://api.weather.gov/products/ae09e2ab-7756-4a26-b9b9-d84058d7ddbc",
+      "id": "ae09e2ab-7756-4a26-b9b9-d84058d7ddbc",
+      "wmoCollectiveId": "FZUS56",
+      "issuingOffice": "KSGX",
+      "issuanceTime": "2026-08-29T21:01:00+00:00",
+      "productCode": "SRF",
+      "productName": "Surf Forecast"
+    },
+    {
+      "@id": "https://api.weather.gov/products/2ed36b15-0506-4153-b140-0625c6585014",
+      "id": "2ed36b15-0506-4153-b140-0625c6585014",
+      "wmoCollectiveId": "FZUS56",
+      "issuingOffice": "KSGX",
+      "issuanceTime": "2026-08-29T07:11:00+00:00",
+      "productCode": "SRF",
+      "productName": "Surf Forecast"
+    },
+    {
+      "@id": "https://api.weather.gov/products/6ba76c17-6450-4b3a-8691-78c9e890eee0",
+      "id": "6ba76c17-6450-4b3a-8691-78c9e890eee0",
+      "wmoCollectiveId": "FZUS56",
+      "issuingOffice": "KSGX",
+      "issuanceTime": "2026-08-28T19:44:00+00:00",
+      "productCode": "SRF",
+      "productName": "Surf Forecast"
+    },
+    {
+      "@id": "https://api.weather.gov/products/5f5fcfda-4187-4b0c-b55d-89095fc4d1b1",
+      "id": "5f5fcfda-4187-4b0c-b55d-89095fc4d1b1",
+      "wmoCollectiveId": "FZUS56",
+      "issuingOffice": "KSGX",
+      "issuanceTime": "2026-08-28T07:11:00+00:00",
+      "productCode": "SRF",
+      "productName": "Surf Forecast"
+    },
+    {
+      "@id": "https://api.weather.gov/products/f0b960f6-415b-47dc-bca7-0c03c82779da",
+      "id": "f0b960f6-415b-47dc-bca7-0c03c82779da",
+      "wmoCollectiveId": "FZUS56",
+      "issuingOffice": "KSGX",
+      "issuanceTime": "2026-08-27T20:39:00+00:00",
+      "productCode": "SRF",
+      "productName": "Surf Forecast"
+    },
+    {
+      "@id": "https://api.weather.gov/products/f87a61af-c081-47d8-85d8-2a88dba1cf3f",
+      "id": "f87a61af-c081-47d8-85d8-2a88dba1cf3f",
+      "wmoCollectiveId": "FZUS56",
+      "issuingOffice": "KSGX",
+      "issuanceTime": "2026-08-27T08:17:00+00:00",
+      "productCode": "SRF",
+      "productName": "Surf Forecast"
+    },
+    {
+      "@id": "https://api.weather.gov/products/906fd832-07e4-4448-bbee-62e2647915e3",
+      "id": "906fd832-07e4-4448-bbee-62e2647915e3",
+      "wmoCollectiveId": "FZUS56",
+      "issuingOffice": "KSGX",
+      "issuanceTime": "2026-08-26T19:10:00+00:00",
+      "productCode": "SRF",
+      "productName": "Surf Forecast"
+    }
+  ]
+}

--- a/src/lib/beaches.test.ts
+++ b/src/lib/beaches.test.ts
@@ -9,6 +9,7 @@ import {
   inventoryReach,
   airStationFor,
   mopLineFor,
+  surfZoneWithheldReason,
   tideStationFor,
   waveBuoyFor,
 } from "./beaches";
@@ -563,5 +564,58 @@ describe("the air station binding", () => {
         `${beach.slug}: ${beach.air_station_null_reason}`,
       ).not.toBeNull();
     }
+  });
+});
+
+describe("which beaches the surf zone forecast describes", () => {
+  /**
+   * Asserted against the shipped inventory rather than a fixture, so it is
+   * evidence about this county's beaches rather than about a file written to
+   * make it pass. The split was 26 open coast to 25 sheltered on 2026-09-02.
+   */
+  test("half the inventory has no surf zone", () => {
+    const withheld = allBeaches().filter(
+      (beach) => surfZoneWithheldReason(beach) !== null,
+    );
+
+    expect(allBeaches()).toHaveLength(51);
+    expect(withheld).toHaveLength(25);
+  });
+
+  /**
+   * Two independent classifications of the same water: the region a beach is
+   * grouped under for the chooser, and the water class its tide station was
+   * bound by. They agreed on all 51, which is why reading either is defensible
+   * and why this holds the agreement still -- a beach that moved region without
+   * moving station, or the reverse, would be a data error worth stopping on
+   * rather than a silent change in who sees a rip current risk.
+   */
+  test("the water class and the region agree on every beach", () => {
+    for (const beach of allBeaches()) {
+      const sheltered = surfZoneWithheldReason(beach) !== null;
+      expect({
+        slug: beach.slug,
+        sheltered,
+      }).toEqual({
+        slug: beach.slug,
+        sheltered: beach.region === "Bays, lagoons and inlets",
+      });
+    }
+  });
+
+  test("an open-coast beach is not withheld", () => {
+    expect(surfZoneWithheldReason(beachBySlug(DEFAULT_BEACH_SLUG)!)).toBeNull();
+  });
+
+  /**
+   * The reason is written for a reader, in the voice `wave_buoy_null_reason`
+   * already uses at these same beaches -- it says what is true of the place,
+   * not that a lookup returned nothing.
+   */
+  test("a sheltered beach's reason names the water rather than the lookup", () => {
+    const reason = surfZoneWithheldReason(beachBySlug("mission-bay-sail-bay")!);
+
+    expect(reason).toContain("bay, lagoon or inlet has no surf zone");
+    expect(reason).not.toMatch(/null|undefined|lookup|binding/i);
   });
 });

--- a/src/lib/beaches.ts
+++ b/src/lib/beaches.ts
@@ -316,6 +316,43 @@ export function tideStationFor(
 }
 
 /**
+ * Why the surf zone forecast does not describe this beach, or null when it does.
+ *
+ * **Half the inventory has no surf zone.** The National Weather Service issues
+ * `CAZ043` for San Diego County *Coastal Areas*, and 25 of the 51 beaches here
+ * are bays, lagoons and inlets. Printing "Rip Current Risk: High" over Sail Bay
+ * would alarm about a hazard that is not there, and would teach a reader that
+ * the line is not about the beach they chose — which costs it on the 26 beaches
+ * where it is the most important thing on the page.
+ *
+ * This is the same withholding the wave join already makes, for the same
+ * reason, and it is deliberately *not* the readout's rule: the readout is drawn
+ * on all 51 because wind blows on a bay, so a wind figure there is true.
+ *
+ * **Read off the tide station's water class rather than off the region.** Both
+ * classify the inventory identically — checked 51 of 51 — but the region is a
+ * grouping for a dropdown while the water class is a joined fact about the
+ * water, carried because the tide join has to bind an open-coast beach to an
+ * open-coast station. A beach with no tide station at all is treated as having
+ * no surf zone, because nothing here then says which water it is in.
+ */
+export function surfZoneWithheldReason(beach: Beach): string | null {
+  const station = tideStationFor(beach);
+  if (station === null) {
+    return (
+      "no tide station is bound to this beach, so nothing here says whether it is open " +
+      "coast or sheltered water, and a surf zone forecast is only true of the one"
+    );
+  }
+  if (station.water === "open-coast") return null;
+  return (
+    "the National Weather Service issues this forecast for San Diego County's coastal " +
+    "areas, and a bay, lagoon or inlet has no surf zone, so it does not describe the " +
+    "water here"
+  );
+}
+
+/**
  * The wave buoy a beach reads, or null when the join bound none.
  *
  * Throws when a beach names a buoy the table does not describe -- a broken pair

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -10,9 +10,11 @@ const fetchLatestNdbcAir = vi.fn();
 const fetchMopForecast = vi.fn();
 const fetchGridForecast = vi.fn();
 const fetchSkyWording = vi.fn();
+const fetchSurfZoneForecast = vi.fn();
 vi.mock("./upstream", () => ({
   fetchGridForecast,
   fetchSkyWording,
+  fetchSurfZoneForecast,
   fetchHourlyTide,
   fetchTideExtremes,
   fetchLatestWave,
@@ -1953,4 +1955,203 @@ test("this read fails apart from the cloud row's, being a separate product", asy
 
   expect(sky.state.kind).toBe("week");
   expect(wording.state.kind).toBe("unavailable");
+});
+
+/**
+ * The surf zone forecast, which is the page's only relayed judgement.
+ *
+ * `readSurfZone` is asserted against fixed instants like every read here. The
+ * bulletin itself is parsed elsewhere; what is under test is the flattening
+ * from the publisher's periods onto this page's days, and the withholding.
+ */
+const SURF_ZONE_MEANINGS = [
+  {
+    level: "Low" as const,
+    meaning:
+      "Life threatening rip currents are unlikely but still could occur.",
+  },
+  {
+    level: "Moderate" as const,
+    meaning: "Life threatening rip currents are possible.",
+  },
+  {
+    level: "High" as const,
+    meaning: "Life threatening rip currents are likely.",
+  },
+];
+
+/** Wednesday 2026-09-02, 9 AM Pacific. */
+const SURF_ZONE_NOW = localMidnightOf("2026-09-02") + 9 * 3_600_000;
+
+function servingSurfZone(
+  periods: {
+    name: string;
+    localDates: string[];
+    level: "Low" | "Moderate" | "High";
+  }[],
+  headline: string | null = null,
+) {
+  fetchSurfZoneForecast.mockResolvedValue({
+    kind: "ok",
+    url: "https://api.weather.gov/products/abc",
+    forecast: {
+      zoneId: "CAZ043",
+      issuedMs: Date.parse("2026-09-02T08:54:00+00:00"),
+      headline,
+      periods,
+      meanings: SURF_ZONE_MEANINGS,
+    },
+  });
+}
+
+test("a period covering two dates becomes two days, both at that period's risk", async () => {
+  const { readSurfZone } = await import("./conditions");
+  // An afternoon bulletin's shape: today's remainder merged with tomorrow.
+  servingSurfZone([
+    {
+      name: "THIS AFTERNOON THROUGH WEDNESDAY",
+      localDates: ["2026-09-01", "2026-09-02"],
+      level: "Moderate",
+    },
+    { name: "THURSDAY", localDates: ["2026-09-03"], level: "High" },
+  ]);
+
+  const view = await readSurfZone(BEACH, SURF_ZONE_NOW);
+
+  expect(view.state.kind).toBe("forecast");
+  if (view.state.kind !== "forecast") return;
+  // 2026-09-01 is behind this page's week, so it is not a day here; the panel
+  // shows the days it has, and the flattening does not invent a past one.
+  expect(view.state.days.map((day) => day.localDate)).toEqual([
+    "2026-09-02",
+    "2026-09-03",
+  ]);
+  expect(view.state.days.map((day) => day.level)).toEqual(["Moderate", "High"]);
+  // Both dates of the merged period keep the publisher's name for it, because
+  // that name is what the page prints rather than a date we chose.
+  expect(view.state.days[0].periodName).toBe(
+    "THIS AFTERNOON THROUGH WEDNESDAY",
+  );
+});
+
+test("the gloss on each day is the bulletin's own sentence", async () => {
+  const { readSurfZone } = await import("./conditions");
+  servingSurfZone([
+    { name: "TODAY", localDates: ["2026-09-02"], level: "High" },
+  ]);
+
+  const view = await readSurfZone(BEACH, SURF_ZONE_NOW);
+
+  expect(view.state.kind).toBe("forecast");
+  if (view.state.kind !== "forecast") return;
+  expect(view.state.days[0].meaning).toBe(
+    "Life threatening rip currents are likely.",
+  );
+});
+
+/**
+ * The headline is the bulletin's and the level is the day's, and on 2026-08-28
+ * they disagreed: HIGH RIP CURRENT RISK over a TODAY that read Moderate,
+ * because Saturday was the High one. Both are correct at their own scope, so
+ * this asserts the read does not quietly reconcile them.
+ */
+test("a headline naming a level no day carries is relayed unreconciled", async () => {
+  const { readSurfZone } = await import("./conditions");
+  servingSurfZone(
+    [{ name: "TODAY", localDates: ["2026-09-02"], level: "Moderate" }],
+    "HIGH RIP CURRENT RISK",
+  );
+
+  const view = await readSurfZone(BEACH, SURF_ZONE_NOW);
+
+  expect(view.state.kind).toBe("forecast");
+  if (view.state.kind !== "forecast") return;
+  expect(view.state.headline).toBe("HIGH RIP CURRENT RISK");
+  expect(view.state.days[0].level).toBe("Moderate");
+});
+
+test("the days the bulletin did not reach are absent rather than padded", async () => {
+  const { readSurfZone } = await import("./conditions");
+  servingSurfZone([
+    { name: "TODAY", localDates: ["2026-09-02"], level: "Low" },
+  ]);
+
+  const view = await readSurfZone(BEACH, SURF_ZONE_NOW);
+
+  expect(view.state.kind).toBe("forecast");
+  if (view.state.kind !== "forecast") return;
+  expect(view.state.days).toHaveLength(1);
+});
+
+/**
+ * Half the inventory. A *surf zone* forecast for coastal areas does not
+ * describe a lagoon, and the request is not made at all rather than made and
+ * discarded.
+ */
+test("a bay beach is withheld with a reason, and the office is not asked", async () => {
+  const { readSurfZone } = await import("./conditions");
+  fetchSurfZoneForecast.mockReset();
+
+  const view = await readSurfZone("mission-bay-sail-bay", SURF_ZONE_NOW);
+
+  expect(view.state.kind).toBe("no-surf-zone");
+  if (view.state.kind !== "no-surf-zone") return;
+  expect(view.state.reason).toContain("no surf zone");
+  expect(fetchSurfZoneForecast).not.toHaveBeenCalled();
+});
+
+test("a quiet office is reported to the reader with its reason", async () => {
+  const { readSurfZone } = await import("./conditions");
+  fetchSurfZoneForecast.mockResolvedValue({
+    kind: "unavailable",
+    reason:
+      "The National Weather Service returned HTTP 503 for SGX's bulletins.",
+    drift: false,
+    url: "https://api.weather.gov/products/types/SRF/locations/SGX",
+  });
+
+  const view = await readSurfZone(BEACH, SURF_ZONE_NOW);
+
+  expect(view.state.kind).toBe("unavailable");
+  if (view.state.kind !== "unavailable") return;
+  expect(view.state.detail).toContain("503");
+  expect(view.state.drift).toBe(false);
+});
+
+test("an unknown slug is a caller's bug rather than an empty forecast", async () => {
+  const { readSurfZone } = await import("./conditions");
+
+  await expect(readSurfZone("not-a-beach", SURF_ZONE_NOW)).rejects.toThrow(
+    /no beach in the inventory/,
+  );
+});
+
+/**
+ * The bulletin defines its own levels in its own body, so a level arriving
+ * without a gloss means the office changed the bulletin -- not that this level
+ * has no meaning. Said plainly rather than left as a blank line under a word
+ * like "High", which is the one place on this page a reader must not be left
+ * to guess.
+ */
+test("a level whose gloss the bulletin dropped says so rather than rendering blank", async () => {
+  const { readSurfZone } = await import("./conditions");
+  fetchSurfZoneForecast.mockResolvedValue({
+    kind: "ok",
+    url: "https://api.weather.gov/products/abc",
+    forecast: {
+      zoneId: "CAZ043",
+      issuedMs: Date.parse("2026-09-02T08:54:00+00:00"),
+      headline: null,
+      periods: [
+        { name: "TODAY", localDates: ["2026-09-02"], level: "High" as const },
+      ],
+      meanings: [],
+    },
+  });
+
+  const view = await readSurfZone(BEACH, SURF_ZONE_NOW);
+
+  expect(view.state.kind).toBe("forecast");
+  if (view.state.kind !== "forecast") return;
+  expect(view.state.days[0].meaning).toMatch(/did not carry/i);
 });

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -16,6 +16,7 @@ import {
   type Beach,
   beachBySlug,
   mopLineFor,
+  surfZoneWithheldReason,
   tideStationFor,
   waveBuoyFor,
   type ObservationStation,
@@ -39,10 +40,12 @@ import type {
   WeatherHour,
 } from "./nws-gridpoint";
 import type { ForecastPeriod } from "./nws-forecast";
+import type { RiskLevel } from "./nws-surf-zone";
 import {
   fetchGridForecast,
   fetchHourlyTide,
   fetchSkyWording,
+  fetchSurfZoneForecast,
   fetchLatestNdbcAir,
   fetchLatestObservation,
   fetchLatestWave,
@@ -1837,4 +1840,127 @@ export async function readSkyWording(
   });
 
   return { ...binding, state: { kind: "week", days } };
+}
+
+/** One day of the surf zone forecast, as the panel prints it. */
+export type SurfZoneDay = {
+  localDate: string;
+  /** The publisher's own name for the period this day was read from. */
+  periodName: string;
+  level: RiskLevel;
+  /** The bulletin's own sentence for that level. */
+  meaning: string;
+};
+
+export type SurfZoneView = {
+  beachName: string;
+  state:
+    | {
+        kind: "forecast";
+        issuedMs: number;
+        /**
+         * The office's own emphasis line, or null.
+         *
+         * Scoped to the bulletin rather than to a day, and it may name a level
+         * no day below it does -- measured 2026-08-28, headline HIGH over a
+         * TODAY that read Moderate. Carried unreconciled, because both are
+         * correct at their own scope.
+         */
+        headline: string | null;
+        /** Only the days the bulletin reached, ascending. Never padded. */
+        days: SurfZoneDay[];
+      }
+    | { kind: "unavailable"; detail: string; drift: boolean }
+    /** This beach has no surf zone, so the product is not about it. */
+    | { kind: "no-surf-zone"; reason: string };
+};
+
+/**
+ * The surf zone forecast for one beach.
+ *
+ * **The zone is the inventory's, not the beach's.** Every beach here resolves
+ * to `CAZ043`, so this read takes no zone argument and there is no per-beach
+ * binding to go stale -- see `SURF_ZONE_ID` for the measurement that decided
+ * it. What is per-beach is whether the product describes this water at all.
+ *
+ * **The withholding is decided before the fetch.** A bay beach does not reach
+ * the National Weather Service at all, which is the right order: asking for a
+ * forecast in order to throw it away would put 25 beaches' worth of requests on
+ * a publisher for nothing.
+ *
+ * `nowMs` is injected for the reason every read here injects it: day selection
+ * is asserted against fixed instants and no clock is read during a render.
+ */
+export async function readSurfZone(
+  slug: string,
+  nowMs: number = Date.now(),
+): Promise<SurfZoneView> {
+  const beach = beachBySlug(slug);
+  if (!beach) {
+    throw new Error(
+      `readSurfZone: no beach in the inventory with slug "${slug}".`,
+    );
+  }
+
+  const withheld = surfZoneWithheldReason(beach);
+  if (withheld !== null) {
+    return {
+      beachName: beach.name,
+      state: { kind: "no-surf-zone", reason: withheld },
+    };
+  }
+
+  const result = await fetchSurfZoneForecast();
+  if (result.kind === "unavailable") {
+    return {
+      beachName: beach.name,
+      state: {
+        kind: "unavailable",
+        detail: result.reason,
+        drift: result.drift,
+      },
+    };
+  }
+
+  const { forecast } = result;
+  const meanings = new Map(
+    forecast.meanings.map((entry) => [entry.level, entry.meaning]),
+  );
+
+  // Flattened from periods to days, because the panel is indexed by day and the
+  // product is not: an afternoon bulletin's first period covers two dates, and
+  // both of them are that period's risk.
+  const byDate = new Map<string, SurfZoneDay>();
+  for (const period of forecast.periods) {
+    for (const localDate of period.localDates) {
+      byDate.set(localDate, {
+        localDate,
+        periodName: period.name,
+        level: period.level,
+        meaning:
+          meanings.get(period.level) ??
+          // The bulletin defines its levels in its own body, so a missing gloss
+          // means the office changed the bulletin rather than that this level
+          // has no meaning. Said plainly rather than left blank.
+          "The bulletin did not carry its usual explanation of this level.",
+      });
+    }
+  }
+
+  // Walked over this page's own week rather than over the payload's dates, so
+  // this cannot disagree with the rows above it about which day is Tuesday.
+  const days = weekOfDays(nowMs).flatMap((frame) => {
+    const day = byDate.get(frame.localDate);
+    return day === undefined ? [] : [day];
+  });
+
+  return {
+    beachName: beach.name,
+    state: {
+      kind: "forecast",
+      issuedMs: forecast.issuedMs,
+      headline: forecast.headline,
+      days,
+    },
+  };
 }

--- a/src/lib/nws-surf-zone.test.ts
+++ b/src/lib/nws-surf-zone.test.ts
@@ -1,0 +1,353 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  NwsSurfZoneDriftError,
+  NwsSurfZoneNoDataError,
+  parseSurfZoneForecast,
+  parseSurfZoneProductList,
+  resolvePeriodDates,
+  SURF_ZONE_ID,
+  surfZoneProductsUrl,
+  surfZoneProductUrl,
+} from "./nws-surf-zone";
+
+/**
+ * Two real bulletins, captured from `api.weather.gov` on 2026-09-02.
+ *
+ * **Both period-label shapes are here on purpose, and one fixture could not
+ * have shown both.** The morning bulletin names its periods `TODAY` and a
+ * weekday; the afternoon one names them `THIS AFTERNOON THROUGH WEDNESDAY` —
+ * today's remainder merged with tomorrow — and then the day after. A capture
+ * taken at a single time of day would have hidden the merge, and the merge is
+ * the case the day panel keys into.
+ *
+ * The afternoon one also carries a headline and the morning one does not,
+ * which is the other split worth having a real payload for rather than a
+ * hand-written one.
+ *
+ * The path is resolved from the working directory rather than
+ * `import.meta.url`, which is not a `file:` URL under this test environment.
+ */
+function fixture(name: string): string {
+  return readFileSync(
+    join(process.cwd(), "src", "lib", "__fixtures__", name),
+    "utf8",
+  );
+}
+
+/** Issued 1:54 AM PDT Wed Sep 2 2026. Periods: TODAY, THURSDAY. No headline. */
+const MORNING = fixture("nws-srf-sgx-20260902-0854z.txt");
+const MORNING_ISSUED = Date.parse("2026-09-02T08:54:00+00:00");
+
+/**
+ * Issued 12:20 PM PDT Tue Sep 1 2026. Periods: THIS AFTERNOON THROUGH
+ * WEDNESDAY, THURSDAY. Headline: MODERATE RIP CURRENT RISK.
+ */
+const AFTERNOON = fixture("nws-srf-sgx-20260901-1920z.txt");
+const AFTERNOON_ISSUED = Date.parse("2026-09-01T19:20:00+00:00");
+
+const LISTING = JSON.parse(fixture("nws-srf-sgx-products-20260902.json"));
+
+describe("the URLs", () => {
+  it("names the office's bulletin listing and one bulletin by id", () => {
+    expect(surfZoneProductsUrl()).toBe(
+      "https://api.weather.gov/products/types/SRF/locations/SGX",
+    );
+    expect(surfZoneProductUrl("abc-123")).toBe(
+      "https://api.weather.gov/products/abc-123",
+    );
+  });
+});
+
+describe("the bulletin listing", () => {
+  it("takes the newest bulletin the office is serving", () => {
+    const ref = parseSurfZoneProductList(LISTING);
+
+    expect(ref.id).toBe("36f48a5d-9b57-4fe2-9808-5f6a68ec4c64");
+    expect(ref.issuedMs).toBe(MORNING_ISSUED);
+  });
+
+  /**
+   * The listing arrives newest-first today and the parser sorts anyway. This
+   * asserts the sort rather than the arrival order, by handing it the same
+   * entries reversed: an implementation taking `[0]` passes the test above and
+   * fails this one.
+   */
+  it("takes the newest by stated issuance, not by position", () => {
+    const reversed = { "@graph": [...LISTING["@graph"]].reverse() };
+
+    expect(parseSurfZoneProductList(reversed).issuedMs).toBe(MORNING_ISSUED);
+  });
+
+  it("refuses an issuance instant with no offset", () => {
+    const noOffset = {
+      "@graph": [{ id: "x", issuanceTime: "2026-09-02T08:54:00" }],
+    };
+
+    expect(() => parseSurfZoneProductList(noOffset)).toThrow(
+      NwsSurfZoneDriftError,
+    );
+  });
+
+  it("reports an office serving nothing as no data rather than as drift", () => {
+    expect(() => parseSurfZoneProductList({ "@graph": [] })).toThrow(
+      NwsSurfZoneNoDataError,
+    );
+  });
+
+  it("refuses a listing that is not the JSON-LD shape it was asked for", () => {
+    expect(() => parseSurfZoneProductList({ features: [] })).toThrow(
+      NwsSurfZoneDriftError,
+    );
+  });
+});
+
+describe("the morning bulletin", () => {
+  it("reads its two periods onto today and tomorrow", () => {
+    const forecast = parseSurfZoneForecast(MORNING, MORNING_ISSUED);
+
+    expect(forecast.zoneId).toBe("CAZ043");
+    expect(forecast.periods.map((period) => period.name)).toEqual([
+      "TODAY",
+      "THURSDAY",
+    ]);
+    expect(forecast.periods.map((period) => period.localDates)).toEqual([
+      ["2026-09-02"],
+      ["2026-09-03"],
+    ]);
+  });
+
+  it("relays the published levels", () => {
+    const forecast = parseSurfZoneForecast(MORNING, MORNING_ISSUED);
+
+    expect(forecast.periods.map((period) => period.level)).toEqual([
+      "Low",
+      "Low",
+    ]);
+  });
+
+  /** 3 of the 14 issuances carried none. A parser requiring one fails on a quiet day. */
+  it("carries no headline when the office published none", () => {
+    expect(parseSurfZoneForecast(MORNING, MORNING_ISSUED).headline).toBeNull();
+  });
+
+  /**
+   * The gloss on the page is the publisher's sentence, not one this site wrote.
+   * ADR-0009 forbids this site forming the judgement; authoring the words that
+   * explain it would be forming it one step removed.
+   */
+  it("carries the bulletin's own glossary of its three levels", () => {
+    const forecast = parseSurfZoneForecast(MORNING, MORNING_ISSUED);
+
+    expect(forecast.meanings).toEqual([
+      {
+        level: "Low",
+        meaning:
+          "Life threatening rip currents are unlikely but still could occur.",
+      },
+      {
+        level: "Moderate",
+        meaning: "Life threatening rip currents are possible.",
+      },
+      { level: "High", meaning: "Life threatening rip currents are likely." },
+    ]);
+  });
+});
+
+describe("the afternoon bulletin", () => {
+  /**
+   * The case a single fixture would have hidden. Issued Tuesday afternoon, its
+   * first period is `THIS AFTERNOON THROUGH WEDNESDAY` and covers two calendar
+   * days, which pushes the second period to Thursday. So an afternoon bulletin
+   * describes three days where a morning one describes two.
+   */
+  it("merges today's remainder with tomorrow, and dates both", () => {
+    const forecast = parseSurfZoneForecast(AFTERNOON, AFTERNOON_ISSUED);
+
+    expect(forecast.periods.map((period) => period.name)).toEqual([
+      "THIS AFTERNOON THROUGH WEDNESDAY",
+      "THURSDAY",
+    ]);
+    expect(forecast.periods[0].localDates).toEqual([
+      "2026-09-01",
+      "2026-09-02",
+    ]);
+    expect(forecast.periods[1].localDates).toEqual(["2026-09-03"]);
+  });
+
+  it("relays the office's own headline without its emphasis markers", () => {
+    const forecast = parseSurfZoneForecast(AFTERNOON, AFTERNOON_ISSUED);
+
+    expect(forecast.headline).toBe("MODERATE RIP CURRENT RISK");
+  });
+});
+
+/**
+ * The failure this parser exists to make loud.
+ *
+ * SGX issues San Diego and Orange County in one bulletin. Measured 2026-09-02,
+ * San Diego read 70 to 74 degrees against Orange's 71 to 78, and quoted tides
+ * at La Jolla against Newport Beach. A parser that fell through to whichever
+ * section it found would render Orange County's forecast under a San Diego
+ * heading and look entirely plausible doing it.
+ */
+describe("the zone section", () => {
+  it("refuses to fall through to the other county in the same bulletin", () => {
+    // The real bulletin with the San Diego section removed, leaving Orange
+    // County's — the exact payload a fallback would have rendered wrongly.
+    const orangeOnly = MORNING.slice(0, MORNING.indexOf("CAZ043-"));
+    expect(orangeOnly).toContain("CAZ552-");
+
+    expect(() => parseSurfZoneForecast(orangeOnly, MORNING_ISSUED)).toThrow(
+      NwsSurfZoneNoDataError,
+    );
+  });
+
+  it("reads the requested zone rather than the first one in the text", () => {
+    // CAZ552 is published first in this bulletin; asking for it must not
+    // return the San Diego section, and asking for San Diego must not return
+    // Orange's, which the period dates below distinguish.
+    const orange = parseSurfZoneForecast(MORNING, MORNING_ISSUED, "CAZ552");
+
+    expect(orange.zoneId).toBe("CAZ552");
+    expect(MORNING.indexOf("CAZ552-")).toBeLessThan(MORNING.indexOf("CAZ043-"));
+    expect(parseSurfZoneForecast(MORNING, MORNING_ISSUED).zoneId).toBe(
+      SURF_ZONE_ID,
+    );
+  });
+
+  it("reports an empty bulletin as no data", () => {
+    expect(() => parseSurfZoneForecast("   ", MORNING_ISSUED)).toThrow(
+      NwsSurfZoneNoDataError,
+    );
+  });
+});
+
+describe("resolving a period's label onto the calendar", () => {
+  it("reads TODAY as the day the bulletin was issued", () => {
+    expect(resolvePeriodDates("TODAY", "2026-09-02")).toEqual(["2026-09-02"]);
+  });
+
+  it("walks a bare weekday forward from where it was told to start", () => {
+    // 2026-09-02 is a Wednesday, so Thursday is the next day...
+    expect(resolvePeriodDates("THURSDAY", "2026-09-02")).toEqual([
+      "2026-09-03",
+    ]);
+    // ...and a Wednesday asked for from that same Wednesday is that day, not
+    // one a week away.
+    expect(resolvePeriodDates("WEDNESDAY", "2026-09-02")).toEqual([
+      "2026-09-02",
+    ]);
+  });
+
+  it("spans every day a THROUGH label covers, inclusive", () => {
+    expect(
+      resolvePeriodDates("THIS AFTERNOON THROUGH FRIDAY", "2026-09-02"),
+    ).toEqual(["2026-09-02", "2026-09-03", "2026-09-04"]);
+  });
+
+  /**
+   * The measured vocabulary is one week of one summer, which is not the whole
+   * of what NWS period naming can produce. A label this cannot place is a
+   * failed read rather than a dropped period: a dropped period is a day
+   * missing from the panel with nothing said about why, which is the failure
+   * this feature exists to correct.
+   */
+  it("throws on a label it cannot place rather than dropping the period", () => {
+    expect(() => resolvePeriodDates("REST OF TONIGHT", "2026-09-02")).toThrow(
+      NwsSurfZoneDriftError,
+    );
+    expect(() =>
+      resolvePeriodDates("THIS AFTERNOON THROUGH BLURSDAY", "2026-09-02"),
+    ).toThrow(NwsSurfZoneDriftError);
+  });
+});
+
+/**
+ * Edit only the San Diego half of a bulletin.
+ *
+ * Necessary rather than tidy, and the first draft of these tests got it wrong:
+ * `CAZ552` is published *before* `CAZ043`, so a plain `replace` lands in Orange
+ * County and leaves the section under test untouched. Both drift tests below
+ * passed against an unmodified San Diego section and reported the parser as
+ * broken. That is the same first-match trap `sectionFor` exists to stop, met
+ * from the other side.
+ */
+function inSanDiego(text: string, from: string | RegExp, to: string): string {
+  const at = text.indexOf(`${SURF_ZONE_ID}-`);
+  return text.slice(0, at) + text.slice(at).replace(from, to);
+}
+
+describe("drift in the fields", () => {
+  it("refuses a risk level outside the three the bulletin defines", () => {
+    const invented = inSanDiego(
+      MORNING,
+      "Rip Current Risk*.............Low.",
+      "Rip Current Risk*.............Extreme.",
+    );
+
+    expect(() => parseSurfZoneForecast(invented, MORNING_ISSUED)).toThrow(
+      NwsSurfZoneDriftError,
+    );
+  });
+
+  it("refuses a period that stopped publishing the risk at all", () => {
+    const dropped = inSanDiego(
+      MORNING,
+      /^Rip Current Risk\*\.+.*$/m,
+      "Surf Height...................1 to 3 feet.",
+    );
+
+    expect(() => parseSurfZoneForecast(dropped, MORNING_ISSUED)).toThrow(
+      NwsSurfZoneDriftError,
+    );
+  });
+});
+
+/**
+ * The three failure paths a real bulletin will not show me.
+ *
+ * One week of one summer is what was available to capture, so the payloads
+ * above exercise the shapes SGX happened to issue. These are the shapes it did
+ * not, reached by editing a real bulletin rather than by writing a synthetic
+ * one -- an invented payload would assert what I expect the office to send,
+ * which is the thing under test.
+ */
+describe("shapes the captured week did not contain", () => {
+  it("refuses a listing entry with no usable id", () => {
+    const nameless = {
+      "@graph": [{ issuanceTime: "2026-09-02T08:54:00+00:00" }],
+    };
+
+    expect(() => parseSurfZoneProductList(nameless)).toThrow(
+      NwsSurfZoneDriftError,
+    );
+  });
+
+  /**
+   * A zone issued twice in one bulletin. Choosing between them would be this
+   * parser guessing which forecast is current, and taking the first would make
+   * the guess silently.
+   */
+  it("refuses a bulletin carrying the same zone twice", () => {
+    const at = MORNING.indexOf(`${SURF_ZONE_ID}-`);
+    const doubled = MORNING + MORNING.slice(at);
+
+    expect(() => parseSurfZoneForecast(doubled, MORNING_ISSUED)).toThrow(
+      NwsSurfZoneDriftError,
+    );
+  });
+
+  it("reports a zone section with no periods as no data", () => {
+    // The header and the glossary, with every `.PERIOD...` block gone.
+    const headerOnly = MORNING.slice(
+      0,
+      MORNING.indexOf("\n.", MORNING.indexOf(`${SURF_ZONE_ID}-`)),
+    );
+
+    expect(() => parseSurfZoneForecast(headerOnly, MORNING_ISSUED)).toThrow(
+      NwsSurfZoneNoDataError,
+    );
+  });
+});

--- a/src/lib/nws-surf-zone.ts
+++ b/src/lib/nws-surf-zone.ts
@@ -1,0 +1,401 @@
+/**
+ * Reading the National Weather Service's surf zone forecast.
+ *
+ * Pure and offline, like the parsers beside it, so a pinned format is asserted
+ * against a committed payload without a network.
+ *
+ * WHAT THIS PRODUCT IS. `SRF` is a text bulletin, not JSON — the only feed on
+ * this page that is. It is not forecaster prose either: the fields are
+ * fixed-width with dot leaders, which is what makes reading it a parse rather
+ * than a guess.
+ *
+ *     Rip Current Risk*.............High.
+ *
+ * THE JUDGEMENT IS RELAYED, NEVER FORMED. ADR-0009 forbids this site deciding
+ * whether conditions are safe, and this is the product that decision was
+ * written about. The risk word leaves here as the word the forecaster
+ * published, and the sentence explaining what it means is the publisher's own:
+ * the bulletin carries its glossary in its own body, so nothing in this file
+ * has to author "what Moderate means". Anything here that reworded either would
+ * be the bug.
+ *
+ * ONE TEXT CARRIES TWO COUNTIES, AND PICKING THE WRONG ONE FAILS SILENTLY.
+ * SGX issues `CAZ043` San Diego County Coastal and `CAZ552` Orange County
+ * Coastal in a single bulletin. Measured 2026-09-02: San Diego read 70 to 74
+ * degrees and quoted tides at La Jolla, Orange read 71 to 78 and quoted Newport
+ * Beach. So the section is selected by zone id and its absence throws. There is
+ * deliberately no "first section" fallback — the fallback renders another
+ * county's forecast under this county's heading, and looks entirely plausible.
+ *
+ * A PERIOD IS NOT A DAY, AND THE PUBLISHER NAMES IT RATHER THAN DATING IT.
+ * Measured across all 14 issuances SGX held on 2026-09-02, every one carried
+ * exactly two periods. A morning issuance (~1 AM PDT) names them `TODAY` then a
+ * weekday. An afternoon one (~1 PM PDT) names them `THIS AFTERNOON THROUGH
+ * <weekday>` — today's remainder merged with tomorrow — then the day after. So
+ * a morning issuance describes two calendar days and an afternoon one describes
+ * three, and neither states a date anywhere. `resolvePeriodDates` is what turns
+ * the words back into days, and an unrecognised word throws rather than
+ * resolving to nothing: a dropped period is a day silently missing from the
+ * page, which is the failure this whole feature exists to correct.
+ *
+ * THE HEADLINE OUTRANKS THE DAY AND MAY DISAGREE WITH IT. The section may open
+ * with the office's own emphasis line, present on 11 of the 14 issuances. It is
+ * scoped to the bulletin rather than to a period: on 2026-08-28 07:11 it read
+ * `HIGH RIP CURRENT RISK` while `TODAY` read Moderate, because `SATURDAY` was
+ * the High one. Both are correct at their own scope, so both are carried and
+ * neither is reconciled here. It also carries an active Beach Hazards Statement
+ * on 3 of 14, which is the only route by which that alert reaches this page.
+ *
+ * THE ISSUANCE INSTANT IS NOT PARSED OUT OF THE TEXT. The bulletin states it as
+ * `1220 PM PDT Tue Sep 1 2026`, and the product listing states the same instant
+ * as ISO with its offset. The machine-readable one is used and the human one is
+ * ignored, for the hazard ADR-0009 records and `nws-forecast.ts` guards: a
+ * timestamp read without its zone ages by seven hours on this coast, which here
+ * would resolve every period onto the wrong day.
+ */
+
+import { addLocalDays, localDateOf, localWeekdayOf } from "./pacific-time";
+
+export class NwsSurfZoneDriftError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NwsSurfZoneDriftError";
+  }
+}
+
+export class NwsSurfZoneNoDataError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NwsSurfZoneNoDataError";
+  }
+}
+
+/**
+ * The forecast office whose surf zone bulletin covers this inventory.
+ *
+ * San Diego. Not a per-beach binding and deliberately not a column in
+ * `beaches.json` — see `SURF_ZONE_ID`.
+ */
+export const SURF_ZONE_OFFICE = "SGX";
+
+/**
+ * The zone every beach in this inventory sits in.
+ *
+ * **This is bound to the inventory, not joined per beach**, which breaks the
+ * pattern every other binding here follows. The reason is measured: resolving
+ * `api.weather.gov/zones?point=` for both ends of all 51 beaches returned
+ * `CAZ043` at both ends for 27, at one end for 14, and **nothing at either end
+ * for 10** — every Coronado beach, Border Field State Park, and the inner-bay
+ * sites. That says nothing about those beaches. `CAZ043` is a *land* polygon,
+ * and a beach coordinate on the water side of the mapped shoreline falls
+ * outside it; a containment join fails at the water's edge where this repo's
+ * nearest-feature joins degrade gracefully.
+ *
+ * The zone follows from the inventory's own definition instead — the
+ * `County = 'San Diego'` filter recorded in `beaches.json`'s `_inclusion` —
+ * so there is one zone for all 51 beaches and nothing to re-join.
+ */
+export const SURF_ZONE_ID = "CAZ043";
+
+/** The three levels this product publishes, and the only ones accepted. */
+export const RISK_LEVELS = ["Low", "Moderate", "High"] as const;
+
+export type RiskLevel = (typeof RISK_LEVELS)[number];
+
+/** One period of the bulletin, as the publisher divided and named it. */
+export interface SurfZonePeriod {
+  /**
+   * The publisher's own label: `TODAY`, `THIS AFTERNOON THROUGH WEDNESDAY`,
+   * `THURSDAY`. Carried verbatim because it is what names the period on the
+   * page when the resolved dates would be a claim of our own.
+   */
+  name: string;
+  /**
+   * Every local calendar date this period describes, `YYYY-MM-DD`, ascending.
+   *
+   * Usually one. Two when an afternoon issuance merges today's remainder with
+   * tomorrow, which is the case the day panel exists to key into.
+   */
+  localDates: string[];
+  /** The published level, one of three. */
+  level: RiskLevel;
+}
+
+/** One line of the bulletin's own glossary of its risk levels. */
+export interface RiskMeaning {
+  level: RiskLevel;
+  /** The publisher's sentence, verbatim. */
+  meaning: string;
+}
+
+export interface SurfZoneForecast {
+  /** The zone this was read for. */
+  zoneId: string;
+  /** When the office issued it, epoch milliseconds UTC. */
+  issuedMs: number;
+  /**
+   * The office's own emphasis line with its `...` markers stripped, or null.
+   *
+   * Scoped to the bulletin, not to a period, and may name a level the first
+   * period does not. Null on a quiet issuance — 3 of 14 carried none.
+   */
+  headline: string | null;
+  /** Every period the bulletin issued, in the order it published them. */
+  periods: SurfZonePeriod[];
+  /** The bulletin's own glossary, so the gloss on the page is the publisher's. */
+  meanings: RiskMeaning[];
+}
+
+/** The listing of recent bulletins from one office. */
+export function surfZoneProductsUrl(office: string = SURF_ZONE_OFFICE): string {
+  return `https://api.weather.gov/products/types/SRF/locations/${office}`;
+}
+
+/** One bulletin by the id the listing gave it. */
+export function surfZoneProductUrl(id: string): string {
+  return `https://api.weather.gov/products/${id}`;
+}
+
+/** The newest bulletin in a listing: its id and when it was issued. */
+export interface SurfZoneProductRef {
+  id: string;
+  issuedMs: number;
+}
+
+/** `2026-09-02T08:54:00+00:00`. Offset-less would be ADR-0009's hazard. */
+const INSTANT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * The newest bulletin the office is currently serving.
+ *
+ * **Newest by stated issuance, not by position.** The listing arrives newest
+ * first today, and sorting rather than taking `[0]` costs one comparison and
+ * removes an assumption about an order the publisher never documented.
+ */
+export function parseSurfZoneProductList(
+  payload: unknown,
+  office: string = SURF_ZONE_OFFICE,
+): SurfZoneProductRef {
+  const graph =
+    typeof payload === "object" && payload !== null
+      ? (payload as Record<string, unknown>)["@graph"]
+      : undefined;
+
+  if (!Array.isArray(graph)) {
+    throw new NwsSurfZoneDriftError(
+      `${office}: the surf zone product listing carried no "@graph" array. This parser ` +
+        `pins the JSON-LD shape the listing is requested in.`,
+    );
+  }
+  if (graph.length === 0) {
+    throw new NwsSurfZoneNoDataError(
+      `${office} is serving no surf zone forecast bulletins at all.`,
+    );
+  }
+
+  const refs: SurfZoneProductRef[] = graph.map((entry, index) => {
+    const row = (entry ?? {}) as Record<string, unknown>;
+    const id = row.id;
+    const issued = row.issuanceTime;
+    if (typeof id !== "string" || id.length === 0) {
+      throw new NwsSurfZoneDriftError(
+        `${office}: bulletin ${index} in the listing carried id ${JSON.stringify(id)}.`,
+      );
+    }
+    if (typeof issued !== "string" || !INSTANT.test(issued)) {
+      throw new NwsSurfZoneDriftError(
+        `${office}: bulletin ${id} carried issuanceTime ${JSON.stringify(issued)}. This ` +
+          `parser pins an ISO instant with its offset stated; one without would be read as ` +
+          `local and tagged UTC, moving the issuance by seven hours and resolving every ` +
+          `period onto the wrong day.`,
+      );
+    }
+    return { id, issuedMs: Date.parse(issued) };
+  });
+
+  refs.sort((a, b) => b.issuedMs - a.issuedMs);
+  return refs[0];
+}
+
+/** A line naming the zones a section covers: `CAZ043-021015-`. */
+function sectionFor(text: string, zoneId: string): string {
+  // `$$` ends a zone's section in this product's own markup.
+  const sections = text.split(/^\$\$\s*$/m);
+  const opensWithZone = new RegExp(`^(?:[A-Z]{3}\\d{3}-)*${zoneId}-`, "m");
+  const matching = sections.filter((section) => opensWithZone.test(section));
+
+  if (matching.length === 0) {
+    throw new NwsSurfZoneNoDataError(
+      `This surf zone bulletin carries no ${zoneId} section. It is not read as whichever ` +
+        `section it does carry: SGX issues San Diego (${SURF_ZONE_ID}) and Orange County ` +
+        `(CAZ552) in one bulletin with different figures, so a fallback would render ` +
+        `another county's forecast under this one's heading.`,
+    );
+  }
+  if (matching.length > 1) {
+    throw new NwsSurfZoneDriftError(
+      `This surf zone bulletin carries ${matching.length} sections for ${zoneId}. One ` +
+        `zone is issued once per bulletin, and choosing between two would be this parser ` +
+        `guessing which forecast is current.`,
+    );
+  }
+  return matching[0];
+}
+
+/** `...HIGH RIP CURRENT RISK...` → `HIGH RIP CURRENT RISK`, or null. */
+function headlineIn(section: string): string | null {
+  const match = /^\.\.\.(.+?)\.\.\.\s*$/m.exec(section);
+  return match === null ? null : match[1].trim();
+}
+
+/** A field's value: everything after the dot leaders, on that line. */
+function fieldIn(block: string, label: string): string | null {
+  const match = new RegExp(`^${label}\\*?\\.{2,}(.*)$`, "m").exec(block);
+  return match === null ? null : match[1].trim();
+}
+
+function levelOf(raw: string, periodName: string): RiskLevel {
+  const word = raw.replace(/\.\s*$/, "").trim();
+  const level = RISK_LEVELS.find((candidate) => candidate === word);
+  if (level === undefined) {
+    throw new NwsSurfZoneDriftError(
+      `The period ${JSON.stringify(periodName)} published a rip current risk of ` +
+        `${JSON.stringify(word)}. This parser pins the three levels the bulletin's own ` +
+        `glossary defines — ${RISK_LEVELS.join(", ")} — and a fourth is a change in what ` +
+        `the office publishes rather than a value to pass through unexplained.`,
+    );
+  }
+  return level;
+}
+
+/**
+ * Which local dates a period's own label describes.
+ *
+ * `searchFrom` is where the calendar walk starts: the issuance's local date for
+ * the first period, and the day after the previous period for each one after.
+ * Without it a bare weekday is ambiguous — `THURSDAY` on a Thursday could be
+ * today or a week away — and the ambiguity would land on the wrong day rather
+ * than raising.
+ *
+ * **An unrecognised label throws.** The measured vocabulary is `TODAY`,
+ * `THIS AFTERNOON THROUGH <weekday>` and a bare weekday, taken from all 14
+ * issuances available on 2026-09-02 — one week of a summer, which is not the
+ * whole of what NWS period naming can produce. So the failure is loud: a label
+ * this does not know is a bulletin this page cannot place in time, and a
+ * silently dropped period is a day missing from the panel with nothing said.
+ */
+export function resolvePeriodDates(name: string, searchFrom: string): string[] {
+  const label = name.trim().toUpperCase();
+
+  if (label === "TODAY") return [searchFrom];
+
+  const through = /^THIS AFTERNOON THROUGH ([A-Z]+)$/.exec(label);
+  if (through !== null) {
+    const last = weekdayOnOrAfter(through[1], searchFrom, name);
+    const dates: string[] = [];
+    for (let day = searchFrom; ; day = addLocalDays(day, 1)) {
+      dates.push(day);
+      if (day === last) return dates;
+    }
+  }
+
+  if (/^[A-Z]+$/.test(label)) {
+    return [weekdayOnOrAfter(label, searchFrom, name)];
+  }
+
+  throw new NwsSurfZoneDriftError(
+    `The surf zone bulletin named a period ${JSON.stringify(name)}, which this parser ` +
+      `cannot place on the calendar. It reads TODAY, "THIS AFTERNOON THROUGH <weekday>" ` +
+      `and a bare weekday. A period it cannot date is not dropped, because a dropped ` +
+      `period is a day missing from the page with nothing said about why.`,
+  );
+}
+
+/** The first date on or after `from` that falls on `weekday`. */
+function weekdayOnOrAfter(
+  weekday: string,
+  from: string,
+  periodName: string,
+): string {
+  const wanted = weekday.trim().toUpperCase();
+  // Seven steps reach every weekday exactly once; an eighth would repeat `from`.
+  let day = from;
+  for (let step = 0; step < 7; step += 1) {
+    if (localWeekdayOf(day).toUpperCase() === wanted) return day;
+    day = addLocalDays(day, 1);
+  }
+  throw new NwsSurfZoneDriftError(
+    `The surf zone bulletin's period ${JSON.stringify(periodName)} named ` +
+      `${JSON.stringify(weekday)}, which is not a weekday. Seven days from ${from} were ` +
+      `checked and none matched.`,
+  );
+}
+
+/** `* Moderate Risk - Life threatening rip currents are possible.` */
+function meaningsIn(section: string): RiskMeaning[] {
+  const meanings: RiskMeaning[] = [];
+  for (const match of section.matchAll(
+    /^\*\s*(Low|Moderate|High) Risk\s*-\s*(.+?)\s*$/gm,
+  )) {
+    meanings.push({ level: match[1] as RiskLevel, meaning: match[2] });
+  }
+  return meanings;
+}
+
+/**
+ * One bulletin, read for one zone.
+ *
+ * `issuedMs` comes from the listing rather than from the bulletin's own
+ * `1220 PM PDT Tue Sep 1 2026` line — see this module's header.
+ */
+export function parseSurfZoneForecast(
+  text: string,
+  issuedMs: number,
+  zoneId: string = SURF_ZONE_ID,
+): SurfZoneForecast {
+  if (typeof text !== "string" || text.trim().length === 0) {
+    throw new NwsSurfZoneNoDataError(
+      `The surf zone bulletin for ${zoneId} was empty.`,
+    );
+  }
+
+  const section = sectionFor(text, zoneId);
+  const meanings = meaningsIn(section);
+
+  // A period opens on a line of its own: `.THURSDAY...`. The leading dot is
+  // what separates it from the `...HEADLINE...` above, whose first character
+  // is also a dot but whose second is not a letter.
+  const blocks = section.split(/^\.(?=[A-Z])/m).slice(1);
+  if (blocks.length === 0) {
+    throw new NwsSurfZoneNoDataError(
+      `The ${zoneId} section of this surf zone bulletin carries no periods.`,
+    );
+  }
+
+  const periods: SurfZonePeriod[] = [];
+  let searchFrom = localDateOf(issuedMs);
+
+  for (const block of blocks) {
+    const name = block.split("...")[0].trim();
+    const risk = fieldIn(block, "Rip Current Risk");
+    if (risk === null) {
+      throw new NwsSurfZoneDriftError(
+        `The period ${JSON.stringify(name)} of the ${zoneId} surf zone bulletin published ` +
+          `no "Rip Current Risk" field. That field is the reason this page reads this ` +
+          `product, and a period without one is a change in the bulletin's shape.`,
+      );
+    }
+
+    const localDates = resolvePeriodDates(name, searchFrom);
+    periods.push({ name, localDates, level: levelOf(risk, name) });
+    searchFrom = addLocalDays(localDates[localDates.length - 1], 1);
+  }
+
+  return {
+    zoneId,
+    issuedMs,
+    headline: headlineIn(section),
+    periods,
+    meanings,
+  };
+}

--- a/src/lib/pacific-time.ts
+++ b/src/lib/pacific-time.ts
@@ -244,6 +244,30 @@ export function localMidnightOf(
  * behind Greenwich — this coast included — names the day before. So the
  * calendar value is put back exactly where it was parsed from.
  */
+/**
+ * The weekday a local date falls on, in full: `Thursday`.
+ *
+ * For matching a publisher's own weekday word back onto the calendar, which is
+ * what `nws-surf-zone.ts` does with a surf zone forecast period named
+ * `THURSDAY`. That product names its periods by weekday and never by date, so
+ * resolving the word is the only way to know which day it describes.
+ *
+ * Full rather than short, because the words being matched are the publisher's
+ * and they are spelled out. Comparison is the caller's to case-fold: this
+ * returns what `Intl` calls the day, not a token shaped for one consumer.
+ *
+ * Same UTC round-trip as `localDayLabel` below, for the reason recorded there —
+ * a date carries no zone, and rendering it anywhere behind Greenwich would name
+ * the day before.
+ */
+export function localWeekdayOf(localDate: string): string {
+  const [year, month, day] = partsOf(localDate);
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: "UTC",
+    weekday: "long",
+  }).format(new Date(Date.UTC(year, month - 1, day)));
+}
+
 export function localDayLabel(localDate: string): string {
   const [year, month, day] = partsOf(localDate);
   return new Intl.DateTimeFormat("en-US", {

--- a/src/lib/upstream.test.ts
+++ b/src/lib/upstream.test.ts
@@ -10,6 +10,7 @@ import {
   fetchLatestWave,
   fetchMopForecast,
   fetchSkyWording,
+  fetchSurfZoneForecast,
   fetchTideExtremes,
   MAX_OBSERVATION_AGE_MINUTES,
   MAX_WAVE_AGE_MINUTES,
@@ -17,6 +18,7 @@ import {
   OBSERVATIONS_REVALIDATE_SECONDS,
   PREDICTIONS_REVALIDATE_SECONDS,
   SKY_WORDING_REVALIDATE_SECONDS,
+  SURF_ZONE_REVALIDATE_SECONDS,
   WAVES_REVALIDATE_SECONDS,
 } from "./upstream";
 
@@ -1062,4 +1064,266 @@ describe("fetchSkyWording", () => {
     if (result.kind !== "unavailable") throw new Error("expected unavailable");
     expect(result.drift).toBe(true);
   });
+});
+
+/**
+ * The surf zone bulletin, which is two requests rather than one.
+ *
+ * The listing has no stable id in it, so what is asserted here is the policy
+ * around the pair: that both are cached, that the second is addressed by the id
+ * the first returned, and that a failure names the URL that actually failed
+ * rather than the one this read started at.
+ */
+describe("fetchSurfZoneForecast", () => {
+  const SRF_LIST = JSON.parse(
+    readFileSync(
+      join(
+        process.cwd(),
+        "src/lib/__fixtures__/nws-srf-sgx-products-20260902.json",
+      ),
+      "utf8",
+    ),
+  );
+  const SRF_TEXT = readFileSync(
+    join(process.cwd(), "src/lib/__fixtures__/nws-srf-sgx-20260902-0854z.txt"),
+    "utf8",
+  );
+  const NEWEST_ID = "36f48a5d-9b57-4fe2-9808-5f6a68ec4c64";
+
+  function servingTheBulletin() {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(SRF_LIST))
+      .mockResolvedValueOnce(jsonResponse({ productText: SRF_TEXT }));
+  }
+
+  test("opts both requests into caching and asks for the newest bulletin by id", async () => {
+    servingTheBulletin();
+
+    const result = await fetchSurfZoneForecast();
+
+    expect(result.kind).toBe("ok");
+    const [listUrl, listOptions] = fetchMock.mock.calls[0];
+    const [textUrl, textOptions] = fetchMock.mock.calls[1];
+    expect(listUrl).toBe(
+      "https://api.weather.gov/products/types/SRF/locations/SGX",
+    );
+    // The listing is JSON-LD; the default media type is a different shape.
+    expect(listOptions.headers.Accept).toBe("application/ld+json");
+    expect(textUrl).toBe(`https://api.weather.gov/products/${NEWEST_ID}`);
+    expect(listOptions.next.revalidate).toBe(SURF_ZONE_REVALIDATE_SECONDS);
+    expect(textOptions.next.revalidate).toBe(SURF_ZONE_REVALIDATE_SECONDS);
+    expect(textOptions.headers["User-Agent"]).toContain("wild-coast-kids");
+  });
+
+  test("reads the San Diego zone out of a bulletin that also carries Orange County", async () => {
+    servingTheBulletin();
+
+    const result = await fetchSurfZoneForecast();
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.forecast.zoneId).toBe("CAZ043");
+    expect(result.forecast.periods.map((period) => period.level)).toEqual([
+      "Low",
+      "Low",
+    ]);
+    // The issuance instant comes from the listing, not from the bulletin's own
+    // "154 AM PDT Wed Sep 2 2026" line, which carries no machine-readable zone.
+    expect(result.forecast.issuedMs).toBe(
+      Date.parse("2026-09-02T08:54:00+00:00"),
+    );
+  });
+
+  test("a quiet listing is reported against the listing's URL", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}, 503));
+
+    const result = await fetchSurfZoneForecast();
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.url).toBe(
+      "https://api.weather.gov/products/types/SRF/locations/SGX",
+    );
+    expect(result.reason).toContain("503");
+    expect(result.drift).toBe(false);
+    // The bulletin is never asked for when the listing did not answer.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * No walking back down the listing to an older bulletin. A surf zone forecast
+   * is a judgement with a stated window, and serving yesterday's under today's
+   * date is the failure this page can least afford.
+   */
+  test("a bulletin the listing named but cannot serve is unavailable, not the one before it", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(SRF_LIST))
+      .mockResolvedValueOnce(jsonResponse({}, 404));
+
+    const result = await fetchSurfZoneForecast();
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.url).toBe(`https://api.weather.gov/products/${NEWEST_ID}`);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("a bulletin with no San Diego section is unavailable rather than Orange County's", async () => {
+    const orangeOnly = SRF_TEXT.slice(0, SRF_TEXT.indexOf("CAZ043-"));
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(SRF_LIST))
+      .mockResolvedValueOnce(jsonResponse({ productText: orangeOnly }));
+
+    const result = await fetchSurfZoneForecast();
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.reason).toContain("CAZ043");
+  });
+
+  test("a bulletin missing its body is drift, not a quiet office", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(SRF_LIST))
+      .mockResolvedValueOnce(jsonResponse({ id: NEWEST_ID }));
+
+    const result = await fetchSurfZoneForecast();
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.drift).toBe(true);
+  });
+
+  test("a network error on the listing is reported rather than thrown", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("ECONNRESET"));
+
+    const result = await fetchSurfZoneForecast();
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.reason).toContain("ECONNRESET");
+  });
+
+  test("a network error on the bulletin names the bulletin's URL, not the listing's", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(SRF_LIST))
+      .mockRejectedValueOnce(new Error("socket hang up"));
+
+    const result = await fetchSurfZoneForecast();
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.url).toBe(`https://api.weather.gov/products/${NEWEST_ID}`);
+    expect(result.reason).toContain("socket hang up");
+  });
+
+  test("a listing that is not JSON is reported against the listing", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("Unexpected token <");
+      },
+    });
+
+    const result = await fetchSurfZoneForecast();
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.reason).toContain("Unexpected token <");
+  });
+
+  test("a bulletin body that is not JSON is reported against the bulletin", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(SRF_LIST))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new Error("Unexpected end of JSON input");
+        },
+      });
+
+    const result = await fetchSurfZoneForecast();
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.url).toBe(`https://api.weather.gov/products/${NEWEST_ID}`);
+    expect(result.reason).toContain("Unexpected end of JSON input");
+  });
+
+  /**
+   * An office serving no bulletins at all is a quiet feed, not a bug here, so
+   * it must not be flagged as drift -- the two are kept apart everywhere in
+   * this module because drift is something to chase and quiet is something to
+   * wait out.
+   */
+  test("an empty listing is quiet rather than drift", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ "@graph": [] }));
+
+    const result = await fetchSurfZoneForecast();
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.drift).toBe(false);
+  });
+
+  test("a listing in the wrong shape is drift", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ features: [] }));
+
+    const result = await fetchSurfZoneForecast();
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.drift).toBe(true);
+  });
+
+  test("a risk level the bulletin does not define is drift", async () => {
+    const at = SRF_TEXT.indexOf("CAZ043-");
+    const invented =
+      SRF_TEXT.slice(0, at) +
+      SRF_TEXT.slice(at).replace(
+        "Rip Current Risk*.............Low.",
+        "Rip Current Risk*.............Extreme.",
+      );
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(SRF_LIST))
+      .mockResolvedValueOnce(jsonResponse({ productText: invented }));
+
+    const result = await fetchSurfZoneForecast();
+
+    expect(result.kind).toBe("unavailable");
+    if (result.kind !== "unavailable") return;
+    expect(result.drift).toBe(true);
+  });
+});
+
+/**
+ * The zone and office are parameters with defaults rather than constants baked
+ * into the request, which is what lets the Orange County section of the same
+ * bulletin be read at all. Nothing on this site asks for it -- the inventory is
+ * one county -- so this is the test that keeps the seam honest.
+ */
+test("reads a zone other than the default when asked for one", async () => {
+  const SRF_LIST = JSON.parse(
+    readFileSync(
+      join(
+        process.cwd(),
+        "src/lib/__fixtures__/nws-srf-sgx-products-20260902.json",
+      ),
+      "utf8",
+    ),
+  );
+  const SRF_TEXT = readFileSync(
+    join(process.cwd(), "src/lib/__fixtures__/nws-srf-sgx-20260902-0854z.txt"),
+    "utf8",
+  );
+  fetchMock
+    .mockResolvedValueOnce(jsonResponse(SRF_LIST))
+    .mockResolvedValueOnce(jsonResponse({ productText: SRF_TEXT }));
+
+  const result = await fetchSurfZoneForecast("CAZ552", "SGX");
+
+  expect(result.kind).toBe("ok");
+  if (result.kind !== "ok") return;
+  expect(result.forecast.zoneId).toBe("CAZ552");
 });

--- a/src/lib/upstream.ts
+++ b/src/lib/upstream.ts
@@ -92,6 +92,18 @@ import {
   parseNwsObservation,
   type StationObservation,
 } from "./nws-observation";
+import {
+  NwsSurfZoneDriftError,
+  NwsSurfZoneNoDataError,
+  parseSurfZoneForecast,
+  parseSurfZoneProductList,
+  SURF_ZONE_ID,
+  SURF_ZONE_OFFICE,
+  type SurfZoneForecast,
+  type SurfZoneProductRef,
+  surfZoneProductsUrl,
+  surfZoneProductUrl,
+} from "./nws-surf-zone";
 
 /** Six hours. Astronomical predictions do not change; the window only rolls forward. */
 export const PREDICTIONS_REVALIDATE_SECONDS = 21600;
@@ -847,5 +859,155 @@ export async function fetchSkyWording(
     if (cause instanceof NwsForecastNoDataError)
       return unavailable(cause.message);
     return unavailable(cause instanceof Error ? cause.message : String(cause));
+  }
+}
+
+/**
+ * Thirty minutes, against a bulletin issued twice a day.
+ *
+ * Its own constant rather than a reuse, per the one-per-product convention
+ * above. The cadence is measured rather than assumed: all 14 issuances SGX held
+ * on 2026-09-02 fell at roughly 1 AM and 1 PM Pacific, with no off-cycle
+ * reissue in the seven days they covered. So a fifteen-minute poll would ask
+ * the office 96 times for two changes, and an hour would leave a new bulletin
+ * unread for up to an hour on a morning the risk has gone up.
+ */
+export const SURF_ZONE_REVALIDATE_SECONDS = 1800;
+
+export type SurfZoneResult =
+  | { kind: "ok"; forecast: SurfZoneForecast; url: string }
+  | { kind: "unavailable"; reason: string; drift: boolean; url: string };
+
+/**
+ * Fetch the surf zone forecast for one zone.
+ *
+ * Never throws.
+ *
+ * TWO REQUESTS, BECAUSE THE PRODUCT HAS NO STABLE URL. Every other read here
+ * addresses its data directly; a bulletin is addressed by an id that changes
+ * with each issuance, so the listing is asked first and the newest id taken
+ * from it. Both requests are reported against the URL that actually failed,
+ * because "the National Weather Service is quiet" and "the bulletin we were
+ * told about has gone" are different things to chase.
+ *
+ * NO FALLBACK TO AN OLDER BULLETIN. If the newest id 404s, this reports
+ * unavailable rather than walking back down the listing. A surf zone forecast
+ * is a judgement with a stated window, and serving yesterday's under today's
+ * date is the failure mode this page is least able to afford.
+ */
+export async function fetchSurfZoneForecast(
+  zoneId: string = SURF_ZONE_ID,
+  office: string = SURF_ZONE_OFFICE,
+): Promise<SurfZoneResult> {
+  const listUrl = surfZoneProductsUrl(office);
+
+  const unavailable = (
+    reason: string,
+    url: string,
+    drift = false,
+  ): SurfZoneResult => ({ kind: "unavailable", reason, drift, url });
+
+  let listResponse: Response;
+  try {
+    listResponse = await fetch(listUrl, {
+      headers: { "User-Agent": USER_AGENT, Accept: "application/ld+json" },
+      next: { revalidate: SURF_ZONE_REVALIDATE_SECONDS },
+    });
+  } catch (cause) {
+    return unavailable(
+      `The request to the National Weather Service for ${office}'s surf zone bulletins ` +
+        `did not complete: ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`,
+      listUrl,
+    );
+  }
+
+  if (!listResponse.ok) {
+    return unavailable(
+      `The National Weather Service returned HTTP ${listResponse.status} for ${office}'s ` +
+        `surf zone bulletins.`,
+      listUrl,
+    );
+  }
+
+  let ref: SurfZoneProductRef;
+  try {
+    ref = parseSurfZoneProductList(await listResponse.json(), office);
+  } catch (cause) {
+    if (cause instanceof NwsSurfZoneDriftError)
+      return unavailable(cause.message, listUrl, true);
+    if (cause instanceof NwsSurfZoneNoDataError)
+      return unavailable(cause.message, listUrl);
+    return unavailable(
+      cause instanceof Error ? cause.message : String(cause),
+      listUrl,
+    );
+  }
+
+  const url = surfZoneProductUrl(ref.id);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { "User-Agent": USER_AGENT },
+      next: { revalidate: SURF_ZONE_REVALIDATE_SECONDS },
+    });
+  } catch (cause) {
+    return unavailable(
+      `The request to the National Weather Service for surf zone bulletin ${ref.id} did ` +
+        `not complete: ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`,
+      url,
+    );
+  }
+
+  if (!response.ok) {
+    return unavailable(
+      `The National Weather Service returned HTTP ${response.status} for surf zone ` +
+        `bulletin ${ref.id}, which its own listing had just named as the newest.`,
+      url,
+    );
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (cause) {
+    return unavailable(
+      `The National Weather Service's surf zone bulletin ${ref.id} was not JSON: ` +
+        `${cause instanceof Error ? cause.message : String(cause)}`,
+      url,
+    );
+  }
+
+  const text =
+    typeof payload === "object" && payload !== null
+      ? (payload as Record<string, unknown>).productText
+      : undefined;
+
+  if (typeof text !== "string") {
+    return unavailable(
+      `The National Weather Service's surf zone bulletin ${ref.id} carried no ` +
+        `productText. This read pins the field the bulletin's body arrives in.`,
+      url,
+      true,
+    );
+  }
+
+  try {
+    return {
+      kind: "ok",
+      forecast: parseSurfZoneForecast(text, ref.issuedMs, zoneId),
+      url,
+    };
+  } catch (cause) {
+    if (cause instanceof NwsSurfZoneDriftError)
+      return unavailable(cause.message, url, true);
+    if (cause instanceof NwsSurfZoneNoDataError)
+      return unavailable(cause.message, url);
+    return unavailable(
+      cause instanceof Error ? cause.message : String(cause),
+      url,
+    );
   }
 }


### PR DESCRIPTION
Closes #217

Slices 2–3 of [`docs/plans/surf-zone-forecast.md`](docs/plans/surf-zone-forecast.md), written in this branch's first commit.

## Why

`/conditions` had no hazard signal. Every figure on it was a number a reader had to interpret, and the one product that answers *should my kid go in the water today* was still a reserved slot.

Measured 2026-09-02 across all 14 SRF issuances NWS SGX still held (seven days, `CAZ043`): rip current risk was **High on 8**, Moderate on 4, Low on 2, and changed value on five of the seven days. It stood at High for six consecutive days, 2026-08-26 to 08-31 — *"life threatening rip currents are likely"* — while this page showed a sub-foot swell figure and said nothing. `/alerts/active` was empty throughout, and only 6 Beach Hazards Statements fired across all of June–August, so alerts are not a substitute.

## What changed

- **`lib/nws-surf-zone.ts`** — a parser with no fallbacks. One bulletin carries San Diego (`CAZ043`) and Orange County (`CAZ552`) with different figures and different tide stations, so the section is selected by zone id and its absence is a failed read. An unrecognised period label is likewise a failed read, never a dropped period.
- **`lib/upstream.ts`** — two requests (listing → bulletin by id), 1800s revalidate, no walking back to an older bulletin when the newest 404s.
- **`lib/conditions.ts`** — flattens the publisher's periods onto this page's days.
- **`components/conditions/SurfZone.tsx`** — the block, below the hour chart and above the measured block.
- **The reserved slot comes out here**, in the change that fills it.

Two ADRs, landing with the slice rather than as documentation afterwards: **[0043](docs/adr/0043-the-surf-zone-forecast-binds-to-the-inventory.md)** (the zone binds to the inventory, and the product is withheld where there is no surf zone) and **[0044](docs/adr/0044-a-two-period-product-is-resolved-onto-days.md)** (a two-period product resolved onto calendar days).

## Verification

`npm run gate`:

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

Coverage dipped below the branch floor (88.54% vs 89.09%) partway through and was answered by covering the new failure paths, not by moving the floor.

**Also rendered against the live NWS feed**, because tests prove the parse and not that a reader gets the page. Open coast (`/conditions`):

```
Rip current risk
Low
Life threatening rip currents are unlikely but still could occur.
For today, from the period the office called "TODAY".
Surf zone forecast, San Diego County Coastal Areas · NWS — issued 1:54 AM
```

Sheltered (`/conditions/mission-bay-sail-bay`):

```
Rip current risk
This forecast is not issued for this beach: the National Weather Service
issues this forecast for San Diego County's coastal areas, and a bay,
lagoon or inlet has no surf zone, so it does not describe the water here.
```

That live render caught two copy defects the fixtures could not, fixed in `cf915af`. The publisher was named twice in one sentence; and the obvious short fix — "none is forecast here" — reads as *there is no rip current risk here*, a claim about the water rather than the product, which ADR-0009 forbids and which would be worst at exactly the beaches carrying it.

## For your eye — this is the `needs-human` part

- **The level carries no colour.** ADR-0015 records that a surface here is decoration and never a verdict. A three-step severity palette would be this site deciding what red means on top of a scale the office publishes in words. So `High` renders in the same weight as `Low`. **I think that may be too quiet for the thing this block exists to say, and it's your call, not a gate's.**
- **The headline can disagree with the day beneath it** — measured on 2026-08-28, `HIGH RIP CURRENT RISK` over a `TODAY` that read Moderate. Both are correct at their own scope and neither is reconciled. Whether the copy makes that read as two scopes rather than as a contradiction wants a person.
- **Placement.** You chose the day panel over a standing block above the week. This puts the site's only hazard signal below a 24-hour chart. If it lands too deep, the fix is question 3 again, not a nudge inside the panel.

## Not done

- **Surf height and water temperature** — slice 4. **Staleness** — slice 5.
- **`docs/plans/conditions-tool.md` still says `~3 d` and still says the bay beaches' water temperature waits for this product.** Both wrong, both left. It is Historical, and `docs/plans/README.md` forbids correcting a shipped plan. The corrections live in ADR-0043 and the new plan.
- **Slices 2 and 3 shipped as one commit.** Splitting them would have meant a parser that deliberately discarded a second period it had already read — a boundary drawn for the plan's benefit rather than the code's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)