### PR TITLE
Show an area's beach where the area holds only one

### DIFF
--- a/docs/adr/0047-areas-nest-and-the-beach-urls-follow.md
+++ b/docs/adr/0047-areas-nest-and-the-beach-urls-follow.md
@@ -54,6 +54,27 @@ a map because the map cannot do it — four of La Jolla's ten beaches fall withi
 under ADR-0004 would need the map **2,634px wide**. The marks orient; the list
 selects.
 
+> **Amended 2026-09-04. An area holding one beach shows it, and has no list.**
+> Six of the eighteen hold one, and this decision drew the list for all of them
+> — a heading over a single entry, which reads as though the rest had failed to
+> load. It is redundant twice over: the chooser above it already names the
+> place, and the only link it offers is the page the reader is on.
+>
+> So an area of one is served **at the area's URL**, rendering its beach, and
+> `/conditions/<area>/<beach>` redirects up to it. One page, one address. That
+> is ADR-0046's own justification for permitting a single-member area at all —
+> "a lone member shares everything with itself and its area is the beach page" —
+> stopping being an argument and becoming what a reader sees.
+>
+> **The canonical path is decided in one place**, `canonicalConditionsPath` in
+> `areas.ts`, and both routes ask it rather than composing a URL themselves.
+> Without that an old `/conditions/sunset-cliffs-park` link would redirect to
+> the nested form and the nested form would redirect to the area — two hops for
+> a reader and two for a crawler, where the rule already knew the answer.
+>
+> Nothing else changes: an area of several keeps its list, on its own page and
+> on each of its beaches' pages alike.
+
 **The selected day moves to `app/conditions/layout.tsx`.** A layout is the only
 thing App Router keeps mounted across a navigation between sibling pages, and
 moving from an area to one of its beaches is now an ordinary thing to do.

--- a/src/app/conditions/[area]/[beach]/page.test.tsx
+++ b/src/app/conditions/[area]/[beach]/page.test.tsx
@@ -97,3 +97,14 @@ test("prerenders nothing at build", () => {
 test("revalidates on the same window as the other conditions routes", () => {
   expect(revalidate).toBe(900);
 });
+
+/**
+ * One page, one address. An area of one serves its beach at the area's URL, so
+ * this level does not exist for it — redirected rather than 404ed, because the
+ * beach is real and this is the URL the beach list linked to until it moved up.
+ */
+test("the nested URL of a one-beach area moves up to the area", async () => {
+  await expect(
+    BeachConditions(params("sunset-cliffs", "sunset-cliffs-park")),
+  ).rejects.toThrow("NEXT_REDIRECT:/conditions/sunset-cliffs");
+});

--- a/src/app/conditions/[area]/[beach]/page.tsx
+++ b/src/app/conditions/[area]/[beach]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound, permanentRedirect } from "next/navigation";
 import { ConditionsSection } from "@/components/conditions/ConditionsSection";
-import { areaBySlug, areaOfBeach } from "@/lib/areas";
+import { areaBySlug, areaOfBeach, soleBeachOf } from "@/lib/areas";
 import { beachBySlug } from "@/lib/beaches";
 
 /**
@@ -35,6 +35,16 @@ function resolvePair(areaSlug: string, beachSlug: string) {
   if (holding.slug !== areaSlug) {
     if (!areaBySlug(areaSlug)) return null;
     permanentRedirect(`/conditions/${holding.slug}/${beach.slug}`);
+  }
+
+  /*
+    An area of one serves its beach at the area's own URL, so this level does
+    not exist for it -- one page, one address. Redirected rather than 404ed:
+    the beach is real and the reader asked for it, and the nested form is the
+    one this route itself linked to until the sole beach moved up.
+  */
+  if (soleBeachOf(holding) !== null) {
+    permanentRedirect(`/conditions/${holding.slug}`);
   }
 
   return { area: holding, beach };

--- a/src/app/conditions/[area]/page.test.tsx
+++ b/src/app/conditions/[area]/page.test.tsx
@@ -121,3 +121,38 @@ test("prerenders nothing at build", () => {
 test("revalidates on the same window as the other conditions routes", () => {
   expect(revalidate).toBe(900);
 });
+
+/**
+ * Six of the eighteen areas hold one beach, and for those the area is the beach
+ * page. ADR-0046 permits a single-member area on the grounds that "a lone
+ * member shares everything with itself"; this is where that stops being an
+ * argument and becomes what a reader sees.
+ */
+test("an area holding one beach shows it rather than offering it", async () => {
+  render(await AreaConditions(params("sunset-cliffs")));
+
+  expect(screen.getByText("week for sunset-cliffs-park")).toBeDefined();
+  expect(screen.getByText("day for sunset-cliffs-park")).toBeDefined();
+  // No list, and no heading over a list of one.
+  expect(screen.queryByRole("heading", { name: /Beaches in/ })).toBeNull();
+});
+
+/**
+ * The old per-beach URL of a one-beach area goes straight to the area, not
+ * through the nested form on the way. Both routes ask
+ * `canonicalConditionsPath`, which is what makes one hop the only hop.
+ */
+test("an old beach URL redirects once, not through the nested form", async () => {
+  await expect(AreaConditions(params("sunset-cliffs-park"))).rejects.toThrow(
+    "NEXT_REDIRECT:/conditions/sunset-cliffs",
+  );
+  expect(permanentRedirect).toHaveBeenCalledTimes(1);
+  expect(permanentRedirect).toHaveBeenCalledWith("/conditions/sunset-cliffs");
+});
+
+/** A beach in an area of several still gets the nested URL. */
+test("a beach with siblings still redirects to the nested URL", async () => {
+  await expect(AreaConditions(params("la-jolla-cove"))).rejects.toThrow(
+    "NEXT_REDIRECT:/conditions/la-jolla/la-jolla-cove",
+  );
+});

--- a/src/app/conditions/[area]/page.tsx
+++ b/src/app/conditions/[area]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound, permanentRedirect } from "next/navigation";
 import { ConditionsSection } from "@/components/conditions/ConditionsSection";
-import { areaBySlug, areaOfBeach } from "@/lib/areas";
+import { areaBySlug, canonicalConditionsPath, soleBeachOf } from "@/lib/areas";
 import { beachBySlug } from "@/lib/beaches";
 
 /**
@@ -45,11 +45,16 @@ async function resolve(slug: string) {
 
   const beach = beachBySlug(slug);
   if (beach) {
-    const holding = areaOfBeach(beach.slug);
+    // Straight to wherever that beach is actually served, which for the sole
+    // beach of its area is the area's own URL. Asking `canonicalConditionsPath`
+    // rather than composing the nested form here is what stops this from
+    // redirecting into a second redirect.
+    //
     // Never null for a beach in the inventory -- the partition is total and the
-    // `areas` gate row keeps it so. Checked rather than asserted, because a
-    // 404 is a better failure here than a redirect to `/conditions/null/...`.
-    if (holding) permanentRedirect(`/conditions/${holding.slug}/${beach.slug}`);
+    // `areas` gate row keeps it so. Checked rather than asserted, because a 404
+    // is a better failure than a redirect to `/conditions/null/...`.
+    const canonical = canonicalConditionsPath(beach.slug);
+    if (canonical) permanentRedirect(canonical);
   }
 
   return null;
@@ -85,9 +90,16 @@ export default async function AreaConditions({
   // one; a stale link can.
   if (!area) notFound();
 
+  /*
+    An area of one holds no choice, so it shows its beach instead of offering it.
+    ADR-0046 permits a single-member area on the grounds that "a lone member
+    shares everything with itself and its area is the beach page" -- this is
+    where that stops being an argument and becomes the page. Six of the eighteen
+    are like this; for the rest `beachSlug` stays null and the reader picks.
+  */
   return (
     <main className="flex-1">
-      <ConditionsSection areaSlug={area.slug} beachSlug={null} />
+      <ConditionsSection areaSlug={area.slug} beachSlug={soleBeachOf(area)} />
     </main>
   );
 }

--- a/src/components/conditions/AreaBeaches.test.tsx
+++ b/src/components/conditions/AreaBeaches.test.tsx
@@ -53,25 +53,13 @@ test("the beach being shown is marked, not removed", () => {
   ).toBeNull();
 });
 
-/**
- * Four areas hold one beach, so the heading has to read as English for both.
- * ADR-0046 permits a single-member area deliberately — it is not a case to
- * design around, so it is one to write copy for.
- */
-test("a one-beach area says 'The beach', not 'Beaches'", () => {
-  render(
-    <AreaBeaches
-      areaSlug="sunset-cliffs"
-      areaName="Sunset Cliffs"
-      beaches={[{ slug: "sunset-cliffs-park", name: "Sunset Cliffs Park" }]}
-      current={null}
-    />,
-  );
-
-  expect(
-    screen.getByRole("heading", { name: "The beach in Sunset Cliffs" }),
-  ).toBeDefined();
-});
+/*
+  A test stood here requiring a one-beach area to say "The beach in Sunset
+  Cliffs" rather than "Beaches". The branch it covered is gone: an area of one
+  does not render this list at all -- it shows its beach instead. The behaviour
+  that replaced it is asserted where it now lives, in `[area]/page.test.tsx` and
+  `ConditionsSection.test.tsx`.
+*/
 
 test("beaches are listed in the order given, which is north to south", () => {
   render(

--- a/src/components/conditions/AreaBeaches.tsx
+++ b/src/components/conditions/AreaBeaches.tsx
@@ -20,6 +20,11 @@ import { TOUCH_TARGET } from "../ui/touchTarget";
  * **Ordered north to south**, which is `areas.json`'s own order and the order
  * the whole inventory is in, so the list reads down the coast.
  *
+ * **Never rendered for an area of one.** `ConditionsSection` does not mount it
+ * there, so the heading is always plural: an area holding a single beach shows
+ * that beach rather than offering it, and a list with one entry under a heading
+ * reads as though the rest had failed to load.
+ *
  * The current beach is marked with `aria-current` rather than removed from the
  * list: a list that drops its own entry changes length as you move through it,
  * and the reader loses the place they are comparing from.
@@ -39,7 +44,7 @@ export function AreaBeaches({
   return (
     <section aria-labelledby="area-beaches-heading">
       <h2 id="area-beaches-heading" className={TOOL_REGION_HEADING}>
-        {beaches.length === 1 ? "The beach" : "Beaches"} in {areaName}
+        Beaches in {areaName}
       </h2>
 
       <ul className="flex flex-wrap gap-x-6 gap-y-1">

--- a/src/components/conditions/ConditionsSection.test.tsx
+++ b/src/components/conditions/ConditionsSection.test.tsx
@@ -413,3 +413,33 @@ test("it refuses an area that is not in the table", () => {
     render(<ConditionsSection areaSlug="atlantis" beachSlug={null} />),
   ).toThrow(/names no area in areas.json/);
 });
+
+/**
+ * The list is a choice, so it is drawn only where there is one. Six of the
+ * eighteen areas hold a single beach, and a heading over a list of one entry
+ * reads as though the rest had failed to load.
+ */
+test("an area of one beach carries no beach list", () => {
+  render(
+    <ConditionsSection
+      areaSlug="sunset-cliffs"
+      beachSlug="sunset-cliffs-park"
+    />,
+  );
+
+  expect(screen.queryByRole("heading", { name: /Beaches in/ })).toBeNull();
+  expect(screen.getByText("week for sunset-cliffs-park")).toBeDefined();
+});
+
+/** And an area of several still carries it, on the beach page as on its own. */
+test("an area of several keeps its list while showing one beach", () => {
+  render(<ConditionsSection areaSlug="la-jolla" beachSlug="la-jolla-cove" />);
+
+  expect(
+    screen.getByRole("heading", { name: "Beaches in La Jolla" }),
+  ).toBeDefined();
+  expect(
+    screen.getAllByRole("link", { name: /La Jolla|WindanSea|Bird Rock/ })
+      .length,
+  ).toBeGreaterThan(1);
+});

--- a/src/components/conditions/ConditionsSection.tsx
+++ b/src/components/conditions/ConditionsSection.tsx
@@ -159,18 +159,27 @@ export function ConditionsSection({
         inside it. It sits above the readings on both pages rather than only on
         the area's, so moving between beaches does not mean scrolling past a
         page of figures to find the list you moved with.
+
+        **Not drawn at all where the area holds one beach**, which six of the
+        eighteen do. A list of one is a choice that is not a choice, and a
+        heading over it reads as though something were missing. Those areas show
+        their beach directly instead -- `[area]/page.tsx` passes it as
+        `beachSlug` -- so the reader who picked Sunset Cliffs gets Sunset Cliffs
+        Park's readings rather than a link to them.
       */}
-      <div className="mb-9">
-        <AreaBeaches
-          areaSlug={group.area.slug}
-          areaName={group.area.name}
-          beaches={group.beaches.map((beach) => ({
-            slug: beach.slug,
-            name: beach.name,
-          }))}
-          current={beachSlug}
-        />
-      </div>
+      {group.beaches.length > 1 && (
+        <div className="mb-9">
+          <AreaBeaches
+            areaSlug={group.area.slug}
+            areaName={group.area.name}
+            beaches={group.beaches.map((beach) => ({
+              slug: beach.slug,
+              name: beach.name,
+            }))}
+            current={beachSlug}
+          />
+        </div>
+      )}
 
       {/*
         WHAT IS TRUE NOW, BEFORE ANYTHING THAT IS TRUE OF A DAY.

--- a/src/lib/areas.ts
+++ b/src/lib/areas.ts
@@ -78,6 +78,37 @@ export function defaultArea(): Area {
   return area;
 }
 
+/**
+ * The one beach an area holds, or null when it holds several.
+ *
+ * Six of the eighteen hold one, and for those the area *is* the beach —
+ * ADR-0046 already says so, in the words it permits a single-member area with:
+ * "a lone member shares everything with itself and its area is the beach page".
+ * This is that sentence made callable.
+ */
+export function soleBeachOf(area: Area): string | null {
+  return area.beaches.length === 1 ? area.beaches[0] : null;
+}
+
+/**
+ * The one URL a beach is served at, or null when the slug names no beach.
+ *
+ * **Two shapes, and the rule lives here so nothing redirects twice.** A beach in
+ * an area of several is at `/conditions/<area>/<beach>`; the sole beach of its
+ * area is at `/conditions/<area>`, because a page offering a choice of one is
+ * not a choice. Both routes ask this rather than deciding for themselves, which
+ * is what stops an old `/conditions/<beach>` link from bouncing through the
+ * nested URL on its way to the area.
+ */
+export function canonicalConditionsPath(beachSlug: string): string | null {
+  const area = areaOfBeach(beachSlug);
+  if (!area) return null;
+
+  return soleBeachOf(area) === null
+    ? `/conditions/${area.slug}/${beachSlug}`
+    : `/conditions/${area.slug}`;
+}
+
 /** One area's beaches, resolved, for a chooser or a heading. */
 export interface AreaGroup {
   area: Area;


### PR DESCRIPTION
Six of the eighteen areas hold a single beach — `Del Mar`, `Mission Beach`,
`San Diego Bay – North`, `Sunset Cliffs`, `Coronado Cays`, `Silver Strand`. #229
drew the beach list for all of them: a heading over one entry, whose only link
was the page the reader was already on. Redundant twice over, since the chooser
above it already names the place.

## What changed

- **An area of one is served at the area's URL and renders its beach.**
  `/conditions/sunset-cliffs` shows Sunset Cliffs Park's readings.
- **`/conditions/<area>/<beach>` redirects up** for those six. One page, one
  address.
- **No beach list where there is no choice.** `AreaBeaches` is not mounted, so
  its singular heading became dead code and is deleted along with the test that
  kept it alive.
- **The canonical path is decided once**, in `canonicalConditionsPath`. Both
  routes ask it rather than composing a URL — without that, an old
  `/conditions/sunset-cliffs-park` link would redirect to the nested form and
  the nested form would redirect to the area: two hops for a reader and two for
  a crawler, where the rule already knew the answer. Asserted:
  `expect(permanentRedirect).toHaveBeenCalledTimes(1)`.

This is ADR-0046's own justification for permitting a single-member area —
*"a lone member shares everything with itself and its area is the beach page"* —
stopping being an argument and becoming what a reader sees. Recorded as a dated
amendment to ADR-0047 rather than a new decision, since it refines the routing
that decision made.

Areas of several are untouched: they keep the list, on their own page and on
each of their beaches' pages alike.

## Gate output

```
> node scripts/run-gates.mjs

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  areas
  PASS  test
  PASS  build
  PASS  stylesheet
```

## Noticed while reviewing #235, not fixed here

**`WeekGrid.tsx:310` has the same defect #235 just fixed in `Caveats`** —
`<p key={note}>{note}</p>`, a prose paragraph used as its own React key, so it
serializes into the flight payload twice.

It is smaller than the one #235 measured: the "no wave forecast for this beach"
note is ~166 bytes and renders in the **steady state on 26 of 51 beaches** (the
ones with no MOP line), against Caveats' 9,291 bytes on every page. The other
`notes` entries only appear during an upstream outage, where several longer ones
can stack.

Not fixed on this branch — one issue per branch — and it is a one-line change
plus a test if you want it. Three smaller instances of the same pattern exist
outside the conditions tool (`QuoteStats` `key={lead}`, `Marquee` `key={phrase}`,
`ConditionsNotes` `key={term}`); `key={term}` is a short label rather than
prose, and the other two are landing-page lists of a handful of items.

## Worth a look

`/conditions/sunset-cliffs` now opens straight on readings with no list above
them, where the other twelve areas show a list first. Worth confirming the two
shapes still read as the same page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
