### PR TITLE
Compress the reading cards and surface today's rip level

### DIFF
--- a/.design/conditions-minimal/TASKS.md
+++ b/.design/conditions-minimal/TASKS.md
@@ -74,7 +74,7 @@ conflicts inside one file.
 > false at its own commit, which is exactly the drift this repo's docstrings are
 > written to avoid. The two slices are otherwise independent.
 
-- [ ] **Slice 1 — Cut the conditions hero to a title and the notice.**
+- [x] **Slice 1 — Cut the conditions hero to a title and the notice.**
       Remove the eyebrow (`Surf · Tide · Wind · Visibility`) and the lead
       paragraph. Drop the `<h1>` from `text-title` to roughly
       `clamp(24px, 3vw, 36px)`. Tighten the ADR-0009 notice to one line, keeping
@@ -89,7 +89,7 @@ conflicts inside one file.
       _The `<h1>` size is a local class, not a token change — nothing else on the
       site uses `text-title` at this rank._
 
-- [ ] **Slice 2 — Quieten the conditions region headings.**
+- [x] **Slice 2 — Quieten the conditions region headings.**
       Add a second heading rank beside `REGION_HEADING` in
       `src/components/ui/headingRank.ts` — roughly `clamp(17px, 1.6vw, 22px)`,
       same black italic — and use it for the three conditions `<h2>`s
@@ -118,7 +118,7 @@ conflicts inside one file.
 > absence branch and nothing else; the band is presentation only. Slices 4 and 5
 > below are renumbered accordingly.
 
-- [ ] **Slice 3 — Move the live readings to the top of the page.**
+- [x] **Slice 3 — Move the live readings to the top of the page.**
       Render `MeasuredPanel` from `ConditionsSection`, in its own Suspense
       boundary, **outside `SelectedDayProvider`**. Remove it from `DayPanel` and
       drop `DayView.measured` from `ChosenDay`. Presentation unchanged — this
@@ -165,7 +165,16 @@ conflicts inside one file.
 > Option 2 is the recommendation: it is the only one that recovers height without
 > touching a decision.
 
-- [ ] **Slice 4 — Compress the two reading cards into one band.**
+- [x] **Slice 4 — Compress the two reading cards into one band.**
+      **Built as option 2 instead, on the designer's call: _give the reading
+      cards fewer rows_.** The band is not built and should not be. Each card
+      keeps its own figure, its own plain-words gloss and its own attribution,
+      which is all ADR-0010 asks; the height comes out of row count instead. The
+      gloss moved onto the figure's row as a `ReadingCard` prop and a stat's
+      label moved beside its value. Measured on the built page: the block 223px
+      → 175px, the page 3296px → 3248px. The 65 existing card tests passed
+      unmodified, so three new ones assert the arrangement as shared parentage
+      rather than as a class.
       Two `rounded-card bg-dark` cards side by side become one dark band with a
       yellow `RIGHT NOW · <beach>` eyebrow: one surface, one set of padding, the
       two readings as groups inside it rather than as separate sections.
@@ -184,7 +193,13 @@ conflicts inside one file.
       the strip's look agreed here, because everything after it is quiet by
       contrast._
 
-- [ ] **Slice 5 — Add today's rip current level to the strip.**
+- [x] **Slice 5 — Add today's rip current level to the strip.**
+      **Built beside the beach chooser rather than in the strip**, which the
+      slice below did not anticipate. The measured band is what instruments
+      read; a rip level is a forecaster's judgement, and ADR-0009 turns on those
+      two being visibly different kinds of thing. It costs 9px there, because
+      `md:items-end` left that column bottom-aligned against a taller one.
+      The absent value needed more care than the level did — see the commit.
       Read the surf zone at page level, find today's `SurfZoneDay` by
       `localDate`, and print its `level` word in the strip. No gloss, no surf or
       water ranges, no period name — those stay in the day panel's full block,

--- a/src/components/conditions/ConditionsSection.test.tsx
+++ b/src/components/conditions/ConditionsSection.test.tsx
@@ -44,12 +44,21 @@ vi.mock("@/components/conditions/MeasuredPanel", () => ({
 // would otherwise carry that swap into every test after them -- silently, since
 // the real cards render figures rather than throwing.
 beforeEach(() => {
+  ripLevel.mockReset();
+  ripLevel.mockImplementation(({ slug }: { slug: string }) => {
+    if (slug === "suspend-the-panels") throw new Promise(() => {});
+    return <p>rip for {slug}</p>;
+  });
   measuredPanel.mockReset();
   measuredPanel.mockImplementation(({ slug }: { slug: string }) => {
     if (slug === "suspend-the-panels") throw new Promise(() => {});
     return <p>measured for {slug}</p>;
   });
 });
+const ripLevel = vi.fn();
+vi.mock("@/components/conditions/RipLevel", () => ({
+  RipLevel: (props: { slug: string }) => ripLevel(props),
+}));
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
 const { ConditionsSection } = await import("./ConditionsSection");
@@ -330,12 +339,12 @@ test("no panel's loading line uses a word the glossary rejects", () => {
     .map((node) => node.textContent ?? "")
     .filter((text) => text.startsWith("Reading "));
 
-  // Three suspended regions: the measured block, the week and the day. It was
-  // two while the measured block sat inside the day panel, on a boundary this
-  // check could not see from here -- so its line was asserted in
+  // Four suspended regions: the rip level, the measured block, the week and the
+  // day. It was two while the measured block sat inside the day panel, on a
+  // boundary this check could not see from here -- so its line was asserted in
   // `DayPanel.test.tsx` instead, and moved back here with the block. Asserted
   // as a count so this cannot pass by finding none of them.
-  expect(loading.length).toBe(3);
+  expect(loading.length).toBe(4);
   for (const line of loading) {
     expect(line.toLowerCase()).not.toContain("weather");
     expect(line.toLowerCase()).not.toContain("forecast");

--- a/src/components/conditions/ConditionsSection.tsx
+++ b/src/components/conditions/ConditionsSection.tsx
@@ -18,6 +18,7 @@ import { BeachSelector } from "./BeachSelector";
 import { ConditionsNotes } from "./ConditionsNotes";
 import { DayPanel } from "./DayPanel";
 import { MeasuredPanel } from "./MeasuredPanel";
+import { RipLevel } from "./RipLevel";
 import { SelectedDayProvider } from "./selectedDay";
 import { WeekPanel } from "./WeekPanel";
 
@@ -93,8 +94,30 @@ export function ConditionsSection({ slug }: { slug: string }) {
           </p>
         </div>
 
+        {/*
+          The chooser's column, and the rip level under it.
+
+          Reading order: choose the beach, then the one relayed judgement about
+          it. And it is nearly free here -- the row is `md:items-end`, so this
+          column is bottom-aligned against a taller one and the space above the
+          chooser was already empty. The same measurement put the standing
+          notice in this column once.
+
+          Its own Suspense boundary, because it is a sixth publisher and the
+          bulletin going quiet must not hold up the chooser, which needs no
+          network at all.
+        */}
         <div className="mt-6 md:mt-0 md:w-72">
           <BeachSelector groups={groups} current={slug} />
+          <Suspense
+            fallback={
+              <p className="mt-4 text-base text-fog">
+                Reading the rip current risk…
+              </p>
+            }
+          >
+            <RipLevel slug={slug} />
+          </Suspense>
         </div>
       </div>
 

--- a/src/components/conditions/MeasuredToday.tsx
+++ b/src/components/conditions/MeasuredToday.tsx
@@ -136,12 +136,12 @@ function SeaCard({ beachName, buoy, state }: WavesView) {
       figure={
         state.kind === "reading" ? `${state.heightFt.toFixed(1)} ft` : null
       }
+      gloss={
+        state.kind === "reading" ? `${heightWords(state.heightFt)}.` : null
+      }
     >
       {state.kind === "reading" && (
         <>
-          <p className={`leading-relaxed mb-3 text-base ${CARD_PROSE}`}>
-            {heightWords(state.heightFt)}.
-          </p>
           {/*
             A null is rendered as an absence rather than dropped: a buoy that
             publishes waves and no water temperature is a measured fact about
@@ -408,19 +408,14 @@ function AirCard({ beachName, airStation, air }: AirView) {
       title="Air"
       context={beachName}
       figure={temperatureWords(air)}
-    >
-      {/*
+      /*
         The plain-words line every card on this page is specified to carry. A
         restatement, never advice: ADR-0009 forbids this site a verdict, so a
         Beaufort-style "a light breeze" is available and "a good day for it" is
         not.
-      */}
-      {words !== null && (
-        <p className={`leading-relaxed mb-3 text-base ${CARD_PROSE}`}>
-          {words}
-        </p>
-      )}
-
+      */
+      gloss={words}
+    >
       {air.kind === "reading" && <StatGroup stats={windStats(air)} />}
 
       {airStation !== null && (

--- a/src/components/conditions/ReadingCard.test.tsx
+++ b/src/components/conditions/ReadingCard.test.tsx
@@ -2,7 +2,7 @@ import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { ReadingCard } from "./ReadingCard";
 
-function card(figure?: string | null) {
+function card(figure?: string | null, gloss?: string | null) {
   return (
     <ReadingCard
       emoji="🐚"
@@ -11,6 +11,7 @@ function card(figure?: string | null) {
       title="Lowest tide today"
       context="La Jolla Shores Beach"
       figure={figure}
+      gloss={gloss}
     >
       <p>the body of the reading</p>
     </ReadingCard>
@@ -199,4 +200,44 @@ test("the card sets no arbitrary glyph size of its own", () => {
   const { container } = render(card("6:24 AM"));
 
   expect(container.innerHTML).not.toContain("text-[34px]");
+});
+
+/**
+ * The gloss shares the figure's row, and that is the whole of what it buys.
+ *
+ * It used to be a paragraph the caller rendered underneath, costing a row per
+ * card -- and there are two cards, at the top of the page, on the block this
+ * compression was for. Beside the figure it costs nothing above `sm` and wraps
+ * to its own line below, which is the layout it had at every width before.
+ *
+ * Asserted as shared parentage rather than as a class, for the reason the glyph
+ * test above uses the same check: jsdom applies no stylesheets (ADR-0001), so
+ * "same row" is a fact about the tree here and a human confirms it renders as
+ * one.
+ */
+test("the gloss sits on the figure's row rather than under it", () => {
+  const { container } = render(card("3.0 ft", "about waist high."));
+
+  const figure = container.querySelector(".text-stat");
+  const gloss = screen.getByText("about waist high.");
+
+  expect(gloss.parentElement).toBe(figure?.parentElement);
+  // And it is not the body: a caller's children still render beneath the row.
+  expect(gloss.parentElement).not.toBe(
+    screen.getByText("the body of the reading").parentElement,
+  );
+});
+
+/**
+ * A station that answered with a figure and no words is not owed a blank row.
+ * The same argument the empty figure slot loses on, one element along -- and
+ * the reason this is a prop with a null case rather than a caller's paragraph
+ * wrapped in a condition each time.
+ */
+test("a card given no gloss has no empty line where one would go", () => {
+  const { container } = render(card("3.0 ft"));
+
+  const row = container.querySelector(".text-stat")?.parentElement;
+  // The glyph and the figure, and nothing standing in for absent words.
+  expect(row?.children.length).toBe(2);
 });

--- a/src/components/conditions/ReadingCard.tsx
+++ b/src/components/conditions/ReadingCard.tsx
@@ -52,6 +52,7 @@
  */
 
 import type { ReactNode } from "react";
+import { CARD_PROSE } from "./cardText";
 
 type ReadingCardProps = {
   /** Sets the subject at a glance; hidden from assistive tech, which reads the heading. */
@@ -106,6 +107,26 @@ type ReadingCardProps = {
    * The one figure that leads. `null` renders no slot rather than an empty one.
    */
   figure?: string | null;
+  /**
+   * The figure in plain words, on the figure's own line: "about waist high",
+   * "Mild, with a light breeze".
+   *
+   * **A prop rather than the first child, and that is what buys the height.**
+   * It used to be a paragraph the caller rendered underneath, which cost a full
+   * row per card -- a 13px line plus its margin, twice over, on the block that
+   * had just moved to the top of the page. Baseline-aligned beside the figure it
+   * glosses, it costs nothing at all above `sm` and wraps to its own line below,
+   * which is the layout it used to have everywhere.
+   *
+   * **It stays per-card, which is the point ADR-0010 turns on.** The temptation
+   * once the cards are being compressed is to merge them; that decision refuses
+   * two provenances behind one sentence, and this is that sentence. A card has
+   * one figure, one gloss for it and one attribution, or it is not a card.
+   *
+   * `null` renders nothing rather than an empty line: a station that answered
+   * with a figure and no words is not owed a blank row.
+   */
+  gloss?: string | null;
   /** Everything this particular reading has to say: sentences, stats, disclosures, provenance. */
   children: ReactNode;
 };
@@ -117,6 +138,7 @@ export function ReadingCard({
   title,
   context = null,
   figure = null,
+  gloss = null,
   children,
 }: ReadingCardProps) {
   // The tag itself, not a branch on it: one rendered path, so there is no arm
@@ -139,13 +161,22 @@ export function ReadingCard({
       </Heading>
 
       {/*
-        One row for the glyph and the figure, and the row renders whether or not
-        there is a figure. A card with no station still has a subject, and
-        dropping its mark when the reading goes quiet makes the card read as
-        more broken than it is -- the same argument the empty figure slot loses
-        on, in the opposite direction.
+        One row for the glyph, the figure and the words for it, and the row
+        renders whether or not there is a figure. A card with no station still
+        has a subject, and dropping its mark when the reading goes quiet makes
+        the card read as more broken than it is -- the same argument the empty
+        figure slot loses on, in the opposite direction.
+
+        `items-baseline` rather than `items-center`, which is what lets three
+        things at 30px, 36px and 13px sit on one line without the smallest of
+        them floating. The glyph takes `leading-none` so its own box does not
+        push that baseline down.
+
+        `flex-wrap` so the gloss drops to its own line when the card is too
+        narrow to hold it -- which is the layout this used to have at every
+        width, so the narrow case is not a compromise, it is where it started.
       */}
-      <div className="mb-2 flex items-center gap-3">
+      <div className="mb-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
         <span aria-hidden="true" className="text-3xl leading-none">
           {emoji}
         </span>
@@ -154,6 +185,10 @@ export function ReadingCard({
           <p className="text-stat leading-none font-black text-white italic">
             {figure}
           </p>
+        )}
+
+        {gloss !== null && (
+          <p className={`leading-relaxed text-base ${CARD_PROSE}`}>{gloss}</p>
         )}
       </div>
 

--- a/src/components/conditions/RipLevel.test.tsx
+++ b/src/components/conditions/RipLevel.test.tsx
@@ -1,0 +1,171 @@
+import { expect, test, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const readSurfZone = vi.fn();
+const readDaylightWeek = vi.fn();
+vi.mock("@/lib/conditions", () => ({ readSurfZone, readDaylightWeek }));
+
+const { RipLevel } = await import("./RipLevel");
+
+const TODAY = "2026-08-17";
+const TOMORROW = "2026-08-18";
+const SLUG = "la-jolla-shores-beach";
+
+/**
+ * The daylight read is computed rather than fetched and cannot fail, so it has
+ * no absent state to cover. What it decides here is which of the bulletin's
+ * dated days is today's, which is the join this component makes and the one
+ * place it could pick the wrong one.
+ */
+function daylight(dates: string[] = [TODAY, TOMORROW]) {
+  readDaylightWeek.mockReturnValue({
+    beachName: "La Jolla Shores Beach",
+    atMs: 0,
+    days: dates.map((localDate, index) => ({
+      localDate,
+      isToday: index === 0,
+    })),
+  });
+}
+
+function forecast(days: { localDate: string; level: string }[]) {
+  readSurfZone.mockResolvedValue({
+    beachName: "La Jolla Shores Beach",
+    state: {
+      kind: "forecast",
+      issuedMs: 0,
+      headline: null,
+      staleAfterHours: null,
+      days: days.map((day) => ({
+        ...day,
+        periodName: "TODAY",
+        meaning: "Life threatening rip currents are unlikely.",
+        surfHeight: "1 to 3 feet.",
+        waterTemperature: "70 to 74 degrees.",
+      })),
+    },
+  });
+}
+
+beforeEach(() => {
+  readSurfZone.mockReset();
+  readDaylightWeek.mockReset();
+  daylight();
+});
+
+test("today's level is the one printed, not the bulletin's first day", async () => {
+  // The bulletin is ascending and today is usually its first entry, so a
+  // component that took days[0] would pass nearly always. Today is put second
+  // in the BULLETIN here so that shortcut fails. The daylight read keeps its
+  // real shape -- today is its first day by construction, which is the fact
+  // this component leans on to know which date to look for.
+  forecast([
+    { localDate: TOMORROW, level: "High" },
+    { localDate: TODAY, level: "Low" },
+  ]);
+
+  render(await RipLevel({ slug: SLUG }));
+
+  expect(screen.getByText("Low")).toBeDefined();
+  expect(screen.queryByText("High")).toBeNull();
+});
+
+test("the label says what the word beside it is", async () => {
+  forecast([{ localDate: TODAY, level: "Moderate" }]);
+
+  render(await RipLevel({ slug: SLUG }));
+
+  expect(screen.getByText("Rip current risk")).toBeDefined();
+  expect(screen.getByText("Moderate")).toBeDefined();
+});
+
+/**
+ * ADR-0015. A surface on this page is decoration and not a verdict, because
+ * ADR-0009 forbids this site the verdict — so a three-step severity palette
+ * would be this site deciding what red means on top of a scale the office
+ * already publishes in words.
+ *
+ * Asserted as the three class strings being identical rather than as the
+ * absence of any one colour: a check for "not red" passes the moment somebody
+ * picks amber.
+ */
+test("the level is set identically whether it says Low or High", async () => {
+  const classes: string[] = [];
+
+  for (const level of ["Low", "Moderate", "High"]) {
+    forecast([{ localDate: TODAY, level }]);
+    const { unmount } = render(await RipLevel({ slug: SLUG }));
+    classes.push(screen.getByText(level).className);
+    unmount();
+  }
+
+  expect(new Set(classes).size).toBe(1);
+});
+
+/**
+ * The trap `SurfZone`'s docstring records, which this line walks into harder
+ * for being shorter. After a label reading "Rip current risk", a value like
+ * "none forecast" parses as *there is no rip current risk here* — a safety
+ * judgement ADR-0009 forbids, and worst at exactly the beaches that reach these
+ * branches, because a lagoon is calm until the day it is not.
+ *
+ * So every absent state is asserted to say nothing about the water. The full,
+ * careful sentence for each of them is in the day panel's block, which is on
+ * the page in all three states.
+ */
+const SILENT_STATES: [string, unknown][] = [
+  [
+    "a beach the product does not describe",
+    { kind: "no-surf-zone", reason: "it is a bay rather than open coast" },
+  ],
+  [
+    "a bulletin that could not be read",
+    { kind: "unavailable", detail: "the request timed out.", drift: false },
+  ],
+];
+
+for (const [name, state] of SILENT_STATES) {
+  test(`${name} says nothing about the water`, async () => {
+    readSurfZone.mockResolvedValue({
+      beachName: "La Jolla Shores Beach",
+      state,
+    });
+
+    const { container } = render(await RipLevel({ slug: SLUG }));
+    const text = (container.textContent ?? "").toLowerCase();
+
+    expect(text).toContain("rip current risk");
+    // The readings that would be verdicts about the water. Matched as whole
+    // words: "below" contains "low", and an over-strict substring check here
+    // fails the honest wording rather than the dishonest one.
+    for (const verdict of [
+      "none",
+      "no rip",
+      "safe",
+      "low",
+      "moderate",
+      "high",
+    ]) {
+      expect(text).not.toMatch(new RegExp(`\b${verdict}\b`));
+    }
+  });
+}
+
+/**
+ * The bulletin reaches a beach but its days stop before today — a real state,
+ * because the office's periods are named rather than dated and a stale one can
+ * cover only days already past.
+ *
+ * Silent would be the failure this repo is built to avoid, so the line still
+ * renders and still carries its label; what it must not do is borrow another
+ * day's level.
+ */
+test("a bulletin that does not reach today borrows no other day's level", async () => {
+  forecast([{ localDate: TOMORROW, level: "High" }]);
+
+  const { container } = render(await RipLevel({ slug: SLUG }));
+
+  expect(screen.queryByText("High")).toBeNull();
+  expect(container.textContent).toContain("Rip current risk");
+  expect(container.textContent).not.toBe("Rip current risk");
+});

--- a/src/components/conditions/RipLevel.tsx
+++ b/src/components/conditions/RipLevel.tsx
@@ -1,0 +1,85 @@
+/**
+ * Today's rip current level, in one line, beside the beach chooser.
+ *
+ * **A summary, never the statement.** `SurfZone` in the day panel is the
+ * statement: the level, the office's own gloss for it, the surf and water
+ * ranges the level rests on, the period's name and the attribution. This is one
+ * word from it, at the top of the page, so a reader who came to decide whether
+ * to take children into the water gets the relayed judgement before they get
+ * anything to interpret. Nothing here is reworded and nothing here is computed
+ * -- the word is the office's, picked out of the same read.
+ *
+ * **It sits beside the chooser rather than inside the measured block, and that
+ * is ADR-0009 as a layout.** The band under this row is what the instruments
+ * read; this is a forecaster's judgement relayed. Putting a judgement inside a
+ * block whose whole claim is "these are measurements" is the blur that ADR
+ * exists to prevent -- and the standing notice one column over says in as many
+ * words that the numbers are not a safety assessment, which only means anything
+ * while the two are visibly different kinds of thing.
+ *
+ * **No colour by level, at any of the three.** ADR-0015: a surface on this page
+ * is decoration and not a verdict, because ADR-0009 forbids this site the
+ * verdict. A three-step palette here would be this site deciding what red means
+ * on top of a scale the office already publishes in words. The level is set in
+ * the same weight and size whether it says Low or High, and the test asserts
+ * that the classes do not vary.
+ *
+ * **The absence wording is the part to be careful with, and it has a trap in
+ * it.** `SurfZone`'s docstring records the trap and this line walks into it
+ * harder, being shorter: the obvious value for a beach the bulletin does not
+ * cover is "none forecast", and after a label reading RIP CURRENT RISK that
+ * parses as *there is no rip current risk here* -- a safety judgement this site
+ * is forbidden to make, and worst at exactly the beaches that reach it, because
+ * a lagoon is calm until the day it is not.
+ *
+ * So the absent value says nothing about the water at all. It points at the
+ * block that does the careful version, which is on the page in every one of
+ * these states and words each of them properly. That keeps this line honest
+ * without making it long, and it is why the value here is never a phrase about
+ * risk.
+ */
+
+import { readDaylightWeek, readSurfZone } from "@/lib/conditions";
+
+/** The label, and the value beside it. One line, `items-baseline`. */
+function Line({ value }: { value: string }) {
+  return (
+    <p className="mt-4 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+      <span className="text-2xs font-extrabold tracking-widest text-ocean uppercase">
+        Rip current risk
+      </span>
+      {/*
+        One class string for every value, which is ADR-0015 in the markup: the
+        level is emphasised by weight and never by colour, so `High` and `Low`
+        are set identically and the difference a reader sees is the word.
+      */}
+      <span className="text-base font-black text-dark">{value}</span>
+    </p>
+  );
+}
+
+export async function RipLevel({ slug }: { slug: string }) {
+  // Both reads are `next.revalidate` fetches the day panel already makes, so
+  // the Data Cache serves them and this costs no upstream request. The daylight
+  // read is computed rather than fetched and cannot fail at all; it is here
+  // because the bulletin dates its days and only that read knows which one is
+  // today.
+  const [surfZone, daylight] = await Promise.all([
+    readSurfZone(slug),
+    Promise.resolve(readDaylightWeek(slug)),
+  ]);
+
+  const today = daylight.days.find((day) => day.isToday)?.localDate;
+
+  const level =
+    surfZone.state.kind === "forecast" && today !== undefined
+      ? (surfZone.state.days.find((day) => day.localDate === today)?.level ??
+        null)
+      : null;
+
+  // See the docstring: not "none forecast", which reads as a verdict about the
+  // water. The day panel's block is present in every state this reaches and
+  // words each one properly, so the value points there rather than paraphrasing
+  // it badly in three words.
+  return <Line value={level ?? "See the day below"} />;
+}

--- a/src/components/conditions/StatGroup.test.tsx
+++ b/src/components/conditions/StatGroup.test.tsx
@@ -100,3 +100,25 @@ test("an absent figure is set apart from a real one, not styled as a value", () 
   const value = container.querySelector("dd");
   expect(value?.className).not.toContain("font-extrabold");
 });
+
+/**
+ * Label beside value rather than above it, which is a row per pair rather than
+ * two -- the height this component gave back when the block it sits in moved to
+ * the top of the page.
+ *
+ * The `dt`/`dd` pairing is what is *not* asserted by this: that is checked
+ * above, and it is the half that carries the relationship for a reader who
+ * cannot see either arrangement. This one is only about the row, so the two can
+ * break independently.
+ */
+test("a label and its figure share one row", () => {
+  const { container } = render(
+    <StatGroup stats={[{ label: "Period", value: "7 s" }]} />,
+  );
+
+  const term = container.querySelector("dt");
+  const value = container.querySelector("dd");
+
+  expect(term?.parentElement).toBe(value?.parentElement);
+  expect(term?.parentElement?.className).toContain("items-baseline");
+});

--- a/src/components/conditions/StatGroup.tsx
+++ b/src/components/conditions/StatGroup.tsx
@@ -49,9 +49,23 @@ export type Stat = {
 
 export function StatGroup({ stats }: { stats: readonly Stat[] }) {
   return (
-    <dl className="mb-3 flex flex-wrap gap-x-7 gap-y-2">
+    <dl className="mb-3 flex flex-wrap gap-x-6 gap-y-1">
       {stats.map(({ label, value }) => (
-        <div key={label}>
+        /*
+          Label beside value rather than above it, which is a row per pair
+          rather than two. The block these sit in moved to the top of the page
+          and every row it does not need is a row the week grid gets back.
+
+          The `dt`/`dd` pairing is untouched, and that is the half that matters:
+          this file's contract is that the relationship is structural rather
+          than a visual accident of one line sitting above another. It is no
+          more an accident side by side than stacked, and a reader who cannot
+          see either layout reads the same list.
+
+          `items-baseline` because the two are 10px and 13px: centred, the caps
+          label floats above the figure it names.
+        */
+        <div key={label} className="flex items-baseline gap-2">
           <dt
             className={`text-2xs font-extrabold tracking-widest uppercase ${CARD_MUTED}`}
           >


### PR DESCRIPTION
Slices 4 and 5. **Stacked on #223** — its base is
`conditions-minimal-top-of-page`, not `main`, so review that one first. The diff
here is only these two slices.

> ⚠️ **Merging #223 with `--delete-branch` will close this PR.** Deleting a
> stacked PR's base closes the child. Retarget this to `main` after #223 merges,
> or merge without deleting and delete the branch afterwards.

## Slice 4 — the reading cards get fewer rows

**Not the change the task list proposed.** It said to merge the two cards into
one band. `MeasuredToday`'s docstring says that is ADR-0010 rather than a layout
preference — that decision permits two provenances behind one *panel* and refuses
them behind one *sentence*, and each card's plain-words line is that sentence.
`CARD_PROSE` and `CARD_MUTED` are measured against `bg-dark` besides, and paint
1.03:1 on the page's cream, a bug already fixed once in three places.

So each card keeps its own figure, its own gloss and its own attribution — all
ADR-0010 asks — and the height comes out of row count instead. Two pairs that
were stacked become two pairs on one line: the plain-words gloss moves onto the
figure's row as a `ReadingCard` prop, and a stat's label moves beside its value.
`StatGroup` keeps `dt`/`dd`, which is the half that matters — that file's
contract is that the pairing is structural rather than a visual accident of one
line above another, and it is no more an accident side by side.

The 65 existing card tests pass **unmodified**, which is the property this slice
was meant to have. So three new ones assert the arrangement itself, as shared
parentage rather than as a class, because jsdom applies no stylesheets and "same
row" is a fact about the tree here.

## Slice 5 — today's rip level beside the beach chooser

**Beside the chooser, not in the measured band**, which the task list did not
anticipate. The band is what the instruments read; a rip level is a forecaster's
judgement relayed. A judgement inside a block whose whole claim is "these are
measurements" is the blur ADR-0009 exists to prevent — and the standing notice
one column over only means something while the two are visibly different kinds of
thing.

**No colour by level.** ADR-0015: a surface here is decoration and not a verdict.
The three levels take one class string, asserted as the three being *identical*
rather than as the absence of any one colour — a check for "not red" passes the
moment somebody picks amber. Verified by making `High` pink and watching the test
fail.

**The absent value was the careful part.** `SurfZone`'s docstring records the
trap and this line walks into it harder for being shorter: after a label reading
"Rip current risk", a value like "none forecast" parses as *there is no rip
current risk here* — a safety judgement ADR-0009 forbids, and worst at exactly
the 25 of 51 beaches that reach it, because a lagoon is calm until the day it is
not. So the absent value says nothing about the water and points at the day
panel's block, which words every one of these states properly and is on the page
in all of them. Three absent states are asserted to contain no verdict word at
all.

## Measured, at 1536×639

Real builds, each served from a freshly started server.

| at 1536×639          | `main` |  #223 | +slice 4 | +slice 5 |
| -------------------- | -----: | ----: | -------: | -------: |
| measured block       |      — | 223px |    175px |    175px |
| week heading top     |  379px | 526px |    478px |    487px |
| whole page           | 3424px | 3296px |   3248px |   3257px |

The rip line costs 9px, because `md:items-end` left the chooser's column
bottom-aligned against a taller one with space already empty above it.

## Also in here

- **A fix to #223, pushed to that branch, not this one.** I shipped three dead
  imports in the previous PR — `Suspense`, `useSelectedDay` and `within` — left
  over from moving the measured block out. My defect. Worth knowing the gate did
  not catch it: `no-unused-vars` is configured as a warning here, so `lint`
  passed with them in place. Whether unused imports should fail the build is its
  own decision and belongs to whoever wants to make it, not to a slice about page
  layout.

## Gate

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

Run after `rm -rf .next`. Both new tests that assert a prohibition were verified
by violating it first and watching them fail.
