### PR TITLE
Raise the coverage floor to what the areas work achieves

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -496,10 +496,48 @@ export default defineConfig({
         // guard is gone rather than covered: `seaWash` asks whether the run has
         // a direction at all and returns null when it has not, which is a state
         // a test can put it in. So `ShoreMap.tsx` leaves the table too.
-        statements: 89.38,
-        branches: 89.09,
-        functions: 94.23,
-        lines: 89.04,
+        // RAISED 2026-09-04, all four, catching up three merged PRs rather
+        // than one. Areas replaced regions (#236), the measured block learned
+        // to answer for an area (#237) and the week, the day chart and the rip
+        // current risk followed (#238); none of the three moved this floor, so
+        // it had drifted about three quarters of a point below what the repo
+        // achieves:
+        //
+        //   statements 3426/3801  89.38 -> 90.13
+        //   branches   2223/2482  89.09 -> 89.56
+        //   functions   788/830   94.23 -> 94.93
+        //   lines      3089/3436  89.04 -> 89.89
+        //
+        // **Branches grew by more at the top than at the bottom** -- and unlike
+        // #200's note above, part of that is a deleted arm rather than new
+        // tests. `areaSources` resolved a product by reading the size of a Set
+        // built over the raw bindings and asking `only === null || only ===
+        // undefined`; the bindings are never `undefined`, so that arm was
+        // uncovered. The rewrite that stopped counting a missing binding as a
+        // source removed it.
+        //
+        // All four are the figures the reporter prints, and each was checked
+        // against the run that produced it rather than read off the table:
+        // `statements: 90.14` fails with "Coverage for statements (90.13%) does
+        // not meet global threshold (90.14%)", so 90.13 is the edge and not
+        // merely a number that passes.
+        //
+        // Three files this work touched are named rather than absorbed, and
+        // every uncovered statement in them is a guard or a publisher's outage
+        // that no test in this suite provokes: `areas.ts` at 96.15% statements,
+        // whose one uncovered line is `areaSources` throwing for an area naming
+        // a beach `beaches.json` does not have; `WeekPanel.tsx` at 98.38%, the
+        // empty-week branch of `sharedRange` and a tide row with no station;
+        // and `DayPanel.tsx` at 98.29%, still the CDIP outage sentence the #192
+        // note named. The identical guard in `surfZoneBeachOf` is covered, so
+        // this work adds no uncovered statement of its own.
+        //
+        // Nothing new is excluded. The same 0% entry-plumbing files named above
+        // still drag all four down in plain sight.
+        statements: 90.13,
+        branches: 89.56,
+        functions: 94.93,
+        lines: 89.9,
       },
     },
   },


### PR DESCRIPTION
One commit. `vitest.config.mts` says "The floor is what the repo actually achieves today, not an aspiration. Raise it when coverage rises." Three merged PRs raised it and none of them moved the floor, so this catches up rather than claiming one PR's uplift.

| | floor was | main achieves | |
| --- | --- | --- | --- |
| statements | 89.38 | 3426/3801 · **90.13** | |
| branches | 89.09 | 2223/2482 · **89.56** | numerator grew by more than the denominator |
| functions | 94.23 | 788/830 · **94.93** | |
| lines | 89.04 | 3089/3436 · **89.9** | |

The drift came from #236 (areas replace regions), #237 (the measured block answers for an area) and #238 (the week, the day chart and the rip current risk).

**Branches grew by more at the top than at the bottom**, and unlike #200's note above this one, part of that is a *deleted* arm rather than new tests. `areaSources` used to ask `only === null || only === undefined` over bindings that are never `undefined`; the rewrite that stopped counting a missing binding as a source removed that uncovered arm.

## Each figure was checked, not read off the table

The floor is set at the edge, and that is measured:

```
ERROR: Coverage for statements (90.13%) does not meet global threshold (90.14%)
```

So `90.13` is where it bites, not merely a number that happens to pass.

**One claim did not survive that check, and it is worth saying.** An earlier draft set `lines: 89.89` with a comment explaining that the true ratio is 89.8952 and a floor of `89.9` would therefore fail. It does not — the threshold check does not see the unrounded figure. The floor is `89.9` and the explanation is gone rather than shipped as a comment nobody would re-run.

## What is still uncovered

Named in the note rather than absorbed, and every one is a guard or a publisher's outage this suite does not provoke:

- `areas.ts` 96.15% statements — `areaSources` throwing for an area naming a beach `beaches.json` does not have.
- `WeekPanel.tsx` 98.38% — the empty-week branch of `sharedRange`, and a tide row with no station.
- `DayPanel.tsx` 98.29% — still the CDIP outage sentence the #192 note named.

The identical guard in `surfZoneBeachOf` is covered, so the areas work adds no uncovered statement of its own. Nothing new is excluded; the same 0% entry-plumbing files still drag all four down in plain sight.

## Gate

Run at `9538857`, clean tree:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  areas
  PASS  test
  PASS  build
  PASS  stylesheet
```

No issue: this is one commit whose whole justification is the note it adds, and an issue would be a third copy of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
