### PR TITLE
Report an area's measured readings where its beaches share them

### DIFF
--- a/docs/adr/0048-an-area-reports-only-what-its-beaches-share.md
+++ b/docs/adr/0048-an-area-reports-only-what-its-beaches-share.md
@@ -1,0 +1,117 @@
+# 0048 — An area reports only what its beaches share, and says which kind of silence it is
+
+Date: 2026-09-04. Status: accepted. Builds on ADR-0046 (an area is authored) and
+ADR-0047 (an area has a page). Decides what goes on that page. ADR-0011 is
+unchanged: an area is still never an input to any join.
+
+## Context
+
+ADR-0047 gave an area a page with no readings on it, because working out what an
+area may report is a decision rather than a wiring job.
+
+**An area could report a figure three ways, and two of them are lies.** It could
+join its own sources to a centroid — but that publishes a reading taken nowhere,
+under a name implying otherwise, in a repo where `_served` exists to state how
+far a measurement may travel from the place it is shown for. It could pick a
+representative beach — same objection, with the added defect that the choice is
+invisible from the page. Or it can report **only what all its beaches share**,
+which says less and says nothing untrue.
+
+## Decision
+
+**An area reports a product when every beach in it binds the same source, and
+withholds it otherwise.** `areaSources` in `src/lib/areas.ts` resolves the five
+products the page draws — tide, waves, swell, sky, air — against the five
+bindings in `beaches.json`.
+
+**Identifier equality, which is the strict form and is knowingly too strict.**
+Two beaches share a product only when they bind the very same station, line or
+cell. That refuses agreement it should allow: CDIP's model lines sit about 100 m
+apart and come from one model run, so La Jolla's nine almost certainly publish
+the same forecast to the one decimal this page prints. The measured form of the
+rule needs a probe against live feeds and is its own slice. Until it exists, this
+version has the property that matters — **everything it calls shared is one
+source** — and the page never overclaims while waiting.
+
+**Three states, not two.** "Shared or not" runs together two facts that owe a
+reader different sentences:
+
+- **`shared`** — one source behind every beach. The area reports it.
+- **`absent`** — no beach has one. The bay's missing buoy: already true one
+  beach at a time, and not news.
+- **`mixed`** — the beaches each have one and disagree. New with areas, and the
+  only state a reader has never seen before.
+
+This is the distinction `beaches.json` already draws about a null `wave_buoy`,
+whose schema says it "carries TWO meanings and wave_buoy_null_reason always
+distinguishes them". Measured over the eighteen areas:
+
+| product | shared | absent | mixed |
+| ------- | -----: | -----: | ----: |
+| air     |     18 |      0 |     0 |
+| tide    |     16 |      0 |     2 |
+| sky     |     11 |      0 |     7 |
+| swell   |      6 |      7 |     5 |
+| waves   |      3 |     13 |     2 |
+
+So only **16 product-instances across 18 areas** are the genuinely new case.
+Everything else either renders or is a silence the page already words.
+
+**An area states the fact and does not borrow a beach's reason.** It cannot: the
+reasons differ between members. Coronado's three beaches name 20.9, 21.6 and
+21.2 km for the buoy that does not reach them, and Tijuana Estuary's two give
+different _kinds_ of reason — one is sheltered water, the other is simply too far
+from a buoy. Lifting any one of them would print a figure about one beach as
+though it were the area's. So `areaSources` returns facts and counts, the page
+writes the sentence, and the sentence sends the reader to a beach for the rest.
+
+**A withheld product is not read.** No request is made for a figure the page has
+already decided not to print.
+
+**A shared reading is labelled with the area.** Both measured cards print
+`beachName` as their context, and leaving the member's there would put "La Jolla
+Shores Beach" over a station every beach in La Jolla binds — which reads as a
+claim about that one beach. The area's name is the true label _because_ the
+source is shared; where it is not shared, nothing is read and there is no label
+to get wrong.
+
+**Which beach an area reads through is immaterial, and that is asserted rather
+than argued.** `areas.test.ts` checks, over every area and every product, that
+where `areaSources` says shared, every beach in the area binds that same source.
+Without that check "read through any member" would be a claim about the data
+made in a comment.
+
+## Consequences
+
+The measured block answers for an area. Air is shared by all eighteen, so every
+area page has something measured on it; three areas also carry a wave reading.
+
+**The withheld card is the card it replaces**, with the same glyph, title,
+heading id and rank passed in by the caller. ADR-0015 makes the glyph a closed
+vocabulary, so a second glyph for waves would be a second word for one thing. A
+first draft of this invented 🌊, its own titles and an `h3`, which would also
+have put a hole in the heading outline; it is called out here because the
+mistake is easy and invisible from the component that makes it.
+
+**The week and the day chart are still one beach at a time**, and the area page
+says so. `WeekPanel` and `DayPanel` mix three and four products respectively, so
+gating them is per-product surgery inside the two largest components on the page
+and is its own slice. Tide is shared by 16 areas and sky by 11, so that slice is
+where most of an area's forecast arrives.
+
+**The rip current risk is still beach-scoped**, though the plan exempts it from
+this rule — it is issued for "San Diego County Coastal Areas", a unit larger than
+any area here, so the intersection rule is a category error against it. That
+exception is real and lands with the forecast slice.
+
+**A props allowlist caught this change, which is what it is for.**
+`ConditionsSection.test.tsx` asserted the measured block is handed exactly
+`{ slug }`, so that no future edit could quietly pass it a chosen day — the
+structural guarantee ADR-0047 converted into an assertion. Adding `area` failed
+it. The list is widened to `{ slug, area }` deliberately and a separate line now
+asserts no day-shaped key, so the guarantee is stated rather than implied by a
+list that will keep growing.
+
+The part most likely to be re-litigated is the strictness. The answer is that it
+is temporary and directional: the probe can only ever _add_ products to an area,
+never remove one, so nothing shown today becomes false when it lands.

--- a/src/app/conditions/[area]/page.test.tsx
+++ b/src/app/conditions/[area]/page.test.tsx
@@ -46,17 +46,17 @@ test("renders the area named in the route", async () => {
 });
 
 /**
- * The area page carries no readings yet — an area reports only what all its
- * beaches share, and measuring that is its own slice. It says so rather than
- * showing an empty frame, and the beaches are one click away.
+ * The area reports what is measured now, and sends the reader to a beach for
+ * what is forecast. Air is shared by all eighteen areas, so every area page has
+ * something measured to say; the week and the day chart are still one beach at
+ * a time.
  */
-test("an area sends the reader to a beach for the readings", async () => {
+test("an area reports what is measured and defers the forecast", async () => {
   render(await AreaConditions(params("la-jolla")));
 
+  expect(screen.getByText(/still shown one beach at a time/)).toBeDefined();
   expect(screen.queryByText(/week for/)).toBeNull();
-  expect(
-    screen.getByText(/reports only the readings every beach in it shares/),
-  ).toBeDefined();
+  expect(screen.queryByText(/day for/)).toBeNull();
 });
 
 /**

--- a/src/components/conditions/ConditionsSection.test.tsx
+++ b/src/components/conditions/ConditionsSection.test.tsx
@@ -155,12 +155,39 @@ test("the measured block is asked for a beach and never for a day", () => {
     />,
   );
 
-  expect(measuredPanel).toHaveBeenCalledWith({ slug: DEFAULT_BEACH_SLUG });
-
-  // Spelled out rather than left to `toHaveBeenCalledWith`'s exact match, so a
-  // reader of this test can see which argument is the forbidden one.
   const [props] = measuredPanel.mock.calls[0] as [Record<string, unknown>];
-  expect(Object.keys(props)).toEqual(["slug"]);
+
+  // An allowlist rather than an exact match, and it grew by one deliberately:
+  // `area` arrived when this block learned to answer for an area as well as a
+  // beach, and this test caught it, which is the allowlist working. What it
+  // must never grow is a day, so that is asserted as its own line rather than
+  // left implicit in the list above it.
+  expect(Object.keys(props).sort()).toEqual(["area", "slug"]);
+  expect(Object.keys(props).some((key) => /day|date/i.test(key))).toBe(false);
+
+  // On a beach page there is no area scope at all, so the block is answering
+  // for that beach and nothing wider.
+  expect(props.slug).toBe(DEFAULT_BEACH_SLUG);
+  expect(props.area).toBeUndefined();
+});
+
+/**
+ * And on an area page it is handed the area, plus a beach to read through.
+ *
+ * Which beach cannot matter: a product is only read when every beach in the
+ * area binds the same source for it, which `areas.test.ts` asserts over the
+ * whole table. Asserted here so that a later change passing a *chosen*
+ * representative — rather than any member — has to say so.
+ */
+test("on an area page the measured block is given the area and a member", () => {
+  render(<ConditionsSection areaSlug="la-jolla" beachSlug={null} />);
+
+  const [props] = measuredPanel.mock.calls[0] as [Record<string, unknown>];
+  const area = props.area as { name: string; beaches: number };
+
+  expect(area.name).toBe("La Jolla");
+  expect(area.beaches).toBe(10);
+  expect(props.slug).toBe("la-jolla-shores-beach");
 });
 
 /**

--- a/src/components/conditions/ConditionsSection.tsx
+++ b/src/components/conditions/ConditionsSection.tsx
@@ -18,7 +18,7 @@
  */
 
 import { Suspense } from "react";
-import { areaBySlug, beachesByArea } from "@/lib/areas";
+import { areaBySlug, areaSources, beachesByArea } from "@/lib/areas";
 import { inventoryCaveats, inventoryReach } from "@/lib/beaches";
 import { AreaBeaches } from "./AreaBeaches";
 import { AreaSelector } from "./AreaSelector";
@@ -214,25 +214,39 @@ export function ConditionsSection({
         agencies go quiet independently and a slow buoy must not hold up the
         week.
       */}
-      {beachSlug === null ? (
-        <p className="leading-relaxed max-w-130 mb-9 text-base text-fog">
-          Choose one of these beaches for its tide, swell and wind. An area
-          reports only the readings every beach in it shares, and which those
-          are is measured rather than assumed — so they are not here yet.
-        </p>
-      ) : (
-        <div className="mb-9">
-          <Suspense
-            fallback={
-              <p className="text-base text-fog">
-                Reading the buoy and the air station…
-              </p>
+      <div className="mb-9">
+        <Suspense
+          fallback={
+            <p className="text-base text-fog">
+              Reading the buoy and the air station…
+            </p>
+          }
+        >
+          {/*
+            On an area page this reads through the area's first beach, and which
+            beach that is cannot matter: a product is only read here when every
+            beach in the area binds the same source for it, which is what
+            `areaSources` calls shared and what `areas.test.ts` asserts over the
+            whole table. A product they do not share is not read at all, so no
+            one beach's figure can arrive labelled as the area's.
+
+            Air is shared by all eighteen areas and a buoy by three, so this
+            block is where an area page has something measured to say at all.
+          */}
+          <MeasuredPanel
+            slug={beachSlug ?? group.beaches[0].slug}
+            area={
+              beachSlug === null
+                ? {
+                    name: group.area.name,
+                    beaches: group.beaches.length,
+                    sources: areaSources(group.area),
+                  }
+                : undefined
             }
-          >
-            <MeasuredPanel slug={beachSlug} />
-          </Suspense>
-        </div>
-      )}
+          />
+        </Suspense>
+      </div>
 
       {/*
         The week and the day are one instrument at two zoom levels, and from
@@ -244,7 +258,12 @@ export function ConditionsSection({
         quiet independently and none may hold up another; a shared choice does
         not change that.
       */}
-      {beachSlug !== null && (
+      {beachSlug === null ? (
+        <p className="leading-relaxed max-w-130 text-base text-fog">
+          The week ahead and the day chart are still shown one beach at a time.
+          Choose one above for its tide, swell and sky.
+        </p>
+      ) : (
         <>
           <div className="mb-9">
             <Suspense

--- a/src/components/conditions/MeasuredPanel.tsx
+++ b/src/components/conditions/MeasuredPanel.tsx
@@ -27,14 +27,83 @@
  * arranged to avoid.
  */
 
+import { type AreaSources } from "@/lib/areas";
 import { readLatestAir, readLatestWaves } from "@/lib/conditions";
-import { MeasuredToday } from "./MeasuredToday";
+import { MeasuredToday, type NotShared } from "./MeasuredToday";
 
-export async function MeasuredPanel({ slug }: { slug: string }) {
+/**
+ * What this block is about, when it is about an area rather than one beach.
+ *
+ * `slug` is still a beach, because every read here is keyed on one — but which
+ * beach is immaterial for a product the area shares, and that is what "shared"
+ * means: `areas.test.ts` asserts that where `areaSources` says shared, every
+ * beach in the area binds that same source. A product it does not share is not
+ * read at all, so no member's figure can leak into an area's card.
+ */
+export type AreaScope = {
+  name: string;
+  beaches: number;
+  sources: AreaSources;
+};
+
+/** A slot the area cannot fill, or null when it can. */
+function withheldBy(
+  scope: AreaScope | undefined,
+  product: "waves" | "air",
+): NotShared | null {
+  if (!scope) return null;
+
+  const source = scope.sources[product];
+  if (source.kind === "shared") return null;
+
+  return {
+    agreement: source.kind,
+    areaName: scope.name,
+    beaches: scope.beaches,
+    distinct: source.kind === "mixed" ? source.distinct : 0,
+  };
+}
+
+export async function MeasuredPanel({
+  slug,
+  area,
+}: {
+  slug: string;
+  /** Present on an area page, absent on a beach's. */
+  area?: AreaScope;
+}) {
+  const withheldWaves = withheldBy(area, "waves");
+  const withheldAir = withheldBy(area, "air");
+
+  /*
+    Only what will be shown is asked for. A withheld product makes no request:
+    there is nothing an area could do with one beach's buoy, and asking would
+    spend a reader's wait on a figure this page has already decided not to
+    print.
+  */
   const [waves, air] = await Promise.all([
-    readLatestWaves(slug),
-    readLatestAir(slug),
+    withheldWaves ? null : readLatestWaves(slug),
+    withheldAir ? null : readLatestAir(slug),
   ]);
 
-  return <MeasuredToday readings={{ waves, air }} />;
+  /*
+    A shared reading is labelled with the area, not with the beach it was read
+    through. Both cards print `beachName` as their context, and leaving the
+    member's there would name one beach for a figure the whole area shares --
+    "La Jolla Shores Beach" over a station every beach in La Jolla binds, which
+    reads as a reading about that one beach. The area's name is the true label
+    precisely because the source is shared; where it is not shared, nothing is
+    read and there is no label to get wrong.
+  */
+  const labelled = <V extends { beachName: string }>(view: V): V =>
+    area ? { ...view, beachName: area.name } : view;
+
+  return (
+    <MeasuredToday
+      readings={{
+        waves: withheldWaves ?? labelled(waves!),
+        air: withheldAir ?? labelled(air!),
+      }}
+    />
+  );
 }

--- a/src/components/conditions/MeasuredToday.test.tsx
+++ b/src/components/conditions/MeasuredToday.test.tsx
@@ -942,3 +942,92 @@ test("the measured block does not follow the chosen day", () => {
   expect(screen.getByText("probe:2026-09-10")).toBeDefined();
   expect(blockOf(container.innerHTML)).toBe(beforeBlock);
 });
+
+/**
+ * An area reports what its beaches share, so a product they do not share gets a
+ * card saying so rather than a figure from one of them.
+ *
+ * Two sentences, because `absent` and `mixed` are two different facts. Thirteen
+ * of the eighteen areas have no wave buoy anywhere in them and two have beaches
+ * that bind different ones; a reader owed "there is none here" must not be told
+ * "they disagree", and the reverse would be worse — it would imply the area has
+ * no instrument when in fact it has several.
+ */
+test("an area with no buoy anywhere says so, and does not blame disagreement", () => {
+  render(
+    <MeasuredToday
+      readings={{
+        waves: {
+          agreement: "absent",
+          areaName: "Mission Bay – West",
+          beaches: 8,
+          distinct: 0,
+        },
+        air: readings().air,
+      }}
+    />,
+  );
+
+  expect(
+    screen.getByText(/No beach in Mission Bay – West has a wave reading/),
+  ).toBeDefined();
+  expect(screen.queryByText(/different sources/)).toBeNull();
+  // The other card still stands: one withheld product must not cost the other.
+  expect(screen.getByText("71°F")).toBeDefined();
+});
+
+test("an area whose beaches disagree names how many, and how many sources", () => {
+  render(
+    <MeasuredToday
+      readings={{
+        waves: {
+          agreement: "mixed",
+          areaName: "La Jolla",
+          beaches: 10,
+          distinct: 2,
+        },
+        air: readings().air,
+      }}
+    />,
+  );
+
+  expect(
+    screen.getByText(
+      /The 10 beaches in La Jolla read 2 different sources for a wave reading/,
+    ),
+  ).toBeDefined();
+});
+
+/**
+ * The withheld card is the card it replaces, not a new one. ADR-0015 makes the
+ * glyph a closed vocabulary, so a second glyph for waves would be a second word
+ * for one thing — and a different heading rank would put a hole in the outline.
+ * A first draft of this component invented both.
+ */
+test("a withheld card keeps the glyph and rank of the card it stands in for", () => {
+  const withReading = render(<MeasuredToday readings={readings()} />);
+  const realHeading = screen.getByRole("heading", { name: "Waves and water" });
+  expect(realHeading.tagName).toBe("H2");
+  withReading.unmount();
+
+  render(
+    <MeasuredToday
+      readings={{
+        waves: {
+          agreement: "absent",
+          areaName: "Coronado",
+          beaches: 3,
+          distinct: 0,
+        },
+        air: readings().air,
+      }}
+    />,
+  );
+
+  const withheldHeading = screen.getByRole("heading", {
+    name: "Waves and water",
+  });
+  expect(withheldHeading.tagName).toBe("H2");
+  expect(withheldHeading.id).toBe("waves-today-heading");
+  expect(screen.getByText("🏄")).toBeDefined();
+});

--- a/src/components/conditions/MeasuredToday.tsx
+++ b/src/components/conditions/MeasuredToday.tsx
@@ -52,10 +52,45 @@ import { ProvenanceLine } from "./ProvenanceLine";
 import { ReadingCard } from "./ReadingCard";
 import { type Stat, StatGroup } from "./StatGroup";
 
-/** The two reads this block renders, as `MeasuredPanel` hands them over. */
+/**
+ * Why an area cannot report a product, when its beaches do not share one.
+ *
+ * **Two agreements, because they owe a reader different sentences.** `absent`
+ * is every beach in the area lacking the instrument, which is the bay's missing
+ * buoy and was already true one beach at a time. `mixed` is the beaches having
+ * one each and disagreeing, which is new with areas and is the only state a
+ * reader has never seen before.
+ *
+ * **It carries facts and not a sentence**, which is this repo's rule about who
+ * owns the copy on this page. It also could not carry one: the beaches' own
+ * reasons differ, and lifting any of them would print one beach's figure as if
+ * it were the area's. Coronado's three name 20.9, 21.6 and 21.2 km for the buoy
+ * that does not reach them.
+ */
+export type NotShared = {
+  agreement: "absent" | "mixed";
+  /** The area's name, for the sentence. */
+  areaName: string;
+  /** How many beaches it holds. */
+  beaches: number;
+  /** How many distinct sources they bind. Only meaningful when `mixed`. */
+  distinct: number;
+};
+
+/** True of a slot the area cannot fill, false of a reading. */
+function notShared(slot: WavesView | AirView | NotShared): slot is NotShared {
+  return "agreement" in slot;
+}
+
+/**
+ * The two slots this block renders, as `MeasuredPanel` hands them over.
+ *
+ * Either a read or the reason there is none, per slot, so there is no state
+ * where a card has neither and no state where it has both.
+ */
 export type MeasuredReadings = {
-  waves: WavesView;
-  air: AirView;
+  waves: WavesView | NotShared;
+  air: AirView | NotShared;
 };
 
 export type MeasuredTodayProps = {
@@ -461,6 +496,58 @@ function AirCard({ beachName, airStation, air }: AirView) {
  * The block
  * ========================================================================= */
 
+/**
+ * A card for a product the area's beaches do not share.
+ *
+ * Same shape as a card with a reading in it — `ReadingCard`, the glyph, the
+ * dark surface — because it is the same kind of thing: this block's answer
+ * about one instrument. What it does not have is a figure, which is exactly
+ * what a `no-buoy` card already looks like at a bay.
+ *
+ * **It takes the same glyph, title, heading id and rank as the card it stands
+ * in for**, passed by the caller rather than chosen here. The glyph especially:
+ * ADR-0015 makes it a closed vocabulary, so a withheld waves card showing
+ * anything but 🏄 would be a second word for one thing. A first draft of this
+ * invented 🌊, its own titles and an `h3`, which would have put a hole in the
+ * heading outline as well.
+ *
+ * **It names the count rather than the reason.** An area cannot borrow its
+ * beaches' sentences — they differ, and one of them would print a distance as
+ * if it were the area's — so it states what is true of the area and sends the
+ * reader to a beach for the rest. That sentence is here rather than in
+ * `lib/areas.ts` because the copy on this page belongs to the page.
+ */
+function NotSharedCard({
+  emoji,
+  title,
+  headingId,
+  product,
+  slot,
+}: {
+  emoji: string;
+  title: string;
+  headingId: string;
+  /** What the reader came for, in their words: "a wave reading". */
+  product: string;
+  slot: NotShared;
+}) {
+  return (
+    <ReadingCard
+      emoji={emoji}
+      headingLevel="h2"
+      headingId={headingId}
+      title={title}
+      context={slot.areaName}
+    >
+      <p className={CARD_PROSE}>
+        {slot.agreement === "absent"
+          ? `No beach in ${slot.areaName} has ${product}. Each says why on its own page.`
+          : `The ${slot.beaches} beaches in ${slot.areaName} read ${slot.distinct} different sources for ${product}, so there is no one figure for the whole area. Choose a beach for it.`}
+      </p>
+    </ReadingCard>
+  );
+}
+
 export function MeasuredToday({ readings }: MeasuredTodayProps) {
   /*
     Two across from `sm`, which is where the three-card band above the page
@@ -470,8 +557,28 @@ export function MeasuredToday({ readings }: MeasuredTodayProps) {
   */
   return (
     <div className="grid items-stretch gap-4 sm:grid-cols-2">
-      <SeaCard {...readings.waves} />
-      <AirCard {...readings.air} />
+      {notShared(readings.waves) ? (
+        <NotSharedCard
+          emoji="🏄"
+          title="Waves and water"
+          headingId="waves-today-heading"
+          product="a wave reading"
+          slot={readings.waves}
+        />
+      ) : (
+        <SeaCard {...readings.waves} />
+      )}
+      {notShared(readings.air) ? (
+        <NotSharedCard
+          emoji="💨"
+          title="Air"
+          headingId="wind-today-heading"
+          product="an air reading"
+          slot={readings.air}
+        />
+      ) : (
+        <AirCard {...readings.air} />
+      )}
     </div>
   );
 }

--- a/src/lib/areas.test.ts
+++ b/src/lib/areas.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import {
   areaBySlug,
+  areaSources,
   areaOfBeach,
   DEFAULT_AREA_SLUG,
   beachesByArea,
@@ -177,5 +178,92 @@ describe("looking one area up", () => {
 
     vi.doUnmock("@/data/areas.json");
     vi.resetModules();
+  });
+});
+
+describe("what an area's beaches agree on", () => {
+  const of = (slug: string) => areaSources(areaBySlug(slug)!);
+
+  /**
+   * An area of one agrees with itself about everything it has. That is
+   * ADR-0046's whole argument for permitting a single-member area, and it is
+   * what makes the degenerate case need no branch in the code.
+   */
+  test("an area of one shares every source it binds", () => {
+    const sources = of("mission-beach");
+
+    for (const product of ["tide", "waves", "swell", "sky", "air"] as const) {
+      expect(sources[product].kind, product).toBe("shared");
+    }
+  });
+
+  /**
+   * The distinction the three states exist for. La Jolla's ten beaches all have
+   * a forecast cell and bind four different ones — that is `mixed`, and it is
+   * new with areas. Mission Bay – West's eight have no MOP line at all — that is
+   * `absent`, and it was already true one beach at a time.
+   */
+  test("disagreeing is not the same as lacking", () => {
+    expect(of("la-jolla").sky).toEqual({ kind: "mixed", distinct: 4 });
+    expect(of("mission-bay-west").swell).toEqual({ kind: "absent" });
+  });
+
+  test("a shared product names the one source behind it", () => {
+    expect(of("la-jolla").air).toEqual({
+      kind: "shared",
+      source: "LJAC1",
+    });
+  });
+
+  /**
+   * Measured across the whole table rather than sampled, because these counts
+   * are what decide how much of an area page renders at all. If a later edit to
+   * `areas.json` moves one, that is a real change to what readers see and it
+   * should be a decision rather than a surprise.
+   */
+  test("the eighteen areas agree exactly this often", () => {
+    const tally = { tide: 0, waves: 0, swell: 0, sky: 0, air: 0 };
+    const absent = { ...tally };
+
+    for (const { area } of beachesByArea()) {
+      const sources = areaSources(area);
+      for (const product of Object.keys(tally) as (keyof typeof tally)[]) {
+        if (sources[product].kind === "shared") tally[product] += 1;
+        if (sources[product].kind === "absent") absent[product] += 1;
+      }
+    }
+
+    expect(tally).toEqual({ tide: 16, waves: 3, swell: 6, sky: 11, air: 18 });
+    expect(absent).toEqual({ tide: 0, waves: 13, swell: 7, sky: 0, air: 0 });
+  });
+
+  /**
+   * The claim that makes "shared" usable: where an area shares a product, any
+   * of its beaches resolves to the same source, so the page may read the
+   * product through any member without choosing a representative. Asserted
+   * over every area and every product rather than argued.
+   */
+  test("a shared source is the one every beach in the area binds", () => {
+    const bySlug = new Map(allBeaches().map((beach) => [beach.slug, beach]));
+    const field = {
+      tide: "tide_station",
+      waves: "wave_buoy",
+      swell: "mop_line",
+      sky: "grid_cell",
+      air: "air_station",
+    } as const;
+
+    for (const { area, beaches } of beachesByArea()) {
+      const sources = areaSources(area);
+      for (const product of Object.keys(field) as (keyof typeof field)[]) {
+        const resolved = sources[product];
+        if (resolved.kind !== "shared") continue;
+        for (const beach of beaches) {
+          expect(bySlug.get(beach.slug)![field[product]], beach.slug).toBe(
+            resolved.source,
+          );
+        }
+      }
+    }
   });
 });

--- a/src/lib/areas.ts
+++ b/src/lib/areas.ts
@@ -143,3 +143,98 @@ export function beachesByArea(): readonly AreaGroup[] {
     }),
   }));
 }
+
+/**
+ * The five products `/conditions` draws, named by what a reader calls them
+ * rather than by the table each comes from.
+ *
+ * One product to one binding, which is why this list is five and not four or
+ * six: `tide` is the tide station's, `waves` the wave buoy's measurement,
+ * `swell` the MOP line's forecast, `sky` everything the forecast cell supplies
+ * (cloud, wind and temperature together, because they come from one cell and
+ * fail together), and `air` the shore station's.
+ */
+export type AreaProduct = "tide" | "waves" | "swell" | "sky" | "air";
+
+/**
+ * What an area can say about one product.
+ *
+ * **Three states, and the middle one is the reason there are three.** An area
+ * reports only what all its beaches share, so the obvious model is shared or
+ * not — but "not" runs together two different facts, and the page owes a
+ * different sentence for each. `absent` is every beach lacking the source, which
+ * is the bay's missing buoy and was already true one beach at a time. `mixed` is
+ * the beaches having one each and disagreeing, which is new with areas and is
+ * the only state a reader has never seen before.
+ *
+ * That is the same distinction `beaches.json` draws about `wave_buoy` null,
+ * whose schema note says it "carries TWO meanings and wave_buoy_null_reason
+ * always distinguishes them".
+ */
+export type AreaSource =
+  | { kind: "shared"; source: string }
+  | { kind: "absent" }
+  | { kind: "mixed"; distinct: number };
+
+export type AreaSources = Readonly<Record<AreaProduct, AreaSource>>;
+
+const BINDING: Readonly<Record<AreaProduct, keyof Beach>> = {
+  tide: "tide_station",
+  waves: "wave_buoy",
+  swell: "mop_line",
+  sky: "grid_cell",
+  air: "air_station",
+};
+
+/**
+ * What every beach in an area agrees on, product by product.
+ *
+ * **Identifier equality, which is the strict form and deliberately so.** Two
+ * beaches share a product here only when they bind the very same station, line
+ * or cell. That refuses some agreement it should allow — CDIP's model lines sit
+ * about 100 m apart and come from one run, so La Jolla's nine almost certainly
+ * publish the same forecast to the decimal the page prints — and the measured
+ * form of the rule is its own slice. Until that probe exists this is the version
+ * that cannot overclaim: everything it calls shared *is* one source.
+ *
+ * **No reason strings.** The wording belongs to the page, which is this repo's
+ * rule about who owns the copy; and for `absent` there is no beach sentence to
+ * lift, because they differ. Coronado's three beaches name 20.9, 21.6 and
+ * 21.2 km for the buoy that does not reach them, and Tijuana Estuary's two give
+ * different kinds of reason entirely — one is sheltered water, the other is
+ * simply too far from a buoy. So an area states the fact and sends the reader to
+ * the beach for its own reason.
+ *
+ * Throws for an area naming a beach the inventory does not have, like
+ * `beachesByArea` and for the same reason.
+ */
+export function areaSources(area: Area): AreaSources {
+  const bySlug = new Map(allBeaches().map((beach) => [beach.slug, beach]));
+  const members = area.beaches.map((slug) => {
+    const beach = bySlug.get(slug);
+    if (!beach) {
+      throw new Error(
+        `areas.json puts ${slug} in ${area.slug}, but beaches.json has no such beach.`,
+      );
+    }
+    return beach;
+  });
+
+  const resolve = (product: AreaProduct): AreaSource => {
+    const bound = new Set(members.map((beach) => beach[BINDING[product]]));
+    if (bound.size > 1) return { kind: "mixed", distinct: bound.size };
+
+    const only = [...bound][0];
+    return only === null || only === undefined
+      ? { kind: "absent" }
+      : { kind: "shared", source: String(only) };
+  };
+
+  return {
+    tide: resolve("tide"),
+    waves: resolve("waves"),
+    swell: resolve("swell"),
+    sky: resolve("sky"),
+    air: resolve("air"),
+  };
+}


### PR DESCRIPTION
> **Stacked on [#236](https://github.com/cweber12/wild-coast-kids/pull/236)**, which is still open — base is `single-beach-areas`, not `main`. Merge #236 first, then this rebases onto `main` on its own. Note that `--delete-branch` on #236 would close this one.

Slice 3 of `docs/plans/areas-over-locations.md`, scoped to the measured block.

## What an area may say

An area could report a figure three ways and two of them are lies. Joining its
own sources to a centroid publishes a reading taken nowhere, in a repo where
`_served` exists to state how far a measurement may travel from where it was
taken. Picking a representative beach does the same with the choice hidden. So
it reports **only what all its beaches share**.

`areaSources` resolves the five products against the five bindings, in **three**
states rather than two — because "shared or not" runs together two facts that
owe a reader different sentences:

| product | shared | absent | mixed |
|---|---:|---:|---:|
| air | **18** | 0 | 0 |
| tide | 16 | 0 | 2 |
| sky | 11 | 0 | 7 |
| swell | 6 | 7 | 5 |
| waves | 3 | 13 | 2 |

`absent` is no beach having the instrument — the bay's missing buoy, already
true one beach at a time. `mixed` is the beaches each having one and
disagreeing, which is new with areas. Only **16 product-instances across 18
areas** are the genuinely new case.

**Air is shared by all eighteen**, so every area page now has something measured
on it; three also carry a wave reading.

## Why the card states a fact and not a reason

It cannot borrow one — the beaches' reasons differ. Measured: Coronado's three
name **20.9, 21.6 and 21.2 km** for the buoy that does not reach them, and
Tijuana Estuary's two give different *kinds* of reason (one is sheltered water,
the other is simply too far). Lifting any one would print a figure about one
beach as though it were the area's.

So the lib returns facts and counts, the page writes the sentence, and the
sentence sends the reader to a beach for the rest.

Also: **a withheld product is not read** — no request for a figure already
decided against. And **a shared reading is labelled with the area**, since
"La Jolla Shores Beach" over a station every La Jolla beach binds reads as a
claim about that one beach.

## Two things I got wrong, and what caught them

1. **The withheld card invented its own glyph, titles and an `h3`.** ADR-0015
   makes the glyph a closed vocabulary, so 🌊 beside the real card's 🏄 would be
   a second word for one thing — and the rank would have holed the heading
   outline. It now takes glyph, title, heading id and rank from the card it
   replaces, with a test asserting it.
2. **The measured block's props allowlist failed.** It asserted exactly
   `{ slug }` so that no edit could quietly pass it a chosen day — the
   structural guarantee ADR-0047 converted into an assertion. Adding `area`
   broke it, which is the allowlist working. Widened deliberately, with a
   separate line now asserting no day-shaped key, so the guarantee is stated
   rather than implied by a list that will keep growing.

## Gate output

```
> node scripts/run-gates.mjs

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  areas
  PASS  test
  PASS  build
  PASS  stylesheet
```

## What I did not do

- **The week and the day chart are still one beach at a time**, and the area
  page says so. `WeekPanel` mixes three products and `DayPanel` four, so gating
  them is per-product surgery inside the two largest components on the page.
  Tide is shared by 16 areas and sky by 11 — that slice is where most of an
  area's forecast arrives.
- **The rip current risk is still beach-scoped**, though the plan exempts it
  from this rule. It lands with the forecast slice and gets its own decision.
- **No probe.** Identifier equality is knowingly too strict — CDIP's lines sit
  ~100 m apart from one model run, so La Jolla's nine almost certainly agree to
  the decimal this page prints. The strictness is directional: the probe can
  only ever *add* products, so nothing shown today becomes false when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
