### PR TITLE
Group the conditions chooser by authored area, not derived region

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -139,6 +139,36 @@ teaser is not part of it and sits at the root of `src/components/` as
 the tool (ADR-0018).
 _Avoid_: weather, forecast, surf report
 
+**Area**:
+A named stretch of this county's coast holding one or more beaches — Del Mar,
+La Jolla, Mission Bay – West. It is what a reader chooses on `/conditions`, and
+`src/data/areas.json` is the table that says which beaches are in which. There
+are 18 over the 51, they partition the inventory totally and disjointly, and a
+gate row says so — the table is written by hand while the inventory beside it is
+rewritten from an upstream resource, so a beach arriving with no area named for
+it would otherwise go missing from the chooser with nothing thrown (ADR-0046).
+
+Four areas hold one beach, which is not a defect: an area publishes what its
+members share, so a lone member shares everything with itself.
+
+It replaced the **region**, which was derived from water class and mean
+latitude and grouped `Childrens Pool` with a wildlife refuge 19 km away because
+both sit in sheltered water. That word now means only one thing here, the one
+ADR-0014 gives it: a section of a page.
+_Avoid_: region (that is a page section), neighbourhood, zone, group
+
+**Beach**:
+One entry in `src/data/beaches.json` — 51 of them, and the member unit an area
+holds. The word is upstream's: the state publishes them as beaches, so a
+wildlife refuge and a bay basin are beaches here too, and a beach is a shoreline
+_segment_ rather than a point.
+
+`docs/plans/areas-over-locations.md` says "location" throughout for the same
+thing. That plan is a dated record and is not corrected; this file is the one
+that picks, and it picks the word the code, the data and the chooser already
+use.
+_Avoid_: location, site, spot, break
+
 **Observation station**:
 One of the stations in `src/data/observation-stations.json` — 62 of them, across
 the National Weather Service's network and NDBC's. The table is read by two

--- a/docs/adr/0046-an-area-is-authored-and-partitions-the-inventory.md
+++ b/docs/adr/0046-an-area-is-authored-and-partitions-the-inventory.md
@@ -1,0 +1,128 @@
+# 0046 — An area is authored, and it partitions the inventory
+
+Date: 2026-09-02. Status: accepted. Replaces `region`, which
+`scripts/seed-beaches.mjs` derived and `beaches.json` carried. ADR-0011 is
+unchanged: what a beach binds is still a join, and an area is still never one
+of its inputs.
+
+## Context
+
+`/conditions` chooses among 51 beaches. They were grouped by **region** — a
+field written into `beaches.json` at seed time by `regionOf(waterClass,
+meanLat)`, four bands, documented as "Display grouping only. Never a join
+input", and read by exactly one thing: the `optgroup` labels in
+`BeachSelector`.
+
+**It groups by water class first, and a reader does not.** `Childrens Pool` sat
+under "Bays, lagoons and inlets" with `Tijuana Slough National Wildlife Refuge`
+19 km away, because both are sheltered water. Nobody looking for the seal beach
+looks there. And "Bays, lagoons and inlets" held 25 of the 51 — half the
+inventory under one heading naming a water class rather than a place.
+
+**A reader thinks in places: Del Mar, La Jolla, Mission Bay.** No committed
+field yields those names, and this was measured before it was asserted:
+
+- **`upstream.nearest_city` is `San Diego` for 43 of 51.** The remainder is
+  Coronado 3, Del Mar 2, Imperial Beach 2, and La Jolla — **one**, which is
+  `Childrens Pool`, the single sheltered site among La Jolla's ten.
+- **Latitude fails at exactly the boundaries that matter.** `Mission Beach`
+  (32.7763, open coast) falls inside Mission Bay's band, 32.7609–32.7951, with
+  13 bay sites north of it and 6 south. Water class does not rescue it:
+  `Fiesta Island` is published as **Open Coast** while sitting in the middle of
+  the bay. And `Sunset Cliffs` (32.7242) falls _below_ `Spanish Landing Park`
+  (32.7284) — opposite shores of the Point Loma peninsula, one latitude band.
+
+So the grouping cannot be derived. It has to be asserted by a person, which
+makes it the second hand-written input in this repo and the first about the
+beaches themselves.
+
+## Decision
+
+**An area is written by hand, in `src/data/areas.json`, and the areas partition
+the inventory totally and disjointly. `region` is deleted.**
+
+Eighteen areas over 51 beaches: slug, display name, member slugs north to
+south.
+
+**Authored, because the alternative is a rule that is a table in disguise.** The
+option considered was keeping `regionOf`'s shape and giving it longitude and
+tuned bounding boxes. It needs no new hand-maintained file and it re-derives on
+every reseed. It was rejected because boxes drawn around known answers are an
+authored table wearing a function's clothes, and worse: they reassign a beach
+silently when upstream nudges a coordinate, where a table refuses to change at
+all. The precedent is one directory over — `tide-stations.json` holds "the one
+field that is written by hand — a station's water class, which no upstream
+authority publishes and which the join needs as an input." An area name is the
+same kind of fact.
+
+**Total and disjoint, asserted by a gate row**, `areas`, running
+`scripts/check-areas.mjs` over `areas-partition.mjs`. Every beach in exactly one
+area, every named slug in the inventory, no area empty, no slug used twice, and
+both orders matching the inventory's own.
+
+**The gate row is the decision, not the file.** `seed-beaches.mjs` rewrites the
+inventory from the state's resource; `areas.json` is written by a person. Two
+files that move for different reasons drift, and this particular drift is
+silent: a new beach arrives, the seed picks it up, it belongs to no area, and it
+is simply absent from the chooser. Nothing throws. That is the failure
+`_excluded` and every `*_null_reason` field in this inventory already exist to
+prevent — a refusal is recorded, never silent — and it is the whole reason the
+partition is a gate rather than a convention.
+
+**An area may hold one beach, and four do.** Not a degenerate case to minimise:
+an area publishes what its members share, so a lone member shares everything
+with itself and its area is the beach page, reached with no branch in the code.
+Forbidding it would mean folding a place into a neighbour it has nothing in
+common with, which is the outcome the rule is protecting against.
+
+**An area slug may equal a beach slug, and three do** — `pacific-beach`,
+`mission-beach`, `ocean-beach`. They are different positions of the route, so
+there is no ambiguity to resolve. Five would have collided before the two bays
+were split into compass points.
+
+## Consequences
+
+`beachesByRegion` becomes `beachesByArea` in `src/lib/areas.ts`; `regionOf` and
+the `region` field leave `seed-beaches.mjs` and all 51 rows of `beaches.json`.
+The chooser's `optgroup` labels are the only rendered change, and there are 18
+of them where there were 4.
+
+**The word "region" is freed, and it was overloaded.** ADR-0014 uses it for a
+_section of a page_ — "The week ahead" is a region — and `beaches.json` used it
+for a group of beaches. Only one meaning is left.
+
+**Two tests lost their second operand and are deleted rather than replaced.**
+Both compared the committed `region` against the water class resolved at
+runtime, which was a genuine cross-check between a frozen artifact and live
+code. Nothing remaining can stand in: `surfZoneWithheldReason` _is_
+`station.water === "bay"`, so comparing them can only pass, and
+`upstream.water_body_type` disagrees with the binding at the two beaches
+`tide-join.mjs` deliberately overrides. `Childrens Pool` proves it — upstream
+calls it a bay, the tide join binds it an open-coast station, and the mop join
+refuses it. The property is still covered by the test asserting the binding
+matches upstream except at those two named beaches, and by the surf zone's
+withheld count of 25. Recorded here because deleting a test is the kind of thing
+that should be argued rather than noticed later.
+
+**A third test is deliberately not carried over.** "Puts bays and inlets in one
+group regardless of latitude" asserted the behaviour this decision removes.
+
+**The areas interleave, and the gate says only what is true.** It cannot assert
+that flattening the areas reproduces the inventory's order, because it does not:
+`mission-bay-north` spans inventory positions 15–22 while `mission-bay-west`
+spans 21–32, with `Mission Beach` at 26 inside both. That is the same interleave
+that stopped latitude from deriving the groups, showing up again in the check.
+So two weaker properties are asserted instead — members sorted within an area,
+areas sorted by their northernmost member — and `areas.test.ts` asserts the
+interleave itself, so that a later reader finding the flattened order unsorted
+does not "fix" the table by moving a beach out of the area it belongs to.
+
+**This decides the grouping and nothing about what an area reports.** That an
+area publishes only what all its members share, how "share" is measured, and
+what its map draws are separate decisions with their own ADRs to come. See
+`docs/plans/areas-over-locations.md`.
+
+The part most likely to be re-litigated is the count: 18 groups for 51 beaches,
+four of them holding one beach. The answer is that the alternative to a
+single-member area is a wrong one, and that the two bays were split because
+20 entries under one heading is the problem this decision started from.

--- a/docs/plans/areas-over-locations.md
+++ b/docs/plans/areas-over-locations.md
@@ -354,8 +354,11 @@ to make cheap.
 > or "Fiesta Island" is local usage this plan cannot verify, and substituting a
 > better name later is a one-line edit to an authored table.
 >
-> **Area slugs may collide with beach slugs, and four do** — `pacific-beach`,
-> `mission-beach`, `ocean-beach`, `coronado-cays`. They sit in different
+> **Area slugs may collide with beach slugs, and three do** — `pacific-beach`,
+> `mission-beach`, `ocean-beach`. §5 counted five; splitting the bays removed
+> two of them, because `mission-bay` and `san-diego-bay` are no longer area
+> slugs. (`coronado-cays` is not a fourth: the beach is `coronado-cays-nr`.)
+> They sit in different
 > positions of the nested route decided in §5, so `/conditions/pacific-beach` is
 > the area and `/conditions/pacific-beach/pacific-beach` the location, with no
 > ambiguity to resolve. The consequence is that those four beaches' old URLs

--- a/docs/plans/areas-over-locations.md
+++ b/docs/plans/areas-over-locations.md
@@ -301,6 +301,68 @@ members do not agree by value either, Mission Bay wants splitting — and that i
 a membership change, not a rule change, which is what the authored table exists
 to make cheap.
 
+> **Addendum, 2026-09-02. Both bays are split, and the table is eighteen areas
+> rather than thirteen.** The paragraph above deferred Mission Bay to what the
+> probe would find. It is settled ahead of the probe instead, because twenty
+> entries under one heading is unusable in the chooser whatever the feeds say,
+> and because a split that survives the strict fallback survives anything the
+> probe could add.
+>
+> **Mission Bay becomes four**, and the four are not arbitrary — they cut along
+> the three axes its bindings actually split on. Tide splits north from south,
+> the two gauges being `9410196` "Mission Bay, Campland" at the north end and
+> `TWC0413` "Quivira Basin" at the entrance. Air splits three ways: Mt. Soledad
+> serves the north and west, Shelter Island the entrance basins, and **San Diego
+> Airport serves Tecolote Shores and Fiesta Island alone** — which is why an
+> east area has to exist at all, since folding those two anywhere else costs
+> that area its air reading. Grid cells split east from west at about
+> −117.228.
+>
+> | area                | n   | reports                  |
+> | ------------------- | --- | ------------------------ |
+> | Mission Bay – North | 7   | tide, air                |
+> | Mission Bay – West  | 8   | tide, sky/wind/temp, air |
+> | Mission Bay – East  | 2   | sky/wind/temp, air       |
+> | Mission Bay – South | 3   | tide, air                |
+>
+> Five partitions were measured. A plain east/west split leaves **both** halves
+> with nothing; a plain north/south split by gauge leaves each with one product.
+> This one leaves every area with at least two of the three a bay can ever
+> report — a bay binds no MOP line and no buoy, and ADR-0043 withholds the surf
+> zone, so tide, the grid cell's products and the air station are the whole
+> field.
+>
+> **`Mission Bay, Sea World` sits in _West_ rather than _South_**, which is the
+> one member placed by its bindings rather than by the map. It binds the west
+> cell and Mt. Soledad; in South it would drop that area from two products to
+> one. Recorded because it is the placement most likely to read wrong to
+> somebody who knows the bay.
+>
+> **San Diego Bay becomes three**, and this one costs nothing: all three report
+> everything. Its four members were never one place — `Coronado Cays` is 12.2 km
+> from `Shoreline Park` and binds a different gauge, a different cell and a
+> different air station.
+>
+> | area                    | n   | reports   |
+> | ----------------------- | --- | --------- |
+> | San Diego Bay – North   | 1   | all three |
+> | San Diego Bay – Central | 2   | all three |
+> | Coronado Cays           | 1   | all three |
+>
+> **The names are compass points because a compass point is what the committed
+> coordinates support.** Whether people say "Sail Bay", "Crown Point", "Quivira"
+> or "Fiesta Island" is local usage this plan cannot verify, and substituting a
+> better name later is a one-line edit to an authored table.
+>
+> **Area slugs may collide with beach slugs, and four do** — `pacific-beach`,
+> `mission-beach`, `ocean-beach`, `coronado-cays`. They sit in different
+> positions of the nested route decided in §5, so `/conditions/pacific-beach` is
+> the area and `/conditions/pacific-beach/pacific-beach` the location, with no
+> ambiguity to resolve. The consequence is that those four beaches' old URLs
+> cannot redirect to their locations, because the old URL _is_ the new area URL;
+> a reader with that bookmark lands on the area containing the beach they saved,
+> which is the right place rather than a broken one.
+
 ## Test seams
 
 Agreed before starting, and chosen from what exists rather than invented.

--- a/scripts/areas-partition.mjs
+++ b/scripts/areas-partition.mjs
@@ -1,0 +1,158 @@
+/**
+ * The verdict behind the `areas` gate row: is `areas.json` still a partition
+ * of the inventory?
+ *
+ * `areas.json` is the one table in this repo a person writes by hand about the
+ * beaches — an area name is a fact about San Diego, and nothing upstream
+ * publishes one. `beaches.json` beside it is rewritten from the state's
+ * resource by `seed-beaches.mjs`. So the two drift for a reason no reviewer
+ * would see: a beach arrives upstream, the seed picks it up, and it belongs to
+ * no area. Nothing throws. It is simply missing from the chooser.
+ *
+ * **That is the failure this file exists to make loud**, and it is the same
+ * argument `_excluded` and every `*_null_reason` field in the inventory already
+ * make: a refusal is recorded, never silent.
+ *
+ * Pure — it is handed two parsed tables and returns a verdict. The reading and
+ * the exit code are `check-areas.mjs`'s, which is ADR-0002's split and the one
+ * `sea-side.mjs` and `adr-numbers.mjs` already use.
+ */
+
+/**
+ * @typedef {{ slug: string, name: string, beaches: string[] }} Area
+ * @typedef {{ slug: string, name: string }} InventoryBeach
+ */
+
+/**
+ * Check that the areas partition the inventory, totally and disjointly.
+ *
+ * Six properties, and each is a way the two files can disagree:
+ *
+ * 1. **Every beach has an area.** The one that catches a new beach upstream.
+ * 2. **No beach has two.** A copy-paste between two areas.
+ * 3. **Every named slug is real.** A rename upstream, or a typo here.
+ * 4. **No area is empty.** An area whose last member moved out.
+ * 5. **Area slugs are unique.** Two areas that would share a URL.
+ * 6. **Both orders run north to south**, matching the inventory's own order.
+ *    Checked rather than trusted, because the chooser reads this order
+ *    straight through and nothing about a hand-written list keeps it sorted.
+ *
+ * @param {{ areas: Area[], beaches: InventoryBeach[] }} tables
+ * @returns {{ ok: boolean, lines: string[] }}
+ */
+export function checkAreaPartition({ areas, beaches }) {
+  /** @type {string[]} */
+  const problems = [];
+
+  const inventoryOrder = new Map(beaches.map((beach, i) => [beach.slug, i]));
+
+  const seenAreaSlugs = new Set();
+  for (const area of areas) {
+    if (seenAreaSlugs.has(area.slug)) {
+      problems.push(`area slug ${JSON.stringify(area.slug)} is used twice`);
+    }
+    seenAreaSlugs.add(area.slug);
+
+    if (area.beaches.length === 0) {
+      problems.push(
+        `area ${JSON.stringify(area.slug)} has no beaches; delete it or give it one`,
+      );
+    }
+  }
+
+  /** Which area claimed each beach, so a double claim can name both. @type {Map<string, string[]>} */
+  const claims = new Map();
+  for (const area of areas) {
+    for (const slug of area.beaches) {
+      if (!inventoryOrder.has(slug)) {
+        problems.push(
+          `area ${JSON.stringify(area.slug)} names ${JSON.stringify(slug)}, ` +
+            `which is not in beaches.json`,
+        );
+        continue;
+      }
+      const existing = claims.get(slug);
+      if (existing) existing.push(area.slug);
+      else claims.set(slug, [area.slug]);
+    }
+  }
+
+  for (const [slug, claimedBy] of claims) {
+    if (claimedBy.length > 1) {
+      problems.push(
+        `${JSON.stringify(slug)} is claimed by ${claimedBy.length} areas: ` +
+          claimedBy.map((a) => JSON.stringify(a)).join(", "),
+      );
+    }
+  }
+
+  for (const beach of beaches) {
+    if (!claims.has(beach.slug)) {
+      problems.push(
+        `${JSON.stringify(beach.slug)} (${beach.name}) belongs to no area. ` +
+          `If it arrived from upstream, name its area in areas.json — it is ` +
+          `unreachable from the chooser until you do`,
+      );
+    }
+  }
+
+  // Order, checked last: it is the least serious of the six and its message is
+  // the least useful when the ones above are already firing.
+  for (const area of areas) {
+    const indices = area.beaches
+      .map((slug) => inventoryOrder.get(slug))
+      .filter((i) => i !== undefined);
+    for (let i = 1; i < indices.length; i++) {
+      if (indices[i] < indices[i - 1]) {
+        problems.push(
+          `area ${JSON.stringify(area.slug)} lists ${JSON.stringify(area.beaches[i])} ` +
+            `after ${JSON.stringify(area.beaches[i - 1])}, but the inventory has it before. ` +
+            `Members run north to south`,
+        );
+        break;
+      }
+    }
+  }
+
+  const firstIndices = areas.map((area) =>
+    Math.min(
+      ...area.beaches
+        .map((slug) => inventoryOrder.get(slug))
+        .filter((i) => i !== undefined),
+    ),
+  );
+  for (let i = 1; i < firstIndices.length; i++) {
+    if (
+      Number.isFinite(firstIndices[i]) &&
+      Number.isFinite(firstIndices[i - 1]) &&
+      firstIndices[i] < firstIndices[i - 1]
+    ) {
+      problems.push(
+        `area ${JSON.stringify(areas[i].slug)} is listed after ` +
+          `${JSON.stringify(areas[i - 1].slug)}, but its northernmost beach is further ` +
+          `north. Areas run north to south`,
+      );
+      break;
+    }
+  }
+
+  if (problems.length > 0) {
+    return {
+      ok: false,
+      lines: [
+        `areas.json is not a partition of beaches.json (${problems.length} problem${
+          problems.length === 1 ? "" : "s"
+        }):`,
+        ...problems.map((problem) => `  - ${problem}`),
+      ],
+    };
+  }
+
+  return {
+    ok: true,
+    lines: [
+      `areas.json partitions the inventory: ${beaches.length} beaches in ` +
+        `${areas.length} areas, total and disjoint, north to south.`,
+    ],
+  };
+}

--- a/scripts/areas-partition.test.mjs
+++ b/scripts/areas-partition.test.mjs
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { checkAreaPartition } from "./areas-partition.mjs";
+import AREAS from "../src/data/areas.json" with { type: "json" };
+import BEACHES from "../src/data/beaches.json" with { type: "json" };
+
+/**
+ * Three beaches on one coast, north to south, in two areas. Small enough that
+ * every failure below is one edit away from it.
+ */
+function fabricated() {
+  return {
+    beaches: [
+      { slug: "north-cove", name: "North Cove" },
+      { slug: "middle-strand", name: "Middle Strand" },
+      { slug: "south-point", name: "South Point" },
+    ],
+    areas: [
+      { slug: "the-north", name: "The North", beaches: ["north-cove"] },
+      {
+        slug: "the-south",
+        name: "The South",
+        beaches: ["middle-strand", "south-point"],
+      },
+    ],
+  };
+}
+
+describe("checkAreaPartition", () => {
+  it("accepts a total, disjoint, north-to-south partition", () => {
+    const { ok, lines } = checkAreaPartition(fabricated());
+
+    expect(ok).toBe(true);
+    expect(lines.join("\n")).toContain("3 beaches in 2 areas");
+  });
+
+  /**
+   * The failure the row exists for. `seed-beaches.mjs` rewrites the inventory
+   * from an upstream resource, so a beach can arrive without anybody naming its
+   * area — and it is then unreachable from the chooser with nothing thrown.
+   */
+  it("rejects a beach that belongs to no area, and names it", () => {
+    const tables = fabricated();
+    tables.beaches.push({ slug: "new-upstream-beach", name: "New Beach" });
+
+    const { ok, lines } = checkAreaPartition(tables);
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toContain("new-upstream-beach");
+    expect(lines.join("\n")).toContain("belongs to no area");
+  });
+
+  it("rejects a beach claimed by two areas, and names both", () => {
+    const tables = fabricated();
+    tables.areas[0].beaches.push("south-point");
+
+    const { ok, lines } = checkAreaPartition(tables);
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toContain("claimed by 2 areas");
+    expect(lines.join("\n")).toContain('"the-north"');
+    expect(lines.join("\n")).toContain('"the-south"');
+  });
+
+  it("rejects an area naming a slug the inventory does not have", () => {
+    const tables = fabricated();
+    tables.areas[1].beaches.push("renamed-upstream");
+
+    const { ok, lines } = checkAreaPartition(tables);
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toContain("not in beaches.json");
+  });
+
+  it("rejects an empty area", () => {
+    const tables = fabricated();
+    tables.areas.push({ slug: "nowhere", name: "Nowhere", beaches: [] });
+
+    const { ok, lines } = checkAreaPartition(tables);
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toContain("has no beaches");
+  });
+
+  it("rejects two areas sharing a slug", () => {
+    const tables = fabricated();
+    tables.areas[1].slug = "the-north";
+
+    const { ok, lines } = checkAreaPartition(tables);
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toContain("used twice");
+  });
+
+  it("rejects members listed out of the inventory's order", () => {
+    const tables = fabricated();
+    tables.areas[1].beaches = ["south-point", "middle-strand"];
+
+    const { ok, lines } = checkAreaPartition(tables);
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toContain("Members run north to south");
+  });
+
+  it("rejects areas listed out of the inventory's order", () => {
+    const tables = fabricated();
+    tables.areas.reverse();
+
+    const { ok, lines } = checkAreaPartition(tables);
+
+    expect(ok).toBe(false);
+    expect(lines.join("\n")).toContain("Areas run north to south");
+  });
+
+  /**
+   * The committed tables, checked here as well as by the gate row. The row is
+   * what fails a build; this is what fails a test run, so a partition broken by
+   * an edit to either file is caught without waiting for the slower gate.
+   */
+  it("holds for the committed inventory", () => {
+    const { ok, lines } = checkAreaPartition({
+      areas: AREAS.areas,
+      beaches: BEACHES.beaches,
+    });
+
+    expect(lines.join("\n")).toContain("total and disjoint");
+    expect(ok).toBe(true);
+  });
+});

--- a/scripts/check-areas.mjs
+++ b/scripts/check-areas.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * The `areas` gate row: asserts `areas.json` still partitions the inventory.
+ *
+ * Entry-point plumbing only — read, print, exit. The verdict lives in
+ * `areas-partition.mjs`, where it is unit-tested against fabricated tables
+ * (ADR-0002, the same split as `check-sea-side.mjs` and
+ * `check-adr-numbers.mjs`).
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { checkAreaPartition } from "./areas-partition.mjs";
+
+const read = (name) =>
+  JSON.parse(
+    readFileSync(
+      fileURLToPath(new URL(`../src/data/${name}`, import.meta.url)),
+      "utf8",
+    ),
+  );
+
+const { ok, lines } = checkAreaPartition({
+  areas: read("areas.json").areas,
+  beaches: read("beaches.json").beaches,
+});
+
+console.log(lines.join("\n"));
+process.exit(ok ? 0 : 1);

--- a/scripts/gates.mjs
+++ b/scripts/gates.mjs
@@ -32,6 +32,12 @@ export const GATES = [
   // checker. See scripts/sea-side.mjs for why the whole-county form of the
   // check is the wrong one.
   { name: "sea-side", command: "node scripts/check-sea-side.mjs" },
+  // Reads only committed JSON, so it sits with the two rows above. areas.json
+  // is the one table about the beaches a person writes by hand, and
+  // beaches.json beside it is rewritten from an upstream resource by
+  // seed-beaches.mjs -- so a beach can arrive with no area named for it and go
+  // missing from the chooser with nothing thrown. See scripts/areas-partition.mjs.
+  { name: "areas", command: "node scripts/check-areas.mjs" },
   // Runs with coverage so the floor in vitest.config.mts is enforced here:
   // Vitest exits non-zero when a threshold is missed, which is the third way
   // CLAUDE.md says this command must fail.

--- a/scripts/seed-beaches.mjs
+++ b/scripts/seed-beaches.mjs
@@ -201,20 +201,6 @@ export function slugify(name) {
   return slug;
 }
 
-/**
- * Display grouping only. Never an input to any join — it exists so a reader can
- * find their beach in a long list, and the bands are latitudes rather
- * than anyone's idea of where a neighbourhood ends. Bay and inlet sites group
- * together regardless of latitude, because that is how someone looks for them.
- */
-export function regionOf(waterClass, meanLat) {
-  if (waterClass === "bay") return "Bays, lagoons and inlets";
-  if (meanLat >= 33.0) return "North County coast";
-  if (meanLat >= 32.8) return "La Jolla and Pacific Beach";
-  if (meanLat >= 32.65) return "Point Loma and Ocean Beach";
-  return "South County coast";
-}
-
 export function build(
   rows,
   stations,
@@ -293,7 +279,6 @@ export function build(
     return {
       slug,
       name: row.Beach_Name,
-      region: regionOf(bound.stationId ? bound.waterClass : null, meanLat),
       segment,
       upstream: {
         usepa_id: row.USEPAID,
@@ -681,8 +666,6 @@ export function document(built, now = new Date()) {
     _schema: {
       slug: "Stable primary key, from the published name. Never change after first write.",
       name: "Display name, as the resource publishes it.",
-      region:
-        "Display grouping only, derived from water class and mean latitude. Never a join input.",
       segment:
         "The shoreline extent, upper and lower endpoints, WGS84 decimal degrees.",
       upstream: "Fields reproduced from the resource, unmodified.",

--- a/scripts/seed-beaches.test.mjs
+++ b/scripts/seed-beaches.test.mjs
@@ -4,7 +4,6 @@ import {
   document,
   dropReplacedBuoy,
   MODELLED_SOURCE_TOLERANCE_M,
-  regionOf,
   segmentFault,
   SERVICE_TOLERANCE_M,
   serviceFault,
@@ -245,20 +244,6 @@ describe("slugify", () => {
 
   it("refuses a name that slugifies to nothing", () => {
     expect(() => slugify("!!!")).toThrow(/slugified to nothing/);
-  });
-});
-
-describe("regionOf", () => {
-  it("groups bays together wherever they are", () => {
-    expect(regionOf("bay", 33.2)).toBe("Bays, lagoons and inlets");
-    expect(regionOf("bay", 32.6)).toBe("Bays, lagoons and inlets");
-  });
-
-  it("bands the open coast by latitude", () => {
-    expect(regionOf("open-coast", 33.2)).toBe("North County coast");
-    expect(regionOf("open-coast", 32.85)).toBe("La Jolla and Pacific Beach");
-    expect(regionOf("open-coast", 32.7)).toBe("Point Loma and Ocean Beach");
-    expect(regionOf("open-coast", 32.58)).toBe("South County coast");
   });
 });
 

--- a/src/components/conditions/BeachSelector.test.tsx
+++ b/src/components/conditions/BeachSelector.test.tsx
@@ -9,14 +9,14 @@ vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }));
 
 const GROUPS = [
   {
-    region: "La Jolla and Pacific Beach",
+    area: "La Jolla",
     beaches: [
-      { slug: "del-mar-city-beach", name: "Del Mar City Beach" },
       { slug: "la-jolla-shores-beach", name: "La Jolla Shores Beach" },
+      { slug: "la-jolla-cove", name: "La Jolla Cove" },
     ],
   },
   {
-    region: "Bays, lagoons and inlets",
+    area: "Mission Bay – South",
     beaches: [{ slug: "mission-bay", name: "Mission Bay" }],
   },
 ];
@@ -29,7 +29,7 @@ test("the chooser is labelled, so it is reachable without sight of it", () => {
   expect((select as HTMLSelectElement).value).toBe("la-jolla-shores-beach");
 });
 
-test("beaches are grouped by region rather than listed flat", () => {
+test("beaches are grouped by area rather than listed flat", () => {
   const { container } = render(
     <BeachSelector groups={GROUPS} current="la-jolla-shores-beach" />,
   );
@@ -37,11 +37,8 @@ test("beaches are grouped by region rather than listed flat", () => {
   const labels = [...container.querySelectorAll("optgroup")].map((group) =>
     group.getAttribute("label"),
   );
-  // Forty-odd entries is still too many to scan as one list.
-  expect(labels).toEqual([
-    "La Jolla and Pacific Beach",
-    "Bays, lagoons and inlets",
-  ]);
+  // Fifty-one entries is far too many to scan as one list.
+  expect(labels).toEqual(["La Jolla", "Mission Bay – South"]);
 });
 
 test("every beach given is offered exactly once", () => {
@@ -53,8 +50,8 @@ test("every beach given is offered exactly once", () => {
     (option) => (option as HTMLOptionElement).value,
   );
   expect(values).toEqual([
-    "del-mar-city-beach",
     "la-jolla-shores-beach",
+    "la-jolla-cove",
     "mission-bay",
   ]);
 });
@@ -68,12 +65,12 @@ test("a beach without scripting is still reachable, as a link", () => {
   );
 
   expect(markup).toContain("<noscript>");
-  expect(markup).toContain("Del Mar City Beach");
+  expect(markup).toContain("La Jolla Cove");
   expect(markup).toContain("/conditions/mission-bay");
   // Two-sided: markup containing every beach twice would pass the lines above
   // whether or not the fallback exists, so the links must be inside it.
   const fallback = markup.slice(markup.indexOf("<noscript>"));
-  expect(fallback).toContain("/conditions/del-mar-city-beach");
+  expect(fallback).toContain("/conditions/la-jolla-cove");
 });
 
 /**

--- a/src/components/conditions/BeachSelector.tsx
+++ b/src/components/conditions/BeachSelector.tsx
@@ -6,10 +6,16 @@ import { TOUCH_TARGET } from "../ui/touchTarget";
 /**
  * Choosing which beach the conditions view is about.
  *
- * The inventory is too long to scan flat, so it is grouped by region — a
- * display grouping the inventory derives from water class and latitude, and
- * never a join input. Bays, lagoons and inlets group together regardless of
- * where they are, because that is how someone looks for them.
+ * The inventory is too long to scan flat, so it is grouped by **area** — Del
+ * Mar, La Jolla, Mission Bay – West — which is a place a reader already has a
+ * name for. It replaced a grouping derived from water class and latitude, whose
+ * bay band held `Childrens Pool` and a wildlife refuge 19 km away because both
+ * sit in sheltered water.
+ *
+ * The areas run north to south and their members run north to south inside
+ * them, which is what makes the list read down the coast. Those two properties
+ * are all that hold: the areas interleave, so the flattened order is not the
+ * inventory's. `src/lib/areas.ts` carries the reason.
  *
  * The `noscript` list is not decoration. Selecting with a `select` needs
  * JavaScript to navigate, and a family checking the tide on a phone with a
@@ -23,7 +29,8 @@ export interface SelectableBeach {
 }
 
 export interface BeachGroup {
-  region: string;
+  /** The area's display name, which labels the group. */
+  area: string;
   beaches: readonly SelectableBeach[];
 }
 
@@ -61,7 +68,7 @@ export function BeachSelector({
         onChange={(event) => router.push(`/conditions/${event.target.value}`)}
       >
         {groups.map((group) => (
-          <optgroup key={group.region} label={group.region}>
+          <optgroup key={group.area} label={group.area}>
             {group.beaches.map((beach) => (
               <option key={beach.slug} value={beach.slug}>
                 {beach.name}
@@ -73,9 +80,9 @@ export function BeachSelector({
 
       <noscript>
         {groups.map((group) => (
-          <div key={group.region} className="mt-4">
+          <div key={group.area} className="mt-4">
             <p className="text-2xs font-extrabold tracking-widest text-ocean uppercase">
-              {group.region}
+              {group.area}
             </p>
             <ul className="leading-relaxed text-base text-fog">
               {group.beaches.map((beach) => (

--- a/src/components/conditions/ConditionsSection.tsx
+++ b/src/components/conditions/ConditionsSection.tsx
@@ -9,11 +9,8 @@
  */
 
 import { Suspense } from "react";
-import {
-  beachesByRegion,
-  inventoryCaveats,
-  inventoryReach,
-} from "@/lib/beaches";
+import { beachesByArea } from "@/lib/areas";
+import { inventoryCaveats, inventoryReach } from "@/lib/beaches";
 import { BeachSelector } from "./BeachSelector";
 import { ConditionsNotes } from "./ConditionsNotes";
 import { DayPanel } from "./DayPanel";
@@ -23,8 +20,8 @@ import { SelectedDayProvider } from "./selectedDay";
 import { WeekPanel } from "./WeekPanel";
 
 export function ConditionsSection({ slug }: { slug: string }) {
-  const groups = beachesByRegion().map((group) => ({
-    region: group.region,
+  const groups = beachesByArea().map((group) => ({
+    area: group.area.name,
     beaches: group.beaches.map((beach) => ({
       slug: beach.slug,
       name: beach.name,

--- a/src/data/areas.json
+++ b/src/data/areas.json
@@ -1,0 +1,148 @@
+{
+  "version": "0.1.0",
+  "generated": "2026-09-02",
+  "_provenance": "Written by hand. Nothing upstream publishes it: the state's resource names a nearest_city, and it says \"San Diego\" for 43 of the 51 beaches -- the only row it labels \"La Jolla\" is Childrens Pool. Latitude cannot stand in for it either, because Mission Beach falls inside Mission Bay's band and Sunset Cliffs falls below Spanish Landing Park on the far side of a peninsula. So an area is a fact about San Diego that a person asserts, the way a tide station's water class in tide-stations.json is. See docs/plans/areas-over-locations.md.",
+  "_partition": "Total and disjoint, and scripts/check-areas.mjs is the gate row that says so: every beach in beaches.json belongs to exactly one area, every listed slug is in the inventory, and no area is empty. That gate is the point of the file. seed-beaches.mjs rewrites the inventory from an upstream resource, and a beach arriving with no area named for it must stop a build rather than become unreachable from the chooser.",
+  "_order": "Two properties, and they are all that can hold at once. Members run north to south within their area, and areas are ordered by their northernmost member. Areas THEMSELVES INTERLEAVE and flattening them does not give beaches.json's order back: mission-bay-north spans inventory positions 15-22 while mission-bay-west spans 21-32, with Mission Beach at 26 inside both. That is the same interleave that stopped latitude from deriving these groups at all. The gate asserts the two properties against the inventory, so both are checked claims rather than conventions.",
+  "_single_member": "An area may hold one location, and four do. It is not a degenerate case to be avoided: an area publishes what all its members share, so a lone member shares everything with itself and its area is the beach page. Forbidding it would mean folding a place into a neighbour it has nothing in common with, which is what the count is protecting against rather than something to minimise.",
+  "_names": "The two bays carry compass points -- Mission Bay - North, San Diego Bay - Central -- because a compass point is what the committed coordinates support. Whether a reader says \"Sail Bay\" or \"Crown Point\" or \"Quivira\" is local usage this repo cannot verify from data, and substituting a better name is a one-line edit here.",
+  "_schema": {
+    "slug": "Stable key for the area. May equal a beach slug, and three do -- pacific-beach, mission-beach, ocean-beach. They are different namespaces: an area and a location sit at different positions of the route, so /conditions/pacific-beach is the area and /conditions/pacific-beach/pacific-beach the location. Five would have collided before the bays were split; mission-bay and san-diego-bay stopped colliding when those areas took compass points.",
+    "name": "What the chooser and the area's heading say.",
+    "beaches": "Member slugs, north to south, each a slug in beaches.json."
+  },
+  "areas": [
+    {
+      "slug": "del-mar",
+      "name": "Del Mar",
+      "beaches": ["del-mar-city-beach"]
+    },
+    {
+      "slug": "torrey-pines",
+      "name": "Torrey Pines",
+      "beaches": ["torrey-pines-state-beach", "torrey-pines-city-beach"]
+    },
+    {
+      "slug": "la-jolla",
+      "name": "La Jolla",
+      "beaches": [
+        "la-jolla-shores-beach",
+        "la-jolla-cove",
+        "shell-beach",
+        "childrens-pool",
+        "south-casa-beach-s-d",
+        "whispering-sands-nicholson-pt",
+        "marine-street-beach",
+        "la-jolla-community-beach",
+        "windansea-beach",
+        "bird-rock-nr"
+      ]
+    },
+    {
+      "slug": "pacific-beach",
+      "name": "Pacific Beach",
+      "beaches": ["tourmaline-surfing-park", "pacific-beach"]
+    },
+    {
+      "slug": "mission-bay-north",
+      "name": "Mission Bay – North",
+      "beaches": [
+        "mission-bay-campland-on-the-bay",
+        "mission-bay-de-anza-cove",
+        "mission-bay-visitor-s-center",
+        "mission-bay-fanuel-park",
+        "mission-bay-leisure-lagoon",
+        "mission-bay-crown-point-shores",
+        "mission-bay-north-pacific-passage"
+      ]
+    },
+    {
+      "slug": "mission-bay-west",
+      "name": "Mission Bay – West",
+      "beaches": [
+        "mission-bay-riviera-shores",
+        "mission-bay-san-juan-cove",
+        "mission-bay-sail-bay",
+        "mission-bay-santa-barbara-cove",
+        "mission-bay-bahia-point",
+        "mission-bay-vacation-isle",
+        "mission-bay-ventura-cove",
+        "mission-bay-sea-world"
+      ]
+    },
+    {
+      "slug": "mission-beach",
+      "name": "Mission Beach",
+      "beaches": ["mission-beach"]
+    },
+    {
+      "slug": "mission-bay-east",
+      "name": "Mission Bay – East",
+      "beaches": ["tecolote-shores", "fiesta-island"]
+    },
+    {
+      "slug": "mission-bay-south",
+      "name": "Mission Bay – South",
+      "beaches": [
+        "mission-bay-mariners-basin",
+        "mission-bay-quivera-basin",
+        "mission-bay"
+      ]
+    },
+    {
+      "slug": "ocean-beach",
+      "name": "Ocean Beach",
+      "beaches": ["dog-beach-o-b", "ocean-beach"]
+    },
+    {
+      "slug": "san-diego-bay-north",
+      "name": "San Diego Bay – North",
+      "beaches": ["spanish-landing-park"]
+    },
+    {
+      "slug": "sunset-cliffs",
+      "name": "Sunset Cliffs",
+      "beaches": ["sunset-cliffs-park"]
+    },
+    {
+      "slug": "san-diego-bay-central",
+      "name": "San Diego Bay – Central",
+      "beaches": ["shoreline-park", "san-diego-bay"]
+    },
+    {
+      "slug": "coronado",
+      "name": "Coronado",
+      "beaches": [
+        "coronado-north-beach",
+        "coronado-central-beach",
+        "coronado-city-beaches"
+      ]
+    },
+    {
+      "slug": "coronado-cays",
+      "name": "Coronado Cays",
+      "beaches": ["coronado-cays-nr"]
+    },
+    {
+      "slug": "silver-strand",
+      "name": "Silver Strand",
+      "beaches": ["silver-strand-state-beach"]
+    },
+    {
+      "slug": "imperial-beach",
+      "name": "Imperial Beach",
+      "beaches": [
+        "north-imperial-beach",
+        "imperial-beach-municipal-beach-other"
+      ]
+    },
+    {
+      "slug": "tijuana-estuary",
+      "name": "Tijuana Estuary",
+      "beaches": [
+        "tijuana-slough-national-wildlife-refuge",
+        "border-field-state-park"
+      ]
+    }
+  ]
+}

--- a/src/data/beaches.json
+++ b/src/data/beaches.json
@@ -13,7 +13,6 @@
   "_schema": {
     "slug": "Stable primary key, from the published name. Never change after first write.",
     "name": "Display name, as the resource publishes it.",
-    "region": "Display grouping only, derived from water class and mean latitude. Never a join input.",
     "segment": "The shoreline extent, upper and lower endpoints, WGS84 decimal degrees.",
     "upstream": "Fields reproduced from the resource, unmodified.",
     "tide_station": "Joined, never typed: the nearest delivering station of the beach's own water class. Re-runnable with scripts/seed-beaches.mjs --check. null means the join could not bind one, and tide_station_null_reason says why.",
@@ -36,7 +35,6 @@
     {
       "slug": "del-mar-city-beach",
       "name": "Del Mar City Beach",
-      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.980308,
@@ -76,7 +74,6 @@
     {
       "slug": "torrey-pines-state-beach",
       "name": "Torrey Pines State Beach",
-      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.948992,
@@ -116,7 +113,6 @@
     {
       "slug": "torrey-pines-city-beach",
       "name": "Torrey Pines City Beach",
-      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.895772,
@@ -156,7 +152,6 @@
     {
       "slug": "la-jolla-shores-beach",
       "name": "La Jolla Shores Beach",
-      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.883647,
@@ -196,7 +191,6 @@
     {
       "slug": "la-jolla-cove",
       "name": "La Jolla Cove",
-      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.850235,
@@ -236,7 +230,6 @@
     {
       "slug": "shell-beach",
       "name": "Shell Beach",
-      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.850043,
@@ -276,7 +269,6 @@
     {
       "slug": "childrens-pool",
       "name": "Childrens Pool",
-      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.8478,
@@ -318,7 +310,6 @@
     {
       "slug": "south-casa-beach-s-d",
       "name": "South Casa Beach S.D.",
-      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.847306,
@@ -358,7 +349,6 @@
     {
       "slug": "whispering-sands-nicholson-pt",
       "name": "Whispering Sands  Nicholson Pt.",
-      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.845887,
@@ -398,7 +388,6 @@
     {
       "slug": "marine-street-beach",
       "name": "Marine Street Beach",
-      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.839494,
@@ -438,7 +427,6 @@
     {
       "slug": "la-jolla-community-beach",
       "name": "La Jolla Community Beach",
-      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.854717,
@@ -478,7 +466,6 @@
     {
       "slug": "windansea-beach",
       "name": "WindanSea Beach",
-      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.836703,
@@ -518,7 +505,6 @@
     {
       "slug": "bird-rock-nr",
       "name": "Bird Rock (NR)",
-      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.815476,
@@ -558,7 +544,6 @@
     {
       "slug": "tourmaline-surfing-park",
       "name": "Tourmaline Surfing Park",
-      "region": "La Jolla and Pacific Beach",
       "segment": {
         "upper": {
           "lat": 32.8079,
@@ -598,7 +583,6 @@
     {
       "slug": "pacific-beach",
       "name": "Pacific Beach",
-      "region": "Point Loma and Ocean Beach",
       "segment": {
         "upper": {
           "lat": 32.8008,
@@ -638,7 +622,6 @@
     {
       "slug": "mission-bay-campland-on-the-bay",
       "name": "Mission Bay, Campland On The Bay",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.794406,
@@ -680,7 +663,6 @@
     {
       "slug": "mission-bay-de-anza-cove",
       "name": "Mission Bay, De Anza Cove",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.794,
@@ -722,7 +704,6 @@
     {
       "slug": "mission-bay-visitor-s-center",
       "name": "Mission Bay, Visitor's Center",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.7932,
@@ -764,7 +745,6 @@
     {
       "slug": "mission-bay-fanuel-park",
       "name": "Mission Bay, Fanuel Park",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.7913,
@@ -806,7 +786,6 @@
     {
       "slug": "mission-bay-leisure-lagoon",
       "name": "Mission Bay, Leisure Lagoon",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.7868,
@@ -848,7 +827,6 @@
     {
       "slug": "mission-bay-crown-point-shores",
       "name": "Mission Bay, Crown Point Shores",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.788545,
@@ -890,7 +868,6 @@
     {
       "slug": "mission-bay-riviera-shores",
       "name": "Mission Bay, Riviera Shores",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.78596,
@@ -932,7 +909,6 @@
     {
       "slug": "mission-bay-north-pacific-passage",
       "name": "Mission Bay, north pacific passage",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.784023,
@@ -974,7 +950,6 @@
     {
       "slug": "mission-bay-san-juan-cove",
       "name": "Mission Bay, San Juan Cove",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.781296,
@@ -1016,7 +991,6 @@
     {
       "slug": "mission-bay-sail-bay",
       "name": "Mission Bay, Sail Bay",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.7799,
@@ -1058,7 +1032,6 @@
     {
       "slug": "mission-bay-santa-barbara-cove",
       "name": "Mission Bay, Santa Barbara Cove",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.777576,
@@ -1100,7 +1073,6 @@
     {
       "slug": "mission-beach",
       "name": "Mission Beach",
-      "region": "Point Loma and Ocean Beach",
       "segment": {
         "upper": {
           "lat": 32.793314,
@@ -1140,7 +1112,6 @@
     {
       "slug": "tecolote-shores",
       "name": "Tecolote Shores",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.777317,
@@ -1182,7 +1153,6 @@
     {
       "slug": "mission-bay-bahia-point",
       "name": "Mission Bay, Bahia Point",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.7759,
@@ -1224,7 +1194,6 @@
     {
       "slug": "mission-bay-vacation-isle",
       "name": "Mission Bay, Vacation Isle",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.7737,
@@ -1266,7 +1235,6 @@
     {
       "slug": "mission-bay-ventura-cove",
       "name": "Mission Bay, Ventura Cove",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.773704,
@@ -1308,7 +1276,6 @@
     {
       "slug": "fiesta-island",
       "name": "Fiesta Island",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.7694,
@@ -1350,7 +1317,6 @@
     {
       "slug": "mission-bay-sea-world",
       "name": "Mission Bay, Sea World",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.769509,
@@ -1392,7 +1358,6 @@
     {
       "slug": "mission-bay-mariners-basin",
       "name": "Mission Bay, Mariners Basin",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.762084,
@@ -1434,7 +1399,6 @@
     {
       "slug": "mission-bay-quivera-basin",
       "name": "Mission Bay, Quivera Basin",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.763274,
@@ -1476,7 +1440,6 @@
     {
       "slug": "mission-bay",
       "name": "Mission Bay",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.760031,
@@ -1518,7 +1481,6 @@
     {
       "slug": "dog-beach-o-b",
       "name": "Dog Beach, O.B.",
-      "region": "Point Loma and Ocean Beach",
       "segment": {
         "upper": {
           "lat": 32.75617,
@@ -1559,7 +1521,6 @@
     {
       "slug": "ocean-beach",
       "name": "Ocean Beach",
-      "region": "Point Loma and Ocean Beach",
       "segment": {
         "upper": {
           "lat": 32.756524,
@@ -1600,7 +1561,6 @@
     {
       "slug": "spanish-landing-park",
       "name": "Spanish Landing Park",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.728278,
@@ -1642,7 +1602,6 @@
     {
       "slug": "sunset-cliffs-park",
       "name": "Sunset Cliffs Park",
-      "region": "Point Loma and Ocean Beach",
       "segment": {
         "upper": {
           "lat": 32.735192,
@@ -1683,7 +1642,6 @@
     {
       "slug": "shoreline-park",
       "name": "Shoreline Park",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.708872,
@@ -1725,7 +1683,6 @@
     {
       "slug": "san-diego-bay",
       "name": "San Diego Bay",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.707794,
@@ -1767,7 +1724,6 @@
     {
       "slug": "coronado-north-beach",
       "name": "Coronado north beach",
-      "region": "Point Loma and Ocean Beach",
       "segment": {
         "upper": {
           "lat": 32.683267,
@@ -1808,7 +1764,6 @@
     {
       "slug": "coronado-central-beach",
       "name": "Coronado, Central beach",
-      "region": "Point Loma and Ocean Beach",
       "segment": {
         "upper": {
           "lat": 32.684744,
@@ -1849,7 +1804,6 @@
     {
       "slug": "coronado-city-beaches",
       "name": "Coronado City beaches",
-      "region": "Point Loma and Ocean Beach",
       "segment": {
         "upper": {
           "lat": 32.6867,
@@ -1890,7 +1844,6 @@
     {
       "slug": "coronado-cays-nr",
       "name": "Coronado Cays (NR)",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.637678,
@@ -1932,7 +1885,6 @@
     {
       "slug": "silver-strand-state-beach",
       "name": "Silver Strand State Beach",
-      "region": "South County coast",
       "segment": {
         "upper": {
           "lat": 32.636836,
@@ -1973,7 +1925,6 @@
     {
       "slug": "north-imperial-beach",
       "name": "north Imperial Beach",
-      "region": "South County coast",
       "segment": {
         "upper": {
           "lat": 32.6089,
@@ -2014,7 +1965,6 @@
     {
       "slug": "imperial-beach-municipal-beach-other",
       "name": "Imperial Beach municipal beach, other",
-      "region": "South County coast",
       "segment": {
         "upper": {
           "lat": 32.587527,
@@ -2055,7 +2005,6 @@
     {
       "slug": "tijuana-slough-national-wildlife-refuge",
       "name": "Tijuana Slough National Wildlife Refuge",
-      "region": "Bays, lagoons and inlets",
       "segment": {
         "upper": {
           "lat": 32.5662,
@@ -2097,7 +2046,6 @@
     {
       "slug": "border-field-state-park",
       "name": "Border Field State Park",
-      "region": "South County coast",
       "segment": {
         "upper": {
           "lat": 32.55282,

--- a/src/lib/areas.test.ts
+++ b/src/lib/areas.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test, vi } from "vitest";
+import { beachesByArea } from "./areas";
+import { allBeaches } from "./beaches";
+
+describe("beachesByArea", () => {
+  test("covers the whole inventory exactly once", () => {
+    const grouped = beachesByArea().flatMap((group) => group.beaches);
+
+    expect(grouped.map((beach) => beach.slug).sort()).toEqual(
+      allBeaches()
+        .map((beach) => beach.slug)
+        .sort(),
+    );
+  });
+
+  test("every area has a name and at least one beach", () => {
+    for (const { area, beaches } of beachesByArea()) {
+      expect(area.name).not.toBe("");
+      expect(beaches.length).toBeGreaterThan(0);
+    }
+  });
+
+  /**
+   * The inventory is sorted north to south, so preserving its order is what
+   * makes the chooser read down the coast. Two separate properties, because
+   * they are all that can be true at once: members are in inventory order
+   * *within* an area, and areas are ordered by their northernmost member.
+   */
+  test("members run north to south within an area", () => {
+    const order = new Map(allBeaches().map((beach, i) => [beach.slug, i]));
+
+    for (const { area, beaches } of beachesByArea()) {
+      const indices = beaches.map((beach) => order.get(beach.slug)!);
+      expect(indices, area.slug).toEqual([...indices].sort((a, b) => a - b));
+    }
+  });
+
+  test("areas are ordered by their northernmost beach", () => {
+    const order = new Map(allBeaches().map((beach, i) => [beach.slug, i]));
+    const firsts = beachesByArea().map((group) =>
+      Math.min(...group.beaches.map((beach) => order.get(beach.slug)!)),
+    );
+
+    expect(firsts).toEqual([...firsts].sort((a, b) => a - b));
+  });
+
+  /**
+   * And the two properties above are all that hold, because **areas interleave
+   * north to south** — flattening them does not give the inventory's order
+   * back. Mission Bay's arms are why: `mission-bay-north` spans inventory
+   * positions 15–22 and `mission-bay-west` spans 21–32, with `Mission Beach`
+   * at 26 sitting inside both, which is the same interleave that stopped
+   * latitude from deriving these groups in the first place.
+   *
+   * Asserted rather than left as a surprise: without this a later reader finds
+   * the flattened order unsorted, reads it as a defect and "fixes" the table
+   * by moving a beach out of the area it belongs to.
+   */
+  test("areas interleave, so the flattened order is not the inventory's", () => {
+    const order = new Map(allBeaches().map((beach, i) => [beach.slug, i]));
+    const flattened = beachesByArea().flatMap((group) =>
+      group.beaches.map((beach) => order.get(beach.slug)!),
+    );
+
+    expect(flattened).not.toEqual([...flattened].sort((a, b) => a - b));
+  });
+
+  /**
+   * The two bays are the reason there are eighteen areas rather than thirteen.
+   * Named here because the split is a decision — see the 2026-09-02 addendum in
+   * `docs/plans/areas-over-locations.md` — and a later edit that quietly folds
+   * them back together should fail rather than merely change a dropdown.
+   */
+  test("Mission Bay is four areas and San Diego Bay is three", () => {
+    const slugs = beachesByArea().map((group) => group.area.slug);
+
+    expect(slugs.filter((slug) => slug.startsWith("mission-bay-"))).toEqual([
+      "mission-bay-north",
+      "mission-bay-west",
+      "mission-bay-east",
+      "mission-bay-south",
+    ]);
+    expect(slugs.filter((slug) => slug.startsWith("san-diego-bay-"))).toEqual([
+      "san-diego-bay-north",
+      "san-diego-bay-central",
+    ]);
+    expect(slugs).toContain("coronado-cays");
+  });
+
+  /**
+   * An area slug may equal a beach slug — three do — because the two sit at
+   * different positions of the route. Asserted rather than left implicit, so
+   * the collision is a recorded property rather than something a later reader
+   * treats as a bug.
+   *
+   * Five beach slugs were candidates before the bays were split; `mission-bay`
+   * and `san-diego-bay` stopped colliding when those areas became
+   * `mission-bay-north` and the rest, so the split removed two of them.
+   */
+  test("an area slug may equal a beach slug", () => {
+    const beachSlugs = new Set(allBeaches().map((beach) => beach.slug));
+    const shared = beachesByArea()
+      .map((group) => group.area.slug)
+      .filter((slug) => beachSlugs.has(slug));
+
+    expect(shared).toEqual(["pacific-beach", "mission-beach", "ocean-beach"]);
+  });
+
+  test("throws when an area names a beach the inventory does not have", async () => {
+    vi.resetModules();
+    vi.doMock("@/data/areas.json", () => ({
+      default: {
+        areas: [{ slug: "nowhere", name: "Nowhere", beaches: ["not-a-beach"] }],
+      },
+    }));
+
+    const { beachesByArea: withBrokenTable } = await import("./areas");
+
+    expect(() => withBrokenTable()).toThrow(/beaches\.json has no such beach/);
+
+    vi.doUnmock("@/data/areas.json");
+    vi.resetModules();
+  });
+});

--- a/src/lib/areas.ts
+++ b/src/lib/areas.ts
@@ -1,0 +1,67 @@
+/**
+ * The areas the inventory is grouped into, typed.
+ *
+ * An **area** is a named stretch of this county's coast holding one or more
+ * beaches — Del Mar, La Jolla, Mission Bay – West. It is what a reader chooses
+ * on `/conditions`, and it replaced `region`, which was derived from water
+ * class and mean latitude and grouped `Childrens Pool` with a wildlife refuge
+ * 19 km away because both are bay-class.
+ *
+ * `src/data/areas.json` is the one table about the beaches that a person writes
+ * by hand, and the reason is in its own `_provenance`: nothing upstream
+ * publishes an area name, and neither latitude nor the resource's own
+ * `nearest_city` can stand in for one. Its counterpart `beaches.json` is
+ * rewritten by a script, so the two can drift — which is what the `areas` gate
+ * row exists to catch, and why the resolution below throws rather than skips.
+ *
+ * Nothing here fetches anything. Like `beaches.ts` beside it, reading a group
+ * is a file read.
+ */
+
+import areaTable from "@/data/areas.json";
+import { allBeaches, type Beach } from "./beaches";
+
+/** One area, as `areas.json` carries it. */
+export interface Area {
+  slug: string;
+  name: string;
+  /** Member beach slugs, north to south. */
+  beaches: readonly string[];
+}
+
+const AREAS: readonly Area[] = areaTable.areas;
+
+/** One area's beaches, resolved, for a chooser or a heading. */
+export interface AreaGroup {
+  area: Area;
+  beaches: readonly Beach[];
+}
+
+/**
+ * Every area with its beaches resolved, north to south and north to south
+ * within each.
+ *
+ * **Throws when an area names a beach the inventory does not have.** That is
+ * two data files disagreeing, not a missing reading, and it should stop a build
+ * rather than quietly serve a chooser with a beach missing from it — the same
+ * argument `tideStationFor` makes about a station it cannot describe. The
+ * `areas` gate row catches it earlier and says more; this is the backstop for
+ * the case where somebody edits one file and runs the app without the gate.
+ */
+export function beachesByArea(): readonly AreaGroup[] {
+  const bySlug = new Map(allBeaches().map((beach) => [beach.slug, beach]));
+
+  return AREAS.map((area) => ({
+    area,
+    beaches: area.beaches.map((slug) => {
+      const beach = bySlug.get(slug);
+      if (!beach) {
+        throw new Error(
+          `areas.json puts ${slug} in ${area.slug}, but beaches.json has no such beach. ` +
+            `Upstream may have renamed it; name its area deliberately.`,
+        );
+      }
+      return beach;
+    }),
+  }));
+}

--- a/src/lib/beaches.test.ts
+++ b/src/lib/beaches.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "vitest";
 import {
   allBeaches,
   beachBySlug,
-  beachesByRegion,
   DEFAULT_BEACH_SLUG,
   defaultBeach,
   inventoryCaveats,
@@ -183,17 +182,26 @@ describe("the tide station binding", () => {
     }
   });
 
-  test("applies the water class to the region label and the join alike", () => {
-    // The class is resolved in one place and read by three joins and the region
-    // label. A beach bound to a bay station but filed under a coastal region
-    // would mean an override reached one reader and not the others -- which is
-    // the failure mode a slug-keyed override invites.
-    for (const beach of allBeaches()) {
-      const station = tideStationFor(beach);
-      if (station === null) continue;
-      expect(station.water === "bay").toBe(beach.region.startsWith("Bays"));
-    }
-  });
+  /*
+    A test stood here asserting that the water class reached the region label
+    and the joins alike. Its whole value was that the two operands were
+    independent: `region` was frozen into beaches.json at seed time from the
+    bound class, and the joins read that class at runtime, so a beach that moved
+    one without the other was a data error worth stopping on.
+
+    `region` is gone -- replaced by an authored area that groups by place rather
+    than by water -- and with it the second operand. What is left cannot be
+    written as a test: `surfZoneWithheldReason` IS `station.water === "bay"`, so
+    comparing them asserts nothing, and `upstream.water_body_type` disagrees at
+    the two beaches tide-join.mjs deliberately overrides. Childrens Pool is the
+    proof: upstream calls it a bay, the tide join binds it an open-coast
+    station, and the mop join refuses it.
+
+    The property is still covered, by the test directly above -- the binding
+    matches upstream except at those two named beaches -- and by the surf zone's
+    withheld count. Recorded rather than replaced with something that can only
+    pass.
+  */
 
   test("never binds to a station that does not deliver", () => {
     for (const beach of allBeaches()) {
@@ -231,32 +239,14 @@ describe("the tide station binding", () => {
   });
 });
 
-describe("grouping for a chooser", () => {
-  test("covers every beach exactly once", () => {
-    const grouped = beachesByRegion().flatMap((group) => group.beaches);
-    expect(grouped).toHaveLength(allBeaches().length);
-    expect(new Set(grouped.map((b) => b.slug)).size).toBe(allBeaches().length);
-  });
-
-  test("names no empty region", () => {
-    for (const group of beachesByRegion()) {
-      expect(group.region).not.toBe("");
-      expect(group.beaches.length).toBeGreaterThan(0);
-    }
-  });
-
-  test("puts bays and inlets in one group regardless of latitude", () => {
-    const bays = beachesByRegion().find((g) => g.region.startsWith("Bays"))!;
-
-    expect(bays.beaches.length).toBeGreaterThan(0);
-    for (const beach of bays.beaches) {
-      // Read from the binding rather than from `upstream.water_body_type`:
-      // that field is what the override in scripts/tide-join.mjs corrects, so
-      // asserting it here would assert the bug instead of the behaviour.
-      expect(tideStationFor(beach)?.water).toBe("bay");
-    }
-  });
-});
+/*
+  `describe("grouping for a chooser")` stood here, over `beachesByRegion`. It is
+  `src/lib/areas.test.ts` now, because the chooser groups by an authored area
+  rather than a derived region. One of its three tests is not carried over on
+  purpose: "puts bays and inlets in one group regardless of latitude" asserted
+  the behaviour this change removes -- Childrens Pool now sits in La Jolla, with
+  the beaches either side of it, rather than with a wildlife refuge 19 km away.
+*/
 
 describe("the default beach", () => {
   test("is in the inventory and has a station", () => {
@@ -582,26 +572,12 @@ describe("which beaches the surf zone forecast describes", () => {
     expect(withheld).toHaveLength(25);
   });
 
-  /**
-   * Two independent classifications of the same water: the region a beach is
-   * grouped under for the chooser, and the water class its tide station was
-   * bound by. They agreed on all 51, which is why reading either is defensible
-   * and why this holds the agreement still -- a beach that moved region without
-   * moving station, or the reverse, would be a data error worth stopping on
-   * rather than a silent change in who sees a rip current risk.
-   */
-  test("the water class and the region agree on every beach", () => {
-    for (const beach of allBeaches()) {
-      const sheltered = surfZoneWithheldReason(beach) !== null;
-      expect({
-        slug: beach.slug,
-        sheltered,
-      }).toEqual({
-        slug: beach.slug,
-        sheltered: beach.region === "Bays, lagoons and inlets",
-      });
-    }
-  });
+  /*
+    And a second test stood here comparing the withheld set against the region
+    each beach was grouped under -- the same pair of operands, and gone for the
+    same reason. The count above is what survives it: 25 withheld of 51, which
+    is the number CONTEXT.md states as "26 of the 51 beaches" reached.
+  */
 
   test("an open-coast beach is not withheld", () => {
     expect(surfZoneWithheldReason(beachBySlug(DEFAULT_BEACH_SLUG)!)).toBeNull();

--- a/src/lib/beaches.ts
+++ b/src/lib/beaches.ts
@@ -35,8 +35,6 @@ export interface BeachSegment {
 export interface Beach {
   slug: string;
   name: string;
-  /** Display grouping only. Never an input to any join. */
-  region: string;
   segment: BeachSegment;
   upstream: {
     usepa_id: string;
@@ -276,24 +274,6 @@ export function beachBySlug(slug: string): Beach | null {
 }
 
 /**
- * Beaches grouped for a chooser, in inventory order within each group and with
- * the groups in the order they first appear — which, the inventory being sorted
- * north to south, runs down the coast.
- */
-export function beachesByRegion(): {
-  region: string;
-  beaches: readonly Beach[];
-}[] {
-  const groups = new Map<string, Beach[]>();
-  for (const beach of BEACHES) {
-    const existing = groups.get(beach.region);
-    if (existing) existing.push(beach);
-    else groups.set(beach.region, [beach]);
-  }
-  return [...groups].map(([region, beaches]) => ({ region, beaches }));
-}
-
-/**
  * The station a beach reads, or null when the join could not bind one.
  *
  * Throws when a beach names a station the table does not describe. That is a
@@ -330,11 +310,13 @@ export function tideStationFor(
  * on all 51 because wind blows on a bay, so a wind figure there is true.
  *
  * **Read off the tide station's water class rather than off the region.** Both
- * classify the inventory identically — checked 51 of 51 — but the region is a
+ * classified the inventory identically — checked 51 of 51 — but the region was a
  * grouping for a dropdown while the water class is a joined fact about the
  * water, carried because the tide join has to bind an open-coast beach to an
- * open-coast station. A beach with no tide station at all is treated as having
- * no surf zone, because nothing here then says which water it is in.
+ * open-coast station. That region is gone, replaced by an authored area that
+ * groups by place rather than by water, so the water class is now the only
+ * thing that says which water a beach is in. A beach with no tide station at
+ * all is treated as having no surf zone, for the same reason.
  */
 export function surfZoneWithheldReason(beach: Beach): string | null {
   const station = tideStationFor(beach);


### PR DESCRIPTION
Slice 1 of `docs/plans/areas-over-locations.md`. Areas replace regions in the
chooser, end to end.

## What changed

**The chooser groups by area.** 18 areas over 51 beaches, ordered north to
south, from a new hand-written `src/data/areas.json`. It replaces `region` — a
field derived at seed time from water class and mean latitude, which put half
the inventory under "Bays, lagoons and inlets" and filed `Childrens Pool` with a
wildlife refuge 19 km away.

**`region` is deleted end to end**: `regionOf` and its emission from
`seed-beaches.mjs`, the field from all 51 rows and from `_schema`,
`beachesByRegion` from `beaches.ts`. `node scripts/seed-beaches.mjs --check`
still reports `beaches.json is current: 51 beaches, join unchanged.`

**A new `areas` gate row** (`scripts/check-areas.mjs` over
`areas-partition.mjs`) asserts the partition is total and disjoint. That row is
the actual decision: `seed-beaches.mjs` rewrites the inventory from an upstream
resource while `areas.json` is written by a person, so a new beach would
otherwise belong to no area and disappear from the chooser with **nothing
thrown**. It sits with `adr-numbers` and `sea-side` above the expensive rows,
since it reads only committed JSON.

**ADR-0046** records why the grouping is authored rather than derived.
**CONTEXT.md** gains `Area` and `Beach`.

## Why authored

Measured before asserting. No committed field yields these names:

- `upstream.nearest_city` is `San Diego` for **43 of 51**. The only row labelled
  `La Jolla` is `Childrens Pool`.
- Latitude fails exactly at the boundaries that matter: `Mission Beach`
  (32.7763, open coast) falls **inside** Mission Bay's band 32.7609–32.7951;
  `Fiesta Island` is published as **Open Coast** from the middle of the bay; and
  `Sunset Cliffs` (32.7242) falls **below** `Spanish Landing Park` (32.7284),
  opposite shores of one peninsula.

## Two tests deleted, and one not carried over

Argued in ADR-0046's consequences rather than done quietly. Both deleted tests
compared the **committed** `region` against the water class resolved at
**runtime** — a real cross-check between a frozen artifact and live code. With
`region` gone there is no second operand, and neither candidate works:

- `surfZoneWithheldReason` **is** `station.water === "bay"`, so comparing them
  can only pass;
- `upstream.water_body_type` disagrees with the binding at the two beaches
  `tide-join.mjs` deliberately overrides. **`Childrens Pool` proves it** —
  upstream calls it a bay, the tide join binds it an open-coast station, and the
  mop join refuses it.

The property is still covered by the neighbouring test (the binding matches
upstream except at those two named beaches) and by the surf zone's withheld
count of 25. The third test, "puts bays and inlets in one group regardless of
latitude", asserted the behaviour this change removes.

Net tests: **−3 deleted, +17 added** (9 in `areas-partition.test.mjs`, 8 in
`areas.test.ts`). Coverage floor held without adjustment.

## A correction, in the same commit

The plan's 2026-09-02 addendum claimed four area slugs collide with beach slugs
and named `coronado-cays`. `areas.test.ts` measured **three** — the beach is
`coronado-cays-nr` — and splitting the bays had already removed two of the five
§5 counted. Corrected in `areas.json`, the ADR and the plan. It is in this
commit rather than amended into the addendum because that is how it was found:
the test falsified it.

## Gate output

```
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… sea-side
… areas
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  areas
  PASS  test
  PASS  build
  PASS  stylesheet
```

Plus, separately, `node scripts/seed-beaches.mjs --check` → exit 0.

## What I did not do

- **No routing.** `/conditions/<area>` is slice 2. The chooser still navigates
  to `/conditions/<beach>`; only the `optgroup` labels change.
- **No area conditions.** What an area reports, and how "shared" is measured,
  are slices 2 and 3 with their own ADRs.
- **Two names are guesses.** `Tijuana Estuary` and `Silver Strand` are mine, and
  the two bays carry compass points because a compass point is what the
  coordinates support. All are one-line edits to an authored table.
- **`Mission Bay, Sea World` sits in _West_ rather than _South_** — the one
  member placed by its bindings rather than by the map. Recorded in the plan's
  addendum; worth a local's eye.

## Worth a look before merging

The chooser now has **18 `optgroup`s where it had 4**, and 4 of them hold a
single beach. That reads correctly to me but it is a visible change to a
finished control, and no gate can assert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
