### PR TITLE
Collapse the conditions notes into a closed disclosure

### DIFF
--- a/.design/conditions-minimal/TASKS.md
+++ b/.design/conditions-minimal/TASKS.md
@@ -279,7 +279,7 @@ is edited once by slice 2 before slice 6 restructures around it.
 
 Two slices. Independent of both PRs above and of each other.
 
-- [ ] **Slice 8 — Collapse "How to read these numbers".**
+- [x] **Slice 8 — Collapse "How to read these numbers".**
       Wrap the whole `ConditionsNotes` region in one `<details>`, closed by
       default, using `DISCLOSURE_TARGET` on the `<summary>`. The `<summary>`
       carries the heading text so the region keeps its landmark; the `<h2>` stays
@@ -293,6 +293,33 @@ Two slices. Independent of both PRs above and of each other.
       `src/components/conditions/` today and adding one would break the gate that
       guarantees every caveat reaches a reader.
       _Modifies: `ConditionsNotes`. Reuses: `DISCLOSURE_TARGET`._
+
+> **Addendum, 2026-09-02, measured. Slice 9 is not built, and should not be
+> built as written.** The numbers are against it in both directions, taken on the
+> built page at 1536x639:
+>
+> | thing                           |  height |
+> | ------------------------------- | ------: |
+> | one `ProvenanceLine`            |    18px |
+> | the week grid's three, together |    54px |
+> | a `DISCLOSURE_TARGET` summary   | 44-49px |
+>
+> **Only one region has more than one line.** The week grid has three — low
+> tide, biggest swell, cloud cover. `HourChart`, `SkyWording`, `SurfZone`,
+> `Compass` and each of the two reading cards have exactly one apiece.
+>
+> So collapsing the week's three saves **10px** and costs an interaction. And
+> everywhere else a single 18px line would be replaced by a 44px summary, making
+> six regions **26px taller each** while hiding the attribution that is most of
+> what this site is for. ADR-0004's touch-target floor is what does it: a
+> disclosure cannot be cheaper than 44px, and provenance lines are 10px text.
+>
+> The pain point behind this slice was answered by slice 8 instead, which took
+> 616px off the page. That is sixty times what this one could recover.
+>
+> **If the designer still wants the sources hidden**, the honest version is the
+> week grid's three only, and it is worth 10px. It is left unbuilt rather than
+> decided here.
 
 - [ ] **Slice 9 — Gather each region's attributions into one `▸ Sources`.**
       New `SourcesDisclosure` wrapping a region's `ProvenanceLine`s in one closed

--- a/src/components/conditions/Caveats.test.tsx
+++ b/src/components/conditions/Caveats.test.tsx
@@ -33,16 +33,12 @@ test("every caveat given is rendered, not a summary of them", () => {
   }
 });
 
-test("says how far the site reaches, in beaches, without being opened", () => {
-  // A reader looking for a beach that is not in the chooser has no way to
-  // tell whether the county never listed it or this site left it out. The
-  // sentence is outside the disclosures for that reason.
-  render(<Caveats entries={ENTRIES} reach={REACH} />);
-
-  expect(
-    screen.getByText(/answers for 41 of the 73 beaches San Diego County lists/),
-  ).toBeDefined();
-});
+/*
+  The reach sentence used to be asserted here. It is rendered by
+  `ConditionsNotes` now -- this whole component sits inside that region's closed
+  disclosure, and the sentence has to stay visible -- so the test moved with it.
+  Left here it would have asserted a sentence this component no longer renders.
+*/
 
 test("names every beach it does not serve, and the reason for each", () => {
   render(<Caveats entries={ENTRIES} reach={REACH} />);
@@ -73,9 +69,6 @@ test("claims no exclusions when there are none", () => {
   );
 
   expect(screen.queryByText(/are not here/)).toBeNull();
-  expect(
-    screen.getByText(/answers for 41 of the 41 beaches San Diego County lists/),
-  ).toBeDefined();
 });
 
 test("they sit behind a disclosure, so the tide time is not buried", () => {
@@ -89,14 +82,12 @@ test("they sit behind a disclosure, so the tide time is not buried", () => {
 
 test("the uncertainty disclosure is absent when there is nothing to disclose", () => {
   // An empty disclosure inviting a reader to open it and find nothing is worse
-  // than no disclosure. The reach sentence stays: it is a statement about what
-  // this site covers rather than a caveat, and it is true either way.
+  // than no disclosure.
   render(<Caveats entries={[]} reach={REACH} />);
 
   expect(
     screen.queryByText("What we are unsure about in this data"),
   ).toBeNull();
-  expect(screen.getByText(/answers for 41 of the 73/)).toBeDefined();
 });
 
 /**

--- a/src/components/conditions/Caveats.tsx
+++ b/src/components/conditions/Caveats.tsx
@@ -11,9 +11,12 @@
  * The inventory's reach is the same obligation pointed the other way. The chooser
  * offers the beaches this site can measure at, which is fewer than the county
  * lists, and a parent looking for one that is missing cannot tell whether the
- * county never listed it or this site left it out. That sentence sits outside the
- * disclosures, because it is the one thing here a reader may need before they
- * have a question.
+ * county never listed it or this site left it out. That sentence is the one thing
+ * here a reader may need *before* they have a question, so it sits outside every
+ * disclosure -- including the one that now closes this whole region. That is why
+ * it is rendered by `ConditionsNotes` rather than here: this component is inside
+ * the closed `<details>` in its entirety, and a sentence that must stay visible
+ * cannot live in it. It still takes `reach`, for the excluded list below.
  *
  * Everything else sits behind a disclosure: the reader came for a tide time and a
  * wall of qualifications would bury it. The disclosure is the compromise that lets
@@ -36,12 +39,7 @@ export function Caveats({
   reach: InventoryReach;
 }) {
   return (
-    <div className="mt-9 max-w-130 text-sm text-fog">
-      <p className="leading-relaxed">
-        This site answers for {reach.served} of the {reach.listed} beaches San
-        Diego County lists.
-      </p>
-
+    <div className="mt-6 max-w-130 text-sm text-fog">
       {reach.excluded.length > 0 && (
         <details className="mt-3">
           <summary className={DISCLOSURE_TARGET}>

--- a/src/components/conditions/ConditionsNotes.test.tsx
+++ b/src/components/conditions/ConditionsNotes.test.tsx
@@ -199,7 +199,12 @@ test("the block's heading takes the region rank", () => {
     name: "How to read these numbers",
   });
 
-  expect(heading.className).toBe(TOOL_REGION_HEADING);
+  // `toContain` rather than `toBe`: the heading sits inside the region's
+  // `<summary>` now and takes `inline` with it, so the marker stays on the
+  // heading's own line rather than above a block. The rank is still composed
+  // rather than spelled, which is what this assertion is for -- and the line
+  // below is what catches a size being added beside it.
+  expect(heading.className).toContain(TOOL_REGION_HEADING);
   // Per ADR-0001 jsdom applies no stylesheets, so this proves the rank is
   // referred to, not that 22px renders. That stays a human check.
   expect(heading.className).not.toContain("text-2xs");
@@ -255,4 +260,95 @@ test("the reader is told why the week leaves the overnight extremes out", () => 
   expect(
     screen.getByText(/nothing here is a judgement about when you should go/),
   ).toBeDefined();
+});
+
+/**
+ * The region is one closed disclosure, and every word is still in the DOM.
+ *
+ * Five multi-sentence notes plus the caveats are the largest block of prose on
+ * this page and they are reference — read once, then never again. Collapsing
+ * them is the point of the slice; losing any of them is the failure it must not
+ * become, and the two are indistinguishable from a height measurement alone.
+ */
+test("the notes are closed on arrival and still entirely present", () => {
+  const { container } = render(
+    <ConditionsNotes entries={ENTRIES} reach={REACH} />,
+  );
+
+  const region = container.querySelector("details")!;
+  expect(region.open).toBe(false);
+
+  // Every note is reachable while it is closed, which is what `getByText`
+  // resolving inside a closed `<details>` proves. This is also why no assertion
+  // in this directory uses `toBeVisible` — see the component.
+  for (const term of [
+    "Tide heights",
+    "Daylight first",
+    "Wave heights",
+    "The wave forecast",
+    "Cloud cover",
+  ]) {
+    expect(screen.getByText(term)).toBeDefined();
+  }
+  for (const caveat of ENTRIES) {
+    expect(screen.getByText(caveat)).toBeDefined();
+  }
+});
+
+/**
+ * `Caveats` records the reason and this is where it is enforced now: a reader
+ * looking for a beach the chooser does not offer cannot tell whether the county
+ * never listed it or this site left it out, so that sentence may not sit behind
+ * a control they have to know to open.
+ *
+ * Asserted as *not inside the details* rather than as merely present — present
+ * is true of the collapsed content too, which is the whole difficulty.
+ */
+test("how far the site reaches is stated outside the disclosure", () => {
+  const { container } = render(
+    <ConditionsNotes entries={ENTRIES} reach={REACH} />,
+  );
+
+  const reach = screen.getByText(
+    /answers for \d+ of the \d+ beaches San Diego County lists/,
+  );
+  expect(container.querySelector("details")!.contains(reach)).toBe(false);
+});
+
+/**
+ * The landmark survives the control. `<summary>`'s content model is phrasing
+ * content optionally intermixed with heading content, so the `<h2>` goes inside
+ * it rather than being replaced by it — which is what keeps the section labelled
+ * by its own heading and keeps the page's outline at four regions rather than
+ * three and a button.
+ */
+test("the region is still labelled by a heading, not by a control", () => {
+  const { container } = render(
+    <ConditionsNotes entries={ENTRIES} reach={REACH} />,
+  );
+
+  const section = container.querySelector("section")!;
+  const heading = screen.getByRole("heading", {
+    name: "How to read these numbers",
+  });
+
+  expect(section.getAttribute("aria-labelledby")).toBe(heading.id);
+  expect(container.querySelector("summary")!.contains(heading)).toBe(true);
+});
+
+/**
+ * ADR-0004, through `DISCLOSURE_TARGET`. This summary carries a heading rather
+ * than a 13px line, so it clears 44px on its own — which is exactly why the
+ * standard is composed rather than judged by eye: the next edit to the heading
+ * rank should not silently drop this below the floor.
+ */
+test("the summary composes the touch-target standard", async () => {
+  const { DISCLOSURE_TARGET } = await import("./disclosure");
+  const { container } = render(
+    <ConditionsNotes entries={ENTRIES} reach={REACH} />,
+  );
+
+  expect(container.querySelector("summary")!.className).toContain(
+    DISCLOSURE_TARGET,
+  );
 });

--- a/src/components/conditions/ConditionsNotes.tsx
+++ b/src/components/conditions/ConditionsNotes.tsx
@@ -45,6 +45,7 @@
 
 import type { InventoryReach } from "@/lib/beaches";
 import { Caveats } from "./Caveats";
+import { DISCLOSURE_TARGET } from "./disclosure";
 import { TOOL_REGION_HEADING } from "../ui/headingRank";
 
 /** One thing worth understanding about every figure of its kind. */
@@ -116,11 +117,42 @@ export function ConditionsNotes({
     // No top margin: the reserved slot above carries the gap. Spacing on both
     // is counted twice, which is the failure `SnapSection`'s docstring records.
     <section aria-labelledby="conditions-notes-heading">
-      <h2 id="conditions-notes-heading" className={TOOL_REGION_HEADING}>
-        How to read these numbers
-      </h2>
-
       {/*
+        CLOSED BY DEFAULT, AND STILL ENTIRELY IN THE DOM.
+
+        Five multi-sentence notes and the caveats under them are the largest
+        block of prose on this page, and they are reference: read once, by a
+        reader who wants to know what "mean lower low water" means, and then
+        never again. Open by default they occupied roughly a screen at the
+        bottom of every visit forever.
+
+        Nothing is removed and nothing is summarised. `<details>` keeps every
+        word in the markup, so a screen reader reaches it, a find-in-page finds
+        it, and the gate asserting that every caveat in every data file arrives
+        here still passes -- those assertions use `getByText`, which resolves
+        inside a closed disclosure. **Do not "improve" them to `toBeVisible`.**
+        There are none in this directory, and adding one would convert a check
+        that a caveat reaches the reader into a check that it is on screen
+        without being asked for, which was never the promise.
+
+        The `<h2>` goes inside the `<summary>` rather than being replaced by it.
+        A summary's content model is phrasing content optionally intermixed with
+        heading content, so this is the arrangement the element is specified for
+        -- and it is what keeps the landmark: the section is still labelled by
+        this heading, and the page's outline still has a fourth region rather
+        than losing one to a control.
+      */}
+      <details>
+        <summary className={DISCLOSURE_TARGET}>
+          <h2
+            id="conditions-notes-heading"
+            className={`${TOOL_REGION_HEADING} inline`}
+          >
+            How to read these numbers
+          </h2>
+        </summary>
+
+        {/*
         A description list rather than paragraphs: each entry is a topic and its
         explanation, and the pairing is what a reader is scanning for. It also
         survives for someone who cannot see the bolding.
@@ -146,16 +178,33 @@ export function ConditionsNotes({
         columns at 1024 where each is 288px, about 47 characters, and this ramp
         never takes prose below roughly 52.
       */}
-      <dl className="leading-relaxed text-sm text-fog md:grid md:grid-cols-2 md:gap-x-8 xl:grid-cols-3">
-        {NOTES.map(({ term, detail }) => (
-          <div key={term} className="mb-3 max-w-130">
-            <dt className="font-extrabold text-dark">{term}</dt>
-            <dd>{detail}</dd>
-          </div>
-        ))}
-      </dl>
+        <dl className="leading-relaxed text-sm text-fog md:grid md:grid-cols-2 md:gap-x-8 xl:grid-cols-3">
+          {NOTES.map(({ term, detail }) => (
+            <div key={term} className="mb-3 max-w-130">
+              <dt className="font-extrabold text-dark">{term}</dt>
+              <dd>{detail}</dd>
+            </div>
+          ))}
+        </dl>
 
-      <Caveats entries={entries} reach={reach} />
+        <Caveats entries={entries} reach={reach} />
+      </details>
+
+      {/*
+        Outside the disclosure, deliberately, and the only thing here that is.
+
+        `Caveats` records why: the chooser offers fewer beaches than the county
+        lists, and a parent looking for one that is missing cannot tell whether
+        the county never listed it or this site left it out. That is the one
+        thing in this region a reader may need *before* they have a question, so
+        it cannot sit behind a control they have to know to open. It is rendered
+        here rather than in `Caveats` because that component is now inside the
+        closed `<details>` in its entirety.
+      */}
+      <p className="leading-relaxed mt-4 max-w-130 text-sm text-fog">
+        This site answers for {reach.served} of the {reach.listed} beaches San
+        Diego County lists.
+      </p>
     </section>
   );
 }


### PR DESCRIPTION
Slice 8, and the measurement that says slice 9 should not be built. Branches
straight off `main` — no stacking this time.

## Slice 8 — the notes region collapses

Five multi-sentence notes plus the caveats under them were the largest block of
prose on the page, and they are reference material: read once by somebody who
wants to know what "mean lower low water" means, then never again.

**Measured on the built page at 1536×639: 3231px → 2615px. 616px off the page.**

**Nothing is removed and nothing is summarised.** `<details>` keeps every word in
the markup, so a screen reader reaches it, find-in-page finds it, and the gate
asserting that every caveat in every data file arrives here still passes — those
assertions use `getByText`, which resolves inside a closed disclosure. A test now
says out loud that no assertion in this directory may be "improved" to
`toBeVisible`; that would convert *a caveat reaches the reader* into *a caveat is
on screen unasked*, which was never the promise.

**The `<h2>` goes inside the `<summary>`** rather than being replaced by it — a
summary's content model is phrasing content optionally intermixed with heading
content, so this is what the element is specified for, and it keeps the section
labelled by its own heading. The outline still has four regions rather than three
and a button.

**One sentence deliberately stays outside**, and it is the only one. `Caveats`
records why: a reader looking for a beach the chooser does not offer cannot tell
whether the county never listed it or this site left it out, so the inventory's
reach may not sit behind a control they have to know to open. It moves out of
`Caveats` into `ConditionsNotes`, because `Caveats` is now inside the closed
disclosure in its entirety. Asserted as **not inside the details** rather than as
merely present — present is true of the collapsed content too, which is the whole
difficulty.

## Slice 9 is not here, and the numbers are why

The plan said to gather each region's provenance lines into one `▸ Sources`
disclosure. Measured on the built page:

| thing                           |  height |
| ------------------------------- | ------: |
| one `ProvenanceLine`            |    18px |
| the week grid's three, together |    54px |
| a `DISCLOSURE_TARGET` summary   | 44–49px |

**Only one region has more than one line.** The week grid has three — low tide,
biggest swell, cloud cover. `HourChart`, `SkyWording`, `SurfZone`, `Compass` and
each of the two reading cards have exactly one apiece.

So collapsing the week's three saves **10px** and costs an interaction. Everywhere
else a single 18px line would become a 44px summary — **six regions 26px taller
each**, while hiding the attribution that is most of what this site is for.
ADR-0004's touch-target floor is what does it: a disclosure cannot be cheaper
than 44px, and provenance lines are 10px text.

The pain point behind that slice was answered by slice 8 instead, which took
616px off the page — sixty times what slice 9 could recover.

**If you still want the sources hidden**, the honest version is the week grid's
three only, worth 10px. Left unbuilt rather than decided for you.

## Gate

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  test
  PASS  build
  PASS  stylesheet
```

Run after `rm -rf .next`. 621 tests across 36 files in the conditions suite.
