### PR TITLE
Add a day strip, and remove the week's daylight note

### DIFF
--- a/.design/conditions-minimal/TASKS.md
+++ b/.design/conditions-minimal/TASKS.md
@@ -225,7 +225,13 @@ conflicts inside one file.
 Two slices. Independent of PR 1 in principle; sequence after it so `ChosenDay`
 is edited once by slice 2 before slice 6 restructures around it.
 
-- [ ] **Slice 6 — Put a day strip above the hourly chart.**
+- [x] **Slice 6 — Put a day strip above the hourly chart.**
+      **Built under the region heading rather than directly above the chart**,
+      with the sky wording between: the office's sentences run one to three
+      lines, so a control below them moves as a reader steps across the week.
+      The plan also missed ADR-0027 — a control mounts only once it can work, so
+      the strip renders nothing before hydration. The existing no-script test
+      caught that, not a review.
       New `DayStrip` client component: seven day pills in one row, directly above
       `HourChart` inside `ChosenDay`. Calls `useSelectedDay()`, so it and
       `WeekGrid` are one control over one fact — choosing in either moves both.
@@ -246,7 +252,9 @@ is edited once by slice 2 before slice 6 restructures around it.
       `outline-offset` clips against it. Use `overflow-x-auto` with vertical
       padding._
 
-- [ ] **Slice 7 — Remove the week grid's daylight note, and record why.**
+- [x] **Slice 7 — Remove the week grid's daylight note, and record why.**
+      **ADR-0045**, re-derived at build time as the plan required — 0041 as
+      guessed in the brief was long since taken, and the highest was 0044.
       Delete the single unconditional note pushed at the top of `WeekPanel`'s
       `notes`. **Keep all seven conditional failure notes exactly as they are.**
       Write an ADR superseding that one clause of ADR-0023, carrying the

--- a/docs/adr/0045-the-day-view-discharges-the-weeks-daylight-note.md
+++ b/docs/adr/0045-the-day-view-discharges-the-weeks-daylight-note.md
@@ -1,0 +1,101 @@
+# 0045 — The day view discharges the week's daylight note
+
+Date: 2026-09-02. Status: accepted. Supersedes one clause of ADR-0023.
+
+## Context
+
+ADR-0023 removed each day's own lowest tide and biggest swell from the week
+grid's cells, keeping only the extremes that fall between sunrise and sunset. It
+allowed that removal on one condition, stated in its Decision:
+
+> **The loss is stated, not silent.** One sentence sits with the grid's other
+> notes: the week shows what falls between sunrise and sunset, overnight lows and
+> swells are real and often bigger, and today's are on the cards above. **This
+> sentence is the condition the drop is allowed under. Removing it while keeping
+> the drop reintroduces exactly the failure ADR-0017 objected to.**
+
+The sentence is `WeekPanel`'s only unconditional note. It is removed here, and
+this decision is what it is removed against.
+
+**The condition ADR-0023 named has been met.** That decision scoped the loss
+precisely, in the same paragraph: the day's own extreme "leaves this grid, and
+does not leave the site", and what is lost is the overnight figure for the six
+future days **"until a day view carries them"**. The day view now exists.
+`ChosenDay` draws all twenty-four hours of the selected day with night shaded,
+on any of the seven, so a 3 AM low is on the page as the dip it is — which is
+what ADR-0023 was waiting for, described in its own words.
+
+**Half the sentence already points at nothing.** It ends "and today's are on the
+cards above". Those cards are gone: the three-card slab was removed as redundant
+against the week grid and the day chart, and the two readings that survived it
+are measurements rather than predicted extremes. A note that directs a reader to
+a card that is not there is worse than no note, which is the standard `WeekPanel`
+already applies to its other sentences — one of them was rewritten for exactly
+this reason when the tide card went.
+
+**The other half is done by the cell header, and by ADR-0023's own mechanism.**
+The sentence's remaining job is to say that a cell's figures are daylight-scoped.
+ADR-0023 put `☀ 6:20 AM to 7:20 PM` at the top of every day's cell precisely so
+that "the header scopes the cell, so the labels do not have to". That header is
+untouched and still prints on all seven days. The qualification a reader needs is
+on the line above the figure, which is where that decision put it.
+
+**What is not a reason.** Height alone would not justify this. The sentence is
+three lines on a page whose largest recoverable spaces were elsewhere, and
+`.design/conditions-minimal/DESIGN_BRIEF.md` states as one of its principles that
+a note reporting a failure or qualifying a visible figure is never removed for
+space. This is removed because its own condition expired, and it would still be
+removed if it cost nothing.
+
+## Decision
+
+**`WeekPanel`'s unconditional daylight note is removed.** ADR-0023's "the loss is
+stated, not silent" clause is superseded: the loss is now shown rather than
+stated, by the day chart that decision was waiting for.
+
+**Nothing else in ADR-0023 changes.** The daylight window is still stated once in
+the day's header; the rows still carry only the figures inside it; the labels are
+still short because the header scopes them; seven columns still start at `xl`.
+
+**The seven conditional notes stay exactly as they are** — NOAA unreachable,
+hourly heights missing, no tide station, no wave line, no cloud cell, cloud
+unavailable, wave unavailable. Those report outages rather than qualifying a
+figure, and `CLAUDE.md`'s "nothing fails silently" is untouched by this decision.
+The test added with this change asserts each of them still appears in its own
+failure state, so removing the intro cannot take an outage message with it.
+
+## Alternatives considered
+
+**Keep the sentence, shortened.** Cheapest, and it was the recommendation until
+the second half was checked: any honest shortening still has to say where the
+overnight figures went, and the answer is no longer "the cards above". A sentence
+that must be rewritten to stay true is a sentence whose reason has moved.
+
+**Fold the scope into the region heading** — "The week ahead, sunrise to sunset".
+Costs no height and reads well. Rejected because it duplicates the per-cell `☀`
+header that ADR-0023 already introduced to do this job, and because it silently
+drops the "overnight lows are often bigger" half rather than deciding about it.
+Two places stating one scope is the drift `REGION_HEADING` and `TOUCH_TARGET`
+were both extracted to stop.
+
+**Leave it and accept the stale clause.** Rejected: "today's are on the cards
+above" is false today, and an ADR whose condition is discharged by a sentence
+nobody can act on is a decision maintained on paper only.
+
+## Consequences
+
+The week region goes from heading to grid on a healthy page, and still explains
+itself on a broken one.
+
+**The "overnight lows are often bigger" fact is no longer stated in prose
+anywhere on the page.** It is shown, on the chart, once a reader selects a day —
+and `ConditionsNotes`' "Daylight first" entry still says it in words for a reader
+who wants it stated. That entry is itself about to sit behind a disclosure, so
+the fact is on the page but is no longer unavoidable. That is the real cost of
+this decision and it is recorded here rather than argued away: a reader who never
+opens the chart or the notes now learns the scope from the `☀` header alone.
+
+**If the day chart is ever removed or made optional, this decision expires with
+it.** The chart is the thing discharging ADR-0023's debt; without it, the debt
+returns and the note has to come back. That is the condition on _this_ ADR, in
+the shape ADR-0023 wrote its own.

--- a/src/components/conditions/ChosenDay.tsx
+++ b/src/components/conditions/ChosenDay.tsx
@@ -37,11 +37,18 @@
  * today.** It says "Today, hour by hour" on arrival and on today, and the
  * grid's own label for the day otherwise, so the two regions call Thursday the
  * same thing.
+ *
+ * **There is a day control in here now.** `DayStrip`, under the heading, which
+ * writes to the same provider the week grid does. It is here because the grid
+ * is ~290px of cells above the chart, so changing the day used to mean
+ * scrolling away from the thing being changed. See that file for why a second
+ * control over one fact is worth having.
  */
 
 "use client";
 
 import type { ReactNode } from "react";
+import { DayStrip } from "./DayStrip";
 import { HourChart, type HourSeries } from "./HourChart";
 import { TOOL_REGION_HEADING } from "../ui/headingRank";
 import { resolveSelected, useSelectedDay } from "./selectedDay";
@@ -130,6 +137,18 @@ export function ChosenDay({
       <h2 id="day-panel-heading" className={TOOL_REGION_HEADING}>
         {day.dayName}, hour by hour
       </h2>
+
+      {/*
+        The control, directly under the heading that names what it changed.
+
+        Above the wording rather than below it, though the chart is what it is
+        really for: the office's sentences run one to three lines depending on
+        the day, so a control under them would move as a reader stepped across
+        the week. This region already orders itself on that rule -- it is why
+        the rip block and the measured block sat below the chart rather than
+        above it -- and a control is the element that can least afford to move.
+      */}
+      <DayStrip days={days} />
 
       <div className="mb-4">{day.wording}</div>
 

--- a/src/components/conditions/DayStrip.test.tsx
+++ b/src/components/conditions/DayStrip.test.tsx
@@ -1,0 +1,170 @@
+import { expect, test } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DayStrip, type DayChoice } from "./DayStrip";
+import { SelectedDayProvider, useSelectedDay } from "./selectedDay";
+import { TOUCH_TARGET } from "../ui/touchTarget";
+
+const DAYS: DayChoice[] = [
+  { localDate: "2026-09-02", dayName: "Today" },
+  { localDate: "2026-09-03", dayName: "Thu, Sep 3" },
+  { localDate: "2026-09-04", dayName: "Fri, Sep 4" },
+];
+
+/** Reports what the provider holds, so a click can be checked at the source. */
+function Showing() {
+  const { selected } = useSelectedDay();
+  return <p>selected: {selected ?? "none"}</p>;
+}
+
+function strip(days: readonly DayChoice[] = DAYS) {
+  return render(
+    <SelectedDayProvider>
+      <DayStrip days={days} />
+      <Showing />
+    </SelectedDayProvider>,
+  );
+}
+
+function pill(name: string) {
+  return screen.getByRole("button", { name });
+}
+
+test("every day on offer gets a pill, named as the heading names it", () => {
+  strip();
+
+  // The same strings the region heading and the week grid use. Three names for
+  // one Thursday is how two regions start disagreeing about which day is which.
+  expect(pill("Today")).toBeDefined();
+  expect(pill("Thu, Sep 3")).toBeDefined();
+  expect(pill("Fri, Sep 4")).toBeDefined();
+});
+
+test("choosing a day writes it to the provider the week grid also reads", () => {
+  strip();
+
+  fireEvent.click(pill("Fri, Sep 4"));
+
+  // Asserted at the provider rather than at this component's own markup: the
+  // point of the strip is that it and the grid cannot hold different answers,
+  // and only the shared state shows that.
+  expect(screen.getByText("selected: 2026-09-04")).toBeDefined();
+});
+
+test("the day being shown is the pressed one, and only that one", () => {
+  strip();
+
+  expect(pill("Today").getAttribute("aria-pressed")).toBe("true");
+  expect(pill("Thu, Sep 3").getAttribute("aria-pressed")).toBe("false");
+
+  fireEvent.click(pill("Thu, Sep 3"));
+
+  expect(pill("Today").getAttribute("aria-pressed")).toBe("false");
+  expect(pill("Thu, Sep 3").getAttribute("aria-pressed")).toBe("true");
+});
+
+/**
+ * Nothing has been chosen yet, so the first day is the one showing —
+ * `resolveSelected` is what both regions use to reach that answer, and it is
+ * shared precisely so the grid and the strip cannot resolve the default
+ * differently on a page nobody has clicked.
+ */
+test("before anything is chosen the first day is the pressed one", () => {
+  strip();
+
+  expect(screen.getByText("selected: none")).toBeDefined();
+  expect(pill("Today").getAttribute("aria-pressed")).toBe("true");
+});
+
+/**
+ * A reader without JavaScript is in this state, and `selectedDay.tsx` records
+ * the decision it turns on: the context default is the null state rather than a
+ * throw, so a region outside the provider shows its first day and offers no
+ * working choice. Making it an error instead would turn a degraded page into a
+ * blank one.
+ */
+test("outside the provider it renders and marks today rather than throwing", () => {
+  render(<DayStrip days={DAYS} />);
+
+  expect(pill("Today").getAttribute("aria-pressed")).toBe("true");
+  // The click is inert rather than fatal.
+  fireEvent.click(pill("Fri, Sep 4"));
+  expect(pill("Today").getAttribute("aria-pressed")).toBe("true");
+});
+
+/**
+ * ADR-0004. Every pill composes the standard rather than spelling a number, and
+ * takes the `md:` opt-out a visible shape is allowed — the box growing is not
+ * invisible here, so there is something to buy by restricting it above `md`.
+ *
+ * jsdom applies no stylesheets (ADR-0001), so this proves the floor is referred
+ * to and a human confirms 44px renders.
+ */
+test("every pill composes the touch-target floor", () => {
+  const { container } = strip();
+
+  for (const button of container.querySelectorAll("button")) {
+    expect(button.className).toContain(TOUCH_TARGET);
+  }
+});
+
+/**
+ * The row scrolls rather than wrapping, and `shrink-0` is the half of that
+ * which is easy to leave out: flex items shrink before their container
+ * overflows, so without it seven pills compress into seven slivers and the
+ * scroller never engages at all.
+ *
+ * The ring is the other half. `globals.css` sets `outline-offset: 2px` on every
+ * focusable thing, so a ring on the first or last pill draws outside the pill's
+ * own box — an `overflow-hidden` scroller clips it, and `overflow-x-auto` with
+ * vertical padding is what keeps it whole.
+ */
+test("the row scrolls sideways and does not clip a focus ring", () => {
+  const { container } = strip();
+
+  const group = container.querySelector('[role="group"]')!;
+  expect(group.className).toContain("overflow-x-auto");
+  expect(group.className).not.toContain("overflow-hidden");
+  expect(group.className).not.toContain("flex-wrap");
+  expect(group.className).toContain("py-1");
+
+  for (const button of container.querySelectorAll("button")) {
+    expect(button.className).toContain("shrink-0");
+  }
+});
+
+/**
+ * The selection is marked twice, which is the rule the week grid states for
+ * itself one region up: a filled band is a colour, and a reader who does not
+ * separate these two colours still has to be able to see which day is showing.
+ */
+test("the showing day is marked by more than its fill", () => {
+  strip();
+
+  expect(pill("Today").className).toContain("underline");
+  expect(pill("Thu, Sep 3").className).not.toContain("underline");
+});
+
+/**
+ * ADR-0027: a control mounts only once it can work. In the server render these
+ * pills would be seven dead buttons for a reader with a blocked script, and
+ * unlike `BeachSelector` -- whose `noscript` list of links does the same job in
+ * plain markup -- day selection exists on this page in no other form. So the
+ * honest fallback is no affordance at all, and the region renders exactly as it
+ * did before this control existed.
+ *
+ * `selectedDay.test.tsx` asserts the same contract across the whole pair of
+ * regions; this is the unit half, so a change here fails at the component that
+ * caused it rather than three files away.
+ */
+test("nothing is rendered before the page can respond to a click", () => {
+  const markup = renderToStaticMarkup(
+    <SelectedDayProvider>
+      <DayStrip days={DAYS} />
+    </SelectedDayProvider>,
+  );
+
+  expect(markup).not.toContain("<button");
+  expect(markup).not.toContain("data-day-pill");
+  expect(markup).not.toContain("Choose a day");
+});

--- a/src/components/conditions/DayStrip.tsx
+++ b/src/components/conditions/DayStrip.tsx
@@ -1,0 +1,133 @@
+/**
+ * The seven days as one row of pills, directly under the day region's heading.
+ *
+ * **A second control over one fact, deliberately.** The week grid above is
+ * still the selector and still marks the showing day; this writes to the same
+ * `SelectedDayProvider`, so choosing in either moves both and neither can hold
+ * a different answer. That is worth a second control because the two are not
+ * the same kind of thing: the grid is a table a reader reads -- each cell
+ * carries that day's daylight low, its swell and its cloud -- and this is a
+ * control a reader operates. Reading a table and operating a control want
+ * different shapes and, more to the point, different places.
+ *
+ * **The place is the whole reason it exists.** The grid is ~290px of cells plus
+ * its heading, and the chart sits under all of it, so changing the day meant
+ * scrolling up to a control, then back down to see what it did -- the control
+ * and its effect never on screen together. This puts a control where the effect
+ * is.
+ *
+ * **Under the heading rather than under the sky wording**, though the wording
+ * sits between it and the chart. The wording is one to three lines depending on
+ * what the office wrote for that day, so a control below it would move up and
+ * down the page as a reader stepped across the week. `ChosenDay` already orders
+ * the region on that rule -- it is why the rip block and the measured block went
+ * below the chart rather than above it -- and a control is the element that can
+ * least afford to move, because a reader is aiming at it.
+ *
+ * **It never wraps.** Seven pills on two lines costs the height this whole
+ * brief is recovering, and it stops reading as one control. Below the width
+ * that fits them it scrolls sideways instead, which is the same choice
+ * `GalleryRow` makes and the same `no-scrollbar` utility.
+ *
+ * **`overflow-x-auto`, never `overflow-hidden`.** The focus ring is
+ * `outline-offset: 2px` in `globals.css`, so a ring on the first or last pill
+ * is drawn outside the pill's own box and an `overflow-hidden` scroller clips
+ * it. `py-1` gives the ring room on the cross axis for the same reason.
+ *
+ * **Buttons with `aria-pressed`, not a tablist.** The chart below already owns
+ * a real tab set -- tide, swell, wind, temperature -- and nesting a second
+ * tablist for days inside the same region would put a reader in two tab
+ * contexts at once. A radiogroup is the closest formal match and it promises
+ * arrow-key roving this does not implement; `aria-pressed` on a labelled group
+ * of buttons says exactly what is true, which is that one of seven is on.
+ *
+ * The label a pill carries is `dayName`, which is the same string the heading
+ * uses and the grid's own label for that day. Three names for one Thursday is
+ * how two regions start disagreeing about which day is which.
+ *
+ * **Nothing renders until the page has hydrated, which is ADR-0027.** A control
+ * mounts only once it can work: seven pills in the server render are seven dead
+ * buttons for a reader with a blocked script. `BeachSelector` can afford to
+ * render early because it has a `noscript` list of real links to fall back to;
+ * day selection does not exist on this page in any other form, so the honest
+ * fallback is no affordance at all and the region renders exactly as it did
+ * before this control existed -- on today, with the week grid above still whole
+ * and still readable. The week grid makes the same call one region up, which is
+ * why `useHydrated` was given a module of its own.
+ */
+
+"use client";
+
+import { TOUCH_TARGET } from "../ui/touchTarget";
+import { useHydrated } from "./hydrated";
+import { resolveSelected, useSelectedDay } from "./selectedDay";
+
+export type DayChoice = {
+  /** `YYYY-MM-DD` in Pacific. What the provider chooses by. */
+  localDate: string;
+  /** "Today", "Thu, Sep 3" — the heading's and the grid's name for this day. */
+  dayName: string;
+};
+
+export function DayStrip({ days }: { days: readonly DayChoice[] }) {
+  const hydrated = useHydrated();
+  const { selected, choose } = useSelectedDay();
+  const showing = resolveSelected(
+    selected,
+    days.map((day) => day.localDate),
+  );
+
+  // ADR-0027, and see this file's header: no affordance at all beats a dead
+  // one. There is nothing to degrade *to* here -- unlike the beach chooser,
+  // whose `noscript` list does the same job in plain markup -- so the region
+  // simply renders as it did before this control existed.
+  if (!hydrated) return null;
+
+  return (
+    <div
+      role="group"
+      aria-label="Choose a day"
+      className="no-scrollbar mb-4 flex gap-2 overflow-x-auto py-1"
+    >
+      {days.map((day) => {
+        const isShowing = day.localDate === showing;
+
+        return (
+          <button
+            key={day.localDate}
+            type="button"
+            onClick={() => choose(day.localDate)}
+            aria-pressed={isShowing}
+            data-day-pill={day.localDate}
+            /*
+              `md:min-h-9` rather than the `md:min-h-0` most callers of
+              `TOUCH_TARGET` take. Both compose the floor rather than replacing
+              it, so ADR-0004 holds below `md` and a pill is 44px on a phone
+              either way. Above `md` this stays a pointer target, which is the
+              same call `WeekGrid`'s day button makes one region up -- and this
+              is the primary day control, so it keeps a little more than that
+              one does.
+
+              `shrink-0` is what makes the row scroll rather than squeeze: flex
+              items shrink before a container overflows, so without it seven
+              pills compress into seven unreadable slivers and never trigger the
+              scroller at all.
+
+              The selected pill is marked twice -- filled, and underlined --
+              because the grid above marks its own selection the same way and
+              for the same reason: fill alone is a colour, and a reader who does
+              not separate these two colours still sees the line.
+            */
+            className={`${TOUCH_TARGET} md:min-h-9 rounded-pill shrink-0 cursor-pointer px-4 text-2xs font-extrabold tracking-widest uppercase ${
+              isShowing
+                ? "bg-ocean text-white underline decoration-2 underline-offset-4"
+                : "bg-mist text-ocean"
+            }`}
+          >
+            {day.dayName}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/conditions/WeekPanel.test.tsx
+++ b/src/components/conditions/WeekPanel.test.tsx
@@ -733,58 +733,163 @@ test("a line with no recorded distance is still named, without one", async () =>
 });
 
 /**
- * ADR-0023 dropped the day's own extremes from the week's cells, and this
- * sentence is the condition it was allowed under. Without it a reader who saw a
- * -0.2 ft at 3:38 AM last week finds it gone with nothing to explain the
- * change -- the silent failure this repo is built to avoid.
+ * ADR-0045. The unconditional daylight sentence is gone: ADR-0023 scoped the
+ * loss it covered as lasting "until a day view carries them", the day view now
+ * draws all twenty-four hours with night shaded, and half the sentence pointed
+ * at cards that no longer exist.
  *
  * Asserted here rather than in `WeekGrid`, because the grid prints whatever
- * notes it is handed and the decision to hand it this one is the panel's.
+ * notes it is handed and deciding what to hand it is the panel's job.
  */
-test("the week says it shows only the daylight window, once", async () => {
+test("no note qualifies the grid when every feed answered", async () => {
   readWeekOfLowestLows.mockResolvedValue({
     ...BINDING,
     state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
-  });
-
-  render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
-
-  expect(
-    screen.getAllByText(/shows what falls between sunrise and sunset/i),
-  ).toHaveLength(1);
-  // And says where the missing figure went, rather than only that it is gone.
-  // It pointed at the tide card until that card came off the page; it points
-  // at the day chart now, which is where an overnight low is actually drawn.
-  expect(
-    screen.getByText(/the day below draws the whole twenty-four hours/i),
-  ).toBeDefined();
-});
-
-test("the scope sentence stands whether or not a feed also failed", async () => {
-  // It qualifies every figure in the grid rather than reporting one feed's
-  // trouble, so an outage must not displace it -- and it leads, because a
-  // reader hits it before the figures it qualifies.
-  readWeekOfLowestLows.mockResolvedValue({
-    ...BINDING,
-    state: {
-      kind: "unavailable",
-      detail: "NOAA returned HTTP 503.",
-      drift: false,
-    },
   });
 
   const { container } = render(
     await WeekPanel({ slug: "la-jolla-shores-beach" }),
   );
 
-  const notes = [...container.querySelectorAll("section > p")].map(
-    (node) => node.textContent,
-  );
-  expect(notes[0]).toMatch(/shows what falls between sunrise and sunset/i);
   expect(
-    notes.some((note) => /could not get this week/i.test(note ?? "")),
-  ).toBe(true);
+    screen.queryByText(/shows what falls between sunrise and sunset/i),
+  ).toBeNull();
+  expect(
+    screen.queryByText(/the day below draws the whole twenty-four hours/i),
+  ).toBeNull();
+  // A healthy week goes from heading to grid, so there is no note at all.
+  expect(container.querySelectorAll("section > p")).toHaveLength(0);
 });
+
+/**
+ * The other half of ADR-0045, and the half that matters more.
+ *
+ * Removing the intro must not take an outage message with it. These seven are
+ * conditional and each names the publisher that went quiet, which is what
+ * `CLAUDE.md`'s "nothing fails silently" is actually about — the intro was a
+ * qualification, and these are failures.
+ *
+ * One state at a time rather than one fixture with everything broken: several
+ * of these are mutually exclusive by construction, and a combined fixture would
+ * assert a page no reader can reach.
+ */
+/**
+ * `beforeEach` resets the tide read with no default, so a fixture that breaks
+ * only the wave or cloud feed leaves the panel with no week at all — which is a
+ * different failure from the one under test. Every case that is not itself
+ * about the tide starts from a healthy one.
+ */
+function healthyTide() {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
+  });
+}
+
+const OUTAGES: [string, () => void, RegExp][] = [
+  [
+    "NOAA could not be reached",
+    () =>
+      readWeekOfLowestLows.mockResolvedValue({
+        ...BINDING,
+        state: {
+          kind: "unavailable",
+          detail: "NOAA returned HTTP 503.",
+          drift: false,
+        },
+      }),
+    /could not get this week's tide predictions from NOAA/i,
+  ],
+  [
+    "the beach has no tide station",
+    () =>
+      readWeekOfLowestLows.mockResolvedValue({
+        ...BINDING,
+        state: { kind: "no-station", reason: "no station within range" },
+      }),
+    /no tide station for this beach/i,
+  ],
+  [
+    "the hourly heights are missing but the figures are not",
+    () => {
+      readWeekOfLowestLows.mockResolvedValue({
+        ...BINDING,
+        state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
+      });
+      readHourlyTide.mockResolvedValue({
+        ...BINDING,
+        state: {
+          kind: "unavailable",
+          detail: "NOAA returned HTTP 500.",
+          drift: false,
+        },
+      });
+    },
+    /hour-by-hour shape behind each day's figure is missing/i,
+  ],
+  [
+    "the beach has no MOP line",
+    () => {
+      healthyTide();
+      readWaveWeek.mockResolvedValue({
+        ...BINDING,
+        state: { kind: "no-line", reason: "inside a bay" },
+      });
+    },
+    /no wave forecast for this beach/i,
+  ],
+  [
+    "CDIP could not be reached",
+    () => {
+      healthyTide();
+      readWaveWeek.mockResolvedValue({
+        ...BINDING,
+        state: {
+          kind: "unavailable",
+          detail: "CDIP returned HTTP 502.",
+          drift: false,
+        },
+      });
+    },
+    /could not get this week's wave forecast from CDIP/i,
+  ],
+  [
+    "the beach sits in no forecast cell",
+    () => {
+      healthyTide();
+      readSkyWeek.mockResolvedValue({
+        ...BINDING,
+        state: { kind: "no-cell", reason: "outside the published grid" },
+      });
+    },
+    /no cloud forecast for this beach/i,
+  ],
+  [
+    "the National Weather Service could not be reached",
+    () => {
+      healthyTide();
+      readSkyWeek.mockResolvedValue({
+        ...BINDING,
+        state: {
+          kind: "unavailable",
+          detail: "the request timed out.",
+          drift: false,
+        },
+      });
+    },
+    /could not get this week's cloud forecast/i,
+  ],
+];
+
+for (const [name, arrange, sentence] of OUTAGES) {
+  test(`${name}: the note survives the intro's removal`, async () => {
+    arrange();
+
+    render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
+
+    expect(screen.getByText(sentence)).toBeDefined();
+  });
+}
 
 /* =========================================================================
  * The shape behind each day's figure
@@ -862,8 +967,11 @@ test("the figure and the window are unchanged by the shape above them", async ()
     "Daylight, 6:14 AM to 7:32 PM",
   );
 
-  // And the sentence ADR-0023 allowed the drop under is still beneath the grid.
-  expect(screen.getByText(/overnight are real and often bigger/)).toBeDefined();
+  // ADR-0045: the sentence ADR-0023 allowed the drop under is gone, because the
+  // day chart it was waiting for now draws the overnight dip it described. What
+  // still carries the scope is that decision's other half -- the window in the
+  // header, asserted just above.
+  expect(screen.queryByText(/overnight are real and often bigger/)).toBeNull();
 });
 
 test("a failed hourly read costs the shape and not the grid", async () => {

--- a/src/components/conditions/WeekPanel.tsx
+++ b/src/components/conditions/WeekPanel.tsx
@@ -330,24 +330,19 @@ export async function WeekPanel({ slug }: { slug: string }) {
   const notes: string[] = [];
 
   /*
-    First, because it qualifies every figure in the grid rather than reporting
-    one feed's trouble. ADR-0023 dropped the day's own extremes from these
-    cells -- a lowest low at 3:38 AM is a real prediction and a useless plan,
-    and the labels naming it never fitted -- and this sentence is the condition
-    that was allowed under. Without it a reader who saw a -0.2 ft here last
-    week finds it gone with nothing to explain the change, which is the silent
-    failure this repo is built to avoid.
+    ADR-0045. An unconditional sentence stood first here, saying that the week
+    shows only the daylight window and that overnight lows are real and often
+    bigger. ADR-0023 named it as the condition its removal of the day's own
+    extremes was allowed under, and it is gone anyway, because that decision
+    scoped the loss as lasting "until a day view carries them" and the day view
+    now draws all twenty-four hours with night shaded. Half the sentence had
+    also stopped being true: it ended by pointing at cards that no longer exist.
 
-    Unconditional, and one sentence rather than seven: the scope is a fact
-    about the grid, the same shape as every other note here. It says where the
-    figure went as well as that it is missing, because "not shown" alone reads
-    as an omission rather than a decision.
+    What is left in this array reports outages and nothing else. Every push
+    below is conditional, and each one names the publisher that went quiet --
+    which is the half `CLAUDE.md`'s "nothing fails silently" is about, and the
+    half this file's tests assert one state at a time.
   */
-  notes.push(
-    "This week shows what falls between sunrise and sunset. Lows and swells " +
-      "overnight are real and often bigger — the day below draws the whole " +
-      "twenty-four hours, with night shaded.",
-  );
 
   /*
     The upstream reason is printed here now rather than pointed at.

--- a/src/components/conditions/selectedDay.test.tsx
+++ b/src/components/conditions/selectedDay.test.tsx
@@ -345,6 +345,46 @@ test("the chosen hour survives it too, resolved against the new day", () => {
   expect(drawnDay(container)).toBe(`Tide on ${DATES[1]}`);
 });
 
+/**
+ * The same two properties again, driven from the new control instead of the
+ * grid. Worth asserting twice rather than trusting the shared provider: the
+ * strip is mounted *inside* `ChosenDay`, where the grid is a sibling above it,
+ * so a re-render that resets the chart would show up here and nowhere else.
+ * These are the two things a second day control is most likely to break.
+ */
+test("the day strip moves the day without disturbing the tab or the hour", () => {
+  const { container } = renderBoth();
+
+  fireEvent.click(container.querySelector('[data-series-tab="swell"]')!);
+  fireEvent.click(container.querySelector('[data-hour-column="9"]')!);
+  expect(drawnDay(container)).toBe(`Swell on ${DATES[0]}`);
+
+  fireEvent.click(container.querySelector(`[data-day-pill="${DATES[2]}"]`)!);
+
+  expect(drawnDay(container)).toBe(`Swell on ${DATES[2]}`);
+  expect(container.querySelector("[data-hour-readout]")?.textContent).toContain(
+    "9 AM",
+  );
+});
+
+/**
+ * One fact, two controls, and this is what stops them holding different
+ * answers. The strip writes to the provider the grid reads, so choosing in one
+ * has to mark the other -- a reader who picks Wednesday down at the chart and
+ * then scrolls up must not find the grid still saying Monday.
+ */
+test("choosing in the strip marks the day in the week grid too", () => {
+  const { container } = renderBoth();
+
+  fireEvent.click(container.querySelector(`[data-day-pill="${DATES[2]}"]`)!);
+
+  const marked = container.querySelector(`[data-day-choice="${DATES[2]}"]`);
+  expect(marked?.className).toContain("underline");
+  expect(
+    container.querySelector(`[data-day-choice="${DATES[0]}"]`)?.className,
+  ).not.toContain("underline");
+});
+
 test("without a script the week is whole and offers no control", () => {
   // This is what the day selection falls back *to*, and why it needs no
   // `noscript` list of its own the way `BeachSelector` does: the week grid is


### PR DESCRIPTION
Slices 6 and 7. **Stacked on #224**, which is stacked on #223 — review in that
order. The diff here is only these two slices.

> ⚠️ Same stacking hazard as #224: merging a base with `--delete-branch` closes
> its child. Merge #223 → retarget #224 → merge #224 → retarget this to `main`.

## Slice 6 — a day strip above the hourly chart

The week grid was the only day control and it sits ~290px of cells plus a
heading above the chart it changes, so picking Thursday meant scrolling up to the
control and back down to see what it did. The control and its effect were never
on screen together. Seven pills now sit inside the day region, writing to the
same `SelectedDayProvider` the grid does.

**Two things the task list got wrong**, both found while building:

- **It goes under the region heading, not directly above the chart.** The sky
  wording sits between them and runs one to three lines depending on what the
  office wrote, so a control below it would move up and down the page as a reader
  stepped across the week. `ChosenDay` already orders itself on that rule — it is
  why the rip and measured blocks went *below* the chart — and a control is the
  element that can least afford to move.
- **The plan never mentioned ADR-0027**, which says a control mounts only once it
  can work. My first version rendered seven pills in the server markup: seven dead
  buttons for a reader with a blocked script. **The existing no-script test caught
  it, not a review** — it asserts the server render contains no `<button>` at all.
  `BeachSelector` can render early because its `noscript` list of links does the
  same job in plain markup; day selection exists on this page in no other form, so
  the honest fallback is no affordance at all.

Two integration tests cover what a second day control is most likely to break:
the chart's chosen tab and chosen hour surviving a click on a pill, and the grid
above marking the day the strip chose.

## Slice 7 — the week's daylight note, and ADR-0045

The note said the week shows only daylight, that overnight lows are real and
often bigger, and that today's are on the cards above.

**ADR-0023 named that sentence as the condition its own removal of each day's
extremes was allowed under**, in terms — *"removing it while keeping the drop
reintroduces exactly the failure ADR-0017 objected to"*. So it does not come off
quietly. **ADR-0045** records why it comes off at all:

- ADR-0023 scoped the loss as lasting **"until a day view carries them"**. The day
  view now draws all twenty-four hours with night shaded, so the 3 AM low is on
  the page as the dip it is.
- Half the sentence had stopped being true independently: it points at cards
  removed with the three-card slab.
- Its remaining job — saying a cell's figures are daylight-scoped — is done by the
  `☀ 6:20 AM to 7:20 PM` line ADR-0023 itself put in every cell header.

**Height is not the reason, and the ADR says so.** The brief states that a note
qualifying a visible figure is never removed for space; this would come off even
if it cost nothing. The ADR also records the real cost in its Consequences: a
reader who never opens the chart or the notes now learns the scope from the `☀`
header alone.

**The seven conditional notes are untouched**, and each now has its own test
asserting it still appears in its own failure state — so the intro's removal
cannot take an outage message with it. Verified by suppressing the wave note and
watching two tests fail.

**ADR number re-derived at build time**, as the plan required. The brief guessed
0041; that was taken long ago and the highest was 0044.

## Measured, at 1536×639

| at 1536×639          |  #224 | this PR |
| -------------------- | ----: | ------: |
| first week cell ends | 900px |   813px |
| whole page           | 3257px |  3231px |

The note's removal takes 87px out of the week region. The page drops less than
that because the day strip adds a row further down — a deliberate trade: the row
it costs is the scrolling it saves.

## Gate

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

Run after `rm -rf .next`. `adr-numbers` passing is also the check that 0045 does
not collide.

## Not in this PR

Slices 8 and 9 — collapsing "How to read these numbers" and gathering the
provenance lines into `▸ Sources`. Those are independent of everything here and
are the last of the plan.
