### PR TITLE
Open the conditions page on its readings

### DIFF
--- a/.design/conditions-minimal/.gitignore
+++ b/.design/conditions-minimal/.gitignore
@@ -1,0 +1,1 @@
+screenshots/

--- a/.design/conditions-minimal/DESIGN_BRIEF.md
+++ b/.design/conditions-minimal/DESIGN_BRIEF.md
@@ -1,0 +1,342 @@
+# Design Brief: Conditions, compressed
+
+Date: 2026-09-02. Status: agreed in the design-flow grill of the same date.
+
+Supersedes nothing. `.design/conditions-page/DESIGN_BRIEF.md` and
+`.design/conditions-day-view/DESIGN_BRIEF.md` are the briefs that built what
+this one edits; both are historical and are not amended here.
+
+---
+
+## Problem
+
+A parent opens `/conditions` on a phone or a laptop to answer one question —
+_is it worth taking the kids to the water today, and if not today, when?_ — and
+the page makes them work for it.
+
+**The answer is buried under an introduction.** Before any number there is an
+eyebrow, a 56px headline, a paragraph explaining what the site is, and a second
+paragraph explaining what the readings are not. The reader already clicked
+"Conditions"; they know what the page is. What they cannot see without scrolling
+is a single measurement.
+
+**The reading they came for is three regions down.** The live surf height, the
+water temperature, the air temperature and the rip current risk sit inside the
+day panel, below the week grid and below the hourly chart. On the review
+machine's 639px-tall window they are off the first screen entirely.
+
+**Changing the day means scrolling away from the thing you are changing.** The
+week grid is the only day selector, and it sits above the hourly chart. To see
+Thursday's tide curve a reader picks Thursday at the top, scrolls down to the
+chart, decides Thursday is wrong, and scrolls back up. The control and its
+effect are never on screen together.
+
+**The page ends in a wall of reference prose.** Five multi-sentence notes about
+the tide datum, the daylight window, buoy heights, the CDIP model and cloud
+cover — correct, carefully written, and read once. They occupy roughly a screen
+at the bottom of every visit forever.
+
+The page is honest and it is thorough. It is not fast, and speed is what this
+particular reader wants.
+
+## Solution
+
+The page opens with a **now-strip**: one compressed band beside the beach
+selector that says what the water and the air are doing at this beach right now,
+and what the National Weather Service calls the rip current risk today. It is the
+first thing on the page and it is the only loud thing on it.
+
+Everything below it becomes a **planning surface**, deliberately quiet: the week
+grid, then a day strip, then the hourly chart for whichever day the strip has
+selected. The day strip sits directly above the chart, so the control and its
+effect are on screen together and stepping across the week costs no scrolling.
+
+The reference prose does not go away — it collapses. "How to read these numbers"
+becomes a single closed disclosure, and each region's source attributions gather
+into one `▸ Sources` line. Every word still ships in the DOM, still reaches a
+screen reader, still satisfies the gate that asserts caveats reach readers. It
+simply stops occupying the page by default.
+
+## Experience Principles
+
+**1. Now above, plan below — and the line between them is visible.**
+
+The strip means _right now at this beach_, always. It does not change when a
+reader picks Thursday, because "right now" has no Thursday. Everything beneath
+the beach selector is about a chosen day. The day strip is the seam: above it,
+the present; below it, whichever day you asked for.
+
+This resolves the tension the current page has never resolved — `MeasuredToday`
+is today-only and `SurfZone` is per-day, and today they are stacked together as
+though they were the same kind of fact. Separating them by position is what makes
+each one honest without a sentence explaining it.
+
+**2. Compressed, not hidden.**
+
+Every removal on this page is one of three things: a duplicate deleted, a
+sentence whose justification has expired, or a disclosure that keeps the content
+in the DOM. Nothing else is cut.
+
+Two categories are never collapsed, at any density: **a note that reports a
+failure** (a feed that went quiet, a station that could not be reached) and **a
+qualification that changes what a visible figure means**. The seven conditional
+week notes stay exactly as they are. The ADR-0009 safety notice stays visible.
+
+**3. One loud thing.**
+
+The page has exactly one expressive surface, and it is the now-strip: the dark
+saturated card ADR-0015 established, the yellow eyebrow, the glyph vocabulary,
+the large italic figures. Everything else is small, quiet and utilitarian.
+
+Personality by concentration rather than distribution. The current page spreads
+its character thinly — an italic heading here, an accent there — which is a large
+part of why trimming it felt like it would leave nothing. Concentrating the voice
+in one band means the rest of the page can go as quiet as the reader needs
+without the page stopping sounding like this site.
+
+## Aesthetic Direction
+
+- **Philosophy**: Instrument panel. A dark, dense readout band above a pale,
+  spacious planning surface. The contrast between the two is the design.
+- **Tone**: Calm and factual, with one moment of warmth. Not urgent — this page
+  relays measurements and ADR-0009 forbids it forming a safety judgement, so
+  nothing may look like an alarm.
+- **Reference points**: A tide clock. A marine VHF weather readout. The dark
+  reading cards this page already ships.
+- **Anti-references**: A surf report with a green/amber/red verdict badge — this
+  is forbidden outright by ADR-0015, which holds that a surface here is
+  decoration and not a verdict. Also: a dashboard of equal-weight tiles, which is
+  what the page becomes if the strip is not clearly louder than everything else.
+
+## Existing Patterns
+
+This design extends the vocabulary already in the repo. It introduces no new
+dependency, no new colour and no new radius.
+
+- **Typography**: `--text-2xs` 10px through `--text-base` 13px for body and
+  labels; `--text-stat` 36px, `--text-quote` clamp(20–34px), `--text-title`
+  clamp(32–56px) for display. Montserrat, black italic for display type.
+- **Colors**: `ocean`, `fog`, `dark`, `mist`, `lavender`, `cream`, yellow accent.
+  Defined in `src/app/globals.css`.
+- **Spacing**: `px-gutter-sm` / `px-gutter`, `py-section-sm` / `py-section`, and
+  Tailwind's default scale for everything inside a section.
+- **Components reused**: `ReadingCard` and `StatGroup` (the dark card and its
+  label/value pairs), `ProvenanceLine` (attribution at 10px), `BeachSelector`,
+  `DISCLOSURE_TARGET` (the 44px-floor `<summary>`), `HourChart`, `WeekGrid`,
+  `SelectedDayProvider` / `resolveSelected`.
+- **Glyphs**: ADR-0015's vocabulary, unchanged — 🐚 lowest tide, 🏄 waves and
+  water, 💨 air. A glyph marks a panel, never a row inside one.
+
+## Component Inventory
+
+| Component           | Status | Notes                                                                                                          |
+| ------------------- | ------ | -------------------------------------------------------------------------------------------------------------- |
+| `NowStrip`          | New    | The compressed band. Composes waves + air + today's rip level word. Client-agnostic; rendered from the server. |
+| `DayStrip`          | New    | Seven day pills above the chart. Client component; reads and writes `SelectedDayProvider`.                     |
+| `SourcesDisclosure` | New    | Wraps a region's `ProvenanceLine`s in one closed `<details>`.                                                  |
+| `ConditionsSection` | Modify | New order: title + notice + selector + strip, then week, then day, then collapsed notes.                       |
+| `ConditionsNotes`   | Modify | Whole region wrapped in one closed `<details>`.                                                                |
+| `WeekPanel`         | Modify | Unconditional daylight note removed. Seven conditional failure notes unchanged.                                |
+| `ChosenDay`         | Modify | Renders `DayStrip` above the chart. Heading takes the smaller rank.                                            |
+| `DayPanel`          | Modify | Keeps the full rip block and the measured block; also supplies today's rip level to the strip.                 |
+| `MeasuredPanel`     | Modify | Read is lifted so both the strip and the day panel can use it. Costs no extra request — see below.             |
+| `headingRank.ts`    | Modify | Adds a second, smaller rank for tool-page regions. `REGION_HEADING` itself is untouched.                       |
+| `SurfZone`          | Keep   | Unchanged. The day panel keeps the full block on every day.                                                    |
+| `ReadingCard`       | Keep   | The strip is built from it rather than replacing it.                                                           |
+
+## Implementation Decisions
+
+**The strip's reads cost nothing extra.** Every upstream call in
+`src/lib/upstream.ts` is a `fetch` with `next: { revalidate: N }`, so Next's Data
+Cache deduplicates identical requests within a render. Reading the surf zone at
+page level for the strip and again in `DayPanel` for the chosen day is one
+upstream request, not two. This was measured against the code, not assumed, and
+it is the fact the whole "lift the reads" decision rests on — if it stops being
+true, the strip must take its values as props from a single read instead.
+
+**The strip is a server render inside its own Suspense boundary.** It follows
+the rule the page already holds to: five agencies go quiet independently and none
+may hold up another. A slow buoy must not delay the week grid.
+
+**The strip never reads `SelectedDayProvider`.** It is deliberately outside it.
+That is what makes "frozen to now" structural rather than a convention someone
+can break later by passing the wrong prop.
+
+**The day strip and the week grid share one provider.** `DayStrip` calls
+`useSelectedDay()` exactly as `WeekGrid` does, so choosing Thursday in either
+control moves both. No second source of truth for which day is showing.
+
+**The heading rank is added, not changed.** A new export beside
+`REGION_HEADING`, used only by the three conditions regions. Changing
+`REGION_HEADING` itself would silently resize `/art`'s two section headings and
+`SessionSchedule`'s, which reaches `/art` and `/coop` — pages that have made no
+such complaint. (Checked against the code: the landing page does not use
+`REGION_HEADING`, so it is unaffected either way.)
+
+## What was considered and rejected
+
+**The strip follows the chosen day.** Rejected: `MeasuredToday` is today-only, so
+on six of seven days the strip would half-empty into "nothing has been measured
+yet" — and it sits _above_ the control that changed it, so a reader would watch
+the top of the page empty for a reason not visible from where they were looking.
+
+**The day panel drops its rip block when today is showing.** Rejected: the block
+would appear and disappear as a reader steps across the week, moving everything
+below it. `ChosenDay`'s current order exists specifically to keep the chart still
+while the day changes, and this would undo it.
+
+**The full rip block moves to the strip.** Rejected: it is the level, a meaning
+sentence, two ranges and a period name. Putting all of it at the top makes the
+top tall, which is the opposite of the request. The strip takes the level word;
+the day panel keeps the block.
+
+**Shrink `REGION_HEADING` globally.** Rejected: one edit, but it moves four pages
+that were designed at the current size.
+
+**Sticky day bar on scroll.** Rejected: most complex option, and on the 639px
+review window a pinned bar spends the scarce resource the whole brief is trying
+to recover.
+
+**Collapse the sky wording.** Rejected by the designer: it is the publisher's own
+prose and the most human block on the page.
+
+**Collapse the safety notice.** Rejected on ADR-0009, which holds that the
+standing notice "has to sit around the readings" and cites it as one of three
+reasons the tool is native rather than embedded. The notice is shortened, not
+hidden.
+
+## The ADR-0023 debt
+
+Removing the week grid's unconditional daylight note contradicts ADR-0023, which
+states in terms: _"This sentence is the condition the drop is allowed under.
+Removing it while keeping the drop reintroduces exactly the failure ADR-0017
+objected to."_
+
+It is removed anyway, and a new ADR records why. The argument is that ADR-0023's
+own conditions have since been met:
+
+- ADR-0023 scoped the loss as lasting **"until a day view carries them"**. The
+  day view now exists and draws the whole twenty-four hours with night shaded, so
+  the overnight extremes it was waiting for are on the page.
+- The sentence points at "the cards above". **Those cards are gone**, removed
+  with the three-card slab, so the sentence already directs a reader to something
+  that is not there.
+- The sentence's other job — saying the cell figures are daylight-scoped — is
+  done by the `☀ 6:20 AM to 7:20 PM` line that ADR-0023 itself placed in every
+  day's header.
+
+The new ADR supersedes that clause of 0023 and nothing else. Its number must be
+re-derived at implementation time rather than taken from this file; the
+`adr-numbers` gate catches a collision, but guessing wastes a run.
+
+## Key Interactions
+
+**Choosing a beach.** Unchanged. The selector navigates; the whole page re-reads
+for the new beach, strip included.
+
+**Choosing a day.** A reader clicks a pill in the day strip or a cell in the week
+grid. Both write the same provider. The hourly chart, the sky wording, the rip
+block and the measured block all follow. **The now-strip does not move.** The
+selected pill and the selected week cell both mark themselves, so the two
+controls always agree.
+
+The chart is not keyed on the day, so the tab a reader chose (tide, swell, wind,
+air) and the hour they selected both survive stepping across the week. This is
+existing behaviour and the day strip must not break it.
+
+**Opening a disclosure.** Native `<details>`. No animation, no JavaScript, works
+before hydration and without it. `DISCLOSURE_TARGET` gives every `<summary>` the
+44px floor ADR-0004 requires.
+
+**Arriving without JavaScript.** The page shows today: the strip renders, the
+week grid renders with today marked, the chart draws today, the disclosures open
+and close natively. Only the day strip's selection is inert, which is the state
+`selectedDay.tsx` already documents as acceptable and degrades to "you get
+today".
+
+## Responsive Behavior
+
+- **Below `md`**: everything stacks. Title, notice, selector, strip full width.
+  The strip's figures wrap to two rows rather than shrinking below legibility.
+  The day strip scrolls horizontally rather than wrapping — seven pills on one
+  line is the point of it.
+- **`md` and up**: title and notice share a row with the selector and the strip,
+  as the current header does.
+- **`xl`**: the week grid reaches seven columns; the chart and shore map sit two
+  thirds to one third, as now.
+
+The day strip is a horizontal scroller at every width where seven pills do not
+fit. It must never wrap to two lines — a wrapped day strip costs the height the
+whole brief is recovering, and it stops reading as a single control.
+
+## Accessibility Requirements
+
+- **Contrast**: 4.5:1 minimum for all text, which is the floor this page already
+  holds itself to. The strip is white and white/85 on the dark surface, matching
+  `ReadingCard`'s existing measured ratios. Any new pale-on-pale pairing must be
+  measured from painted pixels, not from the CSS tree.
+- **Touch targets**: 44px floor for every day pill and every `<summary>`, per
+  ADR-0004. Pills carry a visible background, so they may take the `md:` opt-out
+  that `PillLink` has; summaries do not.
+- **Focus**: every pill and summary keeps a visible focus ring. The day strip is
+  a horizontal scroller, so its container must not be `overflow-hidden` — a 2px
+  `outline-offset` clips against it. Use `overflow-x-auto` with vertical padding
+  for the ring.
+- **Screen readers**: the day strip is a labelled group of buttons with
+  `aria-pressed` (or a tablist, if the chart is treated as its panel — decide at
+  build time and be consistent with `WeekGrid`, which is a list of cells and
+  should stay one). Collapsing a region must not remove its heading from the
+  landmark structure: the `<summary>` carries the heading, so the `<h2>` stays.
+- **Reduced motion**: no new motion is introduced, so nothing new to honour.
+
+## Verification seams
+
+Agreed before implementation, per `CLAUDE.md`. All existing seams; no new ones.
+
+1. **`NowStrip` as a pure component** — takes finished readings and a rip level,
+   renders markup. Every judgement about what to show is testable without a
+   network, exactly as `MeasuredToday` is today.
+2. **`DayStrip` against `SelectedDayProvider`** — render inside the provider,
+   click a pill, assert the selection changed; render outside it, assert it
+   degrades rather than throwing. `selectedDay.test.tsx` already establishes this
+   pattern.
+3. **`ConditionsSection` order** — assert the strip renders above the week
+   region and that it does not re-render on day change. This is the seam that
+   catches "frozen to now" being broken later.
+4. **`WeekPanel` notes** — assert the unconditional note is gone **and** that
+   each of the seven conditional notes still appears in its own failure state.
+   This is the regression test for the ADR-0023 change: it must fail first if a
+   failure note is removed along with the intro.
+5. **Collapsed content still reaches the reader** — the existing
+   `Caveats.test.tsx` and `ConditionsNotes.test.tsx` assertions use `getByText`,
+   which passes inside a closed `<details>`. Verified: there are no
+   `toBeVisible` assertions anywhere in `src/components/conditions/`, so
+   collapsing does not fight the gate. Do not add one.
+6. **Stylesheet gate** — any utility named in prose but not used by a component
+   must stay out of the built CSS, per ADR-0006.
+
+## Height budget
+
+The review machine is 1536×639 at 125% scaling (a 555px working stop). The
+target is that on that window, **the beach selector, the now-strip and the first
+row of the week grid are all above the fold**. That is the measurement this
+brief is judged on, and it must be taken on the branch and against `main` before
+any claim is made about it.
+
+## Out of Scope
+
+- **The shore map, the compass readout and the hourly chart's internals.** Not
+  touched. The chart gains a control above it and nothing else.
+- **The seven conditional week notes.** Their wording, their conditions and their
+  order are unchanged.
+- **Colour-coding rip current risk.** Forbidden by ADR-0015. Issue #217 —
+  whether size and weight are enough emphasis for `High` — stays open and is not
+  resolved here.
+- **Deep-linking a day in the URL.** `selectedDay.tsx` records why this was
+  rejected: `searchParams` makes the route dynamic and forfeits
+  `revalidate = 900`. Adding a second day control does not reopen it.
+- **The landing page, `/art`, `/coop`.** The new heading rank is additive, so
+  none of them move.
+- **`BeachSelector`'s own design.** It gains a neighbour, not a redesign.
+- **Removing the week grid.** It is a table a reader reads, not merely a
+  selector, and it keeps its per-day figures.

--- a/.design/conditions-minimal/DESIGN_BRIEF.md
+++ b/.design/conditions-minimal/DESIGN_BRIEF.md
@@ -323,6 +323,27 @@ row of the week grid are all above the fold**. That is the measurement this
 brief is judged on, and it must be taken on the branch and against `main` before
 any claim is made about it.
 
+> **Addendum, 2026-09-02, measured after slices 1-3.** The target as stated is
+> not reachable, and it was set without measuring the week cell.
+>
+> | at 1536×639          | `main` | slices 1-3 |
+> | -------------------- | -----: | ---------: |
+> | selector bottom      |  343px |  **259px** |
+> | week heading top     |  379px |      526px |
+> | first week cell ends |  807px |      938px |
+> | whole page           | 3424px | **3296px** |
+>
+> The header is 84px shorter and the page 128px shorter, and the readings now
+> land inside the first screen -- they were three regions down. But a week cell
+> is 292px tall on its own, so even with the readings compressed to zero the
+> first row could not finish above 639px from a grid that starts below 340px.
+>
+> **The target is restated**: the selector, the readings in full, and the week's
+> heading with the top of its first row. That is what slices 1-3 deliver.
+> Getting a whole week cell above the fold as well is a change to the week grid,
+> which this brief puts out of scope, and it should not be smuggled in as a
+> consequence of compressing something else.
+
 ## Out of Scope
 
 - **The shore map, the compass readout and the hourly chart's internals.** Not

--- a/.design/conditions-minimal/TASKS.md
+++ b/.design/conditions-minimal/TASKS.md
@@ -62,7 +62,7 @@ less of.
 
 ## PR 1 — The page opens on the readings
 
-Four slices. The top of the page, in reading order. Sequential: slices 1, 3 and 4
+Five slices. The top of the page, in reading order. Sequential: slices 1, 3 and 5
 all edit `ConditionsSection`'s header block, so working them in order avoids
 conflicts inside one file.
 
@@ -103,33 +103,58 @@ conflicts inside one file.
       `ChosenDay`, `ConditionsNotes`._
       _ADR-0014 still holds — region headings outrank card headings, just
       quieter._
-      _The new `--text-region` token needs a `REQUIRED` row in
+      _The new `--text-tool-region` token needs a `REQUIRED` row in
       `scripts/built-css.mjs`: without it, deleting the token would leave
-      `text-region` in the markup compiling to nothing, with every jsdom test
-      still green. This is the same guard `min-h-footer` already carries._
+      `text-tool-region` in the markup compiling to nothing, with every jsdom
+      test still green. This is the same guard `min-h-footer` already carries._
 
-- [ ] **Slice 3 — Move the measured readings into a now-strip.**
-      New `NowStrip` component: a compressed dark band beside the beach selector
-      carrying waves (height, period, water temperature) and air (temperature,
-      wind, gust). Built from `ReadingCard` / `StatGroup` so it inherits the
-      measured contrast ratios. Rendered from `ConditionsSection` inside its own
-      Suspense boundary, **outside `SelectedDayProvider`**. Remove the measured
-      block from `ChosenDay` / `DayPanel` — see the decision above.
-      **Done looks like**: the live readings are at the top of the page; picking
+> **Addendum, 2026-09-02, during implementation.** What was one slice here is
+> now two. Moving the readings and restyling them into a band cannot be
+> described without an "and", and the reason is in the code: `MeasuredToday` is
+> 502 lines against a 983-line test file, every branch of it reasoned about in
+> its own docstring. Rewriting its presentation in the same commit that moves it
+> would put a large refactor and a structural move in one diff, where a
+> regression in either reads as a regression in the other. The move deletes the
+> absence branch and nothing else; the band is presentation only. Slices 4 and 5
+> below are renumbered accordingly.
+
+- [ ] **Slice 3 — Move the live readings to the top of the page.**
+      Render `MeasuredPanel` from `ConditionsSection`, in its own Suspense
+      boundary, **outside `SelectedDayProvider`**. Remove it from `DayPanel` and
+      drop `DayView.measured` from `ChosenDay`. Presentation unchanged — this
+      slice moves the block, it does not restyle it.
+      **Done looks like**: the live readings are above the week grid; picking
       Thursday does not change them.
-      **Test**: (a) `NowStrip` renders finished readings without a network, the
-      way `MeasuredToday` is tested today; (b) `ConditionsSection` renders the
-      strip above the week region; (c) **changing the selected day leaves the
-      strip's values untouched** — this is the seam that catches "frozen to now"
-      being broken later.
-      _New: `NowStrip`. Modifies: `ConditionsSection`, `ChosenDay`, `DayPanel`.
-      Reuses: `ReadingCard`, `StatGroup`, `ProvenanceLine`, `MeasuredPanel`'s two
-      reads._
+      **Test**: (a) `ConditionsSection` renders the readings above the week
+      region; (b) **changing the selected day leaves them untouched** — the seam
+      that catches "frozen to now" being broken later; (c) `ChosenDay` no longer
+      renders a measured block on any of the seven days.
+      _Modifies: `ConditionsSection`, `ChosenDay`, `DayPanel`, `MeasuredToday`._
+      _Deletes: `MeasuredToday`'s `readings === null` branch and its `when` prop,
+      with the tests that cover them. Once the day panel stops rendering the
+      block, nothing can reach that branch — and `CLAUDE.md` forbids leaving it
+      as dead code for a caller that no longer exists._
+
+- [ ] **Slice 4 — Compress the two reading cards into one band.**
+      Two `rounded-card bg-dark` cards side by side become one dark band with a
+      yellow `RIGHT NOW · <beach>` eyebrow: one surface, one set of padding, the
+      two readings as groups inside it rather than as separate sections.
+      Presentation only — every state branch and every wording helper stays
+      exactly as it is.
+      **Done looks like**: the same figures in materially less height, and the
+      band is the one loud thing the brief asks for.
+      **Test**: the existing `MeasuredToday` assertions pass unchanged. Any that
+      break should break because a figure moved, not because a wrapper did — if
+      a wording assertion fails here, the slice has overreached.
+      **Depends on**: Slice 3.
+      _Modifies: `MeasuredToday` (presentation), `ReadingCard` if the band needs
+      a surface-less variant. Reuses: `StatGroup`, `ProvenanceLine`, ADR-0015's
+      glyphs._
       _This is the aesthetic-direction slice: the brief's "one loud thing". Get
       the strip's look agreed here, because everything after it is quiet by
       contrast._
 
-- [ ] **Slice 4 — Add today's rip current level to the strip.**
+- [ ] **Slice 5 — Add today's rip current level to the strip.**
       Read the surf zone at page level, find today's `SurfZoneDay` by
       `localDate`, and print its `level` word in the strip. No gloss, no surf or
       water ranges, no period name — those stay in the day panel's full block,
@@ -141,8 +166,8 @@ conflicts inside one file.
       guess; (b) a bulletin that does not reach today renders the absence rather
       than silently borrowing another day's level; (c) **no severity colour** —
       assert the level's classes do not vary by level, per ADR-0015.
-      **Depends on**: Slice 3.
-      _Modifies: `NowStrip`, `ConditionsSection`. Reuses: `readSurfZone`._
+      **Depends on**: Slice 4.
+      _Modifies: the band, `ConditionsSection`. Reuses: `readSurfZone`._
       _Costs no extra upstream request: `readSurfZone` is a `next.revalidate`
       fetch and `DayPanel` already calls it, so the Data Cache dedupes. **Verify
       this holds at build time** — the brief's fallback is to pass the value down
@@ -153,9 +178,9 @@ conflicts inside one file.
 ## PR 2 — Changing the day without leaving the chart
 
 Two slices. Independent of PR 1 in principle; sequence after it so `ChosenDay`
-is edited once by slice 1 before slice 5 restructures around it.
+is edited once by slice 2 before slice 6 restructures around it.
 
-- [ ] **Slice 5 — Put a day strip above the hourly chart.**
+- [ ] **Slice 6 — Put a day strip above the hourly chart.**
       New `DayStrip` client component: seven day pills in one row, directly above
       `HourChart` inside `ChosenDay`. Calls `useSelectedDay()`, so it and
       `WeekGrid` are one control over one fact — choosing in either moves both.
@@ -176,7 +201,7 @@ is edited once by slice 1 before slice 5 restructures around it.
       `outline-offset` clips against it. Use `overflow-x-auto` with vertical
       padding._
 
-- [ ] **Slice 6 — Remove the week grid's daylight note, and record why.**
+- [ ] **Slice 7 — Remove the week grid's daylight note, and record why.**
       Delete the single unconditional note pushed at the top of `WeekPanel`'s
       `notes`. **Keep all seven conditional failure notes exactly as they are.**
       Write an ADR superseding that one clause of ADR-0023, carrying the
@@ -201,7 +226,7 @@ is edited once by slice 1 before slice 5 restructures around it.
 
 Two slices. Independent of both PRs above and of each other.
 
-- [ ] **Slice 7 — Collapse "How to read these numbers".**
+- [ ] **Slice 8 — Collapse "How to read these numbers".**
       Wrap the whole `ConditionsNotes` region in one `<details>`, closed by
       default, using `DISCLOSURE_TARGET` on the `<summary>`. The `<summary>`
       carries the heading text so the region keeps its landmark; the `<h2>` stays
@@ -216,7 +241,7 @@ Two slices. Independent of both PRs above and of each other.
       guarantees every caveat reaches a reader.
       _Modifies: `ConditionsNotes`. Reuses: `DISCLOSURE_TARGET`._
 
-- [ ] **Slice 8 — Gather each region's attributions into one `▸ Sources`.**
+- [ ] **Slice 9 — Gather each region's attributions into one `▸ Sources`.**
       New `SourcesDisclosure` wrapping a region's `ProvenanceLine`s in one closed
       `<details>`. Applied to the now-strip, the day panel and the week panel.
       **Done looks like**: each region ends in a single `▸ Sources` line instead
@@ -227,7 +252,7 @@ Two slices. Independent of both PRs above and of each other.
       one line, which is the exact failure that ADR forbids.
       _New: `SourcesDisclosure`. Modifies: `NowStrip`, `DayPanel`, `WeekPanel`.
       Reuses: `ProvenanceLine`, `DISCLOSURE_TARGET`._
-      _Depends on Slice 3 only for the strip's own sources; the day and week
+      _Depends on Slice 4 only for the band's own sources; the day and week
       halves are independent._
 
 ---

--- a/.design/conditions-minimal/TASKS.md
+++ b/.design/conditions-minimal/TASKS.md
@@ -135,6 +135,36 @@ conflicts inside one file.
       block, nothing can reach that branch — and `CLAUDE.md` forbids leaving it
       as dead code for a caller that no longer exists._
 
+> **Addendum, 2026-09-02, after slice 3 shipped. Slice 4 as written below is
+> blocked, and must not be built as described.** `MeasuredToday`'s docstring
+> settles it: _"Two cards, not one, and that is ADR-0010 rather than a layout
+> preference. The buoy and the air station are two provenances, which that
+> decision permits behind one *panel* and refuses behind one *sentence*... merging
+> them would produce exactly the sentence ADR-0010 forbids."_
+>
+> A second constraint sits under it. `CARD_PROSE` and `CARD_MUTED` are measured
+> against `bg-dark` and against nothing else -- white at 55% on the page's cream
+> ground is 1.03:1, a bug already fixed once in three places. Any band that is
+> not itself dark takes those two colours out of the surface they were measured
+> on.
+>
+> Three ways forward, for the designer to pick:
+>
+> 1. **Drop it.** The two cards are already the brief's "one loud thing", and
+>    slices 1-3 delivered the compression by other means. Measured cost: the pair
+>    is 223px.
+> 2. **Compress inside the two-card structure.** Each card keeps its own
+>    sentence, its own lead figure and its own provenance line -- which is all
+>    ADR-0010 actually requires -- and the height comes out of padding and row
+>    count instead. No ADR is engaged.
+> 3. **One dark band holding two attributed groups.** Satisfies both constraints
+>    on a literal reading (two sentences, two provenances, still `bg-dark`), but
+>    it reads against the docstring's intent and would need ADR-0010 amended
+>    rather than merely cited. Saves only the gap and one set of padding.
+>
+> Option 2 is the recommendation: it is the only one that recovers height without
+> touching a decision.
+
 - [ ] **Slice 4 — Compress the two reading cards into one band.**
       Two `rounded-card bg-dark` cards side by side become one dark band with a
       yellow `RIGHT NOW · <beach>` eyebrow: one surface, one set of padding, the

--- a/.design/conditions-minimal/TASKS.md
+++ b/.design/conditions-minimal/TASKS.md
@@ -1,0 +1,251 @@
+# Build Tasks: Conditions, compressed
+
+Generated from: `.design/conditions-minimal/DESIGN_BRIEF.md`
+Date: 2026-09-02
+
+## How this list is grouped, and why not the usual way
+
+The `brief-to-tasks` template groups work as Foundation → Core UI → Interactions
+→ Polish. **`CLAUDE.md` forbids that grouping**, in terms:
+
+> Slices are **vertical**: each cuts a complete path through every layer rather
+> than delivering one layer across the whole feature. A slice that delivers only
+> a schema, or only a UI, cannot be demonstrated or verified except by the slice
+> that finally uses it.
+
+So the list below is grouped by **pull request**, and every slice inside one is
+a complete path a reader can see. There is no "add the token" slice separate
+from the slice that uses it, and no "accessibility pass" slice — the 44px floor
+and the focus ring ship inside the slice that creates the control that needs
+them.
+
+Three PRs rather than the two the brief guessed. The boundaries are dependency
+boundaries, and each PR is comfortably inside the ~400-line / ~5-slice
+reviewability guide.
+
+**Every slice below**: own branch off current `main`, own commit, gates green at
+that commit, test in the same commit. Standard full-lane rules apply — none of
+them are restated per slice.
+
+---
+
+## Decision surfaced during the code trace — please confirm
+
+**The measured cards leave the day panel entirely.**
+
+Pain point 3 points at a screenshot containing the rip block _and_ the
+waves/water + air cards, and asks for that info "compressed and displayed at the
+top". That is a move, not a copy. The grill settled that the **rip block stays**
+in the day panel (Q2) but said nothing about the measured cards, so this is the
+gap.
+
+The reading taken here: **`MeasuredToday`'s live cards move to the strip and do
+not stay below.** Two consequences follow, and the second is the one to check:
+
+1. On today, the day panel no longer carries a measured block. Nothing is lost —
+   the same readings are at the top of the page, larger and sooner.
+2. On the other six days, the day panel currently shows a sentence saying
+   nothing has been measured about a day that has not happened. **That sentence
+   goes too.** It exists because the block used to sit in a position where its
+   absence would read as an outage; once no measured block lives in the day panel
+   at all, there is no gap to explain, and the strip is labelled as the present.
+
+This is not a silent failure — no feed is being hidden. A future day having no
+measurement is a logical fact, not an outage, and the seven conditional week
+notes still report every real outage.
+
+**If you would rather keep the absence sentence, say so before Slice 3** — it is
+one line in `ChosenDay` and cheap to keep, but it is text you said you wanted
+less of.
+
+---
+
+## PR 1 — The page opens on the readings
+
+Four slices. The top of the page, in reading order. Sequential: slices 1, 3 and 4
+all edit `ConditionsSection`'s header block, so working them in order avoids
+conflicts inside one file.
+
+> **Ordering note, 2026-09-02, during implementation.** The hero trim and the
+> heading rank were originally listed the other way round. Swapped before the
+> first commit: the heading rank's docstring argues its size is legible against
+> the conditions `<h1>`, citing that `<h1>`'s numbers. Written first, it would
+> have cited numbers that were not true until the next commit — a measured claim
+> false at its own commit, which is exactly the drift this repo's docstrings are
+> written to avoid. The two slices are otherwise independent.
+
+- [ ] **Slice 1 — Cut the conditions hero to a title and the notice.**
+      Remove the eyebrow (`Surf · Tide · Wind · Visibility`) and the lead
+      paragraph. Drop the `<h1>` from `text-title` to roughly
+      `clamp(24px, 3vw, 36px)`. Tighten the ADR-0009 notice to one line, keeping
+      both its claims: these are instrument readings, not a safety assessment;
+      lifeguards and posted signs are the authority.
+      **Done looks like**: the beach selector is visibly higher on a 639px
+      window; the notice is still plainly readable above the selector.
+      **Test**: both halves of the ADR-0009 notice are still present — this is
+      the regression test that stops a later "tighten" from deleting the
+      liability half. Assert the eyebrow and lead copy are gone.
+      _Modifies: `ConditionsSection`._
+      _The `<h1>` size is a local class, not a token change — nothing else on the
+      site uses `text-title` at this rank._
+
+- [ ] **Slice 2 — Quieten the conditions region headings.**
+      Add a second heading rank beside `REGION_HEADING` in
+      `src/components/ui/headingRank.ts` — roughly `clamp(17px, 1.6vw, 22px)`,
+      same black italic — and use it for the three conditions `<h2>`s
+      (`WeekGrid`, `ChosenDay`, `ConditionsNotes`).
+      **Done looks like**: the three region headings render smaller; `/art` and
+      `/coop` are pixel-identical.
+      **Test**: each of the three components refers to the new rank, and
+      `REGION_HEADING`'s own value is unchanged so `/art` and `SessionSchedule`
+      cannot move.
+      _Modifies: `headingRank.ts`, `globals.css`, `built-css.mjs`, `WeekGrid`,
+      `ChosenDay`, `ConditionsNotes`._
+      _ADR-0014 still holds — region headings outrank card headings, just
+      quieter._
+      _The new `--text-region` token needs a `REQUIRED` row in
+      `scripts/built-css.mjs`: without it, deleting the token would leave
+      `text-region` in the markup compiling to nothing, with every jsdom test
+      still green. This is the same guard `min-h-footer` already carries._
+
+- [ ] **Slice 3 — Move the measured readings into a now-strip.**
+      New `NowStrip` component: a compressed dark band beside the beach selector
+      carrying waves (height, period, water temperature) and air (temperature,
+      wind, gust). Built from `ReadingCard` / `StatGroup` so it inherits the
+      measured contrast ratios. Rendered from `ConditionsSection` inside its own
+      Suspense boundary, **outside `SelectedDayProvider`**. Remove the measured
+      block from `ChosenDay` / `DayPanel` — see the decision above.
+      **Done looks like**: the live readings are at the top of the page; picking
+      Thursday does not change them.
+      **Test**: (a) `NowStrip` renders finished readings without a network, the
+      way `MeasuredToday` is tested today; (b) `ConditionsSection` renders the
+      strip above the week region; (c) **changing the selected day leaves the
+      strip's values untouched** — this is the seam that catches "frozen to now"
+      being broken later.
+      _New: `NowStrip`. Modifies: `ConditionsSection`, `ChosenDay`, `DayPanel`.
+      Reuses: `ReadingCard`, `StatGroup`, `ProvenanceLine`, `MeasuredPanel`'s two
+      reads._
+      _This is the aesthetic-direction slice: the brief's "one loud thing". Get
+      the strip's look agreed here, because everything after it is quiet by
+      contrast._
+
+- [ ] **Slice 4 — Add today's rip current level to the strip.**
+      Read the surf zone at page level, find today's `SurfZoneDay` by
+      `localDate`, and print its `level` word in the strip. No gloss, no surf or
+      water ranges, no period name — those stay in the day panel's full block,
+      which is untouched.
+      **Done looks like**: the strip reads e.g. `RIP CURRENT RISK · Low`; the day
+      panel still shows the full block on all seven days.
+      **Test**: (a) every non-`forecast` state — unavailable, no bulletin,
+      sheltered beach — renders something honest rather than a blank or a
+      guess; (b) a bulletin that does not reach today renders the absence rather
+      than silently borrowing another day's level; (c) **no severity colour** —
+      assert the level's classes do not vary by level, per ADR-0015.
+      **Depends on**: Slice 3.
+      _Modifies: `NowStrip`, `ConditionsSection`. Reuses: `readSurfZone`._
+      _Costs no extra upstream request: `readSurfZone` is a `next.revalidate`
+      fetch and `DayPanel` already calls it, so the Data Cache dedupes. **Verify
+      this holds at build time** — the brief's fallback is to pass the value down
+      from a single read instead._
+
+---
+
+## PR 2 — Changing the day without leaving the chart
+
+Two slices. Independent of PR 1 in principle; sequence after it so `ChosenDay`
+is edited once by slice 1 before slice 5 restructures around it.
+
+- [ ] **Slice 5 — Put a day strip above the hourly chart.**
+      New `DayStrip` client component: seven day pills in one row, directly above
+      `HourChart` inside `ChosenDay`. Calls `useSelectedDay()`, so it and
+      `WeekGrid` are one control over one fact — choosing in either moves both.
+      Horizontal scroll (`overflow-x-auto`) where seven pills do not fit; **never
+      wraps to two lines**.
+      **Done looks like**: the day can be changed with the chart on screen, and
+      the week grid's highlight follows.
+      **Test**: (a) clicking a pill changes the selection inside the provider;
+      (b) rendered outside the provider it degrades to today rather than
+      throwing, matching `selectedDay.tsx`'s documented no-JS state;
+      (c) **the chart's selected tab and selected hour survive a day change** —
+      existing behaviour `ChosenDay` documents, and the thing this slice is most
+      likely to break; (d) every pill refers to the 44px touch-target standard
+      per ADR-0004.
+      _New: `DayStrip`. Modifies: `ChosenDay`. Reuses: `SelectedDayProvider`,
+      `resolveSelected`, `TOUCH_TARGET`._
+      _Focus rings: the scroller must not be `overflow-hidden` — a 2px
+      `outline-offset` clips against it. Use `overflow-x-auto` with vertical
+      padding._
+
+- [ ] **Slice 6 — Remove the week grid's daylight note, and record why.**
+      Delete the single unconditional note pushed at the top of `WeekPanel`'s
+      `notes`. **Keep all seven conditional failure notes exactly as they are.**
+      Write an ADR superseding that one clause of ADR-0023, carrying the
+      three-part argument from the brief: the day view it was waiting for now
+      exists, the cards it points at are gone, and the per-cell sunrise/sunset
+      header still scopes every figure.
+      **Done looks like**: the week grid goes straight from heading to grid on a
+      healthy page, and still explains itself on a broken one.
+      **Test**: assert the unconditional note is gone **and** that each of the
+      seven conditional notes still appears in its own failure state. Commit the
+      failure-state half as MUST FAIL first if the gate table supports it — this
+      is the regression test that stops the intro removal quietly taking an
+      outage message with it.
+      _Modifies: `WeekPanel`. New: one ADR._
+      _**Re-derive the ADR number** from `docs/adr/` at build time. Do not take
+      it from the brief — the highest number moves, and the `adr-numbers` gate
+      will fail the run._
+
+---
+
+## PR 3 — The reference text stops occupying the page
+
+Two slices. Independent of both PRs above and of each other.
+
+- [ ] **Slice 7 — Collapse "How to read these numbers".**
+      Wrap the whole `ConditionsNotes` region in one `<details>`, closed by
+      default, using `DISCLOSURE_TARGET` on the `<summary>`. The `<summary>`
+      carries the heading text so the region keeps its landmark; the `<h2>` stays
+      for the same reason. The five notes and the nested `Caveats` disclosures
+      ship unchanged inside it.
+      **Done looks like**: roughly a screen of prose becomes one line, and every
+      word is still in the DOM.
+      **Test**: the existing `ConditionsNotes` and `Caveats` assertions still
+      pass unmodified — they use `getByText`, which resolves inside a closed
+      `<details>`. **Do not add a `toBeVisible` assertion**; there are none in
+      `src/components/conditions/` today and adding one would break the gate that
+      guarantees every caveat reaches a reader.
+      _Modifies: `ConditionsNotes`. Reuses: `DISCLOSURE_TARGET`._
+
+- [ ] **Slice 8 — Gather each region's attributions into one `▸ Sources`.**
+      New `SourcesDisclosure` wrapping a region's `ProvenanceLine`s in one closed
+      `<details>`. Applied to the now-strip, the day panel and the week panel.
+      **Done looks like**: each region ends in a single `▸ Sources` line instead
+      of two to four 10px attribution lines.
+      **Test**: (a) every provenance string still reaches the DOM;
+      (b) **ADR-0010's two air provenances stay separately named and separately
+      distanced** inside the disclosure — gathering them must not merge them into
+      one line, which is the exact failure that ADR forbids.
+      _New: `SourcesDisclosure`. Modifies: `NowStrip`, `DayPanel`, `WeekPanel`.
+      Reuses: `ProvenanceLine`, `DISCLOSURE_TARGET`._
+      _Depends on Slice 3 only for the strip's own sources; the day and week
+      halves are independent._
+
+---
+
+## Measurement, before any PR claims a result
+
+The brief's height budget is the thing this work is judged on: on a 1536×639
+window at 125% scaling, **the beach selector, the now-strip and the first row of
+the week grid all above the fold.**
+
+- [ ] **Measure `main` first, then the branch.** Playwright, from the npx cache.
+      A before-figure taken after the change is not a before-figure.
+- [ ] **Remove `.next/` before believing anything about the built stylesheet.**
+      The build cache hides Tailwind source changes.
+- [ ] Paste real gate output into every PR body. Not "tests pass".
+
+## Review
+
+- [ ] **Design review**: run `/design-review` against
+      `.design/conditions-minimal/DESIGN_BRIEF.md` once PR 1 is merged, so the
+      strip's aesthetic is judged before PRs 2 and 3 build around it.

--- a/docs/adr/0014-region-headings-outrank-card-headings.md
+++ b/docs/adr/0014-region-headings-outrank-card-headings.md
@@ -77,6 +77,26 @@ the `<h1>` already uses, so the brief's rule that any new surface is checked
 before it ships is not engaged. At 34px and 20px it is large text besides,
 needing 3:1 rather than 4.5:1.
 
+> **Amended 2026-09-02.** The rule holds; the sizes it names are no longer the
+> only ones. `/conditions` now takes a **tool register** — `--text-tool-title`
+> for its `<h1>` and `--text-tool-region` for its three region headings, named
+> as `TOOL_REGION_HEADING` beside `REGION_HEADING` — giving 36 / 22 / 10 at 1536
+> and 24 / 17 / 10 at 375. The page is read for a figure rather than arrived at,
+> and the display sizes above are scaled for arrival: at 56 / 34 the first
+> measurement fell off a 639px window.
+>
+> **What this ADR decided is unaffected**, and that is why this is an amendment
+> rather than a superseding decision. A region heading is still display register
+> and a card or day heading still label register; the three levels are still
+> clear at both ends of the clamp, which is the property this decision says
+> actually matters. Only the token pair changes, and only on the page that
+> needed it — `/art` and `SessionSchedule` keep `REGION_HEADING` untouched.
+>
+> The contrast clause survives too, with one narrowing: at 17px the smaller rank
+> is no longer large text under WCAG's 18.66px bold threshold, so it needs
+> 4.5:1 rather than 3:1. It inherits the same ink on the same cream as before,
+> which the page already holds to 4.5:1, so nothing new is owed a measurement.
+
 ## Consequences
 
 `/conditions` gains the middle level its outline always had. The two region

--- a/scripts/built-css.mjs
+++ b/scripts/built-css.mjs
@@ -98,6 +98,14 @@ export const REQUIRED = [
     utility: "scroll-pl-gutter",
     why: "the same, at the width where the gutter is 48px. Written in src/ only as md:scroll-pl-gutter, so this is the bare form for the reason min-h-footer above is — the built selector escapes the variant into the class name. The trailing boundary is what keeps it off scroll-pl-gutter-sm's rule",
   },
+  {
+    utility: "text-tool-title",
+    why: "the /conditions <h1> takes its size from the --text-tool-title token through it. The tool register exists because six other pages take --text-title and none of them opens on a figure, so nothing outside that page would notice the token going: the class name stays in the markup either way and jsdom applies no stylesheets, which leaves a 56px headline silently becoming an inherited 16px one",
+  },
+  {
+    utility: "text-tool-region",
+    why: "the same, one rank down: TOOL_REGION_HEADING sets the three /conditions region headings from --text-tool-region. This one fails more quietly still — losing the token drops the headings to inherited size, which reads as a spacing regression rather than as a missing rule, and the class contract in headingRank's tests asserts the reference rather than the rendered rank",
+  },
 ];
 
 /** A rule body counts as emitting CSS only if it holds a declaration. */

--- a/src/app/conditions/page.test.tsx
+++ b/src/app/conditions/page.test.tsx
@@ -12,8 +12,27 @@ vi.mock("@/components/conditions/DayPanel", () => ({
 }));
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
-const { default: Conditions, revalidate } = await import("./page");
+const { default: Conditions, revalidate, metadata } = await import("./page");
 const { DEFAULT_BEACH_SLUG } = await import("@/lib/beaches");
+
+/**
+ * The sentence that introduces this page now lives only here.
+ *
+ * It used to be a lead paragraph on the page as well, above the readings, where
+ * it described the site to somebody who had just clicked "Conditions" to reach
+ * it. That copy came off for the space; this is the copy that was always doing
+ * the work, because a description is read by people who have *not* arrived.
+ *
+ * Asserted rather than assumed: with the on-page paragraph gone, nothing else
+ * in the suite would notice this string being deleted, and the page would
+ * quietly stop describing itself to search and to a shared link.
+ */
+test("the page still introduces itself where an introduction is read", () => {
+  expect(metadata.description).toContain(
+    "Real-time surf, tide, wind and visibility for San Diego's coast",
+  );
+  expect(metadata.description).toContain("families planning tidepool visits");
+});
 
 test("the conditions page exposes its landmark and heading", () => {
   render(<Conditions />);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,6 +77,10 @@
      smaller `--text-title`, because six other pages take that one and none of
      them has this problem. */
   --text-tool-title: clamp(24px, 3vw, 36px);
+  /* The same register one rank down, for the region headings under that title.
+     `--text-quote` is the rank they had, and at 34px beside a 36px title it
+     stops being a second rank at all. See `TOOL_REGION_HEADING`. */
+  --text-tool-region: clamp(17px, 1.6vw, 22px);
 
   --leading-display: 1;
   --leading-tight: 1.1;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -70,6 +70,13 @@
   --text-title: clamp(32px, 5vw, 56px);
   --text-card: clamp(30px, 3vw, 44px);
   --text-quote: clamp(20px, 2.8vw, 34px);
+  /* The tool register. `/conditions` is a page somebody reads a number off
+     rather than a document they arrive at, and the display sizes above are
+     scaled for arrival: the same `<h1>` that opens /art at 56px pushes the
+     first measurement off a 639px window here. Its own token rather than a
+     smaller `--text-title`, because six other pages take that one and none of
+     them has this problem. */
+  --text-tool-title: clamp(24px, 3vw, 36px);
 
   --leading-display: 1;
   --leading-tight: 1.1;

--- a/src/components/conditions/ChosenDay.tsx
+++ b/src/components/conditions/ChosenDay.tsx
@@ -41,7 +41,7 @@
 
 import type { ReactNode } from "react";
 import { HourChart, type HourSeries } from "./HourChart";
-import { REGION_HEADING } from "../ui/headingRank";
+import { TOOL_REGION_HEADING } from "../ui/headingRank";
 import { resolveSelected, useSelectedDay } from "./selectedDay";
 import type { SparkPoint } from "./DaySpark";
 
@@ -136,7 +136,7 @@ export function ChosenDay({
 
   return (
     <>
-      <h2 id="day-panel-heading" className={REGION_HEADING}>
+      <h2 id="day-panel-heading" className={TOOL_REGION_HEADING}>
         {day.dayName}, hour by hour
       </h2>
 

--- a/src/components/conditions/ChosenDay.tsx
+++ b/src/components/conditions/ChosenDay.tsx
@@ -3,12 +3,14 @@
  *
  * **It holds no reads and makes no choices about the data.** `DayPanel` does
  * every read on the server and hands over seven finished days -- their series,
- * their words, their absences, and what was measured. This picks one. Today's
- * measured block arrives as a suspended node rather than a resolved one, which
- * changes nothing here: it is a `ReactNode` either way. That split is what lets
- * the whole week ship from the first render, which is the point: choosing
- * Thursday costs no request, because every feed here already returns the week
- * in one call and the page has been holding it since it loaded.
+ * their words and their absences. This picks one. That split is what lets the
+ * whole week ship from the first render, which is the point: choosing Thursday
+ * costs no request, because every feed here already returns the week in one
+ * call and the page has been holding it since it loaded.
+ *
+ * **Nothing in this region is measured.** The buoy and the shore station sit
+ * at the top of the page now, outside the provider this component reads,
+ * because they answer for an instant rather than for a day.
  *
  * **Seven days of series is what this costs, and it is the trade the brief
  * asked for.** Four products of twenty-four points across seven days is a few
@@ -74,27 +76,16 @@ export type DayView = {
   /** The publisher's own wording for this day, already rendered. */
   wording: ReactNode;
   /**
-   * What was measured on this day, already rendered: two cards on today, and
-   * on the other six a sentence saying nothing has been measured about a day
-   * that has not happened.
-   *
-   * A finished node for the same reason `wording` is one. The measurements are
-   * server reads and this is a client component, so the alternative is fetching
-   * from the client -- and the decision about which day carries them belongs
-   * with the daylight read that knows which day is today, not here.
-   */
-  measured: ReactNode;
-  /**
    * The National Weather Service's relayed judgement for this day, already
    * rendered: the risk on the days the bulletin reaches, a sentence on the
    * days it does not, and on a sheltered beach a sentence saying the product
    * is not about this water at all.
    *
-   * A finished node for the reason `measured` is one -- a server read handed
-   * to a client component -- and present on all seven days rather than only on
-   * the ones the forecast reaches, so that stepping across the week never
-   * leaves a reader wondering whether the block failed or the day is simply
-   * beyond the horizon.
+   * A finished node for the reason `wording` is one -- a server read handed to
+   * a client component -- and present on all seven days rather than only on the
+   * ones the forecast reaches, so that stepping across the week never leaves a
+   * reader wondering whether the block failed or the day is simply beyond the
+   * horizon.
    */
   surfZone: ReactNode;
 };
@@ -159,9 +150,9 @@ export function ChosenDay({
 
         Below `xl` they stack, chart first. The map does not go full width when
         it does: it is square, so a 1,184px column would draw a 1,184px-tall
-        picture and push the measured block off the screen entirely. Capping the
-        width is what "the map beneath at a reduced height" comes to for a shape
-        that is as tall as it is wide.
+        picture and push the rip current block off the screen entirely. Capping
+        the width is what "the map beneath at a reduced height" comes to for a
+        shape that is as tall as it is wide.
       */}
       <div className="xl:flex xl:items-start xl:gap-6">
         <div className="min-w-0 xl:basis-2/3">
@@ -183,31 +174,19 @@ export function ChosenDay({
       </div>
 
       {/*
-        Between the chart and the measured block, which is reading order rather
-        than layout convenience: the sky, then the day's shape, then what the
-        forecaster judges, then what the instruments read. The relayed
-        judgement comes before the instrument readings because the standing
-        notice at the top of the page says in as many words that the numbers
-        are not a safety assessment and that the authority is someone else's.
+        Last, which is reading order rather than layout convenience: the sky in
+        words, then the day's shape, then what the forecaster judges. The
+        instruments are no longer below it -- they are at the top of the page,
+        ahead of all three, which is what the standing notice beside them
+        already implies: the numbers are not a safety assessment and the
+        authority is someone else's.
 
-        Below the chart and not above it, for the same reason the measured block
-        is: this is several lines on the days the bulletin reaches and one line
-        on the days it does not, so putting it above would move the plot up and
-        down the page as a reader steps across the week.
+        Below the chart and not above it, because this is several lines on the
+        days the bulletin reaches and one line on the days it does not, so
+        putting it above would move the plot up and down the page as a reader
+        steps across the week.
       */}
       <div className="mt-6">{day.surfZone}</div>
-
-      {/*
-        Under the chart, which is the order the brief lists this region in:
-        heading, sky wording, chart, and today's measured block.
-
-        It also keeps the chart still. The block is two cards on today and one
-        sentence on the other six, so putting it above would move the plot up
-        and down the page as a reader steps across the week -- and comparing
-        one day's curve with the next is the whole reason the week is the
-        selector.
-      */}
-      <div className="mt-6">{day.measured}</div>
     </>
   );
 }

--- a/src/components/conditions/ConditionsNotes.test.tsx
+++ b/src/components/conditions/ConditionsNotes.test.tsx
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ConditionsNotes } from "./ConditionsNotes";
-import { REGION_HEADING } from "../ui/headingRank";
+import { TOOL_REGION_HEADING } from "../ui/headingRank";
 
 const ENTRIES = [
   "beach_type is UNKNOWN upstream for most of these beaches.",
@@ -199,9 +199,9 @@ test("the block's heading takes the region rank", () => {
     name: "How to read these numbers",
   });
 
-  expect(heading.className).toBe(REGION_HEADING);
+  expect(heading.className).toBe(TOOL_REGION_HEADING);
   // Per ADR-0001 jsdom applies no stylesheets, so this proves the rank is
-  // referred to, not that 34px renders. That stays a human check.
+  // referred to, not that 22px renders. That stays a human check.
   expect(heading.className).not.toContain("text-2xs");
 });
 

--- a/src/components/conditions/ConditionsNotes.tsx
+++ b/src/components/conditions/ConditionsNotes.tsx
@@ -45,7 +45,7 @@
 
 import type { InventoryReach } from "@/lib/beaches";
 import { Caveats } from "./Caveats";
-import { REGION_HEADING } from "../ui/headingRank";
+import { TOOL_REGION_HEADING } from "../ui/headingRank";
 
 /** One thing worth understanding about every figure of its kind. */
 const NOTES = [
@@ -116,7 +116,7 @@ export function ConditionsNotes({
     // No top margin: the reserved slot above carries the gap. Spacing on both
     // is counted twice, which is the failure `SnapSection`'s docstring records.
     <section aria-labelledby="conditions-notes-heading">
-      <h2 id="conditions-notes-heading" className={REGION_HEADING}>
+      <h2 id="conditions-notes-heading" className={TOOL_REGION_HEADING}>
         How to read these numbers
       </h2>
 

--- a/src/components/conditions/ConditionsSection.test.tsx
+++ b/src/components/conditions/ConditionsSection.test.tsx
@@ -1,5 +1,5 @@
-import { expect, test, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, expect, test, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
 
 /*
   Two regions are left with a Suspense boundary this file owns, and both have
@@ -24,6 +24,32 @@ vi.mock("@/components/conditions/WeekPanel", () => ({
     return <p>week for {slug}</p>;
   },
 }));
+/*
+  The measured block moved up here from the day panel, and its reads came with
+  it. Mocked at the component rather than at `@/lib/conditions`, which is the
+  shape the two panels above already use and which is also what proves its
+  Suspense boundary is real: a block folded into this section synchronously
+  could not be stubbed this way.
+
+  `measuredPanel` is reassigned by the two tests that need the real cards
+  rendered, because a stub's heading is whatever the stub says and the outline
+  is exactly what those two are about.
+*/
+const measuredPanel = vi.fn();
+vi.mock("@/components/conditions/MeasuredPanel", () => ({
+  MeasuredPanel: (props: { slug: string }) => measuredPanel(props),
+}));
+
+// Reset between tests, because two of them swap in the real cards and the spy
+// would otherwise carry that swap into every test after them -- silently, since
+// the real cards render figures rather than throwing.
+beforeEach(() => {
+  measuredPanel.mockReset();
+  measuredPanel.mockImplementation(({ slug }: { slug: string }) => {
+    if (slug === "suspend-the-panels") throw new Promise(() => {});
+    return <p>measured for {slug}</p>;
+  });
+});
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 const { ConditionsSection } = await import("./ConditionsSection");
@@ -49,33 +75,151 @@ test("the view carries the chooser, the two regions and the caveats", () => {
 });
 
 /**
- * The slab is gone, and this is the assertion that it stays gone. Three cards
- * stood between the header and the week -- today's lowest tide, the buoy, the
- * air station -- and every figure on two of them moved into the day panel
- * while the third was already printed by the week grid's first column.
+ * The order the brief asks for: what is measured, then the week, then the day.
  *
- * Asserted as an absence of the components rather than of their text, because
- * their text is exactly what `MeasuredToday` still renders one region down. A
- * check for "2.6 ft" would pass whether the readings moved or were copied.
+ * The slab that stood here once is still gone and this still asserts that.
+ * Three cards sat between the header and the week -- today's lowest tide, the
+ * buoy, the air station -- and the tide one was removed as a duplicate of the
+ * week grid's own first column. What came back is the other two, which were
+ * never duplicated anywhere: the buoy and the shore station are the only
+ * instruments this site reports.
+ *
+ * Asserted as a sequence rather than as three separate presence checks, because
+ * "the readings are on the page" is true of the arrangement this replaces as
+ * well. Being *first* is the change.
  */
-test("no reading stands between the header and the week", () => {
+test("what is measured comes before the week, and the week before the day", () => {
   const { container } = render(<ConditionsSection slug={DEFAULT_BEACH_SLUG} />);
 
+  // The tide card stays gone: its figure is the week grid's first column.
   expect(screen.queryByText(`panel for ${DEFAULT_BEACH_SLUG}`)).toBeNull();
-  expect(screen.queryByText(`waves for ${DEFAULT_BEACH_SLUG}`)).toBeNull();
-  expect(screen.queryByText(`wind for ${DEFAULT_BEACH_SLUG}`)).toBeNull();
 
-  // And the week is the first thing under the header, which is the order the
-  // brief asks for: header, week, day.
   const regions = [...container.querySelectorAll("p")]
     .map((node) => node.textContent ?? "")
     .filter(
-      (text) => text.startsWith("week for ") || text.startsWith("day for "),
+      (text) =>
+        text.startsWith("measured for ") ||
+        text.startsWith("week for ") ||
+        text.startsWith("day for "),
     );
   expect(regions).toEqual([
+    `measured for ${DEFAULT_BEACH_SLUG}`,
     `week for ${DEFAULT_BEACH_SLUG}`,
     `day for ${DEFAULT_BEACH_SLUG}`,
   ]);
+});
+
+/**
+ * The contract of the whole slice, and the one a later change is most likely to
+ * break without noticing: the block says what the instruments read *now*, and
+ * picking Thursday must not move it.
+ *
+ * Asserted as the shape of the call rather than by choosing a day and re-reading
+ * the figures. That second test would pass here whatever the wiring did -- this
+ * file mocks the panel, so its output is a stub's and would not move either way
+ * -- and it would pass in the real page too, because React does not re-render
+ * `children` a provider merely passes through.
+ *
+ * What is actually true is that there is nothing to follow. The block is
+ * rendered outside `SelectedDayProvider` and is handed the beach and nothing
+ * else, so no day is in scope for it to read even by mistake. A later change
+ * that wired one in would have to add an argument, and that is what fails here.
+ */
+test("the measured block is asked for a beach and never for a day", () => {
+  render(<ConditionsSection slug={DEFAULT_BEACH_SLUG} />);
+
+  expect(measuredPanel).toHaveBeenCalledWith({ slug: DEFAULT_BEACH_SLUG });
+
+  // Spelled out rather than left to `toHaveBeenCalledWith`'s exact match, so a
+  // reader of this test can see which argument is the forbidden one.
+  const [props] = measuredPanel.mock.calls[0] as [Record<string, unknown>];
+  expect(Object.keys(props)).toEqual(["slug"]);
+});
+
+/**
+ * Both instruments, as `MeasuredPanel` hands them over once its reads land.
+ * Every other test here stands the panel down to a paragraph, which is all they
+ * need; the outline needs the real cards, because a stub's heading is whatever
+ * the stub says.
+ *
+ * These two tests came from `DayPanel.test.tsx` with the block itself. Left
+ * there they would have asserted a containment that no longer exists.
+ */
+const MEASURED = {
+  waves: {
+    beachName: "La Jolla Shores Beach",
+    buoy: { name: "Scripps Nearshore", distanceM: 1400 },
+    state: {
+      kind: "reading" as const,
+      heightFt: 2.62,
+      periodS: 5,
+      directionDegT: 278,
+      waterTempF: 69.98,
+    },
+  },
+  air: {
+    beachName: "La Jolla Shores Beach",
+    airStation: { name: "Scripps Pier", distanceM: 1381 },
+    air: {
+      kind: "reading" as const,
+      airTempF: 71.42,
+      windMph: 8.05,
+      gustMph: null,
+      windDirDegT: 320,
+    },
+  },
+};
+
+/**
+ * The rank followed the block back up, and this is what says so.
+ *
+ * `ReadingCard` requires `headingLevel` rather than defaulting it, precisely so
+ * that a component moving a card has to answer the question. #176 moved these
+ * two into the day region and left `h2` behind, making them siblings-in-outline
+ * of the heading that contained them. The move back to page level makes `h2`
+ * right again -- they are siblings of the three region headings under the
+ * `<h1>`, and `h3` here would skip a level with nothing in between.
+ */
+test("the measured cards rank as page regions, beside the week and the day", async () => {
+  const { MeasuredToday } = await import("./MeasuredToday");
+  measuredPanel.mockImplementation(() => <MeasuredToday readings={MEASURED} />);
+
+  render(<ConditionsSection slug={DEFAULT_BEACH_SLUG} />);
+
+  const ranks = screen
+    .getAllByRole("heading", { level: 2 })
+    .map((heading) => heading.textContent);
+  expect(ranks).toContain("Waves and water");
+  expect(ranks).toContain("Air");
+
+  // And nothing dropped to a rank that would skip a level under the <h1>.
+  expect(
+    screen
+      .queryAllByRole("heading", { level: 3 })
+      .map((heading) => heading.textContent),
+  ).not.toContain("Waves and water");
+});
+
+/**
+ * The rank moved and the name did not. The accessible name is composed on the
+ * `<section>` from the title and the beach -- `ReadingCard` records why it is an
+ * `aria-label` rather than a hidden span -- so it is reachable from the tag and
+ * must survive a change to it.
+ */
+test("a card is still called what it was called, at its new rank", async () => {
+  const { MeasuredToday } = await import("./MeasuredToday");
+  measuredPanel.mockImplementation(() => <MeasuredToday readings={MEASURED} />);
+
+  render(<ConditionsSection slug={DEFAULT_BEACH_SLUG} />);
+
+  expect(
+    screen.getByRole("region", {
+      name: "Waves and water · La Jolla Shores Beach",
+    }),
+  ).toBeDefined();
+  expect(screen.getByRole("heading", { name: "Waves and water" }).id).toBe(
+    "waves-today-heading",
+  );
 });
 
 test("every caveat the data files carry reaches this page", () => {
@@ -186,11 +330,12 @@ test("no panel's loading line uses a word the glossary rejects", () => {
     .map((node) => node.textContent ?? "")
     .filter((text) => text.startsWith("Reading "));
 
-  // Two suspended regions, the week and the day. It was four while the three
-  // cards stood here; the measured block's own line is one boundary further in
-  // and is checked in `DayPanel.test.tsx`. Asserted so this cannot pass by
-  // finding none of them.
-  expect(loading.length).toBe(2);
+  // Three suspended regions: the measured block, the week and the day. It was
+  // two while the measured block sat inside the day panel, on a boundary this
+  // check could not see from here -- so its line was asserted in
+  // `DayPanel.test.tsx` instead, and moved back here with the block. Asserted
+  // as a count so this cannot pass by finding none of them.
+  expect(loading.length).toBe(3);
   for (const line of loading) {
     expect(line.toLowerCase()).not.toContain("weather");
     expect(line.toLowerCase()).not.toContain("forecast");

--- a/src/components/conditions/ConditionsSection.test.tsx
+++ b/src/components/conditions/ConditionsSection.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, expect, test, vi } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 /*
   Two regions are left with a Suspense boundary this file owns, and both have

--- a/src/components/conditions/ConditionsSection.test.tsx
+++ b/src/components/conditions/ConditionsSection.test.tsx
@@ -109,11 +109,36 @@ test("the page says these are instruments and not a safety assessment", () => {
   render(<ConditionsSection slug={DEFAULT_BEACH_SLUG} />);
 
   expect(
-    screen.getByText(/readings from public instruments, not a safety/),
+    screen.getByText(/Instrument readings, not a safety assessment/),
   ).toBeDefined();
   expect(
-    screen.getByText(/Lifeguards and the signs posted at the beach are the/),
+    screen.getByText(/signs posted at the beach are the authority on the day/),
   ).toBeDefined();
+});
+
+/**
+ * The introduction came off, and this is what may not come off with it.
+ *
+ * The eyebrow and the lead paragraph described the page to a reader who had
+ * already clicked "Conditions" to reach it, and the three of them together with
+ * a 56px headline put the first measurement off a 639px window. Removing them
+ * is the point of the slice; removing either half of the notice beside them
+ * would make a shipped ADR untrue, and the two edits look identical in a diff
+ * that is mostly deletions.
+ *
+ * The lead copy is asserted gone here and asserted present in
+ * `src/app/conditions/page.test.tsx`, which checks the metadata description. It
+ * is one sentence with two jobs, and only one of them was ever done on the page
+ * itself.
+ */
+test("the self-description is gone and the standing notice is not", () => {
+  render(<ConditionsSection slug={DEFAULT_BEACH_SLUG} />);
+
+  expect(screen.queryByText(/Surf · Tide · Wind · Visibility/)).toBeNull();
+  expect(screen.queryByText(/built by a local/)).toBeNull();
+  expect(screen.queryByText(/Know before you go/)).toBeNull();
+
+  expect(screen.getByText(/not a safety assessment/)).toBeDefined();
 });
 
 /**

--- a/src/components/conditions/ConditionsSection.tsx
+++ b/src/components/conditions/ConditionsSection.tsx
@@ -32,54 +32,67 @@ export function ConditionsSection({ slug }: { slug: string }) {
   return (
     <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
       {/*
-        The chooser sits beside the title rather than under the lead paragraph,
-        and the move is worth about 103px of the first screen — enough to decide
-        whether the readings land above the fold on a 639px window or below it.
+        THE PAGE INTRODUCES ITSELF IN ONE LINE, BECAUSE THE READER ARRIVED ON
+        PURPOSE.
 
-        It is also where the control belongs. It decides what every figure on
-        the page means, and it was the fourth element down, under a paragraph,
-        with a 13px label. Bottom-aligned so the two columns finish on the same
-        line; stacked below `md`, where there is no width to share.
+        The chooser sits beside the title rather than under it, and it decides
+        what every figure on the page means: it was the fourth element down,
+        under a paragraph, with a 13px label. Bottom-aligned so the two columns
+        finish on the same line; stacked below `md`, where there is no width to
+        share.
+
+        An eyebrow reading "Surf · Tide · Wind · Visibility" and a paragraph
+        saying the site is real-time surf, tide, wind and visibility for San
+        Diego's coast stood above this. Both described the page to somebody who
+        had just clicked "Conditions" to reach it, and together with a 56px
+        headline they meant the first measurement on a page about measurements
+        was off a 639px window entirely.
+
+        The lead paragraph is not lost, it is where it was always doing the
+        work: the `metadata` export in ../../app/conditions/page.tsx carries it
+        verbatim as the description, which is the place a sentence introducing
+        this page to somebody who has *not* arrived at it is actually read.
+        `ConditionsTeaser` on the landing page carries the other copy of it, for
+        the reader who has not clicked yet.
+
+        The `<h1>` keeps the site's voice and drops a register: `--text-tool-
+        title`, not `--text-title`. See the token's own note -- six other pages
+        take the larger one and none of them opens on a figure.
       */}
-      <div className="mb-9 md:flex md:items-end md:justify-between md:gap-10">
+      <div className="mb-7 md:flex md:items-end md:justify-between md:gap-10">
         <div>
-          <p className="mb-5 text-2xs font-extrabold tracking-widest text-ocean uppercase">
-            Surf · Tide · Wind · Visibility
-          </p>
-          <h1 className="text-title leading-display mb-4 font-black italic">
+          <h1 className="text-tool-title leading-display mb-3 font-black italic">
             Check <span className="text-ocean">conditions</span> first.
           </h1>
+
+          {/*
+            The standing notice ADR-0009 turns on: that decision rejects an
+            embed partly because "the host page is asserting something it does
+            not control", and this sentence is the assertion. It said less than
+            this and sat fourth of four at the bottom of a 2171px page until
+            2026-08-25.
+
+            It moved from the chooser's column to the title's when the lead
+            paragraph came out, and the move is what keeps the row balanced: the
+            row is `md:items-end`, so with nothing under the title this column
+            was a lone heading bottom-aligned against a two-element one. The
+            notice is now the thing the title sits above, which is also the
+            reading order ADR-0009 wants -- the qualification arrives with the
+            page's name rather than as a footnote to the control.
+
+            One sentence rather than two, and both claims kept: instrument
+            readings are not a safety assessment, and the authority on the day
+            is someone else. Those two halves are what the ADR names, and
+            `ConditionsSection.test.tsx` asserts each of them separately so a
+            later tightening cannot quietly drop the liability half.
+          */}
           <p className="leading-relaxed max-w-130 text-base text-fog">
-            Real-time surf, tide, wind and visibility for San Diego&apos;s coast
-            — built by a local, for families planning tidepool visits and hikes.
-            Know before you go.
+            Instrument readings, not a safety assessment — lifeguards and the
+            signs posted at the beach are the authority on the day.
           </p>
         </div>
 
-        {/*
-          The standing notice ADR-0009 turns on: that decision rejects an embed
-          partly because "the host page is asserting something it does not
-          control", and this sentence is the assertion. It said less than this
-          and sat fourth of four at the bottom of a 2171px page until now.
-
-          Here rather than in a band of its own above the readings, and the
-          reason is measured. The row is `md:items-end`, so this column is
-          bottom-aligned to a taller one and 85px sat empty in it; the notice
-          fills waste and costs the first screen 25px, where a band above the
-          readings cost 63px and put the air card's second attribution below
-          the fold. ADR-0010 turns on those two distances being comparable at a
-          glance. See the 2026-08-25 addendum in docs/plans/conditions-tool.md
-          for the three placements and their numbers.
-
-          Above the chooser, not below it, so it is read before the control
-          rather than as a footnote to it.
-        */}
-        <div className="mt-7 md:mt-0 md:w-72">
-          <p className="leading-relaxed mb-4 text-base text-fog">
-            These are readings from public instruments, not a safety assessment.
-            Lifeguards and the signs posted at the beach are the authority on
-            the day.
-          </p>
+        <div className="mt-6 md:mt-0 md:w-72">
           <BeachSelector groups={groups} current={slug} />
         </div>
       </div>

--- a/src/components/conditions/ConditionsSection.tsx
+++ b/src/components/conditions/ConditionsSection.tsx
@@ -17,6 +17,7 @@ import {
 import { BeachSelector } from "./BeachSelector";
 import { ConditionsNotes } from "./ConditionsNotes";
 import { DayPanel } from "./DayPanel";
+import { MeasuredPanel } from "./MeasuredPanel";
 import { SelectedDayProvider } from "./selectedDay";
 import { WeekPanel } from "./WeekPanel";
 
@@ -98,29 +99,50 @@ export function ConditionsSection({ slug }: { slug: string }) {
       </div>
 
       {/*
-        THE PAGE OPENS ON THE WEEK, AND THE READINGS ARE INSIDE THE DAY.
+        WHAT IS TRUE NOW, BEFORE ANYTHING THAT IS TRUE OF A DAY.
 
-        A band of three cards stood here: today's lowest tide, the buoy, the
-        air station. It was the right answer while it was the only answer --
-        a parent weighing a tide time against a wave height had them three
-        screens apart before it, and could not see both at once. What made it
-        wrong is what landed under it. The week grid prints today's lowest
-        daylight tide in its first column and the day chart draws the whole
-        tide, the whole swell and the cell's own wind and temperature, so the
-        band and the two regions below it said the same things in two
-        registers -- which is the redundancy this brief exists to remove.
+        The buoy and the shore station are the only instruments this site
+        reports, and they answer for one instant: now. Everything below this
+        point is a prediction or a model, and everything below this point is
+        scoped to a day a reader chooses.
 
-        The two measurements that were not duplicated moved rather than went.
-        `MeasuredToday` carries them inside the day panel, under the chart, on
-        today alone, because the buoy and the shore station are the only
-        instruments this site reports and today is the only day anybody took a
-        reading of. The other six days say so in a sentence.
+        That is why the block sits here and, more to the point, why it sits
+        OUTSIDE `SelectedDayProvider`. Frozen to the present is the whole
+        contract of this region, and putting it outside the provider is what
+        makes that structural rather than a convention: there is no day in
+        scope here to accidentally read. A later change cannot quietly make
+        these figures follow Thursday, because there is nothing to follow.
 
-        Nothing that was on this page is off it. The tide's daylight low is in
-        the week's today column; its overnight low and CDIP's biggest-all-day
-        are the dips in the curves the chart draws, which is what the brief
-        asked those curves to be for.
+        It used to live inside the day panel, under the chart, rendered on
+        today alone -- with a sentence on the other six days explaining that
+        nothing had been measured about a day that had not happened. That
+        sentence is gone with the move. It existed because the block sat in a
+        position where its absence would have read as an outage; no measured
+        block lives down there now, so there is no gap left to explain, and
+        this band says which instant it means.
+
+        A band of three cards stood in this spot once -- today's lowest tide,
+        the buoy, the air station -- and was removed as redundant against the
+        week grid and the day chart, which print the tide and the swell
+        themselves. The two readings here are the half of that band that was
+        never duplicated: nothing else on this page is measured.
+
+        Its own Suspense boundary, like every region on this page. Five
+        agencies go quiet independently and a slow buoy must not hold up the
+        week.
       */}
+      <div className="mb-9">
+        <Suspense
+          fallback={
+            <p className="text-base text-fog">
+              Reading the buoy and the air station…
+            </p>
+          }
+        >
+          <MeasuredPanel slug={slug} />
+        </Suspense>
+      </div>
+
       {/*
         The week and the day are one instrument at two zoom levels, and from
         here on they share a fact: which day is being shown. It is a client

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, expect, test, vi } from "vitest";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { localMidnightOf } from "@/lib/pacific-time";
-import { SelectedDayProvider, useSelectedDay } from "./selectedDay";
+import { SelectedDayProvider } from "./selectedDay";
 
 const readSkyWording = vi.fn();
 const readSurfZone = vi.fn();

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -1,7 +1,6 @@
 import { beforeEach, expect, test, vi } from "vitest";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { localMidnightOf } from "@/lib/pacific-time";
-import { MeasuredToday, type MeasuredReadings } from "./MeasuredToday";
 import { SelectedDayProvider, useSelectedDay } from "./selectedDay";
 
 const readSkyWording = vi.fn();
@@ -19,21 +18,6 @@ vi.mock("@/lib/conditions", () => ({
   readSkyWeek,
   readWaveWeek,
   readGridpointWeek,
-}));
-
-/**
- * The measured block's own reads live behind `MeasuredPanel`, on a Suspense
- * boundary of their own, so they are mocked at the component rather than at
- * `@/lib/conditions` -- which is also what proves the boundary is real: a
- * panel folded into `DayPanel`'s `Promise.all` could not be stubbed this way.
- *
- * It returns a promise that never settles by default, so the fallback renders
- * and the loading line can be read. `measuredPanel.mockReturnValue` gives a
- * test the resolved form.
- */
-const measuredPanel = vi.fn();
-vi.mock("./MeasuredPanel", () => ({
-  MeasuredPanel: (props: { slug: string }) => measuredPanel(props),
 }));
 
 const { DayPanel } = await import("./DayPanel");
@@ -315,8 +299,6 @@ beforeEach(() => {
   readSkyWeek.mockReset();
   readWaveWeek.mockReset();
   readGridpointWeek.mockReset();
-  measuredPanel.mockReset();
-  measuredPanel.mockImplementation(() => <p>the measured block</p>);
   daylight([TODAY, TOMORROW]);
   tideWeek([TODAY, TOMORROW]);
   waveWeek([TODAY, TOMORROW]);
@@ -786,205 +768,6 @@ test("the four tabs are in the order the page leads with", async () => {
       tab.getAttribute("data-series-tab"),
     ),
   ).toEqual(["tide", "swell", "wind", "temperature"]);
-});
-
-/* =========================================================================
- * The measured block
- * ========================================================================= */
-
-/**
- * A real click through the real provider, so the branch under test is the one
- * a reader reaches by choosing a day in the week above. `WeekGrid` is the
- * control on the page; this is the smallest thing that speaks its API, and it
- * keeps this file from having to mount the grid to test the panel.
- */
-function ChooseDay({ date }: { date: string }) {
-  const { choose } = useSelectedDay();
-  return (
-    <button type="button" onClick={() => choose(date)}>
-      choose that day
-    </button>
-  );
-}
-
-async function renderChoosing(date: string) {
-  const rendered = render(
-    <SelectedDayProvider>
-      <ChooseDay date={date} />
-      {await DayPanel({ slug: "la-jolla-shores-beach" })}
-    </SelectedDayProvider>,
-  );
-  fireEvent.click(screen.getByText("choose that day"));
-  return rendered;
-}
-
-test("today carries the measured block, and it is asked for this beach", async () => {
-  render(await DayPanel({ slug: "la-jolla-shores-beach" }));
-
-  expect(screen.getByText("the measured block")).toBeDefined();
-  expect(measuredPanel).toHaveBeenCalledWith({
-    slug: "la-jolla-shores-beach",
-  });
-});
-
-/**
- * Both instruments, as `MeasuredPanel` would hand them over once its reads
- * land. Every other test here stands the panel down to a paragraph, which is
- * all they need; the outline needs the real cards, because a stub's heading is
- * whatever the stub says.
- */
-const MEASURED: MeasuredReadings = {
-  waves: {
-    beachName: BINDING.beachName,
-    buoy: { name: "Scripps Nearshore", distanceM: 1400 },
-    state: {
-      kind: "reading",
-      heightFt: 2.62,
-      periodS: 5,
-      directionDegT: 278,
-      waterTempF: 69.98,
-    },
-  },
-  air: {
-    beachName: BINDING.beachName,
-    airStation: { name: "Scripps Pier", distanceM: 1381 },
-    air: {
-      kind: "reading",
-      airTempF: 71.42,
-      windMph: 8.05,
-      gustMph: null,
-      windDirDegT: 320,
-    },
-  },
-};
-
-/**
- * The outline, asserted where the containment it turns on is real. See #181.
- *
- * The cards were page-level regions and their `<h2>` was right; #176 moved them
- * inside this one and left the rank behind, so "Waves and water" and "Air"
- * became siblings-in-outline of the heading that contains them. ADR-0014 was
- * written against the arrangement where cards are siblings of regions, and that
- * arrangement no longer holds.
- *
- * The rank is asserted **inside the region** rather than by counting `<h3>`s: a
- * test that only says the card renders a level 3 would pass with the card
- * outside the day region entirely, which is the half of the defect that is
- * about placement rather than about a tag. The real `MeasuredToday` stands in
- * for the mocked panel for the same reason -- the substitution replaces the
- * fetch, not the render.
- */
-test("the cards inside the day region rank below the heading that names it", async () => {
-  measuredPanel.mockImplementation(() => (
-    <MeasuredToday when="today" readings={MEASURED} />
-  ));
-
-  const { container } = render(
-    await DayPanel({ slug: "la-jolla-shores-beach" }),
-  );
-
-  const region = container.querySelector<HTMLElement>(
-    'section[aria-labelledby="day-panel-heading"]',
-  )!;
-
-  // One level 2 in the region, and it is the region's own name. Two cards
-  // sitting at that rank is exactly what this test exists to catch.
-  expect(
-    within(region)
-      .getAllByRole("heading", { level: 2 })
-      .map((heading) => heading.textContent),
-  ).toEqual(["Today, hour by hour"]);
-
-  // And both cards one level under it, inside it.
-  const inside = within(region)
-    .getAllByRole("heading", { level: 3 })
-    .map((heading) => heading.textContent);
-  expect(inside).toContain("Waves and water");
-  expect(inside).toContain("Air");
-});
-
-/**
- * The rank moved and the name did not. The accessible name is composed on the
- * `<section>` from the title and the beach -- `ReadingCard` records why it is
- * an `aria-label` rather than a hidden span -- so it is reachable from the tag
- * and must survive a change to it.
- */
-test("a card is still called what it was called, at its new rank", async () => {
-  measuredPanel.mockImplementation(() => (
-    <MeasuredToday when="today" readings={MEASURED} />
-  ));
-
-  render(await DayPanel({ slug: "la-jolla-shores-beach" }));
-
-  expect(
-    screen.getByRole("region", {
-      name: `Waves and water · ${BINDING.beachName}`,
-    }),
-  ).toBeDefined();
-  expect(screen.getByRole("heading", { name: "Waves and water" }).id).toBe(
-    "waves-today-heading",
-  );
-});
-
-test("a day that has not happened says so rather than showing nothing", async () => {
-  // The other six get a sentence and no request at all. An empty region under
-  // a chart full of curves reads as a load that did not finish, which is the
-  // silent failure this page is built to avoid.
-  await renderChoosing(TOMORROW);
-
-  expect(screen.queryByText("the measured block")).toBeNull();
-  expect(
-    screen.getByText(/Nothing has been measured for Mon, Aug 17/),
-  ).toBeDefined();
-});
-
-test("the absence names the day, the way every other sentence here does", async () => {
-  // `WORDS` above takes a `when` for exactly this reason: "nothing has been
-  // measured today" printed under a heading reading `Mon, Aug 17` is not a
-  // hedge, it is false.
-  await renderChoosing(TOMORROW);
-
-  const sentence = screen.getByText(/Nothing has been measured/);
-  expect(sentence.textContent).not.toContain("today");
-  expect(sentence.textContent).toContain("Mon, Aug 17");
-});
-
-test("the measured block waits on its own boundary, not on the chart's", async () => {
-  // The two instruments are a second set of feeds and they draw no part of the
-  // plot. Folded into this panel's own `Promise.all`, a slow buoy would hold
-  // up a curve it has nothing to do with; on its own boundary it holds up
-  // itself, and the chart is already drawn behind the fallback.
-  measuredPanel.mockImplementation(() => {
-    throw new Promise(() => {});
-  });
-
-  const { container } = render(
-    await DayPanel({ slug: "la-jolla-shores-beach" }),
-  );
-
-  expect(
-    screen.getByText("Reading the buoy and the air station…"),
-  ).toBeDefined();
-  expect(curve(container)).not.toBeNull();
-});
-
-/**
- * `CONTEXT.md`'s `Conditions` entry ends `_Avoid_: weather, forecast, surf
- * report`, and a loading line is the easiest place on this page for one of
- * those to reappear. `ConditionsSection.test.tsx` checks the fallbacks it owns;
- * this one is nested inside the day region, where that check cannot see it.
- */
-test("the measured block's loading line uses no word the glossary rejects", async () => {
-  measuredPanel.mockImplementation(() => {
-    throw new Promise(() => {});
-  });
-
-  render(await DayPanel({ slug: "la-jolla-shores-beach" }));
-
-  const line = screen.getByText(/^Reading /).textContent ?? "";
-  expect(line.toLowerCase()).not.toContain("weather");
-  expect(line.toLowerCase()).not.toContain("forecast");
-  expect(line.toLowerCase()).not.toContain("surf report");
 });
 
 /**

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -52,7 +52,6 @@
  * instant rather than for a day. See `ConditionsSection`.
  */
 
-import { Suspense } from "react";
 import {
   readDaylightWeek,
   readGridpointWeek,

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -43,13 +43,13 @@
  * publisher at all on 25 of the 51 beaches, because a bay, lagoon or inlet has
  * no surf zone to forecast.
  *
- * **And, on today alone, what was measured.** Every read above is a model or a
- * prediction; the buoy and the shore station are the only instruments this
- * site reports at all. They arrive through `MeasuredPanel` on a Suspense
- * boundary of their own rather than joining the five above, because they draw
- * no part of the chart and a slow buoy must not hold up a curve it has nothing
- * to do with. The other six days get a sentence instead, naming the day, for
- * the reason `WORDS` below takes a `when` at all.
+ * **Nothing here is measured, and that is the point of where it sits.** Every
+ * read in this panel is a model or a prediction. The buoy and the shore
+ * station -- the only instruments this site reports at all -- used to arrive
+ * here too, on today alone, with a sentence on the other six days saying
+ * nothing had been measured about a day that had not happened. They now sit at
+ * the top of the page, above `SelectedDayProvider`, because they answer for an
+ * instant rather than for a day. See `ConditionsSection`.
  */
 
 import { Suspense } from "react";
@@ -77,8 +77,6 @@ import {
 } from "@/lib/pacific-time";
 import { ChosenDay, type DayView } from "./ChosenDay";
 import type { HourSeries } from "./HourChart";
-import { MeasuredPanel } from "./MeasuredPanel";
-import { MeasuredToday } from "./MeasuredToday";
 import { ReservedSlot } from "../ui/ReservedSlot";
 import type { CompassNeedle } from "./Compass";
 import {
@@ -658,39 +656,12 @@ export async function DayPanel({ slug }: { slug: string }) {
       series,
       wording: <SkyWording view={wording} localDate={day.localDate} />,
       /*
-        Rendered here and handed over finished, which is the `wording` field's
-        precedent one line up: the reads are the server's and `ChosenDay` is a
-        client component, so a measured block that fetched for itself would
-        have to become one too.
+        Rendered here and handed over finished, the precedent `wording` sets:
+        the read is the server's and `ChosenDay` is a client component.
 
-        `day.isToday` decides it here rather than `ChosenDay` testing
-        `nowMs !== null` downstream. That test would work -- six days carry
-        null -- and it would be reading a coincidence of construction as if it
-        were a contract. The daylight read states which day is today, and this
-        is the one place that fact is already in hand.
-      */
-      measured: day.isToday ? (
-        <Suspense
-          fallback={
-            <p className="text-base text-fog">
-              Reading the buoy and the air station…
-            </p>
-          }
-        >
-          <MeasuredPanel slug={slug} />
-        </Suspense>
-      ) : (
-        <MeasuredToday when={when} readings={null} />
-      ),
-      /*
-        Rendered here and handed over finished, the precedent `wording` and
-        `measured` both set: the read is the server's and `ChosenDay` is a
-        client component.
-
-        Not behind a Suspense boundary of its own, unlike the measured block.
-        That block suspends because it is a second wave of reads taken inside
-        `MeasuredPanel`; this one is already resolved by the `Promise.all`
-        above, so a boundary here would render a loading line that never shows.
+        Not behind a Suspense boundary of its own: it is already resolved by
+        the `Promise.all` above, so a boundary here would render a loading line
+        that never shows.
 
         The same `state` on all seven days and only `localDate` varying, which
         is what lets one bulletin answer for every day it reaches without being

--- a/src/components/conditions/MeasuredPanel.tsx
+++ b/src/components/conditions/MeasuredPanel.tsx
@@ -36,5 +36,5 @@ export async function MeasuredPanel({ slug }: { slug: string }) {
     readLatestAir(slug),
   ]);
 
-  return <MeasuredToday when="today" readings={{ waves, air }} />;
+  return <MeasuredToday readings={{ waves, air }} />;
 }

--- a/src/components/conditions/MeasuredToday.test.tsx
+++ b/src/components/conditions/MeasuredToday.test.tsx
@@ -57,45 +57,11 @@ function readings(
  * ========================================================================= */
 
 test("today carries both instruments, and only today", () => {
-  render(<MeasuredToday when="today" readings={readings()} />);
+  render(<MeasuredToday readings={readings()} />);
 
   expect(screen.getByText("2.6 ft")).toBeDefined();
   expect(screen.getByText("71°F")).toBeDefined();
   expect(screen.queryByText(/Nothing has been measured/)).toBeNull();
-});
-
-/**
- * The region is any of seven days now. A day that has not happened has no
- * measurement and never will have one taken in advance, and the failure this
- * page is built to avoid is a blank where a figure goes -- under a chart full
- * of curves, an empty block reads as a load that did not finish.
- */
-test("a day nobody has measured says so, and names the day", () => {
-  render(<MeasuredToday when="Thu, Aug 27" readings={null} />);
-
-  const sentence = screen.getByText(/Nothing has been measured/);
-  expect(sentence.textContent).toContain("Thu, Aug 27");
-  expect(sentence.textContent).toContain("the day has not happened");
-  // No figure anywhere that a reader could take for a reading of that day.
-  expect(screen.queryByText("2.6 ft")).toBeNull();
-  expect(screen.queryByText(/Buoy/)).toBeNull();
-});
-
-/**
- * The trap this whole slice was warned about. `CARD_MUTED` and `CARD_PROSE` are
- * measured against the reading card's `bg-dark` and paint about 1.03:1 on the
- * page's cream ground -- the bug #175's last commit fixed in three places. This
- * sentence renders outside a card, so it takes the page's own role.
- *
- * jsdom applies no stylesheets (ADR-0001), so this proves the class is
- * referenced; `cardText.test.ts` is what proves the ratio.
- */
-test("the absence sentence takes the page's colour, not the card's", () => {
-  render(<MeasuredToday when="Thu, Aug 27" readings={null} />);
-
-  const sentence = screen.getByText(/Nothing has been measured/);
-  expect(sentence.className).toContain("text-fog");
-  expect(sentence.className).not.toContain("text-white");
 });
 
 /**
@@ -105,9 +71,7 @@ test("the absence sentence takes the page's colour, not the card's", () => {
  * a gentle breeze", which is the forbidden shape exactly.
  */
 test("the two instruments are two cards, each with its own attribution", () => {
-  const { container } = render(
-    <MeasuredToday when="today" readings={readings()} />,
-  );
+  const { container } = render(<MeasuredToday readings={readings()} />);
 
   const cards = container.querySelectorAll("section");
   expect(cards).toHaveLength(2);
@@ -119,9 +83,7 @@ test("the two instruments are two cards, each with its own attribution", () => {
 });
 
 test("one stat group never spans the two sources", () => {
-  const { container } = render(
-    <MeasuredToday when="today" readings={readings()} />,
-  );
+  const { container } = render(<MeasuredToday readings={readings()} />);
 
   const groups = [...container.querySelectorAll("dl")];
   expect(groups).toHaveLength(2);
@@ -141,7 +103,7 @@ test("one stat group never spans the two sources", () => {
  * is that these numbers came off an instrument.
  */
 test("nothing predicted or modelled is in the block", () => {
-  render(<MeasuredToday when="today" readings={readings()} />);
+  render(<MeasuredToday readings={readings()} />);
 
   expect(screen.queryByText(/Lowest daylight tide/)).toBeNull();
   expect(screen.queryByText(/Lowest all day/)).toBeNull();
@@ -155,7 +117,7 @@ test("nothing predicted or modelled is in the block", () => {
  * ========================================================================= */
 
 test("a wave reading leads with the height and puts it in plain words", () => {
-  render(<MeasuredToday when="today" readings={readings()} />);
+  render(<MeasuredToday readings={readings()} />);
 
   expect(screen.getByText("2.6 ft")).toBeDefined();
   // A height alone tells a surfer what they need and a parent very little, so
@@ -165,7 +127,7 @@ test("a wave reading leads with the height and puts it in plain words", () => {
 });
 
 test("water temperature comes from the same reading, rounded", () => {
-  render(<MeasuredToday when="today" readings={readings()} />);
+  render(<MeasuredToday readings={readings()} />);
 
   // The buoy publishes 69.98 and nobody swims to two decimal places.
   expect(screen.getByText("70°F")).toBeDefined();
@@ -174,7 +136,6 @@ test("water temperature comes from the same reading, rounded", () => {
 test("a buoy reporting no water temperature says so rather than omitting it", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         waves: {
           state: { ...WAVE_READING, periodS: null, waterTempF: null },
@@ -214,7 +175,6 @@ test("every wave height band has its own words", () => {
   for (const [heightFt, words] of bands) {
     const { unmount } = render(
       <MeasuredToday
-        when="today"
         readings={readings({ waves: { state: { ...WAVE_READING, heightFt } } })}
       />,
     );
@@ -225,7 +185,7 @@ test("every wave height band has its own words", () => {
 });
 
 test("a nearby buoy is credited without a distance", () => {
-  render(<MeasuredToday when="today" readings={readings()} />);
+  render(<MeasuredToday readings={readings()} />);
 
   const line = screen.getByText(/NDBC/).textContent ?? "";
   expect(line).toContain(NEAR_BUOY.name);
@@ -235,7 +195,6 @@ test("a nearby buoy is credited without a distance", () => {
 test("a distant buoy discloses how far away it is", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         waves: { beachName: "Tijana River", buoy: FAR_BUOY },
       })}
@@ -249,7 +208,6 @@ test("a distant buoy discloses how far away it is", () => {
 test("a bay beach is told this is expected, not a fault", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         waves: {
           beachName: "Agua Hedionda Lagoon",
@@ -299,12 +257,7 @@ const MODELLED_BEACH = {
 };
 
 test("a beach no buoy reaches is told its wave heights are modelled", () => {
-  render(
-    <MeasuredToday
-      when="today"
-      readings={readings({ waves: MODELLED_BEACH })}
-    />,
-  );
+  render(<MeasuredToday readings={readings({ waves: MODELLED_BEACH })} />);
 
   expect(screen.getByText(/nothing here is measured/)).toBeDefined();
   const sentence =
@@ -316,12 +269,7 @@ test("a beach no buoy reaches is told its wave heights are modelled", () => {
 test("the disclosure points at where the modelled heights actually are", () => {
   // It used to say "the wave heights below", which was true when a forecast
   // block sat beneath it on the card. Below this sentence now is the air card.
-  render(
-    <MeasuredToday
-      when="today"
-      readings={readings({ waves: MODELLED_BEACH })}
-    />,
-  );
+  render(<MeasuredToday readings={readings({ waves: MODELLED_BEACH })} />);
 
   const sentence =
     screen.getByText(/nothing here is measured/).textContent ?? "";
@@ -332,12 +280,7 @@ test("the disclosure points at where the modelled heights actually are", () => {
 test("it does not tell an open-coast beach that swell does not reach it", () => {
   // The bay sentence was written for enclosed water. On these ten it states the
   // reason their beach is fine as the reason it is not.
-  render(
-    <MeasuredToday
-      when="today"
-      readings={readings({ waves: MODELLED_BEACH })}
-    />,
-  );
+  render(<MeasuredToday readings={readings({ waves: MODELLED_BEACH })} />);
 
   expect(
     screen.queryByText(/Every wave buoy sits out on the open coast/),
@@ -348,12 +291,7 @@ test("it does not tell an open-coast beach that swell does not reach it", () => 
 test("the refused buoy and the line that replaced it both reach the reader", () => {
   // Either half alone misleads, and this is the last place the pair can be
   // dropped between `beaches.json` and a person.
-  render(
-    <MeasuredToday
-      when="today"
-      readings={readings({ waves: MODELLED_BEACH })}
-    />,
-  );
+  render(<MeasuredToday readings={readings({ waves: MODELLED_BEACH })} />);
 
   const why = screen.getByText(/nearest delivering buoy 46232/);
   expect(why.textContent).toContain("28.2 km");
@@ -364,7 +302,6 @@ test("the refused buoy and the line that replaced it both reach the reader", () 
 test("an unavailable buoy is a sentence with the reason behind a disclosure", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         waves: {
           state: {
@@ -387,7 +324,6 @@ test("an unavailable buoy is a sentence with the reason behind a disclosure", ()
 test("wave drift is named as a bug here rather than a problem at the buoy", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         waves: {
           state: {
@@ -414,7 +350,6 @@ test("wave drift is named as a bug here rather than a problem at the buoy", () =
 test("a beach with no buoy is never told to come back later", () => {
   const { unmount } = render(
     <MeasuredToday
-      when="today"
       readings={readings({
         waves: {
           buoy: null,
@@ -433,7 +368,6 @@ test("a beach with no buoy is never told to come back later", () => {
 
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         waves: {
           state: {
@@ -457,13 +391,13 @@ test("a beach with no buoy is never told to come back later", () => {
  * ========================================================================= */
 
 test("the temperature is the air card's largest figure", () => {
-  render(<MeasuredToday when="today" readings={readings()} />);
+  render(<MeasuredToday readings={readings()} />);
 
   expect(screen.getByText("71°F").className).toContain("text-stat");
 });
 
 test("wind is a figure beneath the temperature, not a sentence", () => {
-  render(<MeasuredToday when="today" readings={readings()} />);
+  render(<MeasuredToday readings={readings()} />);
 
   expect(screen.getByText("Wind")).toBeDefined();
   expect(screen.getByText("8 mph from the north-west")).toBeDefined();
@@ -476,7 +410,7 @@ test("wind is a figure beneath the temperature, not a sentence", () => {
  * a field comes back by accident.
  */
 test("no sky and no visibility appear in the block at all", () => {
-  render(<MeasuredToday when="today" readings={readings()} />);
+  render(<MeasuredToday readings={readings()} />);
 
   expect(screen.queryByText("Sky")).toBeNull();
   expect(screen.queryByText("Visibility")).toBeNull();
@@ -487,7 +421,7 @@ test("no sky and no visibility appear in the block at all", () => {
 test("the air station is named, with its distance", () => {
   // The distance is what tells a reader how near this reading was taken, which
   // is the claim the card is making.
-  render(<MeasuredToday when="today" readings={readings()} />);
+  render(<MeasuredToday readings={readings()} />);
 
   const air = screen.getByText(/Scripps Pier/).textContent ?? "";
   expect(air).toContain("Temperature and wind");
@@ -497,7 +431,6 @@ test("the air station is named, with its distance", () => {
 test("a gust is shown when the station published one", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({ air: { air: { ...AIR_READING, gustMph: 14.2 } } })}
     />,
   );
@@ -509,7 +442,6 @@ test("a gust is shown when the station published one", () => {
 test("wind with no direction is still given as a speed", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         air: { air: { ...AIR_READING, windDirDegT: null } },
       })}
@@ -522,7 +454,6 @@ test("wind with no direction is still given as a speed", () => {
 test("no wind value says so rather than reading as calm", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         air: { air: { ...AIR_READING, windMph: null, windDirDegT: null } },
       })}
@@ -536,7 +467,6 @@ test("no wind value says so rather than reading as calm", () => {
 test("a genuine calm is named as calm, not as a missing reading", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         air: { air: { ...AIR_READING, windMph: 0, windDirDegT: 0 } },
       })}
@@ -555,7 +485,6 @@ test("a genuine calm is named as calm, not as a missing reading", () => {
 test("a calm wind reports no gust, however the instrument twitched", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         air: {
           air: { ...AIR_READING, windMph: 0.4, windDirDegT: 0, gustMph: 2.1 },
@@ -573,7 +502,6 @@ test("a gust with no wind speed at all is not reported either", () => {
   // different hat: a gust is a property of a wind we do not have.
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         air: {
           air: {
@@ -594,7 +522,6 @@ test("a gust with no wind speed at all is not reported either", () => {
 test("a missing temperature says so rather than leaving the card headed by nothing", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({ air: { air: { ...AIR_READING, airTempF: null } } })}
     />,
   );
@@ -605,7 +532,6 @@ test("a missing temperature says so rather than leaving the card headed by nothi
 test("an unavailable air reading says so and does not blank the card", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         air: {
           air: {
@@ -626,7 +552,6 @@ test("an unavailable air reading says so and does not blank the card", () => {
 test("air drift is disclosed as a bug here rather than a problem upstream", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         air: {
           air: {
@@ -647,7 +572,6 @@ test("air drift is disclosed as a bug here rather than a problem upstream", () =
 test("no air station is a permanent fact about the place, with its reason", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         air: {
           airStation: null,
@@ -669,7 +593,7 @@ test("no air station is a permanent fact about the place, with its reason", () =
 });
 
 test("the air card says what its figures mean in plain words", () => {
-  render(<MeasuredToday when="today" readings={readings()} />);
+  render(<MeasuredToday readings={readings()} />);
 
   // 71°F and 8 mph, restated. Never advice: ADR-0009 forbids a verdict, so a
   // Beaufort-style "a gentle breeze" is available and "a good day for it" is
@@ -680,7 +604,6 @@ test("the air card says what its figures mean in plain words", () => {
 test("a calm wind is calm in the words and in the figure", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         air: { air: { ...AIR_READING, windMph: 0.4, gustMph: 2 } },
       })}
@@ -695,7 +618,6 @@ test("a calm wind is calm in the words and in the figure", () => {
 test("either air figure alone still makes a sentence", () => {
   const { unmount } = render(
     <MeasuredToday
-      when="today"
       readings={readings({
         air: { air: { ...AIR_READING, windMph: null, gustMph: null } },
       })}
@@ -706,7 +628,6 @@ test("either air figure alone still makes a sentence", () => {
 
   render(
     <MeasuredToday
-      when="today"
       readings={readings({ air: { air: { ...AIR_READING, airTempF: null } } })}
     />,
   );
@@ -716,7 +637,6 @@ test("either air figure alone still makes a sentence", () => {
 test("no line at all when neither air figure arrived", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         air: {
           air: {
@@ -755,7 +675,6 @@ test("every temperature band has its own word", () => {
   for (const [airTempF, word] of bands) {
     const { unmount } = render(
       <MeasuredToday
-        when="today"
         readings={readings({
           air: {
             air: { ...AIR_READING, airTempF, windMph: null, gustMph: null },
@@ -786,7 +705,6 @@ test("every wind band has its own words", () => {
   for (const [windMph, words] of bands) {
     const { unmount } = render(
       <MeasuredToday
-        when="today"
         readings={readings({
           air: {
             air: { ...AIR_READING, airTempF: null, windMph, gustMph: null },
@@ -817,7 +735,6 @@ test("every compass point has its own words", () => {
   for (const [windDirDegT, words] of bearings) {
     const { unmount } = render(
       <MeasuredToday
-        when="today"
         readings={readings({ air: { air: { ...AIR_READING, windDirDegT } } })}
       />,
     );
@@ -832,7 +749,6 @@ test("a station past ten kilometres loses the decimal its neighbours keep", () =
   // is most of what the figure says at this range -- and pointless past it.
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         air: { airStation: { name: "Miramar MCAS", distanceM: 10_430 } },
       })}
@@ -845,7 +761,6 @@ test("a station past ten kilometres loses the decimal its neighbours keep", () =
 test("a station with no recorded distance is still named", () => {
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         air: { airStation: { name: "Scripps Pier", distanceM: null } },
       })}
@@ -874,7 +789,6 @@ test("every disclosure this block can render composes the touch-target floor", (
   const renders = [
     render(
       <MeasuredToday
-        when="today"
         readings={readings({
           waves: {
             buoy: null,
@@ -893,7 +807,6 @@ test("every disclosure this block can render composes the touch-target floor", (
     ),
     render(
       <MeasuredToday
-        when="today"
         readings={readings({
           waves: {
             state: {
@@ -930,9 +843,7 @@ test("every disclosure this block can render composes the touch-target floor", (
  * instrument readings was the objection to it.
  */
 test("each card keeps the glyph its subject was given", () => {
-  const { container } = render(
-    <MeasuredToday when="today" readings={readings()} />,
-  );
+  const { container } = render(<MeasuredToday readings={readings()} />);
 
   const glyphs = [...container.querySelectorAll('[aria-hidden="true"]')].map(
     (node) => node.textContent,
@@ -948,7 +859,6 @@ test("each card keeps the glyph its subject was given", () => {
 test("a quiet buoy leaves the air standing, and the reverse", () => {
   const { unmount } = render(
     <MeasuredToday
-      when="today"
       readings={readings({
         waves: {
           state: {
@@ -966,7 +876,6 @@ test("a quiet buoy leaves the air standing, and the reverse", () => {
 
   render(
     <MeasuredToday
-      when="today"
       readings={readings({
         air: {
           air: {

--- a/src/components/conditions/MeasuredToday.tsx
+++ b/src/components/conditions/MeasuredToday.tsx
@@ -8,15 +8,17 @@
  * **This is the whole of what the page measures.** Everything else on
  * `/conditions` is a prediction or a model -- NOAA's harmonic tide, CDIP's
  * swell, the National Weather Service's grid cell. The buoy and the air station
- * are the only instruments this site reports at all, which is why they move
- * into the day rather than being deleted with the slab they sat in.
+ * are the only instruments this site reports at all, which is why they were
+ * kept when the slab they sat in was deleted.
  *
- * **Today only, and the other six days say so rather than rendering nothing.**
- * A blank where a measurement goes is the failure this whole page is built to
- * avoid, and it is worse here than anywhere: an empty region under a chart full
- * of curves reads as a load that did not finish. The sentence names the day,
- * because the region is any of seven now -- `DayPanel`'s `WORDS` object takes
- * the same `when` for the same reason.
+ * **Now only, and it takes no day.** This block spent a while inside the day
+ * panel, rendered on today alone, with a sentence on the other six saying
+ * nothing had been measured about a day that had not happened. It is at the top
+ * of the page now, above `SelectedDayProvider`, so there is no day in scope to
+ * name and no absent day to apologise for: an instrument answers for an
+ * instant, and the only instant it answers for is this one. The `when` prop and
+ * the absence sentence went with the move -- with nothing rendering this block
+ * for a future day, neither had a caller left.
  *
  * **Two cards, not one, and that is ADR-0010 rather than a layout preference.**
  * The buoy and the air station are two provenances, which that decision permits
@@ -44,7 +46,7 @@
 
 import type { AirView, WavesView } from "@/lib/conditions";
 import { compassWords } from "./bearing";
-import { CARD_PROSE, PAGE_MUTED } from "./cardText";
+import { CARD_PROSE } from "./cardText";
 import { DISCLOSURE_TARGET } from "./disclosure";
 import { ProvenanceLine } from "./ProvenanceLine";
 import { ReadingCard } from "./ReadingCard";
@@ -57,14 +59,8 @@ export type MeasuredReadings = {
 };
 
 export type MeasuredTodayProps = {
-  /**
-   * How this day is named inside a sentence: "today", or the grid's own label
-   * for one of the other six. Only the absence sentence uses it, because only
-   * the other six days have one.
-   */
-  when: string;
-  /** The measurements, or `null` on a day nobody has taken a reading of. */
-  readings: MeasuredReadings | null;
+  /** The two newest observations. Never null: this block only renders for now. */
+  readings: MeasuredReadings;
 };
 
 /* =========================================================================
@@ -133,7 +129,7 @@ function SeaCard({ beachName, buoy, state }: WavesView) {
   return (
     <ReadingCard
       emoji="🏄"
-      headingLevel="h3"
+      headingLevel="h2"
       headingId="waves-today-heading"
       title="Waves and water"
       context={beachName}
@@ -407,7 +403,7 @@ function AirCard({ beachName, airStation, air }: AirView) {
   return (
     <ReadingCard
       emoji="💨"
-      headingLevel="h3"
+      headingLevel="h2"
       headingId="wind-today-heading"
       title="Air"
       context={beachName}
@@ -470,23 +466,7 @@ function AirCard({ beachName, airStation, air }: AirView) {
  * The block
  * ========================================================================= */
 
-export function MeasuredToday({ when, readings }: MeasuredTodayProps) {
-  if (readings === null) {
-    return (
-      /*
-        `PAGE_MUTED`, not the card's colour: this sentence renders straight onto
-        the page ground, where `CARD_MUTED` paints 1.03:1 and says nothing at
-        all. An absence nobody can see is worse than no absence sentence, and
-        this is the one the reader meets on six days of seven.
-      */
-      <p className={`leading-relaxed text-base ${PAGE_MUTED}`}>
-        Nothing has been measured for {when}: the day has not happened. The buoy
-        and the air station only ever answer for now, so everything above is a
-        prediction or a model.
-      </p>
-    );
-  }
-
+export function MeasuredToday({ readings }: MeasuredTodayProps) {
   /*
     Two across from `sm`, which is where the three-card band above the page
     used to go two across as well. `items-stretch` so a quiet buoy beside a

--- a/src/components/conditions/ReadingCard.tsx
+++ b/src/components/conditions/ReadingCard.tsx
@@ -68,6 +68,12 @@ type ReadingCardProps = {
    * component to move a card has to answer the question rather than inherit an
    * answer taken for somewhere else.
    *
+   * The next component to move a card was the measured block itself, which
+   * left the day region for the top of the page and took `h2` back with it.
+   * That is the prop doing its job rather than a reversal: page-level cards
+   * are siblings of the three region headings under the `<h1>`, and `h3`
+   * there would have skipped a level with nothing in between.
+   *
    * Only the outline moves. The visual register is `text-2xs` at either rank,
    * which is what ADR-0014 decided and what a level says nothing about.
    */

--- a/src/components/conditions/WeekGrid.test.tsx
+++ b/src/components/conditions/WeekGrid.test.tsx
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { REGION_HEADING } from "../ui/headingRank";
+import { TOOL_REGION_HEADING } from "../ui/headingRank";
 import { TOUCH_TARGET } from "../ui/touchTarget";
 import {
   MIN_SPARK_BLOCK_PX,
@@ -282,13 +282,13 @@ test("the week's heading outranks the day headings inside it", () => {
   const { container } = renderGrid();
 
   const region = screen.getByRole("heading", { name: "The week ahead" });
-  expect(region.className).toBe(REGION_HEADING);
+  expect(region.className).toBe(TOOL_REGION_HEADING);
 
   // The other half of the rank: the label register stays where it is. A day
   // heading moving with the region would restore the flat scale one level down.
   const day = container.querySelector("h3");
   expect(day?.className).toContain("text-2xs");
-  expect(day?.className).not.toContain("text-quote");
+  expect(day?.className).not.toContain("text-tool-region");
 
   // And the outline the register is drawn over, stated rather than implied.
   // #181 moves the measured cards to level 3, which is the rank these day

--- a/src/components/conditions/WeekGrid.tsx
+++ b/src/components/conditions/WeekGrid.tsx
@@ -62,7 +62,7 @@ import { MIN_USEFUL_SPARK_WIDTH_PX } from "./DaySpark";
 import { useHydrated } from "./hydrated";
 import { resolveSelected, useSelectedDay } from "./selectedDay";
 import { TOUCH_TARGET } from "../ui/touchTarget";
-import { REGION_HEADING } from "../ui/headingRank";
+import { TOOL_REGION_HEADING } from "../ui/headingRank";
 import { ProvenanceLine } from "./ProvenanceLine";
 import { ReservedSlot } from "../ui/ReservedSlot";
 
@@ -301,7 +301,7 @@ export function WeekGrid({
 
   return (
     <section aria-labelledby={headingId}>
-      <h2 id={headingId} className={REGION_HEADING}>
+      <h2 id={headingId} className={TOOL_REGION_HEADING}>
         {title}
       </h2>
 

--- a/src/components/conditions/selectedDay.test.tsx
+++ b/src/components/conditions/selectedDay.test.tsx
@@ -103,7 +103,6 @@ function dayView(index: number): DayView {
     wording: <p>Words for {localDate}</p>,
     // A stand-in: what these tests assert is the day selection, not this block.
     surfZone: <p>Rip current risk on {localDate}</p>,
-    measured: <p>Measured on {localDate}</p>,
   };
 }
 
@@ -203,12 +202,14 @@ test("choosing a day in the week redraws the panel below", () => {
   );
   expect(drawnDay(container)).toBe(`Tide on ${DATES[2]}`);
   expect(screen.getByText(`Words for ${DATES[2]}`)).toBeDefined();
-  // The measured block moves with the rest of the panel. It is the one region
-  // whose content differs in *kind* between today and the other six -- two
-  // cards against one sentence -- so a block left behind would be the most
-  // visible way for the panel to disagree with its own heading.
-  expect(screen.getByText(`Measured on ${DATES[2]}`)).toBeDefined();
-  expect(screen.queryByText(`Measured on ${DATES[0]}`)).toBeNull();
+  // The rip current block moves with the rest of the panel. It is now the
+  // region whose content differs most between one day and the next -- several
+  // lines where the bulletin reaches, one where it does not -- so a block left
+  // behind is the most visible way for the panel to disagree with its heading.
+  // The measured block used to be checked here; it is no longer in this panel,
+  // and `ConditionsSection.test.tsx` asserts where it went.
+  expect(screen.getByText(`Rip current risk on ${DATES[2]}`)).toBeDefined();
+  expect(screen.queryByText(`Rip current risk on ${DATES[0]}`)).toBeNull();
 });
 
 /**

--- a/src/components/conditions/selectedHour.test.tsx
+++ b/src/components/conditions/selectedHour.test.tsx
@@ -94,7 +94,6 @@ function dayView(index: number, tideHours = 24): DayView {
     wording: <p>Words for {localDate}</p>,
     // A stand-in: what these tests assert is the day selection, not this block.
     surfZone: <p>Rip current risk on {localDate}</p>,
-    measured: <p>Measured on {localDate}</p>,
   };
 }
 

--- a/src/components/ui/headingRank.ts
+++ b/src/components/ui/headingRank.ts
@@ -28,3 +28,41 @@
  */
 export const REGION_HEADING =
   "text-quote leading-display mb-4 font-black italic";
+
+/**
+ * The same rank, on a page that is a tool rather than a document. ADR-0014 is
+ * unaffected: a region heading still outranks a card heading, and this is still
+ * the display register against the label one.
+ *
+ * **Why a second rank rather than a smaller first one.** `REGION_HEADING` is
+ * also `/art`'s two section headings and `SessionSchedule`'s, which reaches
+ * `/art` and `/coop`. Those pages spread their regions down a document, where a
+ * 34px heading is an arrival. `/conditions` stacks three of them inside one
+ * scroll -- the week, the day, the notes -- and a reader there is not arriving
+ * three times, they are looking for a number. Editing the shared constant would
+ * have quietened three pages to answer a complaint only one of them has.
+ *
+ * **It stays in the display register.** `font-black italic` at a size token
+ * with `leading-display`, exactly as the constant above is. The alternative --
+ * dropping these three headings to the label register -- is the flat scale
+ * ADR-0014 was written to escape, where `/conditions` rendered a region, a card
+ * inside it and a day inside that at the same 10px. The rank gets quieter; it
+ * does not change kind.
+ *
+ * **The clamp is legible at both ends, which is the test the constant above
+ * sets itself.** 17px at 375 against the conditions `<h1>`'s 24px, and 22px at
+ * 1536 against its 36px. `--text-quote` fails that here for the mirror image of
+ * the reason `--text-card` failed it there: 34px under a 36px title is not a
+ * second rank, it is the same one twice.
+ *
+ * **`mb-3` rather than `mb-4`.** A smaller heading owns less space beneath it,
+ * and 16px under a 22px line reads as a gap rather than as attachment.
+ *
+ * Like the constant above, this is asserted by reference rather than by
+ * rendered size -- jsdom applies no stylesheets (ADR-0001). The token behind it
+ * carries a `REQUIRED` row in `scripts/built-css.mjs` instead, because a
+ * deleted token leaves `text-tool-region` sitting in the markup where every
+ * jsdom test still finds it, compiling to nothing.
+ */
+export const TOOL_REGION_HEADING =
+  "text-tool-region leading-display mb-3 font-black italic";


### PR DESCRIPTION
Slices 1–3 of the conditions compression. The brief and task list are in
`.design/conditions-minimal/`, committed as the first commit here.

**No `docs/plans/` file.** `.design/` is committed in this repo, so the brief and
task list are already the durable record; a third copy could only go stale on its
own. Stated as a decision rather than left as a lapse, per CLAUDE.md.

## What changed

**Slice 1 — the hero.** The eyebrow (`Surf · Tide · Wind · Visibility`) and the
lead paragraph came off: both describe the page to somebody who just clicked
"Conditions" to reach it. The lead copy is not lost — the `metadata` export in
`app/conditions/page.tsx` has carried it verbatim all along, and that now has a
test, because with the on-page paragraph gone nothing else would notice the
string being deleted. The `<h1>` drops to its own `--text-tool-title` token; six
other pages take `--text-title` and none of them opens on a figure. The ADR-0009
notice stays, as one sentence from two, with both claims and both halves still
separately asserted.

**Slice 2 — the region headings.** The week, day and notes headings take a new
`TOOL_REGION_HEADING` at `--text-tool-region`, added beside `REGION_HEADING`
rather than replacing it — `/art` and `SessionSchedule` take the shared constant
and neither page has this complaint. ADR-0014 is amended, not superseded: what it
decided is untouched, only the token pair changes. The amendment narrows one
clause — at 17px the smaller rank is under WCAG's 18.66px bold threshold, so it
needs 4.5:1 rather than 3:1; it inherits the same ink on the same cream, so
nothing new is owed a measurement.

**Slice 3 — the readings move up.** `MeasuredPanel` renders from
`ConditionsSection`, above the week and **outside `SelectedDayProvider`**. Outside
rather than merely above: an instrument answers for an instant, so being frozen
to the present is the region's contract, and rendering it outside the provider
means there is no selected day in scope for it to read even by mistake. The
absence sentence went with it — nothing measured lives in the day panel now, so
there is no gap left to explain, and `readings` narrows from nullable to required
rather than leaving a branch no caller can reach. The cards take `h2` back:
`ReadingCard` requires `headingLevel` precisely so a component moving a card has
to answer the question, and at page level `h3` would skip a level under the `<h1>`.

## Measured, at 1536×639

Both figures taken from real builds, `main` built from the same commit — not
estimated.

| at 1536×639          |   `main` | this branch |
| -------------------- | -------: | ----------: |
| selector bottom      |    343px |   **259px** |
| first week cell ends |    807px |       938px |
| whole page           |   3424px |  **3296px** |

84px off the header, 128px off the page, and the readings are inside the first
screen where they used to be three regions down.

## Two things I could not do, and why

**The brief's height target is not reachable, and I have restated it.** It asked
for the selector, the readings and the first week row all above the fold. A week
cell is 292px tall on its own, so the first row cannot finish above 639px from a
grid starting below 340px — true even with the readings compressed to nothing.
That target was set without measuring the cell. Getting a whole cell above the
fold is a change to the week grid, which the brief puts out of scope, and it
should not be smuggled in as a side effect of compressing something else.

**Slice 4 is blocked as written and is not in this PR.** It proposed merging the
two reading cards into one band. `MeasuredToday`'s docstring settles it: two
cards is ADR-0010 rather than a layout preference, because that decision refuses
two provenances behind one sentence. `CARD_PROSE` and `CARD_MUTED` are also
measured against `bg-dark` and paint 1.03:1 on cream. Three ways forward are
written into `TASKS.md` with the trade each makes; the choice is the designer's,
so none is taken here.

## Noticed, not filed

- A `next start -p 3000` from 2026-08-30 was still running and holding the build
  directory, so the first measurements I took described the old page entirely.
  Killed. Worth knowing that `pkill -f "next start"` does not reach it on Windows.

## Gate

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

Run at 26fce6b after `rm -rf .next`. Test totals from the same run: 100 files,
1711 tests. Both stylesheet guards added here were verified by deleting each
token and watching the row fail, then restoring it.
