### PR TITLE
Add surf height and water temperature, and say when a bulletin is stale

### DIFF
--- a/docs/plans/surf-zone-forecast.md
+++ b/docs/plans/surf-zone-forecast.md
@@ -326,3 +326,31 @@ no gate can check that it does. It is why #217 is `needs-human`.
 **What it does not do**: deliver active alerts. The headline is the SGX
 forecaster's announcement text, not the alert product, and it appears only when
 that office chooses to lead with it. `Active alerts` stays out of scope above.
+
+### 2026-09-02 — the work is done, and what it cost
+
+All five slices shipped: #216 (the horizon correction), #218 (the block, the
+zone binding, the period resolution) and #219 (the two figures and staleness).
+Three things are worth recording against the plan above.
+
+**Slices 2 and 3 shipped as one commit.** Separating them would have meant a
+parser that deliberately discarded a second period it had already read. The
+boundary was drawn for this document's benefit rather than the code's.
+
+**The rendered page caught two copy defects the fixtures could not**, both in
+the withheld sentence at the 25 sheltered beaches. The publisher was named
+twice in one sentence; and the obvious short fix — "none is forecast here" —
+reads as _there is no rip current risk here_, a claim about the water rather
+than about the product's coverage, which ADR-0009 forbids and which would have
+landed at exactly the beaches least able to carry it. The copy is now about the
+forecast, and a test holds all four states to that line. **Nothing in the test
+suite could have found either.** Rendering against the live feed is what did.
+
+**The surf height sits nearer the buoy than intended.** The decision above
+keeps it away from CDIP's modelled swell, and it does. But `MeasuredToday` is
+the next block down and carries the buoy's measured height, and on 2026-09-02
+the page read "Surf 1 to 3 feet. Sets to 4 feet." above "🏄 3.0 ft — about waist
+high". Those are breaking surf face height and significant wave height at a
+buoy: different quantities, similar numbers that day, two blocks apart. Not
+resolved here — recorded, because it is the same collision the plan reasoned
+about and it turned up against a neighbour the reasoning did not consider.

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -294,10 +294,13 @@ function surfZoneWeek(
       kind: "forecast",
       issuedMs: localMidnightOf(TODAY) + 3_600_000,
       headline: null,
+      staleAfterHours: null,
       days: days.map((day) => ({
         ...day,
         periodName: "TODAY",
         meaning: "Life threatening rip currents are possible.",
+        surfHeight: "2 to 4 feet.",
+        waterTemperature: "70 to 76 degrees.",
       })),
     },
   });

--- a/src/components/conditions/SurfZone.test.tsx
+++ b/src/components/conditions/SurfZone.test.tsx
@@ -18,14 +18,25 @@ function forecast(
     localDate: string;
     periodName: string;
     level: "Low" | "Moderate" | "High";
+    surfHeight?: string;
+    waterTemperature?: string | null;
   }[],
   headline: string | null = null,
+  staleAfterHours: number | null = null,
 ): SurfZoneView["state"] {
   return {
     kind: "forecast",
     issuedMs: ISSUED,
     headline,
-    days: days.map((day) => ({ ...day, meaning: MEANING[day.level] })),
+    staleAfterHours,
+    days: days.map(
+      ({ surfHeight = "1 to 3 feet.", waterTemperature = null, ...day }) => ({
+        ...day,
+        surfHeight,
+        waterTemperature,
+        meaning: MEANING[day.level],
+      }),
+    ),
   };
 }
 
@@ -278,4 +289,121 @@ test("no state implies the water is safe", () => {
 
     unmount();
   }
+});
+
+/**
+ * Surf height is the evidence for the level rather than a surf reading, so it
+ * is relayed whole -- the set height is the part a parsed range would drop and
+ * the part a parent needs.
+ */
+test("relays the surf height verbatim, sets and all", () => {
+  render(
+    <SurfZone
+      state={forecast([
+        {
+          localDate: "2026-09-02",
+          periodName: "TODAY",
+          level: "High",
+          surfHeight: "3 to 5 feet. Sets to 6 feet.",
+        },
+      ])}
+      localDate="2026-09-02"
+      when="today"
+    />,
+  );
+
+  expect(screen.getByText("3 to 5 feet. Sets to 6 feet.")).toBeDefined();
+});
+
+/**
+ * `degrees`, not `°F`. This site's own figures are °F, and reformatting a
+ * quoted product to match this site's conventions edits the office's sentence
+ * to look like ours. It sits under the office's attribution, which is what says
+ * whose sentence it is.
+ */
+test("relays the water temperature in the bulletin's own words", () => {
+  render(
+    <SurfZone
+      state={forecast([
+        {
+          localDate: "2026-09-02",
+          periodName: "TODAY",
+          level: "Low",
+          waterTemperature: "70 to 74 degrees",
+        },
+      ])}
+      localDate="2026-09-02"
+      when="today"
+    />,
+  );
+
+  expect(screen.getByText("70 to 74 degrees")).toBeDefined();
+});
+
+/**
+ * The office publishes water temperature in the first period only -- 14 of 14 --
+ * so the last day of every bulletin lacks one. An absence sentence would appear
+ * on one day in every two or three and would read as a fault that is really a
+ * cadence, so the row is simply not drawn.
+ */
+test("says nothing at all when the bulletin published no water temperature", () => {
+  render(
+    <SurfZone
+      state={forecast([
+        {
+          localDate: "2026-09-02",
+          periodName: "THURSDAY",
+          level: "Low",
+          waterTemperature: null,
+        },
+      ])}
+      localDate="2026-09-02"
+      when="Thursday"
+    />,
+  );
+
+  expect(screen.queryByText("Water")).toBeNull();
+  expect(screen.queryByText(/no water temperature/i)).toBeNull();
+  // The surf height beside it is unaffected: only one of the two is per-period.
+  expect(screen.getByText("Surf")).toBeDefined();
+});
+
+/**
+ * Stated, not withheld -- the opposite of what a stale buoy reading gets.
+ * `MAX_WAVE_AGE_MINUTES` drops an old measurement because a number with no time
+ * attached reads as now. The office's last published judgement is still the
+ * best information anyone has about this water, so hiding it would leave the
+ * page silent on the day that matters most.
+ */
+test("a bulletin past a missed cycle says so and still shows the risk", () => {
+  render(
+    <SurfZone
+      state={forecast(
+        [{ localDate: "2026-09-02", periodName: "TODAY", level: "High" }],
+        null,
+        26,
+      )}
+      localDate="2026-09-02"
+      when="today"
+    />,
+  );
+
+  expect(screen.getByText(/26 hours old/i)).toBeDefined();
+  expect(screen.getByText(/one has been missed/i)).toBeDefined();
+  // Withholding would be the worse failure, so the level is still there.
+  expect(screen.getByText("High")).toBeDefined();
+});
+
+test("a current bulletin carries no staleness line", () => {
+  render(
+    <SurfZone
+      state={forecast([
+        { localDate: "2026-09-02", periodName: "TODAY", level: "Low" },
+      ])}
+      localDate="2026-09-02"
+      when="today"
+    />,
+  );
+
+  expect(screen.queryByText(/hours old/i)).toBeNull();
 });

--- a/src/components/conditions/SurfZone.tsx
+++ b/src/components/conditions/SurfZone.tsx
@@ -90,6 +90,46 @@ function Reading({ day, when }: { day: SurfZoneDay; when: string }) {
         wrote one.
       */}
       <p className="leading-relaxed mb-2 max-w-130 text-base">{day.meaning}</p>
+
+      {/*
+        The two published figures, under the risk they belong to rather than
+        beside the day's swell.
+
+        **Surf height is the evidence for the level, not a surf reading.**
+        "High" alone is a bare word; "High -- 3 to 5 feet. Sets to 6 feet." is
+        one statement. It deliberately does not sit next to CDIP's swell, which
+        the hour chart's swell tab and the map readout both carry: those are
+        significant wave height at 10 m depth and this is breaking surf face
+        height, so the two disagree by several times over and a reader with both
+        in view would take one instrument for broken. Same region, never
+        adjacent, and co-visible only when a reader has chosen the swell tab.
+
+        **Both are relayed verbatim, "degrees" included.** This site's own
+        figures are °F and feet, and reformatting these to match would edit a
+        quoted product to look like our own. They sit under the office's
+        attribution, which is what says whose sentence they are. The set height
+        is the part a range would drop and the part a parent needs.
+      */}
+      <dl className="leading-relaxed mb-2 max-w-130 text-base">
+        <div className="flex gap-2">
+          <dt className={PAGE_MUTED}>Surf</dt>
+          <dd>{day.surfHeight}</dd>
+        </div>
+        {day.waterTemperature !== null && (
+          <div className="flex gap-2">
+            <dt className={PAGE_MUTED}>Water</dt>
+            <dd>{day.waterTemperature}</dd>
+          </div>
+        )}
+      </dl>
+
+      {/*
+        No sentence when the water temperature is missing. It is absent from the
+        last day of every bulletin -- the office publishes it in the first
+        period only, 14 of 14 -- so an absence line would appear on a day out of
+        every two or three and would read as a fault that is really a cadence.
+        The days that have it show it; the days that do not say nothing.
+      */}
       <p className={`leading-relaxed text-sm ${PAGE_MUTED}`}>
         For {when}, from the period the office called &ldquo;{day.periodName}
         &rdquo;.
@@ -161,6 +201,29 @@ export function SurfZone({ state, localDate, when }: SurfZoneProps) {
           <strong className="font-black">{state.headline}</strong>. A headline
           covers the whole bulletin rather than one day, so it can name a level
           no single day below it does.
+        </p>
+      )}
+
+      {state.staleAfterHours !== null && (
+        /*
+          Stated rather than withheld, which is the opposite of what a stale
+          buoy reading gets. `MAX_WAVE_AGE_MINUTES` drops an old measurement
+          because a number with no time attached reads as now; a judgement is
+          different. The office's last published one is still the best
+          information anyone has about this water, and hiding it would leave the
+          page silent on the day that matters most. So it stays, and the reader
+          is told the office has missed a cycle.
+
+          Above the level, because it changes how everything under it should be
+          read.
+        */
+        <p className="leading-relaxed mb-3 max-w-130 text-base">
+          <strong className="font-black">
+            This is {state.staleAfterHours} hours old.
+          </strong>{" "}
+          The National Weather Service issues it twice a day, so a gap this long
+          means one has been missed. What it says below was true when it was
+          written.
         </p>
       )}
 

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -1988,9 +1988,16 @@ function servingSurfZone(
     name: string;
     localDates: string[];
     level: "Low" | "Moderate" | "High";
+    surfHeight?: string;
+    waterTemperature?: string | null;
   }[],
   headline: string | null = null,
 ) {
+  periods = periods.map((period) => ({
+    surfHeight: "1 to 3 feet.",
+    waterTemperature: null,
+    ...period,
+  }));
   fetchSurfZoneForecast.mockResolvedValue({
     kind: "ok",
     url: "https://api.weather.gov/products/abc",
@@ -2154,4 +2161,105 @@ test("a level whose gloss the bulletin dropped says so rather than rendering bla
   expect(view.state.kind).toBe("forecast");
   if (view.state.kind !== "forecast") return;
   expect(view.state.days[0].meaning).toMatch(/did not carry/i);
+});
+
+/**
+ * The first period covers two dates on an afternoon bulletin, and its water
+ * temperature belongs to both -- it is one period's figure, not one day's.
+ */
+test("both dates of a merged period carry that period's two figures", async () => {
+  const { readSurfZone } = await import("./conditions");
+  servingSurfZone([
+    {
+      name: "THIS AFTERNOON THROUGH WEDNESDAY",
+      localDates: ["2026-09-01", "2026-09-02"],
+      level: "Moderate",
+      surfHeight: "2 to 4 feet.",
+      waterTemperature: "70 to 76 degrees.",
+    },
+    {
+      name: "THURSDAY",
+      localDates: ["2026-09-03"],
+      level: "High",
+      surfHeight: "3 to 5 feet. Sets to 6 feet.",
+      waterTemperature: null,
+    },
+  ]);
+
+  const view = await readSurfZone(BEACH, SURF_ZONE_NOW);
+
+  expect(view.state.kind).toBe("forecast");
+  if (view.state.kind !== "forecast") return;
+  expect(view.state.days[0].waterTemperature).toBe("70 to 76 degrees.");
+  expect(view.state.days[0].surfHeight).toBe("2 to 4 feet.");
+  // The last day the bulletin reaches never has a water temperature.
+  expect(view.state.days[1].waterTemperature).toBeNull();
+  expect(view.state.days[1].surfHeight).toBe("3 to 5 feet. Sets to 6 feet.");
+});
+
+/**
+ * Eighteen hours against a product issued twice a day. The office's last
+ * judgement is still shown -- withholding would leave the page silent on the
+ * day it matters most -- but the reader is told a cycle was missed.
+ */
+test("a bulletin past a missed cycle reports its age", async () => {
+  const { readSurfZone, STALE_AFTER_HOURS } = await import("./conditions");
+  // Two periods, so the bulletin still reaches a day that is in the week when
+  // it is finally read. A stale bulletin whose only day has passed is a
+  // different case -- it correctly has no days at all, which is what the
+  // horizon test above already covers, and asserting a day here would have
+  // been asserting that the week never moves.
+  servingSurfZone([
+    { name: "TODAY", localDates: ["2026-09-02"], level: "High" },
+    { name: "THURSDAY", localDates: ["2026-09-03"], level: "High" },
+  ]);
+
+  // The bulletin is issued 2026-09-02T08:54Z; read it a clear cycle later.
+  const late =
+    Date.parse("2026-09-02T08:54:00+00:00") +
+    (STALE_AFTER_HOURS + 8) * 3_600_000;
+  const view = await readSurfZone(BEACH, late);
+
+  expect(view.state.kind).toBe("forecast");
+  if (view.state.kind !== "forecast") return;
+  expect(view.state.staleAfterHours).toBe(STALE_AFTER_HOURS + 8);
+  // Still shown. Withholding a judgement is the worse failure here.
+  expect(view.state.days.map((day) => day.localDate)).toContain("2026-09-03");
+});
+
+test("a bulletin inside its cadence reports no age at all", async () => {
+  const { readSurfZone } = await import("./conditions");
+  servingSurfZone([
+    { name: "TODAY", localDates: ["2026-09-02"], level: "Low" },
+  ]);
+
+  const view = await readSurfZone(
+    BEACH,
+    Date.parse("2026-09-02T08:54:00+00:00") + 3 * 3_600_000,
+  );
+
+  expect(view.state.kind).toBe("forecast");
+  if (view.state.kind !== "forecast") return;
+  expect(view.state.staleAfterHours).toBeNull();
+});
+
+/**
+ * A clock skew can put an issuance in the future. That is not stale, and
+ * `Math.floor` on a negative age would report a large one if the comparison
+ * were written the other way round.
+ */
+test("a bulletin issued in the future is not stale", async () => {
+  const { readSurfZone } = await import("./conditions");
+  servingSurfZone([
+    { name: "TODAY", localDates: ["2026-09-02"], level: "Low" },
+  ]);
+
+  const view = await readSurfZone(
+    BEACH,
+    Date.parse("2026-09-02T08:54:00+00:00") - 2 * 3_600_000,
+  );
+
+  expect(view.state.kind).toBe("forecast");
+  if (view.state.kind !== "forecast") return;
+  expect(view.state.staleAfterHours).toBeNull();
 });

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -1842,6 +1842,23 @@ export async function readSkyWording(
   return { ...binding, state: { kind: "week", days } };
 }
 
+/**
+ * How old a surf zone bulletin may be before the page says so, in hours.
+ *
+ * Eighteen, against a product issued twice a day. Measured 2026-09-02 across
+ * the 14 issuances SGX still held: every one fell at roughly 1 AM or 1 PM
+ * Pacific, and the sampled week held no off-cycle reissue -- so the longest
+ * ordinary gap is about twelve hours, and eighteen clears it with room for a
+ * late issuance without waiting out a whole missed cycle.
+ *
+ * A judgement is not a measurement that merely gets older. `MAX_WAVE_AGE_MINUTES`
+ * withholds a stale buoy reading outright; this one is stated rather than
+ * withheld, because the office's last published judgement is still the best
+ * information anyone has about the water and hiding it would leave the page
+ * saying nothing at all on the day it most matters.
+ */
+export const STALE_AFTER_HOURS = 18;
+
 /** One day of the surf zone forecast, as the panel prints it. */
 export type SurfZoneDay = {
   localDate: string;
@@ -1850,6 +1867,16 @@ export type SurfZoneDay = {
   level: RiskLevel;
   /** The bulletin's own sentence for that level. */
   meaning: string;
+  /** The published surf height, verbatim. The evidence the level rests on. */
+  surfHeight: string;
+  /**
+   * The published water temperature, verbatim, or null.
+   *
+   * Null on the last day a bulletin covers, every time -- the office publishes
+   * it in the first period only. It is the product's shape, not an outage, and
+   * the panel must not word it as one.
+   */
+  waterTemperature: string | null;
 };
 
 export type SurfZoneView = {
@@ -1869,6 +1896,18 @@ export type SurfZoneView = {
         headline: string | null;
         /** Only the days the bulletin reached, ascending. Never padded. */
         days: SurfZoneDay[];
+        /**
+         * How many hours old the bulletin is, rounded down, when that is long
+         * enough to mean the office missed a cycle. Null when it is current.
+         *
+         * The bulletin is issued twice a day and the sampled week held no
+         * off-cycle reissue, so anything past `STALE_AFTER_HOURS` means a cycle
+         * did not happen. A judgement is not a measurement that merely ages:
+         * presenting a missed cycle as current is the one failure this page can
+         * least afford, so the age is carried here and stated rather than left
+         * for a reader to work out of the issuance time.
+         */
+        staleAfterHours: number | null;
       }
     | { kind: "unavailable"; detail: string; drift: boolean }
     /** This beach has no surf zone, so the product is not about it. */
@@ -1937,6 +1976,8 @@ export async function readSurfZone(
         localDate,
         periodName: period.name,
         level: period.level,
+        surfHeight: period.surfHeight,
+        waterTemperature: period.waterTemperature,
         meaning:
           meanings.get(period.level) ??
           // The bulletin defines its levels in its own body, so a missing gloss
@@ -1954,6 +1995,14 @@ export async function readSurfZone(
     return day === undefined ? [] : [day];
   });
 
+  /*
+    Rounded down, so "18 hours old" is never said of something 17 hours and 50
+    minutes old. Negative ages -- a bulletin issued in the future, which a clock
+    skew can produce -- are not stale, and `Math.floor` on a negative would
+    otherwise report a large one after the comparison.
+  */
+  const ageHours = Math.floor((nowMs - forecast.issuedMs) / 3_600_000);
+
   return {
     beachName: beach.name,
     state: {
@@ -1961,6 +2010,7 @@ export async function readSurfZone(
       issuedMs: forecast.issuedMs,
       headline: forecast.headline,
       days,
+      staleAfterHours: ageHours >= STALE_AFTER_HOURS ? ageHours : null,
     },
   };
 }

--- a/src/lib/nws-surf-zone.test.ts
+++ b/src/lib/nws-surf-zone.test.ts
@@ -351,3 +351,45 @@ describe("shapes the captured week did not contain", () => {
     );
   });
 });
+
+describe("the two figures beside the risk", () => {
+  /**
+   * Verbatim, including the second sentence. Across the sampled week the field
+   * read `3 to 5 feet`, `3 to 5 feet. Sets to 6 feet.`, `3 to 5 feet, local
+   * sets to 6 feet` and `3 to 5 feet with sets to 6 feet` — so a parser
+   * extracting a range would drop the set height on three of those four, which
+   * is the number a parent actually needs.
+   */
+  it("relays each period's surf height whole", () => {
+    const forecast = parseSurfZoneForecast(MORNING, MORNING_ISSUED);
+
+    expect(forecast.periods.map((period) => period.surfHeight)).toEqual([
+      "1 to 3 feet. Sets to 4 feet.",
+      "1 to 3 feet. Sets to 4 feet.",
+    ]);
+  });
+
+  /**
+   * The first period only, on all 14 sampled issuances. So the last day a
+   * bulletin covers never carries one, and null here is the product's shape
+   * rather than a feed having a bad day.
+   */
+  it("finds a water temperature in the first period and none in the second", () => {
+    const forecast = parseSurfZoneForecast(MORNING, MORNING_ISSUED);
+
+    expect(forecast.periods[0].waterTemperature).toBe("70 to 74 degrees.");
+    expect(forecast.periods[1].waterTemperature).toBeNull();
+  });
+
+  it("refuses a period that stopped publishing a surf height", () => {
+    const dropped = inSanDiego(
+      MORNING,
+      /^Surf Height\.+.*$/m,
+      "Thunderstorm Potential........None expected.",
+    );
+
+    expect(() => parseSurfZoneForecast(dropped, MORNING_ISSUED)).toThrow(
+      NwsSurfZoneDriftError,
+    );
+  });
+});

--- a/src/lib/nws-surf-zone.ts
+++ b/src/lib/nws-surf-zone.ts
@@ -119,6 +119,32 @@ export interface SurfZonePeriod {
   localDates: string[];
   /** The published level, one of three. */
   level: RiskLevel;
+  /**
+   * The published surf height, verbatim: `3 to 5 feet. Sets to 6 feet.`
+   *
+   * **Not parsed into numbers, and not reworded.** It is prose as often as it
+   * is a range -- across the 14 sampled issuances it read `3 to 5 feet`,
+   * `3 to 5 feet. Sets to 6 feet.`, `3 to 5 feet, local sets to 6 feet` and
+   * `3 to 5 feet with sets to 6 feet`. The set height is the part a parent
+   * needs and the part a range would drop, so the sentence is relayed whole.
+   *
+   * Present in every period of every sampled issuance, so its absence is drift.
+   */
+  surfHeight: string;
+  /**
+   * The published water temperature, verbatim: `70 to 74 degrees`. Null where
+   * the bulletin published none.
+   *
+   * **Null is the product's shape rather than an outage.** It appears in the
+   * first period only -- 14 of 14 -- so the last day a bulletin covers never
+   * carries one, every time. A caller must not read null here as a feed having
+   * a bad day.
+   *
+   * `degrees` rather than `°F`, because it is quoted. This site's own figures
+   * are °F (the presentation rule in `docs/plans/conditions-tool.md`), and this
+   * one is the office's sentence sitting under the office's attribution.
+   */
+  waterTemperature: string | null;
 }
 
 /** One line of the bulletin's own glossary of its risk levels. */
@@ -386,8 +412,26 @@ export function parseSurfZoneForecast(
       );
     }
 
+    const surfHeight = fieldIn(block, "Surf Height");
+    if (surfHeight === null || surfHeight.length === 0) {
+      throw new NwsSurfZoneDriftError(
+        `The period ${JSON.stringify(name)} of the ${zoneId} surf zone bulletin published ` +
+          `no "Surf Height" field. Every period of every sampled issuance carried one, ` +
+          `and it is what the risk above it is evidence of.`,
+      );
+    }
+
     const localDates = resolvePeriodDates(name, searchFrom);
-    periods.push({ name, localDates, level: levelOf(risk, name) });
+    periods.push({
+      name,
+      localDates,
+      level: levelOf(risk, name),
+      surfHeight,
+      // Absent in the second period of every sampled bulletin, so an empty
+      // value is not distinguished from a missing key: both mean the office
+      // published no water temperature for this period.
+      waterTemperature: fieldIn(block, "Water Temperature") || null,
+    });
     searchFrom = addLocalDays(localDates[localDates.length - 1], 1);
   }
 


### PR DESCRIPTION
Closes #219

Slices 4 and 5 — the last of [`docs/plans/surf-zone-forecast.md`](docs/plans/surf-zone-forecast.md).

## What changed

**Both figures are relayed verbatim rather than parsed into numbers.** Across the 14 sampled issuances the surf height read `3 to 5 feet`, `3 to 5 feet. Sets to 6 feet.`, `3 to 5 feet, local sets to 6 feet` and `3 to 5 feet with sets to 6 feet` — a parser extracting a range drops the set height on three of those four, which is the number a parent actually needs. The water temperature keeps `degrees` rather than becoming `°F`: reformatting a quoted product to match this site's own conventions edits the office's sentence to look like ours, and it sits directly under the office's attribution.

**Surf height is the evidence for the level, not a surf reading.** It stays away from CDIP's swell — see the caveat below.

**Water temperature is published in the first period only**, on all 14 issuances, so the last day a bulletin covers never has one. The row is simply not drawn there: an absence sentence would appear on one day in every two or three and would read as a fault that is really a cadence.

**Staleness is stated, not withheld** — the opposite of what `MAX_WAVE_AGE_MINUTES` does to an old buoy reading. A number with no time attached reads as *now*, so a stale measurement is dropped. A judgement is different: the office's last published one is still the best information anyone has about this water, and hiding it would leave the page silent on the day that matters most. 18 hours against a twice-daily product clears the ~12-hour ordinary gap with room for a late issuance.

## Verification

`npm run gate`:

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

Rendered against the live NWS feed (`/conditions`), which also shows ADR-0029's forecast-beside-measurement working:

```
Rip current risk
Low
Life threatening rip currents are unlikely but still could occur.
Surf   1 to 3 feet. Sets to 4 feet.
Water  70 to 74 degrees.
For today, from the period the office called "TODAY".
Surf zone forecast, San Diego County Coastal Areas · NWS — issued 1:54 AM
```
```
Waves and water  🏄 3.0 ft — about waist high.  Period 6 s  Water 73°F
Measured now · Buoy Scripps Nearshore · NDBC
```

The county range (70–74) and the buoy's measured 73°F agree, in separate blocks with separate provenance.

## One thing I got partly wrong, recorded not fixed

**The surf height sits nearer the buoy than the plan considered.** The decision was to keep it away from CDIP's modelled swell, and it does — that lives behind the hour chart's swell tab and in the map readout. But `MeasuredToday` is the *next block down* and carries the buoy's measured height, and on 2026-09-02 the page read `Surf 1 to 3 feet. Sets to 4 feet.` above `🏄 3.0 ft — about waist high`.

Those are breaking surf face height and significant wave height at a buoy: different quantities, similar numbers that day, two blocks apart. The plan reasoned about this collision against CDIP and not against the block immediately beneath it. I've recorded it in the plan rather than fixing it, because the fix is a placement question and you already own those on this block.

## Not done

- Two `TODO(verify)`-class gaps, both stated in ADR-0044 as accepted consequences: the period vocabulary is one week of one summer, and a label outside it takes the block down rather than silently dropping a day.
- The plan is not yet marked Historical. That happens on merge, per `docs/plans/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)