### PR TITLE
Mark the surf zone forecast plan historical

### DIFF
--- a/docs/plans/surf-zone-forecast.md
+++ b/docs/plans/surf-zone-forecast.md
@@ -1,5 +1,9 @@
 # The surf zone forecast on the conditions page (issue #217)
 
+> **Historical.** Planned 2026-09-02, shipped in PRs #216, #218 and #220 on
+> 2026-09-02. It records what was intended then, not what the code does now,
+> and is not maintained. See [`README.md`](README.md).
+
 Date: 2026-09-02.
 
 ## Problem, from the reader's point of view


### PR DESCRIPTION
The surf zone forecast work merged in #220. `docs/plans/README.md` requires the
Historical note to land in the same PR as the merge, and it did not — this is
the correction rather than the intended sequence.

Small lane per `CLAUDE.md`: prose only, no logic, no data shape, no contract,
and it contradicts nothing in `docs/adr/` or `CONTEXT.md`. No test, because
nothing here is behaviour a reader sees — this file is not rendered.

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

## Noticed while doing it

Two other files in `docs/plans/` carry no Historical note. Checked rather than
assumed, and the first answer I wrote here was wrong:

- **`map-weather-readout.md` says "Planned 2026-08-31. In flight." and that is
  correct.** It plans three PRs — #192, #193, #194. The first two are closed;
  **#194 is open**, so slices 7 and 8 (the animated water and air field) have
  not shipped. No ADR for "the animation restates, it never states" exists,
  which corroborates it. Not a defect, and not to be marked.
- **`website-brief-decomposition.md`** has no note either, but it is a
  decomposition index rather than a plan for a unit of work, so it is plausibly
  outside the rule. A judgement call rather than a defect.

**What is actually wrong is `README.md`'s own sentence**: "Today every plan here
is historical; nothing is in flight." That has been false since
`map-weather-readout.md` was written, and it matters more than it looks — the
sentence tells a reader they will not find an in-flight plan in this directory,
which is exactly the thing that decides whether a plan file may be edited. It is
one line, it is in the file this PR is already about, and it is left here
deliberately rather than fixed: it is not this change's subject, and `CLAUDE.md`
is explicit that work which "was right there" belongs to a different branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)