### PR TITLE
Replace the plans README's census with the rule it illustrated

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -16,8 +16,21 @@ Each file carries a note under its title:
 > It records what was intended then, not what the code does now, and is not
 > maintained. See [`README.md`](README.md).
 
-A plan still being worked carries no such note. Today every plan here is
-historical; nothing is in flight.
+A plan still being worked carries the other marker instead, under its title:
+
+> Planned 2026-08-31. In flight.
+
+**Every plan carries one or the other, and which one is the note's whole
+purpose**, because it decides whether the file may be amended — see below. The
+marker changes exactly once, in the pull request that merges the work.
+
+This used to say "a plan still being worked carries no such note" and then
+counted: "today every plan here is historical; nothing is in flight." Both
+halves were wrong. An in-flight plan does carry a marker, and one has been in
+flight since 2026-08-31. A census in a file nobody re-counts goes stale the
+first time someone starts a plan, and this one did — it was read on 2026-09-02
+as licence to freeze a live plan, which is the one mistake these markers exist
+to prevent. The rule is stated here now and the count is not.
 
 ## What that means in practice
 


### PR DESCRIPTION
`docs/plans/README.md` made two claims about itself. Both were wrong, and the
second is the one that matters.

**"A plan still being worked carries no such note"** does not describe practice.
`map-weather-readout.md` carries `Planned 2026-08-31. In flight.` — a marker,
not the absence of one.

**"Today every plan here is historical; nothing is in flight"** has been false
since that plan was written. It names three PRs — #192, #193, #194 — and **#194
is still open**, so slices 7 and 8, the animated water and air field, have not
shipped. The absence of any ADR for "the animation restates, it never states",
which slice 7 was to produce, corroborates it.

## Why this is worth a change rather than a shrug

That second sentence is what a reader consults to decide **whether a plan file
may be amended**, which is the entire distinction the markers exist to draw.

It has already caused the mistake once. On 2026-09-02, while marking the surf
zone plan historical, I read it as licence to conclude `map-weather-readout.md`
was stale and should be marked too — which would have frozen a plan still being
worked and told the next person not to amend it. What caught it was checking
#194's state instead of trusting the count. The first version of #221's body
carried the wrong claim before that check; it has been corrected there.

## What changed

The census goes; the rule stays, with the in-flight marker's form shown beside
the historical one. A count in a file nobody re-counts goes stale the first time
someone starts a plan — which is exactly what happened — while a rule does not.
The paragraph says what went wrong rather than quietly deleting it, because the
next person to add a convenient-sounding count should see why this one was
removed.

Small lane per `CLAUDE.md`: prose only, no logic, no data shape, no contract.
No test — nothing in `docs/plans/` is rendered, so there is no behaviour a
reader sees to assert.

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

## Not done

- **`map-weather-readout.md` is untouched**, which is the point: it is correctly
  marked and #194 is open.
- **`website-brief-decomposition.md` still carries no marker.** It is a
  decomposition index rather than a plan for a unit of work, so it is plausibly
  outside this rule. That is a call about the rule's scope rather than a defect,
  and it is left for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)