### PR TITLE
Stop serializing caveat prose twice and sub-millisecond sunrises

### DIFF
--- a/src/components/conditions/Caveats.test.tsx
+++ b/src/components/conditions/Caveats.test.tsx
@@ -33,6 +33,30 @@ test("every caveat given is rendered, not a summary of them", () => {
   }
 });
 
+/**
+ * A caveat costs its bytes once, not twice.
+ *
+ * This component is a server component, so what reaches the browser is not the
+ * HTML above but a serialization of the element tree it returns — and a React
+ * key is part of that tree. Keying a list item on the caveat prose therefore
+ * ships every paragraph twice: once as the key, once as the child. Measured on
+ * a built beach page before this was fixed: 24 caveats, each present twice,
+ * 9,291 bytes of the flight payload spent on the copies.
+ *
+ * `render` above cannot see it. A key never reaches the DOM, so the defect and
+ * the fix produce byte-identical markup and every assertion in this file passes
+ * either way. So this calls the component and counts occurrences in the tree it
+ * returns, which is the thing that gets serialized.
+ */
+test("no caveat is serialized twice, which keying on the prose would do", () => {
+  const tree = JSON.stringify(Caveats({ entries: ENTRIES, reach: REACH }));
+
+  for (const entry of ENTRIES) {
+    const escaped = JSON.stringify(entry).slice(1, -1);
+    expect(tree.split(escaped)).toHaveLength(2);
+  }
+});
+
 /*
   The reach sentence used to be asserted here. It is rendered by
   `ConditionsNotes` now -- this whole component sits inside that region's closed

--- a/src/components/conditions/Caveats.tsx
+++ b/src/components/conditions/Caveats.tsx
@@ -67,8 +67,17 @@ export function Caveats({
             What we are unsure about in this data
           </summary>
           <ul className="leading-relaxed mt-3">
-            {entries.map((entry) => (
-              <li key={entry} className="mb-3">
+            {/*
+              Keyed on the position, not the prose. `inventoryCaveats` returns
+              bare strings, and the paragraph was the obvious key -- but a key
+              is serialized alongside the child it identifies, so keying on the
+              prose shipped every caveat to the browser twice. The list is built
+              from six data files in a fixed order and never reordered or
+              filtered within a render, so the position is stable for exactly as
+              long as a key needs to be.
+            */}
+            {entries.map((entry, position) => (
+              <li key={position} className="mb-3">
                 {entry}
               </li>
             ))}

--- a/src/components/conditions/WeekPanel.test.tsx
+++ b/src/components/conditions/WeekPanel.test.tsx
@@ -140,8 +140,8 @@ function daylightWeek() {
       ...date,
       sunriseLabel: index === 0 ? "6:14 AM" : "6:15 AM",
       sunsetLabel: index === 0 ? "7:32 PM" : "7:31 PM",
-      // The unrounded instants the night band is drawn from, alongside the
-      // labels the header prints. Roughly 6:14 AM and 7:32 PM Pacific.
+      // The instants the night band is drawn from, alongside the labels the
+      // header prints. Roughly 6:14 AM and 7:32 PM Pacific.
       sunriseMs: localMidnightOf(date.localDate) + 6 * HOUR_MS + 14 * 60_000,
       sunsetMs: localMidnightOf(date.localDate) + 19 * HOUR_MS + 32 * 60_000,
     })),

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -559,14 +559,15 @@ export interface DaylightWeekDay extends WeekDayFrame {
   /** Pacific wall-clock sunset, already worded and rounded. */
   sunsetLabel: string;
   /**
-   * The same two instants, unrounded.
+   * The same two instants, before the labels round them to the minute.
    *
    * The labels are for reading and these are for drawing: a plot that shaded
    * night from a formatted string would have to parse it back, and the day
-   * spark needs the boundary to the millisecond it was computed at rather than
-   * to the minute it is printed at. Both come from one `daylightOn` call, so
-   * the shaded edge and the printed time cannot disagree about when the sun
-   * came up.
+   * spark needs the boundary where it was computed rather than where it is
+   * printed. `daylightOn` gives it to the second, which across a day drawn a
+   * few hundred pixels wide is well under a pixel. Both come from one
+   * `daylightOn` call, so the shaded edge and the printed time cannot disagree
+   * about when the sun came up.
    */
   sunriseMs: number;
   sunsetMs: number;

--- a/src/lib/daylight.test.ts
+++ b/src/lib/daylight.test.ts
@@ -114,6 +114,32 @@ test("the sun rises before it sets, which a sign error would reverse", () => {
   expect((sunsetMs - sunriseMs) / 3_600_000).toBeCloseTo(9.98, 1);
 });
 
+/**
+ * The instants are whole seconds, and the tolerance above is why.
+ *
+ * This series agrees with USNO to within 32 seconds, so a value carrying
+ * fractional milliseconds -- `1788441902729.5322` was one -- is stating four
+ * more digits than the astronomy has, on top of the four the tolerance already
+ * covers. That is not only untidy: the beach page serializes 28 of these into
+ * its flight payload, where the fractions cost a measured 136 bytes.
+ *
+ * Seconds are lossless for every reader in this repo. The labels are rounded to
+ * the minute where they are built, and the day chart's night band turns these
+ * into a pixel boundary. Half a second is also two orders of magnitude below
+ * the accuracy the tests above assert, so rounding here cannot flatter the
+ * comparison with the Naval Observatory -- which is the objection the header
+ * used to raise against rounding at all, and it was an objection to rounding to
+ * the *minute*.
+ */
+test("both instants are whole seconds, not raw float milliseconds", () => {
+  for (const { date, at } of REFERENCES) {
+    const { sunriseMs, sunsetMs } = daylightOn(date, at);
+
+    expect(sunriseMs % 1000).toBe(0);
+    expect(sunsetMs % 1000).toBe(0);
+  }
+});
+
 test("a latitude where the sun does not rise is a coding error, not a NaN", () => {
   // No beach in this inventory is anywhere near it, which is exactly why this
   // must raise: a silent NaN would reach a reader as an empty cell.

--- a/src/lib/daylight.ts
+++ b/src/lib/daylight.ts
@@ -22,13 +22,19 @@
  * with the service and the query recorded there. This file's output agreeing
  * with this file's expectations would prove nothing.
  *
- * **What comes back is the computed instant, not a rounded one.** Rounding to
- * the minute is a display decision and it is made where the label is built, in
- * `conditions.ts`. Keeping it out of here is what lets the tests state the
- * accuracy honestly: measured against the instant, this agrees with USNO to
- * within 32 seconds at every reference point, where a rounded value could only
- * ever be shown to be within a minute — a claim that says nothing about whether
- * the astronomy is right or the rounding is lucky.
+ * **What comes back is the instant to the second, and no finer.** Rounding to
+ * the *minute* is a display decision and it is still made where the label is
+ * built, in `conditions.ts`. Keeping that out of here is what lets the tests
+ * state the accuracy honestly: measured to the second, this agrees with USNO to
+ * within 32 seconds at every reference point, where a minute-rounded value
+ * could only ever be shown to be within a minute — a claim that says nothing
+ * about whether the astronomy is right or the rounding is lucky.
+ *
+ * It stops at the second because the second is already about sixty times finer
+ * than the series is, so everything below it is noise — and noise that costs
+ * something. A beach page serializes 28 of these instants into its flight
+ * payload, and as raw floats they spent 136 bytes there on digits stating a
+ * sunrise to a ten-thousandth of a millisecond.
  *
  * **A place, not a segment.** Everything else on this page treats a beach as a
  * shoreline segment, because that is how the state publishes it and because a
@@ -43,6 +49,7 @@ const HORIZON_ZENITH_DEG = 90.833;
 
 const RAD = Math.PI / 180;
 const MS_PER_MINUTE = 60_000;
+const MS_PER_SECOND = 1_000;
 
 /** A point on the coast, WGS84 decimal degrees. Longitude is east-positive, so this coast is negative. */
 export interface Coordinates {
@@ -52,9 +59,9 @@ export interface Coordinates {
 
 /** Sunrise and sunset for one place on one day, as instants. */
 export interface Daylight {
-  /** Instant of sunrise, epoch milliseconds UTC. Not rounded; see the header. */
+  /** Instant of sunrise, epoch milliseconds UTC, to the second; see the header. */
   sunriseMs: number;
-  /** Instant of sunset, epoch milliseconds UTC. Not rounded; see the header. */
+  /** Instant of sunset, epoch milliseconds UTC, to the second; see the header. */
   sunsetMs: number;
 }
 
@@ -213,7 +220,8 @@ export function daylightOn(localDate: string, at: Coordinates): Daylight {
   const jdMidnight = midnightUtcMs / 86_400_000 + 2440587.5;
 
   const toInstant = (minutes: number) =>
-    midnightUtcMs + minutes * MS_PER_MINUTE;
+    Math.round((midnightUtcMs + minutes * MS_PER_MINUTE) / MS_PER_SECOND) *
+    MS_PER_SECOND;
 
   return {
     sunriseMs: toInstant(eventMinutesUtc(jdMidnight, at, localDate, -1)),

--- a/src/lib/tide-day.ts
+++ b/src/lib/tide-day.ts
@@ -59,8 +59,8 @@ export function lowestLowOn(
  *
  * **Both ends inclusive.** A low at the instant of sunrise is a low a reader
  * can stand in front of. The alternative excludes a reading for being exactly
- * on a boundary computed to the millisecond from an ephemeris, which is
- * precision neither the sunrise nor the prediction has.
+ * on a boundary computed to the second from an ephemeris, which is precision
+ * neither the sunrise nor the prediction has.
  *
  * Null means no low falls in the window. On this coast that is close to
  * unreachable — two lows about twelve and a half hours apart against ten to


### PR DESCRIPTION
Closes #233

Plan: [`docs/plans/conditions-fetching-audit.md`](https://github.com/cweber12/wild-coast-kids/blob/main/docs/plans/conditions-fetching-audit.md) — Issue C.

## Preflight

The issue said not to trust its figures. Both findings are still present on
`main` (`0c9aa29`), re-derived from a fresh production build served with
`next start` and a real request to `/conditions/del-mar/del-mar-city-beach`:

```
page bytes        : 360407
flight bytes      : 241494 (67.0% of page)

caveat entries found in data files: 24
  ...every one of them x2...
caveats appearing more than once : 24
bytes wasted by the repeats      : 9291

sunriseMs/sunsetMs occurrences : 28
  of which non-integer         : 28
  bytes of excess digits       : 136
  sample                       : "sunriseMs":1788441902729.5322
```

Two figures moved and neither changes the work:

- **24 caveats, 9,291 B** where the issue said 23 and 8,895 B. One caveat has
  been added to the data files since it was written.
- **Flight payload 241,494 B / 67.0%** where the issue said 272,143 B / 75.2%.
  The two extractions are probably not counting the same thing — mine sums the
  decoded `self.__next_f.push([1,"…"])` chunks and excludes the script-tag
  wrapper. The share is large either way, and neither of these two fixes is
  priced off it.

`Caveats.tsx:71` still keyed on `entry`; `daylight.ts` is still where the
instant is produced; `gh pr list` was empty, so no open branch had moved either
line.

## What changed

**Slice 1 — `Caveats` keys on position, not on the prose.** A React key is
serialized alongside the child it identifies, so keying a caveat's `<li>` on the
caveat paragraph shipped every paragraph to the browser twice. The list is built
from six data files in a fixed order and is never reordered or filtered within a
render, so the position is a stable key.

The existing tests could not have caught this and would not catch a regression:
a key never reaches the DOM, so the defect and the fix render byte-identical
HTML. The new test calls the component and counts occurrences in the element
tree it returns — the thing that actually gets serialized. It fails on the old
code:

```
FAIL  src/components/conditions/Caveats.test.tsx > no caveat is serialized twice, which keying on the prose would do
AssertionError: expected [ …(3) ] to have a length of 2 but got 3
```

**Slice 2 — `daylightOn` rounds to the second.** It returned raw float
milliseconds for a value the tests document as agreeing with the Naval
Observatory to within 32 seconds. Rounded where the value is produced rather
than at each of the seven call sites.

The file's header used to defend returning the unrounded instant. That argument
was about rounding to the **minute** — which would make the USNO comparison turn
on which side of `:30` a value fell — and half a second cannot do that; the
minute-rounding for labels still happens in `conditions.ts`, untouched. The
header, the `Daylight` field comments, the `DaylightWeekDay` docstring and
`tide-day.ts`'s "a boundary computed to the millisecond" all said something this
change makes false, so they are corrected in the same commit rather than left to
drift. Its test also fails on the old code:

```
FAIL  src/lib/daylight.test.ts > both instants are whole seconds, not raw float milliseconds
AssertionError: expected 75.75732421875 to be +0 // Object.is equality
```

## Result, from the same measurement on the branch

Rebuilt, served, and the same URL requested again:

| | `main` | branch |
| --- | --- | --- |
| page bytes | 360,407 | **350,738** |
| flight payload bytes | 241,494 | **232,015** |
| caveats appearing more than once | 24 | **0** |
| bytes duplicated by those repeats | 9,291 | **0** |
| non-integer `sunriseMs`/`sunsetMs` | 28 of 28 | **0 of 28** |
| bytes of excess digits | 136 | **0** |

9,479 bytes off the flight payload, 3.9% of it. The 9,291 + 136 the two findings
predicted, plus ~52 bytes of the JSON syntax that carried the keys.

## Gates

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… sea-side
… areas
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  areas
  PASS  test
  PASS  build
  PASS  stylesheet
```

Exit 0. Run at `2018470`, the tip of this branch.

## What I did not do

- **No plan file.** `docs/plans/conditions-fetching-audit.md` already is one and
  already contains this work as Issue C. A second file would be a third copy of
  the issue and the PR body, free to go stale on its own.
- **No addendum to that plan.** Its figures moved, but it says so itself
  ("Figures expire. Re-derive before implementing"), so a re-derivation matching
  its direction is the plan working rather than the plan changing. The
  re-derived numbers are above, where the work that used them is.
- **Did not re-price the rest of the payload.** That is C6 in the plan and a
  separate decision; the ~232 KB that remains is untouched.
- **Rounded to the second, not to the whole millisecond.** Both satisfy the
  issue's "are integers" and both save the same 136 bytes, since trailing zeros
  in `1788441903000` cost what the digits they replaced did. The second is what
  the plan prescribed and it is the honest stopping point: it is still about
  sixty times finer than the series it comes from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
