### PR TITLE
Discharge the plan's two provenance caveats

### DIFF
--- a/docs/plans/conditions-fetching-audit.md
+++ b/docs/plans/conditions-fetching-audit.md
@@ -19,6 +19,27 @@ The defects live in the panels and the readers, which both route shapes share.
 or `selectedDay.tsx`, which is everything this plan changes. The two can run
 concurrently.
 
+> **Addendum, 2026-09-03. Both caveats above are discharged: #229 and this
+> plan's own PR #230 have merged, and `main` is now `e046333`.**
+>
+> The two paragraphs above hedge against a gap that no longer exists. The
+> figures were taken against the nested route on an unmerged branch, and that
+> route is now what `main` serves — so they describe `main` directly rather than
+> a branch it had yet to take. The prediction that #229 would not collide held:
+> it moved none of the lines this plan cites.
+>
+> **Every finding was re-derived against `e046333` and none moved.**
+> `DayPanel.tsx:386` and `WeekPanel.tsx:138` still read their clocks either side
+> of the await; `readSkyWeek` and `readGridpointWeek` still sit at
+> `conditions.ts:1421` and `:1608` with two calls to `fetchGridForecast`;
+> `Caveats.tsx:71` still keys on `entry`; `src/` still contains no
+> `React.cache()`; `conditions.ts` is still 2,016 lines.
+>
+> **This does not retire the preflight.** These figures were re-derived once, on
+> the day they were written, which is the cheapest possible case. The rule in
+> _Working these issues_ stands for every session that follows: re-derive, and
+> close the issue if the finding has gone.
+
 ## The problem, from the reader's point of view
 
 Nothing here is visible to a reader today except one bug, and that one only at


### PR DESCRIPTION
Small lane — prose only, no logic, no contract. The conditions audit plan opened with two hedges that #229 and #230 merging have made false.

## What changed

The plan said the figures were measured against `area-routes` while `main` still served `/conditions/<slug>`, and that #229 might collide. Both are now spent: `main` is `e046333`, it serves the nested route the figures were taken on, and #229 moved none of the cited lines.

Left alone, those paragraphs would mislead the next session on #231/#232/#233 about which route shape `main` serves and whether a merged PR is a live risk — the exact failure the audit itself names.

## Re-derived against `e046333`

| Finding | Status |
| --- | --- |
| `DayPanel.tsx:386` / `WeekPanel.tsx:138` clocks either side of the await | unmoved |
| `readSkyWeek` `:1421` / `readGridpointWeek` `:1608`, 2× `fetchGridForecast` | unmoved |
| `Caveats.tsx:71` keys on `entry` | unmoved |
| No `React.cache()` in `src/` | still none |
| `conditions.ts` | still 2,016 lines |

**The addendum does not retire the preflight.** It says so explicitly — verified once, on the day it was written, is the weakest warrant for trusting a figure later.

## How

Dated blockquote addendum inline, following the convention in 26ddaba. The plan is in flight, and `docs/plans/README.md` permits dated addenda while forbidding rewrites of what was decided — so nothing above it was edited.

## Gate

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  areas
  PASS  test
  PASS  build
  PASS  stylesheet
```

## Not done

No plan file and no slice table — this is the small lane, and CLAUDE.md asks that the omission be stated as a decision rather than a lapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)