### PR TITLE
Report an area's week, day chart and rip current risk

### DIFF
--- a/docs/adr/0048-an-area-reports-only-what-its-beaches-share.md
+++ b/docs/adr/0048-an-area-reports-only-what-its-beaches-share.md
@@ -39,8 +39,18 @@ reader different sentences:
 - **`shared`** — one source behind every beach. The area reports it.
 - **`absent`** — no beach has one. The bay's missing buoy: already true one
   beach at a time, and not news.
-- **`mixed`** — the beaches each have one and disagree. New with areas, and the
+- **`mixed`** — the beaches do not all read one source. New with areas, and the
   only state a reader has never seen before.
+
+`mixed` covers two shapes and counts them apart: the beaches read different
+sources, or some read one and some read none. Both mean no single figure answers
+for the area, so both are one state — but the page prints the numbers, and
+"2 different sources" is false of nine beaches sharing a buoy and a tenth
+lacking it. That is La Jolla's own wave buoy, and the default area's page said
+it until `distinct` learned to tell a source from a gap; two more
+product-instances are the same shape (La Jolla's swell, Tijuana Estuary's).
+So `areaSources` returns `distinct` for the sources and `without` for the
+beaches that have none.
 
 This is the distinction `beaches.json` already draws about a null `wave_buoy`,
 whose schema says it "carries TWO meanings and wave_buoy_null_reason always

--- a/docs/adr/0048-an-area-reports-only-what-its-beaches-share.md
+++ b/docs/adr/0048-an-area-reports-only-what-its-beaches-share.md
@@ -103,16 +103,20 @@ first draft of this invented 🌊, its own titles and an `h3`, which would also
 have put a hole in the heading outline; it is called out here because the
 mistake is easy and invisible from the component that makes it.
 
-**The week and the day chart are still one beach at a time**, and the area page
-says so. `WeekPanel` and `DayPanel` mix three and four products respectively, so
-gating them is per-product surgery inside the two largest components on the page
-and is its own slice. Tide is shared by 16 areas and sky by 11, so that slice is
-where most of an area's forecast arrives.
+**The week and the day chart followed, per product.** They were left one beach at
+a time here, because `WeekPanel` and `DayPanel` mix three and four products
+respectively and gating them is surgery inside the two largest components on the
+page. ADR-0049 is that slice: a withheld product is worded in the slot its own
+panel already uses for an absence — no row and a note under the week grid, the
+tab kept with the sentence where the plot would be in the day chart. Tide is
+shared by 16 areas and sky by 11, so it is where most of an area's forecast
+arrives, as expected here.
 
-**The rip current risk is still beach-scoped**, though the plan exempts it from
-this rule — it is issued for "San Diego County Coastal Areas", a unit larger than
-any area here, so the intersection rule is a category error against it. That
-exception is real and lands with the forecast slice.
+**The rip current risk is the one exception, and ADR-0050 records it.** It is
+issued for "San Diego County Coastal Areas", a unit larger than any area here,
+so the intersection rule is a category error against it — there is no per-beach
+source to intersect. It is read through a member the forecast is issued for
+instead, and is on every area page rather than beach pages alone.
 
 **A props allowlist caught this change, which is what it is for.**
 `ConditionsSection.test.tsx` asserted the measured block is handed exactly

--- a/docs/adr/0049-a-withheld-product-keeps-its-slot.md
+++ b/docs/adr/0049-a-withheld-product-keeps-its-slot.md
@@ -1,0 +1,128 @@
+# 0049 — A withheld product keeps the slot it would have filled, and is worded there
+
+Date: 2026-09-04. Status: accepted. Applies ADR-0048 to the two forecast
+regions. ADR-0015's closed vocabulary is what it is arguing from.
+
+## Context
+
+ADR-0048 settled what an area may report: a product every one of its beaches
+binds the same source for, and nothing else. It settled it against the measured
+block, where the answer was easy — that block is two cards, one per product, so
+a withheld product is a card, and the withheld card takes the glyph, title,
+heading id and rank of the card it replaces.
+
+The week and the day chart are not two cards. `WeekPanel` draws three products
+as rows of one grid; `DayPanel` draws four tabs off three publishers, sharing
+one frame, one night band and one cloud wash. Neither has a card-shaped hole to
+put a sentence in, and the question ADR-0048 did not answer is what shape the
+hole is.
+
+Measured over the eighteen areas, this is not a rare state. Tide is shared by
+16 and sky by 11, so most areas draw most of the week — but La Jolla, the
+default area and the largest, shares a tide station and neither a model line
+nor a forecast cell. Something has to stand where its swell and its sky would
+be, on both regions, and it will be the first thing most readers of an area page
+see withheld.
+
+## Decision
+
+**A withheld product is worded in the slot its own panel already uses for a
+product it cannot draw.** Not a new element per region, and not silence.
+
+- **In the week, that is no row and a note under the grid.** A beach with no MOP
+  line has had no wave row and a sentence beneath the grid since long before
+  areas existed; `no-station`, `no-line` and `no-cell` have all pushed into that
+  array. An area with no agreement on a product gets the same shape, in its own
+  words.
+- **In the day chart, that is the tab, kept, with the sentence where the plot
+  would be.** `HourSeries.absence` is documented as "what to say instead of a
+  plot when `points` is empty", and its own docstring gives the reason the
+  sentence differs per product: "a beach with no MOP line will never have a
+  swell curve, where a cell that answered without a wind series is a fact about
+  one forecast run". An area that shares no model line is a third such reason,
+  in the same slot.
+
+**The tab stays. Dropping it was the alternative and it is the wrong one.** Four
+tabs are this region's whole vocabulary for its four products, which is
+ADR-0015's argument about the reading-card glyph applied to a control: a page
+that shows a different set of tabs per area is a different control per area
+rather than one control with less in it. La Jolla would have a tab bar one tab
+wide, and a reader would never learn that this page has a swell at all — which
+is worse than a tab that says why it is empty, because it cannot be asked.
+
+**One wording for all three positions**, in `areaScope.ts`, parameterised by the
+product's noun. `ProvenanceLine`'s docstring records what a second call site
+usually costs this repo — it printed one station two ways on one card — and
+`WORDS` in `DayPanel` already declines to invent a second register for an outage
+`WeekPanel` had words for. A reader meeting the same silence in the week and
+again in the chart meets the same sentence.
+
+**Per product, never per panel.** A panel gated whole would take La Jolla's tide
+away in order to withhold its cloud. The counts are what make that obvious:
+
+| product | shared | absent | mixed |
+| ------- | -----: | -----: | ----: |
+| tide    |     16 |      0 |     2 |
+| sky     |     11 |      0 |     7 |
+| swell   |      6 |      7 |     5 |
+
+**Daylight is not gated, and that is measured rather than assumed.** It is
+computed from a beach's coordinates rather than bound to a source, so
+`areaSources` has nothing to say about it. Across the eighteen areas the widest
+internal spread is 9 seconds of sunrise (Mission Bay – North) and 8 of sunset,
+against a page that prints both to the nearest minute. `midpointOf` already
+makes the same argument one scale up: "sunset differs by a minute across the
+entire county". So the week's columns and the chart's night band come from the
+member the region reads through, and no area is told a sunrise it could see was
+false.
+
+**The map is not in this.** It draws one beach's own stretch of coast; an area
+has no such run until the area map lands, with a tick per member and a frame
+taking the bbox's own aspect. That is its own slice and its own decision,
+because ADR-0033 says the map draws a place and not an inventory and a mark per
+beach amends it. Until then the column carries a sentence saying so. Drawing the
+first member's coastline under the area's name would be exactly the
+representative-beach lie ADR-0048 refuses, one layer down.
+
+The readout goes with the map, and that is the part worth recording. ADR-0034's
+surviving clause has the readout rendered on every beach including those with no
+coast drawn, so a bearing dial without a shoreline is a shape this page already
+permits. It is deferred anyway because `ShoreMap` owns the coupling ADR-0038
+settled — one `hasReadout` gating the block and its sources together — and
+hoisting it out is a second change to a contract that decision has just finished
+drawing. It arrives with the area's own coast, which is the frame that makes a
+wind bearing mean anything.
+
+## Consequences
+
+Every region of `/conditions/<area>` now answers for the area. The sentence that
+stood in for the week and the day chart is gone.
+
+**An area page can carry the same sentence twice**, once in the week's notes and
+once in a chart tab, when a product is withheld in both. That is accepted rather
+than solved: they are two regions and each owes its own reader an explanation
+where they are standing, and the alternative — one of them silent, pointing at
+the other — is the failure `WeekPanel`'s own notes fixed when the tide card they
+delegated to was deleted.
+
+**A withheld product costs no request.** Six reads become as few as one on an
+area page, which is the same property ADR-0048 gave the measured block.
+
+**`Answered<V>` is new**, in `areaScope.ts`: a product's read or its
+withholding, as one value, so nothing composing a chart tab has to assert that
+the two line up. `WeekPanel` does not use it and takes plain nulls, because its
+reads feed `if` guards that narrow a null on their own; the day chart's feed
+object literals, which do not.
+
+**The rip current risk is still beach-scoped**, and is still the exception this
+rule does not cover. It is issued for "San Diego County Coastal Areas", a unit
+larger than any area here, so an intersection rule designed for point
+measurements is a category error against it. It is read through the member the
+rest of the region reads through, which gives every area but one the answer the
+exception would give it anyway. That exception is real and gets its own
+decision.
+
+The part most likely to be re-litigated is the kept tab, on the grounds that a
+tab which never has a curve is clutter. The answer is that it is not "never" —
+it is "not for this area", the reader is one click from the beach that has it,
+and the sentence in the tab is what tells them so.

--- a/docs/adr/0050-the-surf-zone-forecast-is-exempt-from-the-intersection-rule.md
+++ b/docs/adr/0050-the-surf-zone-forecast-is-exempt-from-the-intersection-rule.md
@@ -1,0 +1,140 @@
+# 0050 — The surf zone forecast is exempt from the intersection rule
+
+Date: 2026-09-04. Status: accepted. The one exception to ADR-0048, which is
+otherwise unchanged. Builds on ADR-0043, which bound this forecast to the
+inventory, and ADR-0009, which is why the product is on this site at all.
+
+## Context
+
+ADR-0048 says an area reports a product only where every one of its beaches
+binds the same source for it. ADR-0049 applied that to the week and the day
+chart. Applied to the surf zone bulletin as well, it produces an answer to a
+question the product cannot be asked.
+
+**The bulletin is not a point measurement, and the rule is built entirely out of
+point measurements.** A tide station stands at a pier, a buoy floats at a
+coordinate, a model line sits at 10 m depth, a forecast cell is a 2.5 km square
+of map. Each is somewhere, `_served` exists to say how far its reading may
+travel from that somewhere, and the intersection rule is what stops an area
+publishing a figure measured at a place some of its beaches are not near.
+
+The National Weather Service issues `CAZ043` for **San Diego County Coastal
+Areas**. One bulletin, for a unit larger than every area in this table put
+together. There is no per-beach source to intersect: `readSurfZone` reaches
+`fetchSurfZoneForecast()`, which takes no beach at all. The only per-beach input
+is `surfZoneWithheldReason`, which asks whether the beach is open coast or
+sheltered water — a question about _coverage_, not about which instrument was
+read.
+
+So intersecting it across members is not a strict rule; it is a category error.
+Two beaches "disagreeing" about the bulletin is not a state that exists.
+
+### What it is worth, measured
+
+`docs/plans/areas-over-locations.md` §4 argued this exemption from La Jolla,
+saying a strict rule would cost that area its rip current risk because
+`Childrens Pool` is bay-class. **That example has expired.** `Childrens Pool`
+binds `9410230`, which is `open-coast`, and La Jolla is 10 of 10 open coast. The
+argument above does not depend on it.
+
+Measured over the twelve areas that hold more than one beach, on 2026-09-04:
+
+|                                                          |       |
+| -------------------------------------------------------- | ----- |
+| areas carrying the bulletin                              | **7** |
+| areas wholly sheltered, withholding it                   | **5** |
+| areas reading it through a beach that is not their first | **1** |
+
+The one is **Tijuana Estuary**, whose first member is the slough — sheltered
+water — and whose second is Border Field State Park, which is open coast. Read
+through the member everything else on that page is read through, the area would
+withhold a forecast that is issued for half of it.
+
+The larger visible change is not that one. It is that **the rip current risk
+appears on all twelve multi-beach area pages**, where before it was drawn only
+on a beach page. On the seven it names a level; on the five it says why there is
+none. It is the single line on this page that answers whether to put children in
+the water, and an area page without it was the page's most important omission.
+
+## Decision
+
+**The surf zone bulletin is read through a member the forecast is issued for,
+and is not resolved against `areaSources`.**
+
+`surfZoneBeachOf(area)` in `src/lib/areas.ts` returns the first member whose
+`surfZoneWithheldReason` is null, and the first member otherwise. It is carried
+on `AreaScope` as `bulletinBeach`, beside `sources` rather than inside it,
+because it is not a source the beaches agree about.
+
+**This is not picking a representative, and that distinction is the whole
+defence.** ADR-0048 rejects a representative beach because the figure would be a
+measurement taken at one place published under the name of a wider one. Here
+every open-coast member reads the _same_ bulletin — there is only one — so the
+choice decides whether the area gets it, not which figure it gets.
+
+**The fallback is what makes the withheld case honest.** Reaching it means no
+member is open coast, so the reason that comes back is true of every beach in
+the area rather than of the one it was read through. That is what licenses the
+page saying "this forecast is not issued for **any beach in** Mission Bay –
+West" having asked about one of them, and `areas.test.ts` asserts it over the
+whole table rather than leaving it in a comment.
+
+**The withheld sentence is the only copy an area changes.** The bulletin itself
+names no beach — `SurfZone` prints the office's level, gloss, surf and water
+ranges and period name, all of which are already true at either scope — so
+`areaName` reaches exactly one sentence.
+
+**ADR-0043 is unchanged and this depends on it.** That decision withholds the
+bulletin at 25 sheltered beaches, on the grounds that "Rip Current Risk: High"
+over Sail Bay would alarm about a hazard that is not there. Nothing here
+publishes it at a beach ADR-0043 withholds it from; an area with no open-coast
+member withholds it exactly as its members do.
+
+**ADR-0009 is unchanged and this is still the only relayed judgement on the
+page.** It sits beside the chooser rather than inside the measured block, which
+is that decision as a layout: the band below is what the instruments read, this
+is a forecaster's verdict relayed. Widening its scope does not widen what the
+site is willing to say.
+
+## Alternatives considered
+
+**Apply the intersection rule anyway.** Five of the twelve areas would keep the
+bulletin, Tijuana Estuary would lose it, and the rule would be answering a
+question about agreement between sources where there is one source. Rejected on
+the category argument, which does not depend on the count.
+
+**Give the area its own zone lookup.** `CAZ043` covers the whole county, so this
+is the same answer reached expensively, and it would make an area an input to a
+join — which ADR-0011 forbids and ADR-0046 restated.
+
+**Withhold it wherever any member is sheltered.** The strictest reading, and it
+loses the product at Tijuana Estuary while gaining nothing: the bulletin does
+not become less true of Border Field State Park because the slough is next to
+it. It would also make an area's rip current line depend on where a membership
+boundary was drawn, which is an authored table.
+
+**Word the withheld case from the area rather than from a member's reason.**
+Rejected for ADR-0048's own reason about borrowed reasons — except that here
+there is nothing to choose between, since every sheltered member gives the same
+sentence. The member's reason is used, and the claim that it speaks for all of
+them is asserted rather than assumed.
+
+## Consequences
+
+Every region of an area page now answers for the area, including the one that
+answers by exception.
+
+**`bulletinBeach` is a second slug on `AreaScope`,** so a panel can read one
+product through a different member from the rest. That is a real widening: it is
+now possible to read anything through a beach the area did not agree about.
+`ConditionsSection` composes both and hands them down, and the props allowlists
+on all three panels are what keep a third slug from arriving unannounced.
+
+**The plan's §4 example is stale and is not repaired.** `docs/plans/` is a dated
+record once its work merges, and this ADR is the thing kept current — which is
+exactly the split `docs/plans/README.md` draws. The addendum on that plan says
+so.
+
+The part most likely to be re-litigated is whether an exception recorded once
+becomes a habit. The answer is the test for it: a product is exempt when it has
+no per-beach source to intersect. Every other product on this page has one.

--- a/docs/plans/areas-over-locations.md
+++ b/docs/plans/areas-over-locations.md
@@ -366,6 +366,37 @@ to make cheap.
 > a reader with that bookmark lands on the area containing the beach they saved,
 > which is the right place rather than a broken one.
 
+> **Addendum, 2026-09-04. The week and the day chart answer for an area, and
+> §4's example has expired.**
+>
+> §4 argued the surf zone exemption from La Jolla, saying a strict rule would
+> cost that area its rip current risk "because `Childrens Pool` is bay-class and
+> ADR-0043 withholds the bulletin there". Measured while implementing it:
+> `Childrens Pool` binds `9410230`, which is `open-coast`, and La Jolla is 10 of
+> 10 open coast. The exemption is right for the reason that outlives the
+> example — one bulletin, for a unit larger than any area here — and ADR-0050 is
+> where it is recorded and kept current. Measured today it is worth the bulletin
+> to exactly one area, **Tijuana Estuary**, whose first member is the slough.
+>
+> **The forecast is gated per product inside both panels rather than per
+> panel**, which §"Slices" left open. A withheld product is worded in the slot
+> its own panel already uses for an absence: no row and a note under the week
+> grid, and the tab kept with the sentence where the plot would be in the day
+> chart. ADR-0049. The tab is kept because four tabs are that region's
+> vocabulary for its four products — La Jolla shares only the tide, so a bar
+> gated to what it can draw would be one tab wide.
+>
+> **Two things this slice found rather than planned.** `areaSources` counted a
+> beach binding nothing as a source, so `/conditions/la-jolla` said its ten
+> beaches read two wave buoys when nine read one and `childrens-pool` reads
+> none; fixed with a regression test ahead of the rest. And daylight needs no
+> gating, which is measured rather than assumed: 9 seconds of sunrise spread
+> inside the widest area against a page that prints to the minute.
+>
+> **The area map is still §6's**, and the day region carries a sentence where it
+> will go. The readout goes with it rather than standing alone, because
+> `ShoreMap` owns the coupling ADR-0038 settled.
+
 ## Test seams
 
 Agreed before starting, and chosen from what exists rather than invented.

--- a/src/app/conditions/[area]/page.test.tsx
+++ b/src/app/conditions/[area]/page.test.tsx
@@ -46,16 +46,18 @@ test("renders the area named in the route", async () => {
 });
 
 /**
- * The area reports what is measured now, and sends the reader to a beach for
- * what is forecast. Air is shared by all eighteen areas, so every area page has
- * something measured to say; the week and the day chart are still one beach at
- * a time.
+ * The area reports what is measured now and what its beaches agree on for the
+ * week, and sends the reader to a beach for the hour-by-hour chart. Air is
+ * shared by all eighteen areas and a tide station by sixteen, so every area
+ * page has something to say in both regions.
  */
-test("an area reports what is measured and defers the forecast", async () => {
+test("an area reports the week and defers the day chart", async () => {
   render(await AreaConditions(params("la-jolla")));
 
-  expect(screen.getByText(/still shown one beach at a time/)).toBeDefined();
-  expect(screen.queryByText(/week for/)).toBeNull();
+  expect(screen.getByText(/week for la-jolla-shores-beach/)).toBeDefined();
+  expect(
+    screen.getByText(/day chart is still shown one beach at a time/),
+  ).toBeDefined();
   expect(screen.queryByText(/day for/)).toBeNull();
 });
 

--- a/src/app/conditions/[area]/page.test.tsx
+++ b/src/app/conditions/[area]/page.test.tsx
@@ -46,19 +46,19 @@ test("renders the area named in the route", async () => {
 });
 
 /**
- * The area reports what is measured now and what its beaches agree on for the
- * week, and sends the reader to a beach for the hour-by-hour chart. Air is
- * shared by all eighteen areas and a tide station by sixteen, so every area
- * page has something to say in both regions.
+ * Every region on the page answers for the area now: what is measured, the week
+ * and the day chart. Air is shared by all eighteen areas and a tide station by
+ * sixteen, so each of them has something to say.
+ *
+ * Read through the area's first member, which cannot matter: a product is read
+ * only where every beach in the area binds the same source for it.
  */
-test("an area reports the week and defers the day chart", async () => {
+test("an area reports all three regions, through one of its beaches", async () => {
   render(await AreaConditions(params("la-jolla")));
 
   expect(screen.getByText(/week for la-jolla-shores-beach/)).toBeDefined();
-  expect(
-    screen.getByText(/day chart is still shown one beach at a time/),
-  ).toBeDefined();
-  expect(screen.queryByText(/day for/)).toBeNull();
+  expect(screen.getByText(/day for la-jolla-shores-beach/)).toBeDefined();
+  expect(screen.queryByText(/one beach at a time/)).toBeNull();
 });
 
 /**

--- a/src/components/conditions/ConditionsSection.test.tsx
+++ b/src/components/conditions/ConditionsSection.test.tsx
@@ -21,11 +21,9 @@ vi.mock("@/components/conditions/DayPanel", () => ({
     return <p>day for {slug}</p>;
   },
 }));
+const weekPanel = vi.fn();
 vi.mock("@/components/conditions/WeekPanel", () => ({
-  WeekPanel: ({ slug }: { slug: string }) => {
-    if (slug === "suspend-the-panels") throw new Promise(() => {});
-    return <p>week for {slug}</p>;
-  },
+  WeekPanel: (props: { slug: string }) => weekPanel(props),
 }));
 /*
   The measured block moved up here from the day panel, and its reads came with
@@ -56,6 +54,11 @@ beforeEach(() => {
   measuredPanel.mockImplementation(({ slug }: { slug: string }) => {
     if (slug === "suspend-the-panels") throw new Promise(() => {});
     return <p>measured for {slug}</p>;
+  });
+  weekPanel.mockReset();
+  weekPanel.mockImplementation(({ slug }: { slug: string }) => {
+    if (slug === "suspend-the-panels") throw new Promise(() => {});
+    return <p>week for {slug}</p>;
   });
 });
 const ripLevel = vi.fn();
@@ -469,4 +472,67 @@ test("an area of several keeps its list while showing one beach", () => {
     screen.getAllByRole("link", { name: /La Jolla|WindanSea|Bird Rock/ })
       .length,
   ).toBeGreaterThan(1);
+});
+
+/**
+ * The week is handed the same pair the measured block is, and the allowlist is
+ * here for the reason that one is: what a panel is given decides what it can
+ * answer for, and an argument added quietly is how a region comes to answer for
+ * something nobody chose.
+ *
+ * What it must never grow is a *chosen* member. "Read through any beach" is
+ * only honest because a product is read only where every beach in the area
+ * binds the same source, which `areas.test.ts` asserts over the whole table; a
+ * representative passed deliberately would be the thing ADR-0048 rejects.
+ */
+test("the week is asked for a beach and the area it stands for", () => {
+  render(<ConditionsSection areaSlug="la-jolla" beachSlug={null} />);
+
+  const [props] = weekPanel.mock.calls[0] as [Record<string, unknown>];
+  expect(Object.keys(props).sort()).toEqual(["area", "slug"]);
+
+  const area = props.area as { name: string; beaches: number };
+  expect(area.name).toBe("La Jolla");
+  expect(area.beaches).toBe(10);
+  expect(props.slug).toBe("la-jolla-shores-beach");
+});
+
+/** And on a beach page there is no scope at all, so nothing is withheld. */
+test("on a beach page the week answers for that beach alone", () => {
+  render(<ConditionsSection areaSlug="la-jolla" beachSlug="windansea-beach" />);
+
+  const [props] = weekPanel.mock.calls[0] as [Record<string, unknown>];
+  expect(props.slug).toBe("windansea-beach");
+  expect(props.area).toBeUndefined();
+});
+
+/**
+ * The week and the measured block read through the same member, which is what
+ * stops one region answering for a different beach than the one beside it.
+ * Asserted rather than assumed, because the two call sites composed the pair
+ * separately until they were lifted into one.
+ */
+test("every region on an area page reads through the same member", () => {
+  render(<ConditionsSection areaSlug="la-jolla" beachSlug={null} />);
+
+  const [measured] = measuredPanel.mock.calls[0] as [Record<string, unknown>];
+  const [week] = weekPanel.mock.calls[0] as [Record<string, unknown>];
+
+  expect(week.slug).toBe(measured.slug);
+  expect(week.area).toEqual(measured.area);
+});
+
+/**
+ * The day chart is the region still to come, and the area page says so rather
+ * than leaving a gap where it will be. The sentence names what a reader would
+ * find there, since it is the whole of what the area cannot yet give them.
+ */
+test("an area page says the day chart is still one beach at a time", () => {
+  render(<ConditionsSection areaSlug="la-jolla" beachSlug={null} />);
+
+  expect(
+    screen.getByText(/day chart is still shown one beach at a time/),
+  ).toBeDefined();
+  expect(screen.getByText(/week for la-jolla-shores-beach/)).toBeDefined();
+  expect(screen.queryByText(/day for/)).toBeNull();
 });

--- a/src/components/conditions/ConditionsSection.test.tsx
+++ b/src/components/conditions/ConditionsSection.test.tsx
@@ -15,11 +15,9 @@ const DEFAULT_AREA = "la-jolla";
   declared beside it is not initialised when the factory is defined.
 */
 const SUSPEND = "suspend-the-panels";
+const dayPanel = vi.fn();
 vi.mock("@/components/conditions/DayPanel", () => ({
-  DayPanel: ({ slug }: { slug: string }) => {
-    if (slug === "suspend-the-panels") throw new Promise(() => {});
-    return <p>day for {slug}</p>;
-  },
+  DayPanel: (props: { slug: string }) => dayPanel(props),
 }));
 const weekPanel = vi.fn();
 vi.mock("@/components/conditions/WeekPanel", () => ({
@@ -59,6 +57,11 @@ beforeEach(() => {
   weekPanel.mockImplementation(({ slug }: { slug: string }) => {
     if (slug === "suspend-the-panels") throw new Promise(() => {});
     return <p>week for {slug}</p>;
+  });
+  dayPanel.mockReset();
+  dayPanel.mockImplementation(({ slug }: { slug: string }) => {
+    if (slug === "suspend-the-panels") throw new Promise(() => {});
+    return <p>day for {slug}</p>;
   });
 });
 const ripLevel = vi.fn();
@@ -518,21 +521,40 @@ test("every region on an area page reads through the same member", () => {
   const [measured] = measuredPanel.mock.calls[0] as [Record<string, unknown>];
   const [week] = weekPanel.mock.calls[0] as [Record<string, unknown>];
 
+  const [day] = dayPanel.mock.calls[0] as [Record<string, unknown>];
+
   expect(week.slug).toBe(measured.slug);
+  expect(day.slug).toBe(measured.slug);
   expect(week.area).toEqual(measured.area);
+  expect(day.area).toEqual(measured.area);
 });
 
 /**
- * The day chart is the region still to come, and the area page says so rather
- * than leaving a gap where it will be. The sentence names what a reader would
- * find there, since it is the whole of what the area cannot yet give them.
+ * The day chart takes the same pair, and the allowlist is here for the reason
+ * the other two carry one: an argument added quietly is how a region comes to
+ * answer for something nobody chose.
  */
-test("an area page says the day chart is still one beach at a time", () => {
+test("the day chart is asked for a beach and the area it stands for", () => {
   render(<ConditionsSection areaSlug="la-jolla" beachSlug={null} />);
 
-  expect(
-    screen.getByText(/day chart is still shown one beach at a time/),
-  ).toBeDefined();
+  const [props] = dayPanel.mock.calls[0] as [Record<string, unknown>];
+  expect(Object.keys(props).sort()).toEqual(["area", "slug"]);
+
+  const area = props.area as { name: string; beaches: number };
+  expect(area.name).toBe("La Jolla");
+  expect(props.slug).toBe("la-jolla-shores-beach");
+});
+
+/**
+ * All three regions answer for the area now, and the sentence that stood in for
+ * two of them is gone. Asserted as an absence as well as a presence: the
+ * placeholder is the thing a later change is most likely to leave behind.
+ */
+test("an area page carries every region, and no sentence standing in for one", () => {
+  render(<ConditionsSection areaSlug="la-jolla" beachSlug={null} />);
+
+  expect(screen.getByText(/measured for la-jolla-shores-beach/)).toBeDefined();
   expect(screen.getByText(/week for la-jolla-shores-beach/)).toBeDefined();
-  expect(screen.queryByText(/day for/)).toBeNull();
+  expect(screen.getByText(/day for la-jolla-shores-beach/)).toBeDefined();
+  expect(screen.queryByText(/one beach at a time/)).toBeNull();
 });

--- a/src/components/conditions/ConditionsSection.test.tsx
+++ b/src/components/conditions/ConditionsSection.test.tsx
@@ -530,6 +530,32 @@ test("every region on an area page reads through the same member", () => {
 });
 
 /**
+ * The rip current risk is on an area page, and it is the one product that
+ * reaches it without the area's beaches agreeing about a source: the National
+ * Weather Service issues one bulletin for a unit larger than any area here.
+ * ADR-0050.
+ *
+ * Read through a member the forecast is issued for rather than the member
+ * everything else is read through, which for Tijuana Estuary is a different
+ * beach.
+ */
+test("an area page carries the rip current risk", () => {
+  render(<ConditionsSection areaSlug="la-jolla" beachSlug={null} />);
+
+  expect(screen.getByText(/rip for la-jolla-shores-beach/)).toBeDefined();
+});
+
+test("the bulletin is read through the member it is issued for", () => {
+  render(<ConditionsSection areaSlug="tijuana-estuary" beachSlug={null} />);
+
+  // Everything else reads through the area's first beach, which is the slough.
+  const [week] = weekPanel.mock.calls[0] as [Record<string, unknown>];
+  expect(week.slug).toBe("tijuana-slough-national-wildlife-refuge");
+  // The bulletin does not.
+  expect(screen.getByText(/rip for border-field-state-park/)).toBeDefined();
+});
+
+/**
  * The day chart takes the same pair, and the allowlist is here for the reason
  * the other two carry one: an argument added quietly is how a region comes to
  * answer for something nobody chose.

--- a/src/components/conditions/ConditionsSection.tsx
+++ b/src/components/conditions/ConditionsSection.tsx
@@ -23,7 +23,8 @@
  */
 
 import { Suspense } from "react";
-import { areaBySlug, areaSources, beachesByArea } from "@/lib/areas";
+import { areaBySlug, beachesByArea } from "@/lib/areas";
+import { scopeFor } from "./areaScope";
 import { inventoryCaveats, inventoryReach } from "@/lib/beaches";
 import { AreaBeaches } from "./AreaBeaches";
 import { AreaSelector } from "./AreaSelector";
@@ -74,14 +75,20 @@ export function ConditionsSection({
     reads and draws what it always did.
   */
   const reading = beachSlug ?? group.beaches[0].slug;
-  const scope =
-    beachSlug === null
-      ? {
-          name: group.area.name,
-          beaches: group.beaches.length,
-          sources: areaSources(group.area),
-        }
-      : undefined;
+  const scope = beachSlug === null ? scopeFor(group.area) : undefined;
+
+  /*
+    And the member the surf zone bulletin is read through, which is a different
+    question from `reading` and sometimes a different beach.
+
+    Every other product on this page is a point measurement, and an area
+    publishes one only where all its beaches are served by the same source. The
+    bulletin is not: the National Weather Service issues one for "San Diego
+    County Coastal Areas", a unit larger than any area in this table, so what it
+    needs is not a member they agree about but a member it is *issued* for. See
+    ADR-0050.
+  */
+  const bulletin = scope === undefined ? reading : scope.bulletinBeach;
 
   return (
     <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
@@ -162,24 +169,22 @@ export function ConditionsSection({
         <div className="mt-6 md:mt-0 md:w-72">
           <AreaSelector areas={areas} current={areaSlug} />
           {/*
-            The bulletin is scoped to a beach here, so it waits for one. It is
-            the single product an area may report without its beaches agreeing
-            -- the National Weather Service issues it for "San Diego County
-            Coastal Areas", a unit larger than any area in this table, so the
-            intersection rule is a category error against it. That exception
-            lands with the area's readings in PR 3 and gets its own decision.
+            The one relayed judgement on this page, and the one product an area
+            reports without its beaches agreeing about a source. It is on the
+            area page as well as the beach page for that reason: withholding it
+            from an area would be applying a rule about point measurements to
+            something that is not one, and it is the single line here that
+            answers whether to put children in the water.
           */}
-          {beachSlug !== null && (
-            <Suspense
-              fallback={
-                <p className="mt-4 text-base text-fog">
-                  Reading the rip current risk…
-                </p>
-              }
-            >
-              <RipLevel slug={beachSlug} />
-            </Suspense>
-          )}
+          <Suspense
+            fallback={
+              <p className="mt-4 text-base text-fog">
+                Reading the rip current risk…
+              </p>
+            }
+          >
+            <RipLevel slug={bulletin} />
+          </Suspense>
         </div>
       </div>
 

--- a/src/components/conditions/ConditionsSection.tsx
+++ b/src/components/conditions/ConditionsSection.tsx
@@ -8,12 +8,16 @@
  * **`beachSlug` is what says which scope.** Null is the area's own page and a
  * slug is one beach inside it. The header, the chooser and the beach list are
  * the same either way; what changes is whether the readings below them answer
- * for a beach or, once PR 3 lands, for everything the area's beaches share.
+ * for a beach or for everything the area's beaches share.
  *
- * Until then the area page carries its header and its list and says plainly
- * that the readings are one level down, which is true rather than a placeholder:
- * an area reports only what all its beaches share, and working out what that is
- * for eighteen areas is its own slice. See
+ * **Every panel is handed the same pair**, composed once here: the beach a read
+ * is keyed on, and the area scope that says which products may be reported.
+ * `undefined` for the scope is the beach page, and it is what makes that path
+ * unchanged rather than merely equivalent -- with nothing to withhold, each
+ * panel reads and draws exactly what it did before areas existed. See ADR-0048
+ * and `areaScope.ts`.
+ *
+ * The day chart is still one beach at a time and the area page says so. See
  * `docs/plans/areas-over-locations.md`.
  */
 
@@ -51,6 +55,32 @@ export function ConditionsSection({
       `ConditionsSection was given ${areaSlug}, which names no area in areas.json.`,
     );
   }
+
+  /*
+    The two things every panel below is handed, composed once because two of
+    them now take both and a third is coming.
+
+    `reading` is the beach a read is keyed on -- every function in
+    `lib/conditions.ts` takes a slug -- and on an area page it is the first
+    member. Which member cannot matter: a product is read only where every beach
+    in the area binds the same source for it, which is what `areaSources` calls
+    shared and what `areas.test.ts` asserts over the whole table. A product they
+    do not share is not read at all, so no one beach's figure can arrive
+    labelled as the area's.
+
+    `scope` is undefined on a beach page, and that is what keeps the beach-scoped
+    path exactly as it was: with no scope nothing is withheld, so every panel
+    reads and draws what it always did.
+  */
+  const reading = beachSlug ?? group.beaches[0].slug;
+  const scope =
+    beachSlug === null
+      ? {
+          name: group.area.name,
+          beaches: group.beaches.length,
+          sources: areaSources(group.area),
+        }
+      : undefined;
 
   return (
     <section className="px-gutter-sm py-section-sm md:px-gutter md:py-section">
@@ -233,18 +263,7 @@ export function ConditionsSection({
             Air is shared by all eighteen areas and a buoy by three, so this
             block is where an area page has something measured to say at all.
           */}
-          <MeasuredPanel
-            slug={beachSlug ?? group.beaches[0].slug}
-            area={
-              beachSlug === null
-                ? {
-                    name: group.area.name,
-                    beaches: group.beaches.length,
-                    sources: areaSources(group.area),
-                  }
-                : undefined
-            }
-          />
+          <MeasuredPanel slug={reading} area={scope} />
         </Suspense>
       </div>
 
@@ -258,25 +277,30 @@ export function ConditionsSection({
         quiet independently and none may hold up another; a shared choice does
         not change that.
       */}
+      <div className="mb-9">
+        <Suspense
+          fallback={
+            <p className="text-base text-fog">Reading the week from NOAA…</p>
+          }
+        >
+          {/*
+            The same scope the measured block above takes, and for the same
+            reason: a row is drawn only where every beach in the area binds one
+            source for it, and a row that is not drawn says so in the notes
+            under the grid. Sixteen areas share a tide station and eleven a
+            forecast cell, so this is where most of an area's forecast arrives.
+          */}
+          <WeekPanel slug={reading} area={scope} />
+        </Suspense>
+      </div>
+
       {beachSlug === null ? (
         <p className="leading-relaxed max-w-130 text-base text-fog">
-          The week ahead and the day chart are still shown one beach at a time.
-          Choose one above for its tide, swell and sky.
+          The day chart is still shown one beach at a time. Choose one above for
+          its hour-by-hour tide, swell, wind and air temperature.
         </p>
       ) : (
         <>
-          <div className="mb-9">
-            <Suspense
-              fallback={
-                <p className="text-base text-fog">
-                  Reading the week from NOAA…
-                </p>
-              }
-            >
-              <WeekPanel slug={beachSlug} />
-            </Suspense>
-          </div>
-
           {/*
         The day opens under the week. Its own suspense boundary for the same
         reason every region here has one: this is a second request to the

--- a/src/components/conditions/ConditionsSection.tsx
+++ b/src/components/conditions/ConditionsSection.tsx
@@ -17,8 +17,9 @@
  * panel reads and draws exactly what it did before areas existed. See ADR-0048
  * and `areaScope.ts`.
  *
- * The day chart is still one beach at a time and the area page says so. See
- * `docs/plans/areas-over-locations.md`.
+ * The map inside the day region is still one beach's own stretch of coast, and
+ * the area page says so where a map would be: the area map is its own slice.
+ * See `docs/plans/areas-over-locations.md`.
  */
 
 import { Suspense } from "react";
@@ -294,14 +295,7 @@ export function ConditionsSection({
         </Suspense>
       </div>
 
-      {beachSlug === null ? (
-        <p className="leading-relaxed max-w-130 text-base text-fog">
-          The day chart is still shown one beach at a time. Choose one above for
-          its hour-by-hour tide, swell, wind and air temperature.
-        </p>
-      ) : (
-        <>
-          {/*
+      {/*
         The day opens under the week. Its own suspense boundary for the same
         reason every region here has one: this is a second request to the
         National Weather Service — the words, where the week's cloud row reads
@@ -323,17 +317,21 @@ export function ConditionsSection({
         this file's tests mock `DayPanel` — so it is asserted in that panel's
         own tests instead.
       */}
-          <div className="mb-9">
-            <Suspense
-              fallback={
-                <p className="text-base text-fog">Reading the sky in words…</p>
-              }
-            >
-              <DayPanel slug={beachSlug} />
-            </Suspense>
-          </div>
-        </>
-      )}
+      <div className="mb-9">
+        <Suspense
+          fallback={
+            <p className="text-base text-fog">Reading the sky in words…</p>
+          }
+        >
+          {/*
+            The same pair again, and the last region to take it. A tab whose
+            product the area's beaches do not share keeps its place in the bar
+            and says so where the curve would be, which is the slot this chart
+            already uses for a beach with no MOP line.
+          */}
+          <DayPanel slug={reading} area={scope} />
+        </Suspense>
+      </div>
 
       {/*
         One block for everything true of every reading — the datum, what a buoy

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -1661,13 +1661,9 @@ test("the map's caption names a spring-forward hour ahead, not behind", async ()
  * the way ADR-0048's own counts drifted once.
  */
 async function areaScope(slug: string) {
-  const { areaBySlug, areaSources } = await import("@/lib/areas");
-  const area = areaBySlug(slug)!;
-  return {
-    name: area.name,
-    beaches: area.beaches.length,
-    sources: areaSources(area),
-  };
+  const { areaBySlug } = await import("@/lib/areas");
+  const { scopeFor } = await import("./areaScope");
+  return scopeFor(areaBySlug(slug)!);
 }
 
 /**
@@ -1854,4 +1850,73 @@ test("the surf zone bulletin is read at either scope", async () => {
   );
 
   expect(readSurfZone).toHaveBeenCalledWith("la-jolla-shores-beach");
+});
+
+/**
+ * The exception, and it is a category difference rather than a relaxation. The
+ * National Weather Service issues one bulletin for "San Diego County Coastal
+ * Areas", so what an area needs is not a member its beaches agree about but a
+ * member the forecast is issued for — which for Tijuana Estuary is not the
+ * member everything else in this region is read through. ADR-0050.
+ */
+test("the bulletin is read through a member the forecast is issued for", async () => {
+  render(
+    await DayPanel({
+      slug: "tijuana-slough-national-wildlife-refuge",
+      area: await areaScope("tijuana-estuary"),
+    }),
+  );
+
+  // Everything else reads through the slug it was given; the bulletin does not.
+  expect(readSurfZone).toHaveBeenCalledWith("border-field-state-park");
+  expect(readSurfZone).not.toHaveBeenCalledWith(
+    "tijuana-slough-national-wildlife-refuge",
+  );
+});
+
+/**
+ * And where the forecast reaches no member, the sentence is about the area
+ * rather than about the beach it was read through. That is a claim rather than
+ * a hedge: `surfZoneBeachOf` falls back only when every member is sheltered,
+ * which `areas.test.ts` asserts over the whole table.
+ */
+test("a wholly sheltered area is told the forecast is not issued for any of it", async () => {
+  readSurfZone.mockResolvedValue({
+    beachName: "Mission Bay, Riviera Shores",
+    state: {
+      kind: "no-surf-zone",
+      reason:
+        "the National Weather Service issues this forecast for San Diego County's coastal " +
+        "areas, and a bay, lagoon or inlet has no surf zone, so it does not describe the " +
+        "water here",
+    },
+  });
+
+  render(
+    await DayPanel({
+      slug: "mission-bay-riviera-shores",
+      area: await areaScope("mission-bay-west"),
+    }),
+  );
+
+  expect(
+    screen.getByText(
+      /This forecast is not issued for any beach in Mission Bay – West/,
+    ),
+  ).toBeDefined();
+  expect(screen.queryByText(/not issued for this beach/)).toBeNull();
+});
+
+/** And a beach page still says "this beach", which is what it is. */
+test("a beach page keeps the beach-scoped wording", async () => {
+  readSurfZone.mockResolvedValue({
+    beachName: "Mission Bay, Riviera Shores",
+    state: { kind: "no-surf-zone", reason: "a bay has no surf zone" },
+  });
+
+  render(await DayPanel({ slug: "mission-bay-riviera-shores" }));
+
+  expect(
+    screen.getByText(/This forecast is not issued for this beach/),
+  ).toBeDefined();
 });

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -1649,3 +1649,209 @@ test("the map's caption names a spring-forward hour ahead, not behind", async ()
     "3 AM",
   );
 });
+
+/* =========================================================================
+ * The day, answering for an area
+ * ========================================================================= */
+
+/**
+ * The scope a page hands this panel, built from `areas.json` rather than
+ * invented. `areaSources` is not mocked: the point is what this region does
+ * with what the real table says, and a fixture would let the two drift apart in
+ * the way ADR-0048's own counts drifted once.
+ */
+async function areaScope(slug: string) {
+  const { areaBySlug, areaSources } = await import("@/lib/areas");
+  const area = areaBySlug(slug)!;
+  return {
+    name: area.name,
+    beaches: area.beaches.length,
+    sources: areaSources(area),
+  };
+}
+
+/**
+ * A product the area's beaches share is read and drawn. La Jolla's ten all bind
+ * `9410230`, so the tide curve is the area's.
+ */
+test("an area draws the curve its beaches share", async () => {
+  const { container } = render(
+    await DayPanel({
+      slug: "la-jolla-shores-beach",
+      area: await areaScope("la-jolla"),
+    }),
+  );
+
+  expect(readHourlyTide).toHaveBeenCalledWith("la-jolla-shores-beach");
+  expect(
+    container.querySelector('svg[aria-label^="Tide today"] [data-curve]'),
+  ).not.toBeNull();
+});
+
+/**
+ * And a product they do not share keeps its tab, is not read, and carries the
+ * area's sentence where the plot would be.
+ *
+ * The tab staying is the decision: four tabs are this region's vocabulary for
+ * its four products, and La Jolla shares only the tide, so a bar gated to what
+ * it can draw would be one tab wide and a reader would never learn the swell
+ * exists. ADR-0049.
+ */
+test("a withheld product keeps its tab and says why it is empty", async () => {
+  const { container } = render(
+    await DayPanel({
+      slug: "la-jolla-shores-beach",
+      area: await areaScope("la-jolla"),
+    }),
+  );
+
+  const swell = container.querySelector('[data-series-tab="swell"]');
+  expect(swell).not.toBeNull();
+  fireEvent.click(swell!);
+
+  // No curve, and no request that could have produced one.
+  expect(
+    container.querySelector('svg[aria-label^="Swell today"] [data-curve]'),
+  ).toBeNull();
+  expect(readWaveWeek).not.toHaveBeenCalled();
+
+  // The area's own sentence, and the counts in it are La Jolla's real ones:
+  // nine of ten beaches read eight model lines and one reads none.
+  expect(
+    screen.getByText(
+      /Only 9 of the 10 beaches in La Jolla have a swell forecast, and they read 8 different sources/,
+    ),
+  ).toBeDefined();
+});
+
+/**
+ * The four tabs are three publishers, and the cell's two go together. So do the
+ * cloud band drawn behind every tab and the office's own wording above the
+ * chart, which come off that same cell.
+ */
+test("a withheld cell takes both its tabs, the cloud and the wording", async () => {
+  const { container } = render(
+    await DayPanel({
+      slug: "la-jolla-shores-beach",
+      area: await areaScope("la-jolla"),
+    }),
+  );
+
+  expect(readGridpointWeek).not.toHaveBeenCalled();
+  expect(readSkyWeek).not.toHaveBeenCalled();
+  expect(readSkyWording).not.toHaveBeenCalled();
+
+  // The office's sentences are replaced rather than dropped: one member's
+  // wording under the whole area's name is the thing this refuses.
+  expect(screen.queryByText("Patchy Fog then Mostly Sunny")).toBeNull();
+  expect(
+    screen.getAllByText(
+      /The 10 beaches in La Jolla read 4 different sources for a forecast in words/,
+    ).length,
+  ).toBeGreaterThan(0);
+
+  for (const [tab, product] of [
+    ["wind", "a wind forecast"],
+    ["temperature", "an air temperature forecast"],
+  ] as const) {
+    fireEvent.click(container.querySelector(`[data-series-tab="${tab}"]`)!);
+    expect(
+      screen.getByText(new RegExp(`4 different sources for ${product}`)),
+      tab,
+    ).toBeDefined();
+  }
+});
+
+/**
+ * The bar keeps all four tabs whatever the area shares. This is the assertion
+ * the decision turns on, so it is made against the area that would lose the
+ * most: La Jolla shares one of the chart's three products.
+ */
+test("the tab bar is the same four tabs at either scope", async () => {
+  const tabsOf = (root: HTMLElement) =>
+    [...root.querySelectorAll("[data-series-tab]")].map((node) =>
+      node.getAttribute("data-series-tab"),
+    );
+
+  const beach = render(await DayPanel({ slug: "la-jolla-shores-beach" }));
+  const onBeach = tabsOf(beach.container);
+  beach.unmount();
+
+  const { container } = render(
+    await DayPanel({
+      slug: "la-jolla-shores-beach",
+      area: await areaScope("la-jolla"),
+    }),
+  );
+
+  expect(onBeach).toEqual(["tide", "swell", "wind", "temperature"]);
+  expect(tabsOf(container)).toEqual(onBeach);
+});
+
+/**
+ * The map draws one beach's own stretch of coast. An area has no such run until
+ * the area map lands, and drawing the first member's under the area's name is
+ * the representative-beach lie ADR-0048 refuses -- so the column says what it
+ * is missing rather than showing the wrong thing or nothing at all.
+ */
+test("an area page carries no map, and says what is there instead", async () => {
+  const { container } = render(
+    await DayPanel({
+      slug: "la-jolla-shores-beach",
+      area: await areaScope("la-jolla"),
+    }),
+  );
+
+  expect(container.querySelector("svg[aria-label^='A map of']")).toBeNull();
+  expect(
+    screen.getByText(/The map draws one beach's own stretch of coast/),
+  ).toBeDefined();
+  expect(screen.getByText(/Choose a beach above for La Jolla's/)).toBeDefined();
+});
+
+/** And the beach page still draws it, which is what says the map was gated and not lost. */
+test("a beach page still draws its map", async () => {
+  const { container } = render(
+    await DayPanel({ slug: "la-jolla-shores-beach" }),
+  );
+
+  expect(container.querySelector("svg[aria-label^='A map of']")).not.toBeNull();
+  expect(screen.queryByText(/The map draws one beach's own/)).toBeNull();
+});
+
+/**
+ * The beach page is unchanged, and this says so structurally rather than by
+ * re-asserting every tab: with no scope there is nothing to withhold, so all
+ * six reads are made exactly as they were before areas existed.
+ */
+test("with no area scope every product is still read", async () => {
+  render(await DayPanel({ slug: "la-jolla-shores-beach" }));
+
+  for (const read of [
+    readHourlyTide,
+    readWaveWeek,
+    readSkyWeek,
+    readGridpointWeek,
+    readSkyWording,
+    readSurfZone,
+  ]) {
+    expect(read).toHaveBeenCalledWith("la-jolla-shores-beach");
+  }
+});
+
+/**
+ * The bulletin is not gated by the area's agreement, and that is deliberate
+ * rather than an oversight: the National Weather Service issues one for "San
+ * Diego County Coastal Areas", a unit larger than any area in this table. It is
+ * still read through a member here; the exception gets its own decision.
+ */
+test("the surf zone bulletin is read at either scope", async () => {
+  render(
+    await DayPanel({
+      slug: "la-jolla-shores-beach",
+      area: await areaScope("la-jolla"),
+    }),
+  );
+
+  expect(readSurfZone).toHaveBeenCalledWith("la-jolla-shores-beach");
+});

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -50,6 +50,31 @@
  * nothing had been measured about a day that had not happened. They now sit at
  * the top of the page, above `SelectedDayProvider`, because they answer for an
  * instant rather than for a day. See `ConditionsSection`.
+ *
+ * **It answers for an area as well as for a beach, one tab at a time.** On an
+ * area page it is handed an `AreaScope`, and a product the area's beaches do
+ * not share is not read and draws no curve -- but keeps its tab, which stands
+ * where it stood and carries the area's sentence where the plot would be.
+ * `HourSeries` already has that slot: an empty `points` renders `absence`, and
+ * that is how a bay with no MOP line has always been told there is no swell
+ * curve. See ADR-0048 and ADR-0049.
+ *
+ * **The tab stays, and dropping it was the alternative.** Four tabs are this
+ * region's whole vocabulary for its four products, and an area that showed
+ * fewer would be a different control rather than the same one with less in it.
+ * La Jolla shares a tide station and nothing else the chart draws, so a bar
+ * gated to what it can draw would be one tab wide -- and a reader would never
+ * learn the swell exists.
+ *
+ * **Three products and four tabs, because the wind and the air temperature are
+ * one cell.** They are withheld or drawn together, and so are the cloud band
+ * behind every tab and the office's own wording above the chart, which come off
+ * that same cell.
+ *
+ * **The map is one beach's, so an area page carries a sentence instead of
+ * one.** The area map is its own slice and its own decision; drawing the first
+ * member's coast under the area's name is the representative-beach lie ADR-0048
+ * refuses. The readout goes with it -- see the note at the map itself.
  */
 
 import {
@@ -74,6 +99,7 @@ import {
   localTimeOf,
   hourLabelAt,
 } from "@/lib/pacific-time";
+import { answer, type AreaScope, withheldBy, withheldWords } from "./areaScope";
 import { ChosenDay, type DayView } from "./ChosenDay";
 import type { HourSeries } from "./HourChart";
 import { ReservedSlot } from "../ui/ReservedSlot";
@@ -382,19 +408,47 @@ function mapDescription(beachName: string): string {
   );
 }
 
-export async function DayPanel({ slug }: { slug: string }) {
+export async function DayPanel({
+  slug,
+  area,
+}: {
+  slug: string;
+  /** Present on an area page, absent on a beach's. */
+  area?: AreaScope;
+}) {
+  /*
+    Which of the three products this area may draw, asked before anything is
+    fetched. Null on a beach page, where nothing is withheld and this whole
+    region behaves as it did before areas existed.
+
+    Three and not four, because the four tabs are three publishers: the wind and
+    the air temperature are both the forecast cell's, so they are withheld or
+    drawn together. The cloud band behind every tab and the office's own wording
+    above the chart are that same cell's, and go with them.
+  */
+  const withheldTide = withheldBy(area, "tide");
+  const withheldSwell = withheldBy(area, "swell");
+  const withheldSky = withheldBy(area, "sky");
+
   const daylight = readDaylightWeek(slug);
   const [hourly, waves, sky, grid, wording, surfZone] = await Promise.all([
-    readHourlyTide(slug),
-    readWaveWeek(slug),
-    readSkyWeek(slug),
-    readGridpointWeek(slug),
-    readSkyWording(slug),
+    answer(withheldTide, () => readHourlyTide(slug)),
+    answer(withheldSwell, () => readWaveWeek(slug)),
+    answer(withheldSky, () => readSkyWeek(slug)),
+    answer(withheldSky, () => readGridpointWeek(slug)),
+    answer(withheldSky, () => readSkyWording(slug)),
     // A sixth read and a third publisher's product, joining the others for the
     // reason they are all here: five agencies go quiet independently, and the
     // surf zone bulletin failing must cost its own block and nothing else. It
     // is the only one of the six that reaches no network at all on 25 of the
     // 51 beaches, because a bay has no surf zone to forecast.
+    //
+    // Not answered against the area's scope, and that is deliberate rather than
+    // an omission: it is one bulletin for "San Diego County Coastal Areas", a
+    // unit larger than any area in this table, so an intersection rule designed
+    // for point measurements is a category error against it. Read through the
+    // member the rest of this region reads through until that exception lands
+    // with its own decision.
     readSurfZone(slug),
   ]);
 
@@ -415,12 +469,12 @@ export async function DayPanel({ slug }: { slug: string }) {
   */
   const cellNote = [
     GRID_MODEL_NOTE,
-    gridCellCaveat(grid.cell?.elevationM ?? null),
+    gridCellCaveat(grid.view?.cell?.elevationM ?? null),
   ]
     .filter((part): part is string => part !== null)
     .join("; ");
 
-  const station = hourly.station;
+  const station = hourly.view?.station ?? null;
   const tideProvenance: ProvenanceFacts | null =
     station === null
       ? null
@@ -433,13 +487,13 @@ export async function DayPanel({ slug }: { slug: string }) {
         };
 
   const swellProvenance: ProvenanceFacts | null =
-    waves.line === null
+    waves.view === null || waves.view.line === null
       ? null
       : {
           label: "Swell",
-          source: mopLineSource(waves.line.id),
+          source: mopLineSource(waves.view.line.id),
           network: MOP_NETWORK,
-          distanceKm: mopLineDistanceKm(waves.line.distanceM),
+          distanceKm: mopLineDistanceKm(waves.view.line.distanceM),
           note: MOP_MODEL_NOTE,
         };
 
@@ -454,7 +508,7 @@ export async function DayPanel({ slug }: { slug: string }) {
     a model line, which stand at a point.
   */
   const cellProvenance = (label: string): ProvenanceFacts | null =>
-    grid.cell === null
+    grid.view === null || grid.view.cell === null
       ? null
       : { label, source: GRID_SOURCE, network: GRID_NETWORK, note: cellNote };
 
@@ -493,24 +547,26 @@ export async function DayPanel({ slug }: { slug: string }) {
     const chartWhen = day.isToday ? "today" : `on ${day.dayLabel}`;
 
     const tideDay =
-      hourly.state.kind === "week"
-        ? hourly.state.days.find((each) => each.localDate === day.localDate)
+      hourly.view?.state.kind === "week"
+        ? hourly.view.state.days.find(
+            (each) => each.localDate === day.localDate,
+          )
         : undefined;
 
     const waveDay =
-      waves.state.kind === "week"
-        ? waves.state.days.find((each) => each.localDate === day.localDate)
+      waves.view?.state.kind === "week"
+        ? waves.view.state.days.find((each) => each.localDate === day.localDate)
         : undefined;
 
     const cloudHours =
-      sky.state.kind === "week"
-        ? (sky.state.days.find((each) => each.localDate === day.localDate)
+      sky.view?.state.kind === "week"
+        ? (sky.view.state.days.find((each) => each.localDate === day.localDate)
             ?.hours ?? [])
         : [];
 
     const gridDay =
-      grid.state.kind === "week"
-        ? grid.state.days.find((each) => each.localDate === day.localDate)
+      grid.view?.state.kind === "week"
+        ? grid.view.state.days.find((each) => each.localDate === day.localDate)
         : undefined;
 
     /*
@@ -538,7 +594,10 @@ export async function DayPanel({ slug }: { slug: string }) {
                 day.sunsetLabel,
                 WATER_DECIMALS,
               ),
-        absence: absenceFor(hourly, WORDS.tide, when),
+        absence:
+          hourly.view === null
+            ? withheldWords(hourly.withheld, "an hour-by-hour tide prediction")
+            : absenceFor(hourly.view, WORDS.tide, when),
         provenance: tideProvenance,
       },
       {
@@ -557,7 +616,10 @@ export async function DayPanel({ slug }: { slug: string }) {
                 day.sunsetLabel,
                 WATER_DECIMALS,
               ),
-        absence: absenceFor(waves, WORDS.swell, when),
+        absence:
+          waves.view === null
+            ? withheldWords(waves.withheld, "a swell forecast")
+            : absenceFor(waves.view, WORDS.swell, when),
         provenance: swellProvenance,
       },
       {
@@ -576,7 +638,10 @@ export async function DayPanel({ slug }: { slug: string }) {
           WORDS.wind.outOfReach(when),
           GRID_DECIMALS,
         ),
-        absence: gridAbsenceFor(grid, gridDay?.windMph, WORDS.wind, when),
+        absence:
+          grid.view === null
+            ? withheldWords(grid.withheld, "a wind forecast")
+            : gridAbsenceFor(grid.view, gridDay?.windMph, WORDS.wind, when),
         provenance: cellProvenance("Wind"),
       },
       {
@@ -607,12 +672,15 @@ export async function DayPanel({ slug }: { slug: string }) {
           WORDS.temperature.outOfReach(when),
           GRID_DECIMALS,
         ),
-        absence: gridAbsenceFor(
-          grid,
-          gridDay?.airTempF,
-          WORDS.temperature,
-          when,
-        ),
+        absence:
+          grid.view === null
+            ? withheldWords(grid.withheld, "an air temperature forecast")
+            : gridAbsenceFor(
+                grid.view,
+                gridDay?.airTempF,
+                WORDS.temperature,
+                when,
+              ),
         // The word the tab drops, put back. Same rule as the spoken
         // description and the sentence under the plot: "Temp" buys width on a
         // 375px tab bar, and nothing else on this page pays for it.
@@ -653,7 +721,20 @@ export async function DayPanel({ slug }: { slug: string }) {
       })),
       cloudDescription: cloudBandDescription(cloudHours, when),
       series,
-      wording: <SkyWording view={wording} localDate={day.localDate} />,
+      /*
+        The office's own sentences about this day, and they are the forecast
+        cell's like the wind and the temperature are. An area whose beaches read
+        different cells gets the area's sentence in their place rather than one
+        member's wording under the whole area's name.
+      */
+      wording:
+        wording.view === null ? (
+          <p className="leading-relaxed mb-4 text-base text-fog">
+            {withheldWords(wording.withheld, "a forecast in words")}
+          </p>
+        ) : (
+          <SkyWording view={wording.view} localDate={day.localDate} />
+        ),
       /*
         Rendered here and handed over finished, the precedent `wording` sets:
         the read is the server's and `ChosenDay` is a client component.
@@ -683,13 +764,33 @@ export async function DayPanel({ slug }: { slug: string }) {
     that travels separately. It is also the one thing in this region that reads
     no feed -- `beaches.json` and `mop-lines.json` are committed -- so it cannot
     go quiet and does not belong behind a Suspense boundary.
+  */
+  /*
+    **No map on an area page, and a sentence in its place.**
+
+    The map draws one beach's own stretch of coast, heavier than the shore
+    either side of it. There is no such run for an area -- the area map, with a
+    tick per member and a frame taking the bbox's own aspect, is its own slice
+    and its own decision, because ADR-0033 says the map draws a place and not an
+    inventory and a mark per beach amends that. Drawing the first member's coast
+    here in the meantime is exactly the representative-beach lie ADR-0048
+    refuses: it would put one beach's shoreline under the area's name.
+
+    The readout goes with it, and that is the part worth stating. ADR-0034's
+    surviving clause has the readout rendered on every beach including the ones
+    with no coast, so a bearing dial without a shoreline is a shape this page
+    already permits -- but `ShoreMap` owns the coupling ADR-0038 settled, one
+    `hasReadout` gating the block and its sources together, and hoisting it out
+    would be a second change to a contract that decision has just finished
+    drawing. It arrives with the area map, over the area's own coast, which is
+    the frame that makes a wind bearing mean anything.
 
     A beach the inventory does not hold is not this component's error to invent
     a map for: the route already answered that question before rendering, and
     `beachBySlug` returning null here would mean the page is showing a beach it
     does not have.
   */
-  const beach = beachBySlug(slug);
+  const beach = area ? null : beachBySlug(slug);
   const shore = beach === null ? null : shoreViewFor(beach);
 
   /*
@@ -709,16 +810,16 @@ export async function DayPanel({ slug }: { slug: string }) {
   */
   const compassDays: CompassDay[] = daylight.days.map((day) => {
     const gridDay =
-      grid.state.kind === "week"
-        ? grid.state.days.find((each) => each.localDate === day.localDate)
+      grid.view?.state.kind === "week"
+        ? grid.view.state.days.find((each) => each.localDate === day.localDate)
         : undefined;
 
     const swellDay =
-      waves.state.kind === "week"
-        ? waves.state.days.find((each) => each.localDate === day.localDate)
+      waves.view?.state.kind === "week"
+        ? waves.view.state.days.find((each) => each.localDate === day.localDate)
         : undefined;
 
-    const line = waves.line;
+    const line = waves.view?.line ?? null;
     const dayStartMs = localMidnightOf(day.localDate);
 
     /*
@@ -919,7 +1020,13 @@ export async function DayPanel({ slug }: { slug: string }) {
         <ChosenDay
           days={days}
           map={
-            shore === null ? null : (
+            area ? (
+              <p className="leading-relaxed text-base text-fog">
+                The map draws one beach&apos;s own stretch of coast, with the
+                day&apos;s wind and swell laid under it. Choose a beach above
+                for {area.name}&apos;s.
+              </p>
+            ) : shore === null ? null : (
               <>
                 <ShoreMap
                   {...shore}

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -443,13 +443,14 @@ export async function DayPanel({
     // is the only one of the six that reaches no network at all on 25 of the
     // 51 beaches, because a bay has no surf zone to forecast.
     //
-    // Not answered against the area's scope, and that is deliberate rather than
-    // an omission: it is one bulletin for "San Diego County Coastal Areas", a
-    // unit larger than any area in this table, so an intersection rule designed
-    // for point measurements is a category error against it. Read through the
-    // member the rest of this region reads through until that exception lands
-    // with its own decision.
-    readSurfZone(slug),
+    // Not answered against the area's scope, and that is the exception rather
+    // than an omission: it is one bulletin for "San Diego County Coastal
+    // Areas", a unit larger than any area in this table, so an intersection
+    // rule designed for point measurements asks it a question it has no answer
+    // to. What it needs is a member the forecast is *issued* for, which is a
+    // different member from the one everything else here is read through
+    // wherever an area's first beach is sheltered. See ADR-0050.
+    readSurfZone(area?.bulletinBeach ?? slug),
   ]);
 
   /*
@@ -752,6 +753,7 @@ export async function DayPanel({
           state={surfZone.state}
           localDate={day.localDate}
           when={when}
+          areaName={area?.name}
         />
       ),
     };

--- a/src/components/conditions/MeasuredPanel.test.tsx
+++ b/src/components/conditions/MeasuredPanel.test.tsx
@@ -125,6 +125,7 @@ test("a failure to resolve the beach is not swallowed into a rendered nothing", 
  */
 test("a withheld card states what the area's beaches really bind", async () => {
   const { areaBySlug, areaSources } = await import("@/lib/areas");
+  const { scopeFor } = await import("./areaScope");
   const area = areaBySlug("la-jolla")!;
 
   // The probe. If La Jolla ever shares a buoy, this test is asserting nothing
@@ -134,11 +135,7 @@ test("a withheld card states what the area's beaches really bind", async () => {
   render(
     await MeasuredPanel({
       slug: "la-jolla-shores-beach",
-      area: {
-        name: area.name,
-        beaches: area.beaches.length,
-        sources: areaSources(area),
-      },
+      area: scopeFor(area),
     }),
   );
 

--- a/src/components/conditions/MeasuredPanel.test.tsx
+++ b/src/components/conditions/MeasuredPanel.test.tsx
@@ -107,3 +107,49 @@ test("a failure to resolve the beach is not swallowed into a rendered nothing", 
     /no beach in the inventory/,
   );
 });
+
+/**
+ * The withheld card's sentence, against what `areaSources` really returns.
+ *
+ * Every other assertion about that card hands `MeasuredToday` a hand-written
+ * `NotShared`, so it can only ever check that the component renders the numbers
+ * it was given. That is how `/conditions/la-jolla` came to say "The 10 beaches
+ * in La Jolla read 2 different sources for a wave reading" with a passing test
+ * over it: nine read buoy 46254 and `childrens-pool` reads none, and the
+ * fixture said 2 because a `null` had been counted as a source.
+ *
+ * So this one builds the scope the way the page does -- from `areaSources` over
+ * committed data -- and reads the sentence off the rendered card. Both operands
+ * are not the same source: the left is the component's output and the right is
+ * what La Jolla's ten beaches actually bind.
+ */
+test("a withheld card states what the area's beaches really bind", async () => {
+  const { areaBySlug, areaSources } = await import("@/lib/areas");
+  const area = areaBySlug("la-jolla")!;
+
+  // The probe. If La Jolla ever shares a buoy, this test is asserting nothing
+  // and should be pointed at whichever area still has the gap.
+  expect(areaSources(area).waves.kind).toBe("mixed");
+
+  render(
+    await MeasuredPanel({
+      slug: "la-jolla-shores-beach",
+      area: {
+        name: area.name,
+        beaches: area.beaches.length,
+        sources: areaSources(area),
+      },
+    }),
+  );
+
+  expect(
+    screen.getByText(
+      /Only 9 of the 10 beaches in La Jolla have a wave reading, and they share one source/,
+    ),
+  ).toBeDefined();
+  expect(screen.queryByText(/different sources/)).toBeNull();
+
+  // And the withheld product was not read, which is the other half of the
+  // contract: there is nothing an area could do with one beach's buoy.
+  expect(readLatestWaves).not.toHaveBeenCalled();
+});

--- a/src/components/conditions/MeasuredPanel.tsx
+++ b/src/components/conditions/MeasuredPanel.tsx
@@ -61,6 +61,7 @@ function withheldBy(
     areaName: scope.name,
     beaches: scope.beaches,
     distinct: source.kind === "mixed" ? source.distinct : 0,
+    without: source.kind === "mixed" ? source.without : 0,
   };
 }
 

--- a/src/components/conditions/MeasuredPanel.tsx
+++ b/src/components/conditions/MeasuredPanel.tsx
@@ -27,43 +27,9 @@
  * arranged to avoid.
  */
 
-import { type AreaSources } from "@/lib/areas";
 import { readLatestAir, readLatestWaves } from "@/lib/conditions";
-import { MeasuredToday, type NotShared } from "./MeasuredToday";
-
-/**
- * What this block is about, when it is about an area rather than one beach.
- *
- * `slug` is still a beach, because every read here is keyed on one — but which
- * beach is immaterial for a product the area shares, and that is what "shared"
- * means: `areas.test.ts` asserts that where `areaSources` says shared, every
- * beach in the area binds that same source. A product it does not share is not
- * read at all, so no member's figure can leak into an area's card.
- */
-export type AreaScope = {
-  name: string;
-  beaches: number;
-  sources: AreaSources;
-};
-
-/** A slot the area cannot fill, or null when it can. */
-function withheldBy(
-  scope: AreaScope | undefined,
-  product: "waves" | "air",
-): NotShared | null {
-  if (!scope) return null;
-
-  const source = scope.sources[product];
-  if (source.kind === "shared") return null;
-
-  return {
-    agreement: source.kind,
-    areaName: scope.name,
-    beaches: scope.beaches,
-    distinct: source.kind === "mixed" ? source.distinct : 0,
-    without: source.kind === "mixed" ? source.without : 0,
-  };
-}
+import { type AreaScope, withheldBy } from "./areaScope";
+import { MeasuredToday } from "./MeasuredToday";
 
 export async function MeasuredPanel({
   slug,

--- a/src/components/conditions/MeasuredToday.test.tsx
+++ b/src/components/conditions/MeasuredToday.test.tsx
@@ -962,6 +962,7 @@ test("an area with no buoy anywhere says so, and does not blame disagreement", (
           areaName: "Mission Bay – West",
           beaches: 8,
           distinct: 0,
+          without: 8,
         },
         air: readings().air,
       }}
@@ -982,9 +983,10 @@ test("an area whose beaches disagree names how many, and how many sources", () =
       readings={{
         waves: {
           agreement: "mixed",
-          areaName: "La Jolla",
-          beaches: 10,
+          areaName: "Torrey Pines",
+          beaches: 2,
           distinct: 2,
+          without: 0,
         },
         air: readings().air,
       }}
@@ -993,9 +995,47 @@ test("an area whose beaches disagree names how many, and how many sources", () =
 
   expect(
     screen.getByText(
-      /The 10 beaches in La Jolla read 2 different sources for a wave reading/,
+      /The 2 beaches in Torrey Pines read 2 different sources for a wave reading/,
     ),
   ).toBeDefined();
+});
+
+/**
+ * The other shape of `mixed`, and the one the count was wrong about.
+ *
+ * Nine of La Jolla's ten beaches read buoy 46254 and `childrens-pool` reads
+ * none. That is one source and one gap, and this card said "2 different
+ * sources" over it on the default area's own page — because `areaSources` put
+ * `null` in the set with the identifiers, and because the test above this one
+ * asserted the sentence against a `distinct` nobody had read off the data.
+ *
+ * These numbers are the real ones, and `MeasuredPanel.test.tsx` asserts the
+ * same sentence against `areaSources`' actual output rather than against a
+ * fixture, which is the half that could have caught it.
+ */
+test("an area where some beaches have none says that, not that they disagree", () => {
+  render(
+    <MeasuredToday
+      readings={{
+        waves: {
+          agreement: "mixed",
+          areaName: "La Jolla",
+          beaches: 10,
+          distinct: 1,
+          without: 1,
+        },
+        air: readings().air,
+      }}
+    />,
+  );
+
+  expect(
+    screen.getByText(
+      /Only 9 of the 10 beaches in La Jolla have a wave reading, and they share one source/,
+    ),
+  ).toBeDefined();
+  // The claim that was false: they read one buoy, not two.
+  expect(screen.queryByText(/different sources/)).toBeNull();
 });
 
 /**
@@ -1018,6 +1058,7 @@ test("a withheld card keeps the glyph and rank of the card it stands in for", ()
           areaName: "Coronado",
           beaches: 3,
           distinct: 0,
+          without: 3,
         },
         air: readings().air,
       }}

--- a/src/components/conditions/MeasuredToday.tsx
+++ b/src/components/conditions/MeasuredToday.tsx
@@ -57,9 +57,15 @@ import { type Stat, StatGroup } from "./StatGroup";
  *
  * **Two agreements, because they owe a reader different sentences.** `absent`
  * is every beach in the area lacking the instrument, which is the bay's missing
- * buoy and was already true one beach at a time. `mixed` is the beaches having
- * one each and disagreeing, which is new with areas and is the only state a
- * reader has never seen before.
+ * buoy and was already true one beach at a time. `mixed` is the beaches not all
+ * reading one source, which is new with areas and is the only state a reader has
+ * never seen before.
+ *
+ * **`mixed` has two shapes and the sentence says which.** Either the beaches
+ * read different sources, or some read one and some read none — three of the
+ * sixteen mixed product-instances are the second, La Jolla's own wave buoy
+ * among them. Both mean no single figure answers for the area; only the first
+ * is what "different sources" describes.
  *
  * **It carries facts and not a sentence**, which is this repo's rule about who
  * owns the copy on this page. It also could not carry one: the beaches' own
@@ -75,6 +81,15 @@ export type NotShared = {
   beaches: number;
   /** How many distinct sources they bind. Only meaningful when `mixed`. */
   distinct: number;
+  /**
+   * How many of them bind no source at all. Only meaningful when `mixed`.
+   *
+   * **Beside `distinct` because the sentence needs both.** Nine beaches reading
+   * one buoy and a tenth reading none is not ten beaches reading two buoys, and
+   * only the second is what "2 different sources" describes. It was the first
+   * that `/conditions/la-jolla` printed the second sentence over.
+   */
+  without: number;
 };
 
 /** True of a slot the area cannot fill, false of a reading. */
@@ -517,6 +532,38 @@ function AirCard({ beachName, airStation, air }: AirView) {
  * reader to a beach for the rest. That sentence is here rather than in
  * `lib/areas.ts` because the copy on this page belongs to the page.
  */
+/**
+ * What the card says instead of a figure, in one sentence.
+ *
+ * **Three sentences and not two, because `mixed` has two shapes.** The plain
+ * one is beaches reading different sources. The other is some reading a source
+ * and some reading none, and saying "read 2 different sources" of nine beaches
+ * sharing a buoy and one lacking it is false — which is what this card printed
+ * on `/conditions/la-jolla`, the default area, until the count learned to tell
+ * a gap from a source.
+ *
+ * **It counts the beaches that have the product rather than the ones that do
+ * not**, which is what keeps one sentence covering both counts without a
+ * plural to agree: "Only 9 of the 10 beaches" needs no branch where "and 1 has
+ * none" would need one, and a reader learns the same thing from it.
+ */
+function notSharedWords(slot: NotShared, product: string): string {
+  if (slot.agreement === "absent") {
+    return `No beach in ${slot.areaName} has ${product}. Each says why on its own page.`;
+  }
+
+  const sources =
+    slot.distinct === 1
+      ? "they share one source"
+      : `they read ${slot.distinct} different sources`;
+
+  const tail = `so there is no one figure for the whole area. Choose a beach for it.`;
+
+  return slot.without === 0
+    ? `The ${slot.beaches} beaches in ${slot.areaName} read ${slot.distinct} different sources for ${product}, ${tail}`
+    : `Only ${slot.beaches - slot.without} of the ${slot.beaches} beaches in ${slot.areaName} have ${product}, and ${sources} — ${tail}`;
+}
+
 function NotSharedCard({
   emoji,
   title,
@@ -539,11 +586,7 @@ function NotSharedCard({
       title={title}
       context={slot.areaName}
     >
-      <p className={CARD_PROSE}>
-        {slot.agreement === "absent"
-          ? `No beach in ${slot.areaName} has ${product}. Each says why on its own page.`
-          : `The ${slot.beaches} beaches in ${slot.areaName} read ${slot.distinct} different sources for ${product}, so there is no one figure for the whole area. Choose a beach for it.`}
-      </p>
+      <p className={CARD_PROSE}>{notSharedWords(slot, product)}</p>
     </ReadingCard>
   );
 }

--- a/src/components/conditions/MeasuredToday.tsx
+++ b/src/components/conditions/MeasuredToday.tsx
@@ -45,52 +45,13 @@
  */
 
 import type { AirView, WavesView } from "@/lib/conditions";
+import type { NotShared } from "./areaScope";
 import { compassWords } from "./bearing";
 import { CARD_PROSE } from "./cardText";
 import { DISCLOSURE_TARGET } from "./disclosure";
 import { ProvenanceLine } from "./ProvenanceLine";
 import { ReadingCard } from "./ReadingCard";
 import { type Stat, StatGroup } from "./StatGroup";
-
-/**
- * Why an area cannot report a product, when its beaches do not share one.
- *
- * **Two agreements, because they owe a reader different sentences.** `absent`
- * is every beach in the area lacking the instrument, which is the bay's missing
- * buoy and was already true one beach at a time. `mixed` is the beaches not all
- * reading one source, which is new with areas and is the only state a reader has
- * never seen before.
- *
- * **`mixed` has two shapes and the sentence says which.** Either the beaches
- * read different sources, or some read one and some read none — three of the
- * sixteen mixed product-instances are the second, La Jolla's own wave buoy
- * among them. Both mean no single figure answers for the area; only the first
- * is what "different sources" describes.
- *
- * **It carries facts and not a sentence**, which is this repo's rule about who
- * owns the copy on this page. It also could not carry one: the beaches' own
- * reasons differ, and lifting any of them would print one beach's figure as if
- * it were the area's. Coronado's three name 20.9, 21.6 and 21.2 km for the buoy
- * that does not reach them.
- */
-export type NotShared = {
-  agreement: "absent" | "mixed";
-  /** The area's name, for the sentence. */
-  areaName: string;
-  /** How many beaches it holds. */
-  beaches: number;
-  /** How many distinct sources they bind. Only meaningful when `mixed`. */
-  distinct: number;
-  /**
-   * How many of them bind no source at all. Only meaningful when `mixed`.
-   *
-   * **Beside `distinct` because the sentence needs both.** Nine beaches reading
-   * one buoy and a tenth reading none is not ten beaches reading two buoys, and
-   * only the second is what "2 different sources" describes. It was the first
-   * that `/conditions/la-jolla` printed the second sentence over.
-   */
-  without: number;
-};
 
 /** True of a slot the area cannot fill, false of a reading. */
 function notShared(slot: WavesView | AirView | NotShared): slot is NotShared {

--- a/src/components/conditions/MeasuredToday.tsx
+++ b/src/components/conditions/MeasuredToday.tsx
@@ -45,7 +45,7 @@
  */
 
 import type { AirView, WavesView } from "@/lib/conditions";
-import type { NotShared } from "./areaScope";
+import { type NotShared, withheldWords } from "./areaScope";
 import { compassWords } from "./bearing";
 import { CARD_PROSE } from "./cardText";
 import { DISCLOSURE_TARGET } from "./disclosure";
@@ -493,38 +493,6 @@ function AirCard({ beachName, airStation, air }: AirView) {
  * reader to a beach for the rest. That sentence is here rather than in
  * `lib/areas.ts` because the copy on this page belongs to the page.
  */
-/**
- * What the card says instead of a figure, in one sentence.
- *
- * **Three sentences and not two, because `mixed` has two shapes.** The plain
- * one is beaches reading different sources. The other is some reading a source
- * and some reading none, and saying "read 2 different sources" of nine beaches
- * sharing a buoy and one lacking it is false — which is what this card printed
- * on `/conditions/la-jolla`, the default area, until the count learned to tell
- * a gap from a source.
- *
- * **It counts the beaches that have the product rather than the ones that do
- * not**, which is what keeps one sentence covering both counts without a
- * plural to agree: "Only 9 of the 10 beaches" needs no branch where "and 1 has
- * none" would need one, and a reader learns the same thing from it.
- */
-function notSharedWords(slot: NotShared, product: string): string {
-  if (slot.agreement === "absent") {
-    return `No beach in ${slot.areaName} has ${product}. Each says why on its own page.`;
-  }
-
-  const sources =
-    slot.distinct === 1
-      ? "they share one source"
-      : `they read ${slot.distinct} different sources`;
-
-  const tail = `so there is no one figure for the whole area. Choose a beach for it.`;
-
-  return slot.without === 0
-    ? `The ${slot.beaches} beaches in ${slot.areaName} read ${slot.distinct} different sources for ${product}, ${tail}`
-    : `Only ${slot.beaches - slot.without} of the ${slot.beaches} beaches in ${slot.areaName} have ${product}, and ${sources} — ${tail}`;
-}
-
 function NotSharedCard({
   emoji,
   title,
@@ -547,7 +515,7 @@ function NotSharedCard({
       title={title}
       context={slot.areaName}
     >
-      <p className={CARD_PROSE}>{notSharedWords(slot, product)}</p>
+      <p className={CARD_PROSE}>{withheldWords(slot, product)}</p>
     </ReadingCard>
   );
 }

--- a/src/components/conditions/SurfZone.tsx
+++ b/src/components/conditions/SurfZone.tsx
@@ -62,6 +62,16 @@ export type SurfZoneProps = {
   localDate: string;
   /** That day, worded for a reader: `Thursday`. Matches the panel's heading. */
   when: string;
+  /**
+   * The area this block is answering for, or undefined on a beach page.
+   *
+   * **Only the withheld sentence reads it**, and that is the whole of what an
+   * area changes here. The bulletin itself is issued for "San Diego County
+   * Coastal Areas" and says nothing about a beach, so a relayed forecast is
+   * already true at either scope; what is not true at either scope is "not
+   * issued for this beach" printed over an area. See ADR-0050.
+   */
+  areaName?: string;
 };
 
 /** The one sentence a reader gets when there is nothing to relay. */
@@ -138,7 +148,7 @@ function Reading({ day, when }: { day: SurfZoneDay; when: string }) {
   );
 }
 
-export function SurfZone({ state, localDate, when }: SurfZoneProps) {
+export function SurfZone({ state, localDate, when, areaName }: SurfZoneProps) {
   if (state.kind === "no-surf-zone") {
     return (
       <section>
@@ -157,8 +167,20 @@ export function SurfZone({ state, localDate, when }: SurfZoneProps) {
           than in a fixture, which is why the absence path is worth looking at
           rather than only asserting.
         */}
+        {/*
+          "any beach in <area>" rather than "this beach" where the block is
+          answering for one, and it is a claim rather than a hedge: reaching
+          this state on an area page means no member of it is open coast, so
+          the reason read through one member is the reason every member gives.
+          `surfZoneBeachOf` is what guarantees that -- it returns a member the
+          forecast is issued for wherever one exists -- and `areas.test.ts`
+          asserts it over the whole table rather than leaving it in this
+          comment.
+        */}
         <Absence>
-          This forecast is not issued for this beach: {state.reason}.
+          This forecast is not issued for{" "}
+          {areaName === undefined ? "this beach" : `any beach in ${areaName}`}:{" "}
+          {state.reason}.
         </Absence>
       </section>
     );

--- a/src/components/conditions/WeekPanel.test.tsx
+++ b/src/components/conditions/WeekPanel.test.tsx
@@ -1256,13 +1256,9 @@ test("a beach with no tide station is attributed to nothing rather than to a bla
  * two drift apart in exactly the way ADR-0048's counts already drifted once.
  */
 async function areaScope(slug: string) {
-  const { areaBySlug, areaSources } = await import("@/lib/areas");
-  const area = areaBySlug(slug)!;
-  return {
-    name: area.name,
-    beaches: area.beaches.length,
-    sources: areaSources(area),
-  };
+  const { areaBySlug } = await import("@/lib/areas");
+  const { scopeFor } = await import("./areaScope");
+  return scopeFor(areaBySlug(slug)!);
 }
 
 /**

--- a/src/components/conditions/WeekPanel.test.tsx
+++ b/src/components/conditions/WeekPanel.test.tsx
@@ -1244,3 +1244,169 @@ test("a beach with no tide station is attributed to nothing rather than to a bla
 
   expect(screen.queryByText(/NOAA Tides & Currents/)).toBeNull();
 });
+
+/* =========================================================================
+ * The week, answering for an area
+ * ========================================================================= */
+
+/**
+ * The scope a page hands this panel, built from `areas.json` rather than
+ * invented. `areaSources` is not mocked here — the point of these tests is what
+ * this panel does with what the real table says, and a fixture would let the
+ * two drift apart in exactly the way ADR-0048's counts already drifted once.
+ */
+async function areaScope(slug: string) {
+  const { areaBySlug, areaSources } = await import("@/lib/areas");
+  const area = areaBySlug(slug)!;
+  return {
+    name: area.name,
+    beaches: area.beaches.length,
+    sources: areaSources(area),
+  };
+}
+
+/**
+ * A row the area's beaches share is drawn, and it is not qualified.
+ *
+ * La Jolla's ten beaches all bind `9410230`, so the tide is the area's and the
+ * row says what it says on a beach page. Sixteen of the eighteen areas are like
+ * this, which is why gating the panel whole would have been the wrong shape.
+ */
+test("an area draws the row its beaches share", async () => {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: {
+      kind: "week",
+      days: [tideDay(0, "6:41 PM", 0.9), tideDay(1, "7:10 AM", -0.42)],
+    },
+  });
+
+  const { container } = render(
+    await WeekPanel({
+      slug: "la-jolla-shores-beach",
+      area: await areaScope("la-jolla"),
+    }),
+  );
+
+  expect(countOf(cellLabels(container), "Low tide")).toBe(2);
+  // Two of La Jolla's three rows are withheld and say so, so "is there a
+  // withheld note on the page" would pass here whatever the tide did. What
+  // must be true is that none of them is about the tide.
+  expect(screen.queryByText(/tide prediction/)).toBeNull();
+  expect(readWeekOfLowestLows).toHaveBeenCalledWith("la-jolla-shores-beach");
+});
+
+/**
+ * And a row they do not share is not drawn, is not read, and is said out loud.
+ *
+ * La Jolla's ten bind four forecast cells. The note under the grid is the slot
+ * this panel already uses for a row it cannot draw — a beach with no MOP line
+ * has had no wave row and a sentence there since long before areas existed.
+ */
+test("an area withholds the row its beaches disagree on, and says so", async () => {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: {
+      kind: "week",
+      days: [tideDay(0, "6:41 PM", 0.9), tideDay(1, "7:10 AM", -0.42)],
+    },
+  });
+
+  const { container } = render(
+    await WeekPanel({
+      slug: "la-jolla-shores-beach",
+      area: await areaScope("la-jolla"),
+    }),
+  );
+
+  // No cloud row.
+  expect(countOf(cellLabels(container), "Cloud")).toBe(0);
+  // And the reader is told why, in the area's own terms.
+  expect(
+    screen.getByText(
+      /The 10 beaches in La Jolla read 4 different sources for a cloud forecast/,
+    ),
+  ).toBeDefined();
+  // Nothing was asked for. There is nothing this grid could do with one
+  // member's cell, and the wait would be spent on a row it will not draw.
+  expect(readSkyWeek).not.toHaveBeenCalled();
+});
+
+/**
+ * The tide's two reads are one product and go together.
+ *
+ * The row's figures and the hourly shape behind them come from one station
+ * through two requests. A shape drawn under a row that is not there would be a
+ * curve attributed to nobody, so a withheld tide costs both.
+ */
+test("a withheld tide takes its hourly shape with it", async () => {
+  const { container } = render(
+    await WeekPanel({
+      slug: "tijuana-slough-national-wildlife-refuge",
+      area: await areaScope("tijuana-estuary"),
+    }),
+  );
+
+  expect(readWeekOfLowestLows).not.toHaveBeenCalled();
+  expect(readHourlyTide).not.toHaveBeenCalled();
+  expect(countOf(cellLabels(container), "Low tide")).toBe(0);
+  expect(container.querySelector('svg[aria-label^="Tide through"]')).toBeNull();
+  expect(
+    screen.getByText(
+      /The 2 beaches in Tijuana Estuary read 2 different sources for a tide prediction/,
+    ),
+  ).toBeDefined();
+});
+
+/**
+ * The other silence, and it must not be worded as disagreement. Mission Bay –
+ * West's eight beaches have no MOP line between them, which is a bay having no
+ * swell rather than eight beaches failing to agree about one.
+ */
+test("an area with no source anywhere says nobody has it", async () => {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: {
+      kind: "week",
+      days: [tideDay(0, "6:41 PM", 0.9), tideDay(1, "7:10 AM", -0.42)],
+    },
+  });
+
+  const { container } = render(
+    await WeekPanel({
+      slug: "mission-bay-bahia-point",
+      area: await areaScope("mission-bay-west"),
+    }),
+  );
+
+  expect(countOf(cellLabels(container), "Swell")).toBe(0);
+  expect(
+    screen.getByText(
+      /No beach in Mission Bay – West has a swell forecast\. Each says why on its own page\./,
+    ),
+  ).toBeDefined();
+  expect(screen.queryByText(/different sources for a swell/)).toBeNull();
+  expect(readWaveWeek).not.toHaveBeenCalled();
+});
+
+/**
+ * The beach page is unchanged, and this is what says so structurally rather
+ * than by re-asserting every row: with no scope there is nothing to withhold,
+ * so all four reads are made exactly as they were before areas existed.
+ */
+test("with no area scope every product is still read", async () => {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: {
+      kind: "week",
+      days: [tideDay(0, "6:41 PM", 0.9), tideDay(1, "7:10 AM", -0.42)],
+    },
+  });
+
+  render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
+
+  expect(readWeekOfLowestLows).toHaveBeenCalledWith("la-jolla-shores-beach");
+  expect(readHourlyTide).toHaveBeenCalledWith("la-jolla-shores-beach");
+  expect(readWaveWeek).toHaveBeenCalledWith("la-jolla-shores-beach");
+  expect(readSkyWeek).toHaveBeenCalledWith("la-jolla-shores-beach");
+});

--- a/src/components/conditions/WeekPanel.tsx
+++ b/src/components/conditions/WeekPanel.tsx
@@ -35,6 +35,26 @@
  * **Composing the shapes is this file's job and not the grid's**, for the
  * reason the row mapping is: three publishers' hours have to become one series
  * plus two background layers, and `WeekGrid` must not know what a tide is.
+ *
+ * **It answers for an area as well as for a beach, one row at a time.** On an
+ * area page it is handed an `AreaScope`, and a product the area's beaches do
+ * not share is not read, draws no row, and is said out loud in the notes
+ * beneath the grid instead. That is the slot this panel already uses for a
+ * product it cannot draw: a beach with no MOP line has had no wave row and a
+ * sentence under the grid since long before areas existed, so an area with no
+ * agreement on one gets the same shape and a sentence in its own words. See
+ * ADR-0048 and `areaScope.ts`.
+ *
+ * **Gating rows and not the panel is what makes an area page worth having.**
+ * Sixteen of the eighteen areas share a tide station and eleven share a
+ * forecast cell, so a panel gated whole would go missing from areas that can
+ * answer for two of its three rows. Per product, the same grid renders with
+ * whichever rows the area may draw.
+ *
+ * **Which beach an area reads through cannot matter**, and that is asserted
+ * rather than argued: a product is only read here when every beach in the area
+ * binds the same source for it, which `areas.test.ts` checks over the whole
+ * table. So the row is the area's, whichever member the request named.
  */
 
 import {
@@ -45,6 +65,7 @@ import {
   readWeekOfLowestLows,
   type TideHourlyDay,
 } from "@/lib/conditions";
+import { type AreaScope, withheldBy, withheldWords } from "./areaScope";
 import { DaylightWeek } from "./DaylightWeek";
 import { DaySpark } from "./DaySpark";
 import { tidePoints } from "./series";
@@ -120,7 +141,28 @@ function sparkDescription(
   );
 }
 
-export async function WeekPanel({ slug }: { slug: string }) {
+export async function WeekPanel({
+  slug,
+  area,
+}: {
+  slug: string;
+  /** Present on an area page, absent on a beach's. */
+  area?: AreaScope;
+}) {
+  /*
+    Which of the three rows this area may draw at all, asked before anything is
+    fetched. Null on a beach page, where nothing is withheld and the whole panel
+    behaves as it did before areas existed.
+
+    Two of the three products are the tide's: the row's figures and the shape
+    behind them come from one station through two requests, so they are withheld
+    or read together. A shape drawn under a row that is not there would be a
+    curve attributed to nobody.
+  */
+  const withheldTide = withheldBy(area, "tide");
+  const withheldSwell = withheldBy(area, "swell");
+  const withheldSky = withheldBy(area, "sky");
+
   // Concurrently, and failing apart: NOAA and CDIP share no publisher and no
   // outage, so neither may hold up or take down the other's row.
   //
@@ -129,12 +171,24 @@ export async function WeekPanel({ slug }: { slug: string }) {
   // one response. It fails apart from the figures it sits under for the same
   // reason the others do: an outage on the hourly series must cost the shape
   // and not the week.
+  //
+  // A withheld product makes no request at all. There is nothing this grid
+  // could do with one member's station, and asking would spend a reader's wait
+  // on a row the page has already decided not to draw.
   const [view, hourly, waves, sky] = await Promise.all([
-    readWeekOfLowestLows(slug),
-    readHourlyTide(slug),
-    readWaveWeek(slug),
-    readSkyWeek(slug),
+    withheldTide ? null : readWeekOfLowestLows(slug),
+    withheldTide ? null : readHourlyTide(slug),
+    withheldSwell ? null : readWaveWeek(slug),
+    withheldSky ? null : readSkyWeek(slug),
   ]);
+  /*
+    Daylight is read at every scope, and that is measured rather than assumed.
+    It is computed from a beach's own coordinates rather than bound to a source,
+    so `areaSources` has nothing to say about it -- and the spread inside the
+    widest area is 9 seconds of sunrise and 8 of sunset, against a header that
+    prints both to the nearest minute. `midpointOf` makes the same argument one
+    scale up: sunset differs by a minute across the entire county.
+  */
   const daylight = readDaylightWeek(slug);
 
   /*
@@ -170,12 +224,12 @@ export async function WeekPanel({ slug }: { slug: string }) {
     figure that is or puts a second one in the cell.
   */
   const hourlyByDate = new Map(
-    hourly.state.kind === "week"
+    hourly?.state.kind === "week"
       ? hourly.state.days.map((day) => [day.localDate, day])
       : [],
   );
   const range =
-    hourly.state.kind === "week" ? sharedRange(hourly.state.days) : null;
+    hourly?.state.kind === "week" ? sharedRange(hourly.state.days) : null;
 
   const days = daylight.days.map((day) => {
     const series = hourlyByDate.get(day.localDate);
@@ -214,7 +268,7 @@ export async function WeekPanel({ slug }: { slug: string }) {
 
   const rows: WeekRow[] = [];
 
-  if (view.state.kind === "week") {
+  if (view !== null && view.state.kind === "week") {
     const tideDays = view.state.days;
     const station = view.station;
     rows.push({
@@ -265,7 +319,7 @@ export async function WeekPanel({ slug }: { slug: string }) {
     Ragged by construction: only the days the forecast reached become cells, and
     the grid draws no pair where a row has none.
   */
-  if (waves.state.kind === "week" && waves.line !== null) {
+  if (waves !== null && waves.state.kind === "week" && waves.line !== null) {
     const line = waves.line;
     rows.push({
       ...WAVE_WEEK_ROW,
@@ -298,7 +352,7 @@ export async function WeekPanel({ slug }: { slug: string }) {
     Ragged like the wave row, and for the same reason: the product reaches about
     seven and a half days and the far column may have none.
   */
-  if (sky.state.kind === "week" && sky.cell !== null) {
+  if (sky !== null && sky.state.kind === "week" && sky.cell !== null) {
     const cell = sky.cell;
     rows.push({
       ...SKY_WEEK_ROW,
@@ -338,11 +392,30 @@ export async function WeekPanel({ slug }: { slug: string }) {
     now draws all twenty-four hours with night shaded. Half the sentence had
     also stopped being true: it ended by pointing at cards that no longer exist.
 
-    What is left in this array reports outages and nothing else. Every push
-    below is conditional, and each one names the publisher that went quiet --
-    which is the half `CLAUDE.md`'s "nothing fails silently" is about, and the
-    half this file's tests assert one state at a time.
+    What is left in this array says why a row a reader expected is not there.
+    Every push below is conditional, and each one names what is missing rather
+    than leaving a gap -- which is the half `CLAUDE.md`'s "nothing fails
+    silently" is about, and the half this file's tests assert one state at a
+    time.
+
+    **Three kinds of reason and not one**, which is why the pushes are grouped
+    by product rather than by kind. A publisher went quiet, which is a fact
+    about this quarter of an hour. A join bound nothing, which is a permanent
+    fact about the place -- `no-station`, `no-line` and `no-cell` have been in
+    this array since before areas existed, so this was never an outage log. Or
+    the area's beaches do not share the source, which is new with areas and is
+    the only one a reader has not met before.
+
+    A withheld row and an outage on the same row cannot both happen: a withheld
+    product is never read, so there is no publisher to have gone quiet. The
+    grouping is what makes that legible rather than something to check.
   */
+  const withheldNote = (
+    slot: ReturnType<typeof withheldBy>,
+    product: string,
+  ): void => {
+    if (slot !== null) notes.push(withheldWords(slot, product));
+  };
 
   /*
     The upstream reason is printed here now rather than pointed at.
@@ -355,7 +428,8 @@ export async function WeekPanel({ slug }: { slug: string }) {
     sentence -- so this one carries the detail, in the shape `DayPanel`'s
     `absenceFor` already uses for the same kind of failure.
   */
-  if (view.state.kind === "unavailable") {
+  withheldNote(withheldTide, "a tide prediction");
+  if (view !== null && view.state.kind === "unavailable") {
     notes.push(
       "We could not get this week's tide predictions from NOAA just now. " +
         `Nothing is wrong with the beach. ${view.state.detail}`,
@@ -371,7 +445,12 @@ export async function WeekPanel({ slug }: { slug: string }) {
     Only when the figures came through. When both failed the sentence above
     already says so, and saying it twice would make one outage read as two.
   */
-  if (view.state.kind === "week" && hourly.state.kind === "unavailable") {
+  if (
+    view !== null &&
+    view.state.kind === "week" &&
+    hourly !== null &&
+    hourly.state.kind === "unavailable"
+  ) {
     notes.push(
       "The hour-by-hour shape behind each day's figure is missing this time: " +
         "NOAA answered for the day's high and low tides but not for the hourly " +
@@ -379,7 +458,7 @@ export async function WeekPanel({ slug }: { slug: string }) {
     );
   }
 
-  if (view.state.kind === "no-station") {
+  if (view !== null && view.state.kind === "no-station") {
     notes.push(
       "We have no tide station for this beach, so there is nothing to predict " +
         "this week from. The tide here is not different; we simply have no " +
@@ -394,7 +473,8 @@ export async function WeekPanel({ slug }: { slug: string }) {
     read here and nowhere else, so a failure that said only "we could not get
     it" would be the silent half of a failure.
   */
-  if (waves.state.kind === "no-line") {
+  withheldNote(withheldSwell, "a swell forecast");
+  if (waves !== null && waves.state.kind === "no-line") {
     notes.push(
       "There is no wave forecast for this beach either, and for the same reason " +
         "as the reading above: every point the model publishes sits at 10 m " +
@@ -408,14 +488,15 @@ export async function WeekPanel({ slug }: { slug: string }) {
     all rather than told it elsewhere -- and a silent gap would read as a clear
     week.
   */
-  if (sky.state.kind === "no-cell") {
+  withheldNote(withheldSky, "a cloud forecast");
+  if (sky !== null && sky.state.kind === "no-cell") {
     notes.push(
       "We have no cloud forecast for this beach. The National Weather Service " +
         "publishes its forecasts for squares of the map, and this beach does not " +
         "sit in one we can read.",
     );
   }
-  if (sky.state.kind === "unavailable") {
+  if (sky !== null && sky.state.kind === "unavailable") {
     notes.push(
       `We could not get this week's cloud forecast from the National Weather Service just ` +
         `now. ${sky.state.detail}` +
@@ -426,7 +507,7 @@ export async function WeekPanel({ slug }: { slug: string }) {
     );
   }
 
-  if (waves.state.kind === "unavailable") {
+  if (waves !== null && waves.state.kind === "unavailable") {
     notes.push(
       `We could not get this week's wave forecast from CDIP just now. ${waves.state.detail}` +
         (waves.state.drift

--- a/src/components/conditions/areaScope.test.ts
+++ b/src/components/conditions/areaScope.test.ts
@@ -114,3 +114,53 @@ test("a gap and a disagreement are both counted", () => {
       "so there is no one figure for the whole area. Choose a beach for it.",
   );
 });
+
+/**
+ * One beach having the product, which the general form got wrong: "Only 1 of
+ * the 2 beaches ... have a swell forecast, and they share one source" is the
+ * wrong verb over a clause that says nothing, since one beach trivially reads
+ * one source.
+ *
+ * Tijuana Estuary is the case, and it is the only one in the table today —
+ * asserted as a count so that a membership change which removes it shows up as
+ * a test that has stopped covering anything.
+ */
+test("one beach having the product takes the singular, and drops the clause", () => {
+  const words = withheldWords(
+    withheldBy(scopeOf("tijuana-estuary"), "swell")!,
+    "a swell forecast",
+  );
+
+  expect(words).toBe(
+    "Only 1 of the 2 beaches in Tijuana Estuary has a swell forecast, " +
+      "so there is no one figure for the whole area. Choose a beach for it.",
+  );
+  expect(words).not.toContain("have a swell");
+  expect(words).not.toContain("share one source");
+});
+
+/** Every sentence the table actually produces, read for a verb that disagrees. */
+test("no area's sentence puts a plural verb on a count of one", async () => {
+  const { beachesByArea } = await import("@/lib/areas");
+  let singular = 0;
+
+  for (const { area } of beachesByArea()) {
+    if (area.beaches.length < 2) continue;
+    const scope = scopeFor(area);
+
+    for (const product of ["tide", "waves", "swell", "sky", "air"] as const) {
+      const slot = withheldBy(scope, product);
+      if (slot === null) continue;
+
+      const words = withheldWords(slot, `a ${product} reading`);
+      if (/^Only 1 of the/.test(words)) singular += 1;
+      expect(words, `${area.slug} ${product}`).not.toMatch(
+        /^Only 1 of the .* have /,
+      );
+    }
+  }
+
+  // The probe: Tijuana Estuary's swell is the one instance in the table today,
+  // so a run finding none is a run asserting nothing.
+  expect(singular).toBe(1);
+});

--- a/src/components/conditions/areaScope.test.ts
+++ b/src/components/conditions/areaScope.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
 import { areaBySlug, areaSources } from "@/lib/areas";
-import { type AreaScope, withheldBy } from "./areaScope";
+import { type AreaScope, withheldBy, withheldWords } from "./areaScope";
 
 /** The scope a page builds, from the table rather than from a fixture. */
 function scopeFor(slug: string): AreaScope {
@@ -63,4 +63,61 @@ test("a mixed product carries its sources and its gaps apart", () => {
     distinct: 4,
     without: 0,
   });
+});
+
+/**
+ * The sentence, in the three shapes it has. It stands in a card, a note under
+ * the week grid and a chart tab, so a reader who meets the same silence twice
+ * on one page meets it in the same words.
+ */
+test("an absent product says nobody has it, and does not blame disagreement", () => {
+  const words = withheldWords(
+    withheldBy(scopeFor("mission-bay-west"), "swell")!,
+    "a swell forecast",
+  );
+
+  expect(words).toBe(
+    "No beach in Mission Bay – West has a swell forecast. Each says why on its own page.",
+  );
+  expect(words).not.toContain("different sources");
+});
+
+test("a plain disagreement counts the sources", () => {
+  expect(
+    withheldWords(withheldBy(scopeFor("la-jolla"), "sky")!, "a cloud forecast"),
+  ).toBe(
+    "The 10 beaches in La Jolla read 4 different sources for a cloud forecast, " +
+      "so there is no one figure for the whole area. Choose a beach for it.",
+  );
+});
+
+/**
+ * The shape the count used to be wrong about. Nine of La Jolla's ten read buoy
+ * 46254 and one reads none: one source and one gap, which is not "2 different
+ * sources".
+ */
+test("a disagreement with a gap in it counts the beaches that have the product", () => {
+  const words = withheldWords(
+    withheldBy(scopeFor("la-jolla"), "waves")!,
+    "a wave reading",
+  );
+
+  expect(words).toBe(
+    "Only 9 of the 10 beaches in La Jolla have a wave reading, and they share one source — " +
+      "so there is no one figure for the whole area. Choose a beach for it.",
+  );
+  expect(words).not.toContain("different sources");
+});
+
+/** And the same shape where the beaches that have it disagree as well. */
+test("a gap and a disagreement are both counted", () => {
+  expect(
+    withheldWords(
+      withheldBy(scopeFor("la-jolla"), "swell")!,
+      "a swell forecast",
+    ),
+  ).toBe(
+    "Only 9 of the 10 beaches in La Jolla have a swell forecast, and they read 8 different sources — " +
+      "so there is no one figure for the whole area. Choose a beach for it.",
+  );
 });

--- a/src/components/conditions/areaScope.test.ts
+++ b/src/components/conditions/areaScope.test.ts
@@ -1,16 +1,9 @@
 import { expect, test } from "vitest";
-import { areaBySlug, areaSources } from "@/lib/areas";
-import { type AreaScope, withheldBy, withheldWords } from "./areaScope";
+import { areaBySlug } from "@/lib/areas";
+import { scopeFor, withheldBy, withheldWords } from "./areaScope";
 
 /** The scope a page builds, from the table rather than from a fixture. */
-function scopeFor(slug: string): AreaScope {
-  const area = areaBySlug(slug)!;
-  return {
-    name: area.name,
-    beaches: area.beaches.length,
-    sources: areaSources(area),
-  };
-}
+const scopeOf = (slug: string) => scopeFor(areaBySlug(slug)!);
 
 /**
  * The beach page's path, and the reason every panel's beach-scoped behaviour is
@@ -26,7 +19,7 @@ test("no scope withholds nothing", () => {
 test("a shared product is not withheld", () => {
   // Air is shared by all eighteen areas, which is why every area page has
   // something measured on it at all.
-  expect(withheldBy(scopeFor("la-jolla"), "air")).toBeNull();
+  expect(withheldBy(scopeOf("la-jolla"), "air")).toBeNull();
 });
 
 /**
@@ -34,7 +27,7 @@ test("a shared product is not withheld", () => {
  * was already true one beach at a time; `mixed` is new with areas.
  */
 test("an absent product carries the area and no counts", () => {
-  expect(withheldBy(scopeFor("mission-bay-west"), "swell")).toEqual({
+  expect(withheldBy(scopeOf("mission-bay-west"), "swell")).toEqual({
     agreement: "absent",
     areaName: "Mission Bay – West",
     beaches: 8,
@@ -47,7 +40,7 @@ test("a mixed product carries its sources and its gaps apart", () => {
   // Nine of La Jolla's ten read buoy 46254 and `childrens-pool` reads none:
   // one source, one gap. Counting the gap as a source is what made the default
   // area's page say "2 different sources" over it.
-  expect(withheldBy(scopeFor("la-jolla"), "waves")).toEqual({
+  expect(withheldBy(scopeOf("la-jolla"), "waves")).toEqual({
     agreement: "mixed",
     areaName: "La Jolla",
     beaches: 10,
@@ -56,7 +49,7 @@ test("a mixed product carries its sources and its gaps apart", () => {
   });
 
   // And the plain disagreement, which is 13 of the 16 mixed product-instances.
-  expect(withheldBy(scopeFor("la-jolla"), "sky")).toEqual({
+  expect(withheldBy(scopeOf("la-jolla"), "sky")).toEqual({
     agreement: "mixed",
     areaName: "La Jolla",
     beaches: 10,
@@ -72,7 +65,7 @@ test("a mixed product carries its sources and its gaps apart", () => {
  */
 test("an absent product says nobody has it, and does not blame disagreement", () => {
   const words = withheldWords(
-    withheldBy(scopeFor("mission-bay-west"), "swell")!,
+    withheldBy(scopeOf("mission-bay-west"), "swell")!,
     "a swell forecast",
   );
 
@@ -84,7 +77,7 @@ test("an absent product says nobody has it, and does not blame disagreement", ()
 
 test("a plain disagreement counts the sources", () => {
   expect(
-    withheldWords(withheldBy(scopeFor("la-jolla"), "sky")!, "a cloud forecast"),
+    withheldWords(withheldBy(scopeOf("la-jolla"), "sky")!, "a cloud forecast"),
   ).toBe(
     "The 10 beaches in La Jolla read 4 different sources for a cloud forecast, " +
       "so there is no one figure for the whole area. Choose a beach for it.",
@@ -98,7 +91,7 @@ test("a plain disagreement counts the sources", () => {
  */
 test("a disagreement with a gap in it counts the beaches that have the product", () => {
   const words = withheldWords(
-    withheldBy(scopeFor("la-jolla"), "waves")!,
+    withheldBy(scopeOf("la-jolla"), "waves")!,
     "a wave reading",
   );
 
@@ -113,7 +106,7 @@ test("a disagreement with a gap in it counts the beaches that have the product",
 test("a gap and a disagreement are both counted", () => {
   expect(
     withheldWords(
-      withheldBy(scopeFor("la-jolla"), "swell")!,
+      withheldBy(scopeOf("la-jolla"), "swell")!,
       "a swell forecast",
     ),
   ).toBe(

--- a/src/components/conditions/areaScope.test.ts
+++ b/src/components/conditions/areaScope.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "vitest";
+import { areaBySlug, areaSources } from "@/lib/areas";
+import { type AreaScope, withheldBy } from "./areaScope";
+
+/** The scope a page builds, from the table rather than from a fixture. */
+function scopeFor(slug: string): AreaScope {
+  const area = areaBySlug(slug)!;
+  return {
+    name: area.name,
+    beaches: area.beaches.length,
+    sources: areaSources(area),
+  };
+}
+
+/**
+ * The beach page's path, and the reason every panel's beach-scoped behaviour is
+ * unchanged: with no scope there is nothing to withhold, so every product is
+ * read and drawn exactly as it was before areas existed.
+ */
+test("no scope withholds nothing", () => {
+  for (const product of ["tide", "waves", "swell", "sky", "air"] as const) {
+    expect(withheldBy(undefined, product), product).toBeNull();
+  }
+});
+
+test("a shared product is not withheld", () => {
+  // Air is shared by all eighteen areas, which is why every area page has
+  // something measured on it at all.
+  expect(withheldBy(scopeFor("la-jolla"), "air")).toBeNull();
+});
+
+/**
+ * The two silences, told apart. `absent` is every beach lacking the source and
+ * was already true one beach at a time; `mixed` is new with areas.
+ */
+test("an absent product carries the area and no counts", () => {
+  expect(withheldBy(scopeFor("mission-bay-west"), "swell")).toEqual({
+    agreement: "absent",
+    areaName: "Mission Bay – West",
+    beaches: 8,
+    distinct: 0,
+    without: 0,
+  });
+});
+
+test("a mixed product carries its sources and its gaps apart", () => {
+  // Nine of La Jolla's ten read buoy 46254 and `childrens-pool` reads none:
+  // one source, one gap. Counting the gap as a source is what made the default
+  // area's page say "2 different sources" over it.
+  expect(withheldBy(scopeFor("la-jolla"), "waves")).toEqual({
+    agreement: "mixed",
+    areaName: "La Jolla",
+    beaches: 10,
+    distinct: 1,
+    without: 1,
+  });
+
+  // And the plain disagreement, which is 13 of the 16 mixed product-instances.
+  expect(withheldBy(scopeFor("la-jolla"), "sky")).toEqual({
+    agreement: "mixed",
+    areaName: "La Jolla",
+    beaches: 10,
+    distinct: 4,
+    without: 0,
+  });
+});

--- a/src/components/conditions/areaScope.ts
+++ b/src/components/conditions/areaScope.ts
@@ -14,12 +14,19 @@
  * to be the same in all three or an area reports a tide in one region and
  * withholds it in the next.
  *
- * **Facts and counts, never a sentence.** The copy on this page belongs to the
- * page, and each of the three panels words a withheld product in the slot it
- * already uses for an absence -- a card, a note under the grid, a chart tab. It
- * also could not carry a sentence: the beaches' own reasons differ, and lifting
- * any one of them would print a figure about one beach as though it were the
- * area's. See ADR-0048.
+ * **The sentence is here and not in `lib/areas.ts`.** ADR-0048 has the resolver
+ * return facts and counts and leaves the copy to the page, and this is the
+ * page: `mopLine.ts` and `gridCell.ts` beside it own wording for the same
+ * reason. What the resolver could not do is borrow a beach's own reason -- the
+ * members' reasons differ, and lifting any one of them would print a figure
+ * about one beach as though it were the area's. Coronado's three name 20.9,
+ * 21.6 and 21.2 km for the buoy that does not reach them.
+ *
+ * **One sentence for three positions**, because they are three positions and
+ * not three facts. It stands in a card in the measured block, in a note under
+ * the week grid and in a chart tab in the day region, and a reader moving down
+ * the page meets the same silence three times. Only the product's noun
+ * changes.
  *
  * Nothing here fetches anything, and nothing here is a component.
  */
@@ -99,4 +106,40 @@ export function withheldBy(
     distinct: source.kind === "mixed" ? source.distinct : 0,
     without: source.kind === "mixed" ? source.without : 0,
   };
+}
+
+/**
+ * What a panel says instead of a figure, in one sentence.
+ *
+ * `product` is what the reader came for, in their words: "a wave reading", "a
+ * swell forecast". It is the only thing that varies between the three
+ * positions this sentence stands in.
+ *
+ * **Three sentences and not two, because `mixed` has two shapes.** The plain
+ * one is beaches reading different sources. The other is some reading a source
+ * and some reading none, and saying "read 2 different sources" of nine beaches
+ * sharing a buoy and one lacking it is false — which is what the measured block
+ * printed on `/conditions/la-jolla`, the default area, until the count learned
+ * to tell a gap from a source.
+ *
+ * **It counts the beaches that have the product rather than the ones that do
+ * not**, which is what keeps one sentence covering both counts without a
+ * plural to agree: "Only 9 of the 10 beaches" needs no branch where "and 1 has
+ * none" would need one, and a reader learns the same thing from it.
+ */
+export function withheldWords(slot: NotShared, product: string): string {
+  if (slot.agreement === "absent") {
+    return `No beach in ${slot.areaName} has ${product}. Each says why on its own page.`;
+  }
+
+  const sources =
+    slot.distinct === 1
+      ? "they share one source"
+      : `they read ${slot.distinct} different sources`;
+
+  const tail = `so there is no one figure for the whole area. Choose a beach for it.`;
+
+  return slot.without === 0
+    ? `The ${slot.beaches} beaches in ${slot.areaName} read ${slot.distinct} different sources for ${product}, ${tail}`
+    : `Only ${slot.beaches - slot.without} of the ${slot.beaches} beaches in ${slot.areaName} have ${product}, and ${sources} — ${tail}`;
 }

--- a/src/components/conditions/areaScope.ts
+++ b/src/components/conditions/areaScope.ts
@@ -143,3 +143,30 @@ export function withheldWords(slot: NotShared, product: string): string {
     ? `The ${slot.beaches} beaches in ${slot.areaName} read ${slot.distinct} different sources for ${product}, ${tail}`
     : `Only ${slot.beaches - slot.without} of the ${slot.beaches} beaches in ${slot.areaName} have ${product}, and ${sources} — ${tail}`;
 }
+
+/**
+ * One product's answer: what was read, or why the area cannot report it.
+ *
+ * **Exclusive by construction, and typed rather than checked.** A withheld
+ * product is never read -- that is ADR-0048, and it is why an area page makes
+ * no request for a figure it has already decided not to print -- so exactly one
+ * of these two is present. Stating it in the type is what lets a component
+ * compose a chart tab out of it with a branch instead of an assertion that the
+ * read and the withholding line up.
+ *
+ * `WeekPanel` needs none of this and takes plain nulls, because its reads feed
+ * `if` guards that narrow a null on their own. The day chart's feed object
+ * literals, which do not.
+ */
+export type Answered<V> =
+  { view: V; withheld: null } | { view: null; withheld: NotShared };
+
+/** The read, or the withholding, as one awaitable. */
+export function answer<V>(
+  withheld: NotShared | null,
+  read: () => Promise<V>,
+): Promise<Answered<V>> {
+  return withheld === null
+    ? read().then((view) => ({ view, withheld: null }))
+    : Promise.resolve({ view: null, withheld });
+}

--- a/src/components/conditions/areaScope.ts
+++ b/src/components/conditions/areaScope.ts
@@ -31,7 +31,13 @@
  * Nothing here fetches anything, and nothing here is a component.
  */
 
-import { type AreaProduct, type AreaSources } from "@/lib/areas";
+import {
+  type Area,
+  type AreaProduct,
+  type AreaSources,
+  areaSources,
+  surfZoneBeachOf,
+} from "@/lib/areas";
 
 /**
  * What a panel is about, when it is about an area rather than one beach.
@@ -47,6 +53,18 @@ export type AreaScope = {
   name: string;
   beaches: number;
   sources: AreaSources;
+  /**
+   * The member the surf zone bulletin is read through, which is not the member
+   * everything else is read through.
+   *
+   * **The one product outside `sources` entirely**, because it is outside the
+   * rule `sources` resolves: the National Weather Service issues one bulletin
+   * for "San Diego County Coastal Areas", a unit larger than any area here, so
+   * intersecting it across members asks a question it has no answer to. What it
+   * needs instead is a member the forecast is *issued* for, which
+   * `surfZoneBeachOf` picks. See ADR-0050.
+   */
+  bulletinBeach: string;
 };
 
 /**
@@ -82,6 +100,22 @@ export type NotShared = {
    */
   without: number;
 };
+
+/**
+ * The scope a page hands its panels, built from the area.
+ *
+ * One place composes it, so the three regions of an area page cannot come to
+ * different conclusions about what the area may report -- and so a new field
+ * reaches all of them at once. `bulletinBeach` arrived that way.
+ */
+export function scopeFor(area: Area): AreaScope {
+  return {
+    name: area.name,
+    beaches: area.beaches.length,
+    sources: areaSources(area),
+    bulletinBeach: surfZoneBeachOf(area),
+  };
+}
 
 /**
  * A product the area cannot report, or null when it can.

--- a/src/components/conditions/areaScope.ts
+++ b/src/components/conditions/areaScope.ts
@@ -157,25 +157,40 @@ export function withheldBy(
  * to tell a gap from a source.
  *
  * **It counts the beaches that have the product rather than the ones that do
- * not**, which is what keeps one sentence covering both counts without a
- * plural to agree: "Only 9 of the 10 beaches" needs no branch where "and 1 has
- * none" would need one, and a reader learns the same thing from it.
+ * not**, which is what keeps the gap sentence covering both counts without a
+ * second plural to agree: "Only 9 of the 10 beaches" needs no branch where
+ * "and 1 has none" would need one, and a reader learns the same thing from it.
+ *
+ * **One beach having the product is still its own sentence.** Tijuana Estuary
+ * is that case today -- Border Field State Park binds a model line and the
+ * slough binds none -- and the general form said "Only 1 of the 2 beaches ...
+ * have a swell forecast, and they share one source", which is the wrong verb
+ * over a clause that says nothing. One beach trivially reads one source, so the
+ * clause goes and the verb agrees. Found on the rendered page rather than in a
+ * fixture, which is why the area pages are worth looking at rather than only
+ * asserting.
  */
 export function withheldWords(slot: NotShared, product: string): string {
   if (slot.agreement === "absent") {
     return `No beach in ${slot.areaName} has ${product}. Each says why on its own page.`;
   }
 
+  const tail = `so there is no one figure for the whole area. Choose a beach for it.`;
+
+  if (slot.without === 0) {
+    return `The ${slot.beaches} beaches in ${slot.areaName} read ${slot.distinct} different sources for ${product}, ${tail}`;
+  }
+
+  const having = slot.beaches - slot.without;
+  if (having === 1) {
+    return `Only 1 of the ${slot.beaches} beaches in ${slot.areaName} has ${product}, ${tail}`;
+  }
+
   const sources =
     slot.distinct === 1
       ? "they share one source"
       : `they read ${slot.distinct} different sources`;
-
-  const tail = `so there is no one figure for the whole area. Choose a beach for it.`;
-
-  return slot.without === 0
-    ? `The ${slot.beaches} beaches in ${slot.areaName} read ${slot.distinct} different sources for ${product}, ${tail}`
-    : `Only ${slot.beaches - slot.without} of the ${slot.beaches} beaches in ${slot.areaName} have ${product}, and ${sources} — ${tail}`;
+  return `Only ${having} of the ${slot.beaches} beaches in ${slot.areaName} have ${product}, and ${sources} — ${tail}`;
 }
 
 /**

--- a/src/components/conditions/areaScope.ts
+++ b/src/components/conditions/areaScope.ts
@@ -1,0 +1,102 @@
+/**
+ * What an area may report, asked once for every panel that draws a product.
+ *
+ * Three panels on `/conditions` render at two scopes -- one beach, or an area
+ * holding several -- and each of them has to ask the same question of every
+ * product it draws: may this area report it, and if not, which silence is it?
+ * `lib/areas.ts` resolves the bindings; this is the shape a component takes
+ * that answer in.
+ *
+ * It exists for the reason `mopLine.ts`, `gridCell.ts` and `tideStation.ts`
+ * beside it do: two call sites answering one question is how `ProvenanceLine`
+ * came to print the same station two ways on one card. Here the question is
+ * asked by the measured block, the week and the day chart, and the answer has
+ * to be the same in all three or an area reports a tide in one region and
+ * withholds it in the next.
+ *
+ * **Facts and counts, never a sentence.** The copy on this page belongs to the
+ * page, and each of the three panels words a withheld product in the slot it
+ * already uses for an absence -- a card, a note under the grid, a chart tab. It
+ * also could not carry a sentence: the beaches' own reasons differ, and lifting
+ * any one of them would print a figure about one beach as though it were the
+ * area's. See ADR-0048.
+ *
+ * Nothing here fetches anything, and nothing here is a component.
+ */
+
+import { type AreaProduct, type AreaSources } from "@/lib/areas";
+
+/**
+ * What a panel is about, when it is about an area rather than one beach.
+ *
+ * Absent on a beach page, present on an area's. The panels still read through
+ * a beach slug, because every read in `lib/conditions.ts` is keyed on one --
+ * but which beach is immaterial for a product the area shares, and that is what
+ * "shared" means: `areas.test.ts` asserts that where `areaSources` says shared,
+ * every beach in the area binds that same source. A product it does not share
+ * is not read at all, so no member's figure can leak into an area's answer.
+ */
+export type AreaScope = {
+  name: string;
+  beaches: number;
+  sources: AreaSources;
+};
+
+/**
+ * Why an area cannot report a product, when its beaches do not share one.
+ *
+ * **Two agreements, because they owe a reader different sentences.** `absent`
+ * is every beach in the area lacking the source, which is the bay's missing
+ * buoy and was already true one beach at a time. `mixed` is the beaches not all
+ * reading one source, which is new with areas and is the only state a reader
+ * has never seen before.
+ *
+ * **`mixed` has two shapes and the counts tell them apart.** Either the beaches
+ * read different sources, or some read one and some read none — three of the
+ * sixteen mixed product-instances are the second, La Jolla's own wave buoy
+ * among them. Both mean no single figure answers for the area; only the first
+ * is what "different sources" describes.
+ */
+export type NotShared = {
+  agreement: "absent" | "mixed";
+  /** The area's name, for the sentence. */
+  areaName: string;
+  /** How many beaches it holds. */
+  beaches: number;
+  /** How many distinct sources they bind. Only meaningful when `mixed`. */
+  distinct: number;
+  /**
+   * How many of them bind no source at all. Only meaningful when `mixed`.
+   *
+   * **Beside `distinct` because the sentence needs both.** Nine beaches reading
+   * one buoy and a tenth reading none is not ten beaches reading two buoys, and
+   * only the second is what "2 different sources" describes. It was the first
+   * that `/conditions/la-jolla` printed the second sentence over.
+   */
+  without: number;
+};
+
+/**
+ * A product the area cannot report, or null when it can.
+ *
+ * Null on a beach page too, and that is the whole of what makes a panel's
+ * beach-scoped path unchanged: with no scope there is nothing to withhold, so
+ * every product is read and drawn exactly as it was before areas existed.
+ */
+export function withheldBy(
+  scope: AreaScope | undefined,
+  product: AreaProduct,
+): NotShared | null {
+  if (!scope) return null;
+
+  const source = scope.sources[product];
+  if (source.kind === "shared") return null;
+
+  return {
+    agreement: source.kind,
+    areaName: scope.name,
+    beaches: scope.beaches,
+    distinct: source.kind === "mixed" ? source.distinct : 0,
+    without: source.kind === "mixed" ? source.without : 0,
+  };
+}

--- a/src/lib/areas.test.ts
+++ b/src/lib/areas.test.ts
@@ -396,6 +396,33 @@ describe("the beach an area reads the surf zone bulletin through", () => {
   });
 
   /**
+   * Two data files disagreeing, which should stop a build rather than quietly
+   * pick a beach the inventory does not have. The same guard `beachesByArea`
+   * and `areaSources` carry, for the same reason: the `areas` gate row catches
+   * it earlier and says more, and this is the backstop for somebody editing one
+   * file and running the app without the gate.
+   */
+  test("throws when an area names a beach the inventory does not have", async () => {
+    vi.resetModules();
+    vi.doMock("@/data/areas.json", () => ({
+      default: {
+        areas: [
+          { slug: "la-jolla", name: "La Jolla", beaches: ["not-a-beach"] },
+        ],
+      },
+    }));
+
+    const { areaBySlug: bySlug, surfZoneBeachOf: withBadTable } =
+      await import("./areas");
+    expect(() => withBadTable(bySlug("la-jolla")!)).toThrow(
+      /beaches.json has no such beach/,
+    );
+
+    vi.doUnmock("@/data/areas.json");
+    vi.resetModules();
+  });
+
+  /**
    * The area the exception is actually worth something to today, named so that
    * a membership change which quietly removes the case is visible.
    *

--- a/src/lib/areas.test.ts
+++ b/src/lib/areas.test.ts
@@ -267,3 +267,59 @@ describe("what an area's beaches agree on", () => {
     }
   });
 });
+
+/**
+ * `mixed` counts sources, and a beach binding nothing is not one of them.
+ *
+ * `areaSources` builds its set out of the raw bindings, `null` included, so a
+ * product nine beaches share and a tenth lacks reads as two sources. It is not:
+ * it is one source and one gap, and the page prints the number. La Jolla is the
+ * default area, and `/conditions/la-jolla` says "The 10 beaches in La Jolla read
+ * 2 different sources for a wave reading" over nine beaches reading buoy 46254
+ * and `childrens-pool` reading none.
+ *
+ * The state is right either way -- nine agreeing and one lacking still means no
+ * one figure answers for the area -- so nothing failed. Only the count is wrong.
+ *
+ * Derived over the whole table rather than asserted against three copied
+ * numbers, because the three are a property of `beaches.json` today and the
+ * invariant is a property of the resolver. `MeasuredToday.test.tsx` has the
+ * other kind: a hand-written `distinct: 2` for La Jolla, which is why the card
+ * that prints the wrong figure has a passing test over it.
+ */
+describe("a mixed product's count", () => {
+  const FIELD = {
+    tide: "tide_station",
+    waves: "wave_buoy",
+    swell: "mop_line",
+    sky: "grid_cell",
+    air: "air_station",
+  } as const;
+
+  test("never counts a missing binding among the sources", () => {
+    const bySlug = new Map(allBeaches().map((beach) => [beach.slug, beach]));
+    let withAGap = 0;
+
+    for (const { area, beaches } of beachesByArea()) {
+      const sources = areaSources(area);
+      for (const product of Object.keys(FIELD) as (keyof typeof FIELD)[]) {
+        const resolved = sources[product];
+        if (resolved.kind !== "mixed") continue;
+
+        const bound = beaches.map(
+          (beach) => bySlug.get(beach.slug)![FIELD[product]],
+        );
+        const real = bound.filter((id) => id !== null);
+        if (real.length < bound.length) withAGap += 1;
+
+        expect(resolved.distinct, `${area.slug} ${product}`).toBe(
+          new Set(real).size,
+        );
+      }
+    }
+
+    // The probe. Without it this loop passes on a table where no mixed product
+    // has a gap in it, which is a table this assertion says nothing about.
+    expect(withAGap).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/areas.test.ts
+++ b/src/lib/areas.test.ts
@@ -202,10 +202,25 @@ describe("what an area's beaches agree on", () => {
    * a forecast cell and bind four different ones — that is `mixed`, and it is
    * new with areas. Mission Bay – West's eight have no MOP line at all — that is
    * `absent`, and it was already true one beach at a time.
+   *
+   * And the case between them, which is `mixed` too: nine of La Jolla's ten
+   * read buoy 46254 and `childrens-pool` reads none. No single figure answers
+   * for the area either way, so the state is the same — but it is one source
+   * and one gap, and `without` is what keeps the page from calling that two
+   * sources.
    */
   test("disagreeing is not the same as lacking", () => {
-    expect(of("la-jolla").sky).toEqual({ kind: "mixed", distinct: 4 });
+    expect(of("la-jolla").sky).toEqual({
+      kind: "mixed",
+      distinct: 4,
+      without: 0,
+    });
     expect(of("mission-bay-west").swell).toEqual({ kind: "absent" });
+    expect(of("la-jolla").waves).toEqual({
+      kind: "mixed",
+      distinct: 1,
+      without: 1,
+    });
   });
 
   test("a shared product names the one source behind it", () => {

--- a/src/lib/areas.test.ts
+++ b/src/lib/areas.test.ts
@@ -6,8 +6,9 @@ import {
   DEFAULT_AREA_SLUG,
   beachesByArea,
   defaultArea,
+  surfZoneBeachOf,
 } from "./areas";
-import { allBeaches } from "./beaches";
+import { allBeaches, surfZoneWithheldReason } from "./beaches";
 
 describe("beachesByArea", () => {
   test("covers the whole inventory exactly once", () => {
@@ -336,5 +337,76 @@ describe("a mixed product's count", () => {
     // The probe. Without it this loop passes on a table where no mixed product
     // has a gap in it, which is a table this assertion says nothing about.
     expect(withAGap).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * The one product an area reports without its beaches agreeing about a source,
+ * because it has no source to agree about: the National Weather Service issues
+ * one bulletin for "San Diego County Coastal Areas". ADR-0050.
+ */
+describe("the beach an area reads the surf zone bulletin through", () => {
+  const bySlug = () =>
+    new Map(allBeaches().map((beach) => [beach.slug, beach]));
+
+  /**
+   * The claim the page's own wording rests on, asserted rather than argued.
+   *
+   * On an area page the withheld sentence says the forecast is not issued for
+   * *any* beach in the area, having read it through one. That is only true
+   * because the fallback is reached exactly when no member is open coast — so
+   * where this returns a withheld member, every member is withheld.
+   */
+  test("falls back only where the forecast reaches no member at all", () => {
+    const beaches = bySlug();
+    let withheldAreas = 0;
+
+    for (const { area } of beachesByArea()) {
+      const chosen = beaches.get(surfZoneBeachOf(area))!;
+      if (surfZoneWithheldReason(chosen) === null) continue;
+
+      withheldAreas += 1;
+      for (const slug of area.beaches) {
+        expect(surfZoneWithheldReason(beaches.get(slug)!), slug).not.toBeNull();
+      }
+    }
+
+    // The probe, and a count rather than a floor: seven of the eighteen areas
+    // are wholly sheltered today. A table where none was would make the loop
+    // above assert nothing, and a table where that number moved is a real
+    // change to which area pages carry a rip current level.
+    expect(withheldAreas).toBe(7);
+  });
+
+  /** And where it does reach one, that member is one it is issued for. */
+  test("prefers a member the forecast is issued for", () => {
+    const beaches = bySlug();
+
+    for (const { area } of beachesByArea()) {
+      const issued = area.beaches.some(
+        (slug) => surfZoneWithheldReason(beaches.get(slug)!) === null,
+      );
+      if (!issued) continue;
+
+      expect(
+        surfZoneWithheldReason(beaches.get(surfZoneBeachOf(area))!),
+        area.slug,
+      ).toBeNull();
+    }
+  });
+
+  /**
+   * The area the exception is actually worth something to today, named so that
+   * a membership change which quietly removes the case is visible.
+   *
+   * Tijuana Estuary holds the slough, which is sheltered water, and Border
+   * Field State Park, which is not. Read through its first member the area
+   * would withhold a bulletin that is issued for half of it.
+   */
+  test("Tijuana Estuary reads it through the member that is open coast", () => {
+    const area = areaBySlug("tijuana-estuary")!;
+
+    expect(area.beaches[0]).toBe("tijuana-slough-national-wildlife-refuge");
+    expect(surfZoneBeachOf(area)).toBe("border-field-state-park");
   });
 });

--- a/src/lib/areas.ts
+++ b/src/lib/areas.ts
@@ -19,7 +19,7 @@
  */
 
 import areaTable from "@/data/areas.json";
-import { allBeaches, type Beach } from "./beaches";
+import { allBeaches, surfZoneWithheldReason, type Beach } from "./beaches";
 
 /** One area, as `areas.json` carries it. */
 export interface Area {
@@ -142,6 +142,46 @@ export function beachesByArea(): readonly AreaGroup[] {
       return beach;
     }),
   }));
+}
+
+/**
+ * The beach an area reads the surf zone bulletin through.
+ *
+ * **The one product an area may report without its beaches agreeing, and the
+ * exception is a category difference rather than a relaxation.** ADR-0048's
+ * rule is about point measurements: a station, a buoy, a model line and a
+ * forecast cell each stand somewhere, and an area may only publish one every
+ * member is served by. The surf zone bulletin stands nowhere. The National
+ * Weather Service issues `CAZ043` for San Diego County *Coastal Areas* -- one
+ * bulletin, for a unit larger than any area in this table -- so intersecting it
+ * across members asks a question it has no answer to. See ADR-0050.
+ *
+ * **The first member the forecast is issued for, or the first member.** The
+ * choice is not a representative: every open-coast member reads the same
+ * bulletin, because there is only one. What the choice decides is whether the
+ * area gets the bulletin at all, and the fallback is what makes the withheld
+ * case honest -- reaching it means no member is open-coast, so the reason that
+ * comes back is true of every beach in the area rather than of the one it was
+ * read through. `areas.test.ts` asserts that over the whole table.
+ *
+ * Measured over the twelve areas holding more than one beach: seven carry the
+ * bulletin, five are wholly sheltered and withhold it, and exactly one --
+ * Tijuana Estuary, whose northern member is the slough -- reads it through a
+ * beach that is not its first.
+ */
+export function surfZoneBeachOf(area: Area): string {
+  const bySlug = new Map(allBeaches().map((beach) => [beach.slug, beach]));
+  const issued = area.beaches.find((slug) => {
+    const beach = bySlug.get(slug);
+    if (!beach) {
+      throw new Error(
+        `areas.json puts ${slug} in ${area.slug}, but beaches.json has no such beach.`,
+      );
+    }
+    return surfZoneWithheldReason(beach) === null;
+  });
+
+  return issued ?? area.beaches[0];
 }
 
 /**

--- a/src/lib/areas.ts
+++ b/src/lib/areas.ts
@@ -164,8 +164,16 @@ export type AreaProduct = "tide" | "waves" | "swell" | "sky" | "air";
  * not — but "not" runs together two different facts, and the page owes a
  * different sentence for each. `absent` is every beach lacking the source, which
  * is the bay's missing buoy and was already true one beach at a time. `mixed` is
- * the beaches having one each and disagreeing, which is new with areas and is
- * the only state a reader has never seen before.
+ * the beaches not all reading one source, which is new with areas and is the
+ * only state a reader has never seen before.
+ *
+ * **`mixed` covers two shapes and counts them apart.** The plain one is beaches
+ * reading different sources; the other is some reading a source and some
+ * reading none, which is neither `absent` nor agreement. Both mean no single
+ * figure answers for the area, so both are one state -- but the page prints the
+ * numbers, and "two sources" said of nine beaches sharing a buoy and one
+ * lacking it is false. So `distinct` counts sources and `without` counts the
+ * beaches that have none.
  *
  * That is the same distinction `beaches.json` draws about `wave_buoy` null,
  * whose schema note says it "carries TWO meanings and wave_buoy_null_reason
@@ -174,7 +182,32 @@ export type AreaProduct = "tide" | "waves" | "swell" | "sky" | "air";
 export type AreaSource =
   | { kind: "shared"; source: string }
   | { kind: "absent" }
-  | { kind: "mixed"; distinct: number };
+  | {
+      kind: "mixed";
+      /**
+       * How many distinct sources the area's beaches read between them.
+       *
+       * **Sources, so a beach binding nothing is not counted as one.** The
+       * first version of this read the size of a set built over the raw
+       * bindings, `null` included, and La Jolla's ten beaches came back as two
+       * wave buoys: nine read 46254 and `childrens-pool` reads none. The page
+       * prints this figure, so it said the default area's beaches read two
+       * buoys when they read one. At least 1, because a `mixed` product has at
+       * least one beach that has it -- with none it would be `absent`.
+       */
+      distinct: number;
+      /**
+       * How many of the area's beaches bind no source at all.
+       *
+       * **Beside `distinct` rather than folded into it**, because they are two
+       * facts and the sentence needs both: nine beaches reading one buoy and
+       * one reading none is not the same page as ten beaches reading two
+       * buoys, and only the second is what "2 different sources" describes.
+       * Zero for the ordinary disagreement, which is 13 of the 16 mixed
+       * product-instances.
+       */
+      without: number;
+    };
 
 export type AreaSources = Readonly<Record<AreaProduct, AreaSource>>;
 
@@ -196,6 +229,12 @@ const BINDING: Readonly<Record<AreaProduct, keyof Beach>> = {
  * publish the same forecast to the decimal the page prints — and the measured
  * form of the rule is its own slice. Until that probe exists this is the version
  * that cannot overclaim: everything it calls shared *is* one source.
+ *
+ * **A beach binding nothing is a gap and never a source.** Counting `null` in
+ * with the identifiers is how the default area came to say its ten beaches read
+ * two wave buoys when nine read 46254 and `childrens-pool` reads none. It did
+ * not change any area's state -- nine agreeing and one lacking still means no
+ * single figure -- which is why nothing failed.
  *
  * **No reason strings.** The wording belongs to the page, which is this repo's
  * rule about who owns the copy; and for `absent` there is no beach sentence to
@@ -221,13 +260,23 @@ export function areaSources(area: Area): AreaSources {
   });
 
   const resolve = (product: AreaProduct): AreaSource => {
-    const bound = new Set(members.map((beach) => beach[BINDING[product]]));
-    if (bound.size > 1) return { kind: "mixed", distinct: bound.size };
+    const bound = members.map((beach) => beach[BINDING[product]]);
 
-    const only = [...bound][0];
-    return only === null || only === undefined
-      ? { kind: "absent" }
-      : { kind: "shared", source: String(only) };
+    /*
+      Sources and gaps counted apart, because they are different facts and the
+      page states both. A set built over the raw bindings counts `null` as a
+      source, which made La Jolla's ten beaches read "2 different sources" for
+      a buoy nine of them share and one lacks.
+    */
+    const has = (id: (typeof bound)[number]) => id !== null && id !== undefined;
+    const sources = new Set(bound.filter(has));
+    const without = bound.length - bound.filter(has).length;
+
+    if (sources.size === 0) return { kind: "absent" };
+    if (sources.size === 1 && without === 0) {
+      return { kind: "shared", source: String([...sources][0]) };
+    }
+    return { kind: "mixed", distinct: sources.size, without };
   };
 
   return {


### PR DESCRIPTION
Stacked on **#237** (`area-readings`), which is open and unmerged — `origin/main` is at `af7d60a` and does not contain `dd20481`, checked rather than assumed. Base is `area-readings`, not `main`.

`/conditions/<area>` carried the measured block and a sentence saying the week and the day chart were still one beach at a time. It is now all three regions, plus the rip current risk, each answering for the area under ADR-0048's rule — per product, never per panel.

No issue was filed: this is one branch's work and the plan file plus this body are the durable record, so splitting it into issues would have bought nothing (CLAUDE.md §5). The plan gets a dated addendum rather than a new file.

## The slices

1. **Prove a mixed product counts an absence as a source, as a MUST FAIL test** — the gate is red at this commit, deliberately, per the repo's convention (`b8f131f` and four others).
2. **Count an area's sources apart from its gaps** — the fix.
3. **Ask one place whether an area may report a product** — `AreaScope`/`withheldBy` out of `MeasuredPanel` into `areaScope.ts`. Pure move.
4. **Word a withheld product once, for every slot it stands in** — the sentence follows, so three regions say the same thing about the same silence.
5. **Report an area's week, one row at a time.**
6. **Report an area's day chart, one tab at a time** — ADR-0049.
7. **Report an area's rip current risk, by exception** — ADR-0050.
8. **Point ADR-0048's consequences at what discharged them.**
9. **Say "has" where one beach in an area has the product** — found on the rendered page.
10. **Cover the guard `surfZoneBeachOf` carries.**

## A live defect found on the way in

`areaSources` built its set over the raw bindings with `null` in it, so a beach binding **nothing** counted as a **source**. The state was right; the count was not, and the page prints the count.

| area | product | said | truth |
| --- | --- | --: | --- |
| la-jolla | waves | 2 sources | 1 buoy (`46254`), 1 beach with none |
| la-jolla | swell | 9 sources | 8 lines, 1 beach with none |
| tijuana-estuary | swell | 2 sources | 1 line (`D0001`), 1 beach with none |

`/conditions/la-jolla` is the **default area** and read _"The 10 beaches in La Jolla read 2 different sources for a wave reading"_ over nine beaches reading one buoy and `childrens-pool` reading none.

Nothing caught it because the test over that card invents both its operands — `MeasuredToday.test.tsx` handed the component a hand-written `distinct: 2` and asserted the sentence built from it. The regression test derives both sides from `beaches.json` and carries a probe, so it cannot pass against a table with no gap in it. The card's test now points at Torrey Pines, a real disagreement with no gap, and `MeasuredPanel.test.tsx` carries the version that reads `areaSources` for real.

## What a withheld product looks like

Worded in the slot its own panel already uses for a product it cannot draw — **ADR-0049**:

- **Week:** no row, and a note under the grid. A beach with no MOP line has had exactly that since long before areas existed.
- **Day chart:** the tab stays, with the sentence where the plot would be. `HourSeries.absence` is already documented as "what to say instead of a plot when `points` is empty".

**The tab stays, and dropping it was the alternative.** Four tabs are that region's whole vocabulary for its four products — ADR-0015's closed-vocabulary argument applied to a control. La Jolla shares only the tide, so a bar gated to what it can draw would be **one tab wide**, and a reader would never learn the page has a swell at all.

**Per product, never per panel.** Gating panels whole would take La Jolla's tide away in order to withhold its cloud.

## The surf zone exemption (ADR-0050)

Not a relaxation of ADR-0048 — a category difference. `fetchSurfZoneForecast()` takes no beach at all: it is one bulletin for "San Diego County Coastal Areas", larger than every area here put together, so there is no per-beach source to intersect. Read through a member the forecast is _issued_ for.

Measured over the twelve multi-beach areas: **7** carry the bulletin, **5** are wholly sheltered, **1** (Tijuana Estuary) reads it through a beach that is not its first. The bigger visible change is that the rip current line is now on all twelve area pages — the single line on this page that answers whether to put children in the water.

**The plan's own argument for this exemption had expired.** §4 reasoned from La Jolla, "because `Childrens Pool` is bay-class". That beach binds `9410230`, which is `open-coast`; La Jolla is 10 of 10 open coast. The exemption is right for the reason that outlives the example. The addendum says so and ADR-0050 is what is kept current.

## Numbers, re-derived rather than trusted

Reproduced exactly from `areas.json` × `beaches.json`: air 18/0/0, tide 16/0/2, sky 11/0/7, swell 6/7/5, waves 3/13/2.

**Daylight needs no gating, and that is measured.** It is computed from coordinates rather than bound to a source, so `areaSources` says nothing about it. Widest internal spread across the eighteen areas: **9 s of sunrise** (Mission Bay – North), **8 s of sunset** — against a page that prints both to the nearest minute.

## Verified on the rendered page, not just in jsdom

`next build` does not render these routes (`generateStaticParams` returns `[]`), so three area pages were fetched off a dev server and read:

- `la-jolla` — 200. Tide row and curve drawn; swell, cloud and wording withheld with the right counts; **Rip current risk: High**.
- `mission-bay-west` — 200. Both silences worded as absence, not disagreement; _"This forecast is not issued for any beach in Mission Bay – West"_; rip line reads _"See the day below"_.
- `tijuana-estuary` — 200. **Rip current risk: High**, read through `border-field-state-park` — the exemption working on a live page.

That is where slice 9 came from: _"Only 1 of the 2 beaches in Tijuana Estuary **have** a swell forecast, and they share one source"_ — wrong verb over a vacuous clause. Two other things that looked wrong there were not: `La Jolla<!-- -->&#x27;s` is React's separator between adjacent text nodes and reads correctly, and the en dash in "Mission Bay – West" survives fine.

## Gate

Clean `.next`, run at `eed1ecc`:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… sea-side
… areas
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  areas
  PASS  test
  PASS  build
  PASS  stylesheet
```

`1826 tests, 108 files`, all passing.

At slice 1 the gate is **red on the `test` row**, which is the point of that commit:

```
 FAIL  src/lib/areas.test.ts > a mixed product's count > never counts a missing binding among the sources
AssertionError: la-jolla waves: expected 2 to be 1 // Object.is equality

- Expected
+ Received

- 1
+ 2
```

## Coverage — up on all four, floor deliberately not raised

Measured against the base branch (`dd20481`), not `main`, since #237 is unmerged:

| | base | here | |
| --- | --- | --- | --- |
| statements | 3380/3755 · 90.01% | 3426/3801 · **90.13%** | +46/+46 — every statement added is covered |
| branches | 2153/2414 · 89.19% | 2223/2482 · **89.56%** | +70/+68 — numerator grew _more_ |
| functions | 774/816 · 94.85% | 788/830 · **94.94%** | +14/+14 |
| lines | 89.77% | **89.90%** | |

Branches grew by more than the denominator because an uncovered arm was **deleted**: `resolve`'s old `only === null || only === undefined` had an `undefined` case the bindings never produce, and the rewrite drops it.

**The floor stays at 89.38 / 89.09 / 94.23 / 89.04, and that is a decision.** `vitest.config.mts` says to raise it when coverage rises, but the base branch already achieves 90.01 with that floor — #237 did not raise it — so raising here would fold that PR's uplift into this one, and the number would be measured against a tree that is not on `main` yet. It should be raised against `main` once the stack merges; say the word and I will add that commit after #237 lands.

## Not done

- **The area map.** Still §6 of the plan. The day region carries a sentence where it will go, because drawing the first member's coastline under the area's name is the representative-beach lie ADR-0048 refuses. The readout goes with it rather than standing alone — ADR-0034's surviving clause would permit a dial with no coast, but `ShoreMap` owns the coupling ADR-0038 just settled, and hoisting it out is a second change to that contract.
- **The agreement probe.** Identifier equality stands, knowingly strict. Directional: the probe can only add products, never remove one.
- **`WeekGrid.tsx:309` renders `<p key={note}>{note}</p>`** — a prose paragraph used as its own React key, so it serialises into the flight payload twice. The same defect #235 fixed in `Caveats`. ~166 bytes, in the steady state on 26 of 51 beaches. Noticed while adding withheld notes to that array and deliberately **not** folded in: one issue per branch. Worth a tracker entry — one line plus a test — say the word and I will file it.

## One thing to weigh

Ten slices, ~890 lines of source, ~980 of tests, ~335 of docs — past CLAUDE.md's "~400 changed lines or ~5 slices" guide. The dependency boundary it would split at is **`8aa3454`** ("Report an area's week"): slices 1–5 in one PR, 6–10 stacked on it. I did not split it because the base is itself an unmerged PR and a three-deep stack costs more coordination than the review it saves — and because splitting leaves `/conditions/<area>` with a week but no day chart, which is the state the work was asked to end. Happy to split it if you would rather review it in two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
