### PR TITLE
Draw the area on the map, with every beach it holds marked

### DIFF
--- a/docs/adr/0051-the-area-map-is-square.md
+++ b/docs/adr/0051-the-area-map-is-square.md
@@ -1,0 +1,118 @@
+# 0051 — The area map takes a square frame, not the area's own aspect
+
+Date: 2026-09-04. Status: accepted. Gives `/conditions/<area>` a map, which
+ADR-0049 recorded as missing. **Reverses `docs/plans/areas-over-locations.md`
+§6's frame decision**, on a measurement §6 did not make. ADR-0036, ADR-0037,
+ADR-0039 and ADR-0041 are untouched — the frame is built and the sea drawn
+exactly as they say.
+
+## Context
+
+An area page had readings, a chooser and a list of its beaches, and no picture
+of the place any of it was about. A beach page had a map. That inverts the whole
+argument for making the area the thing a reader picks.
+
+ADR-0049 recorded the map as deferred and gave the reason: an area has no single
+coast run, and drawing the first member's coastline under the area's name would
+be the representative-beach lie ADR-0048 refuses, one layer down from a reading.
+What was needed was a frame built from every member.
+
+**The plan already specified that frame, and specified it wrongly.** §6 says
+"The area frame is not square", rejecting `squareToward` because "La Jolla's
+bbox is 8,213 m north–south by 2,773 m east–west; Del Mar's is 9,411 by 1,773.
+`squareToward` would spend two thirds to four fifths of the width on slack."
+
+### What was measured
+
+The map column is **472px wide** at the review viewport (1536×639, measured in
+the browser, not derived from the breakpoints). Only the twelve areas holding
+more than one beach draw an area map; the other six show their single beach's.
+Taking each area's own bbox aspect, at that width:
+
+|                | bbox aspect (§6) | square | capped 1.5:1 |
+| -------------- | ---------------: | -----: | -----------: |
+| tallest frame  |      **1,908px** |  472px |        708px |
+| shortest frame |            199px |  472px |        199px |
+| worst tick gap |           11.4px |  5.5px |        7.9px |
+
+Seven of the twelve exceed 1,000px under §6's rule. Imperial Beach is 1,908px —
+three screens for one picture in a 639px window — and Coronado is a 199px
+letterbox. The swing between areas is ten-fold, so the map would not be one
+thing a reader learns to read.
+
+**What that height buys is an axis §6 had already conceded.** The tightest pair
+of marks goes from 5.5px to 11.4px, and §6 itself says of that cluster: "The
+ticks still crowd, and that is accepted rather than solved… La Jolla's point
+genuinely _is_ a cluster of four beaches inside 550 m." Both figures are far
+below any separation that would make the four readable as four, so the choice is
+between two illegible clusters — and only one of them costs three screens.
+
+**The slack is not empty.** §6's objection assumes the extra width is waste.
+ADR-0041 has the wash close on the frame, so it renders as sea. On Coronado —
+the widest area, 0.42:1 — the square frame is what shows the whole peninsula
+with the bay behind it, which its own aspect would have cropped to a strip.
+
+**§6's figures no longer reproduce either.** It gives Del Mar as 9,411 m by
+1,773 m, an aspect of 5.31:1; measured today from the traced coast runs it is
+4,191 by 2,798, or 1.50:1. §6 predates ADR-0039's traced shoreline, so it was
+measuring a different geometry. The direction of its argument survived that; the
+numbers did not.
+
+## Decision
+
+**`shoreViewForArea(area)` builds one square frame from every member's coast
+run**, and `ShoreMap` draws it exactly as it draws a beach's.
+
+- **The box is built from the members' runs, never from their sand**, which is
+  the rule `shoreViewFor` already states one scope down: what the box is built
+  from should be what the box shows.
+- **`squareToward` is reused, not re-derived.** No new constant, no new rule,
+  and the frame is the one the page already has.
+- **The seaward direction is read off the coastline's own walk order**, by
+  windowing the county line to the draft box first. Members are ordered north to
+  south, so joining their runs end to end makes a walk that doubles back — and
+  `seawardFrom` takes a run's two ends, so it would answer about a chord across
+  the doubling rather than about the coast. This is the one place the area case
+  is not simply the beach case with more points.
+- **Nothing is drawn heavy.** `segment` is null: no one beach is the subject of
+  an area map, and picking one out would be the lie ADR-0048 refuses, drawn
+  instead of stated.
+- **A member the traced coast does not reach contributes nothing to the box.**
+  That is `mission-bay-vacation-isle`, whose island the committed mainland ring
+  does not hold, and whose frame is its neighbours'.
+
+**The zoom §6 describes needs no mechanism.** `/conditions/<area>` gets this
+frame and `/conditions/<area>/<beach>` gets `shoreViewFor`'s, with that beach's
+run heavy. They are two committed frames and the route swaps between them,
+which is exactly what §6 asked for and is now true by construction.
+
+**The readout arrives with the map, and only where there is a bearing to
+state.** ADR-0049 said it would. An area reports a wind bearing only where its
+beaches share a forecast cell and a swell bearing only where they share a model
+line, so an area sharing neither has no needle on any hour — and `DayCompass`
+renders null in that state while `ShoreMap` would still draw the box around it.
+That put an empty labelled block under La Jolla's coast. The caller now answers
+`ShoreMap`'s one `hasReadout` question honestly. A beach page never reached this:
+every beach in the inventory binds a forecast cell, so there is always a wind
+arrow.
+
+## Consequences
+
+Every area page has a map of its own coast. Mission Bay – West and the other
+areas that share a forecast cell get their wind readout on it; La Jolla and
+Coronado get the coast alone.
+
+**§6's remaining half stands**: a tick per member, which is the next slice and
+amends ADR-0033. This decision deliberately ships the frame without the marks,
+because a frame that is wrong is worth finding before ten marks are drawn on it.
+
+**The plan is not repaired, and that is the split `docs/plans/README.md`
+draws.** A plan is a dated record of what was decided; this ADR is the thing
+kept current. The plan gets an addendum saying its frame decision was reversed
+and where to read why.
+
+The part most likely to be re-litigated is the slack on a long thin area —
+Imperial Beach's coast runs 5,734 m north to south and 1,419 m across, so a
+square frame is three quarters water. The answer is that it is water, drawn as
+water, and that the alternative is 1,908 pixels of picture in a 639-pixel
+window.

--- a/docs/adr/0052-a-beach-is-marked-on-its-areas-map.md
+++ b/docs/adr/0052-a-beach-is-marked-on-its-areas-map.md
@@ -1,0 +1,103 @@
+# 0052 — A beach is marked on its area's map
+
+Date: 2026-09-04. Status: accepted. **Amends ADR-0033**, which says the map
+plots nothing but the place. Completes ADR-0051, which gave an area a frame and
+deliberately shipped it without marks. Nothing about a beach's own map changes.
+
+## Context
+
+ADR-0051 gave `/conditions/<area>` a square frame built from every member's
+coast run. What it draws is a coastline and the water beside it — the same
+picture at either scope, only wider — and nothing on it says which of an area's
+beaches is where. On La Jolla that is ten beaches inside one shoreline, and the
+picture is equally true of any of them.
+
+That is the half of the map that makes it about an **area**. Without it the
+frame is a stretch of coast that happens to be wide.
+
+**ADR-0033 appears to forbid it, and the appearance is worth taking
+seriously.** That decision is titled "The map draws a place, not an inventory"
+and its first clause is "No markers." It was written against a picture carrying
+the MOP line, the wave buoy, the tide station and the air station as four glyphs
+in four shapes, two of which overlapped wherever a tide gauge is bolted to the
+pier an air station stands on.
+
+## Decision
+
+**Each beach an area holds is marked on the area's map, with one mark type.**
+
+**The distinction ADR-0033 was drawing is between an instrument and a
+subject.** Every glyph it removed stood for a source the page _reads_ — a
+station, a buoy, a model line — and its objection was that drawing them
+answered ADR-0010 twice and "cost the picture its subject". A beach is not a
+source. On an area map the beaches **are** the subject, and marking them is the
+picture having a subject rather than losing one.
+
+The rest of ADR-0033 stands and is untouched: no station, buoy, cell or model
+line is drawn, the wash is one flat tint whose edge is the drawn line, and the
+frame is sized by coast rather than by anything not on the picture.
+
+**One mark type, not four.** ADR-0033's four glyphs of four shapes needed a halo
+to be told apart; these are all the same short line and they mean one thing.
+
+**Marks, never targets, and that is arithmetic rather than taste.** Four of La
+Jolla's ten fall within 549 m of one another, so four tap targets at ADR-0004's
+44px floor would need the map 2,634px wide against the 472px it has. The list of
+beaches above the map is the control; the marks are for orientation.
+
+**The mark sits at the middle of the beach's own drawn run, never at the middle
+of its two ends.** Those ends are corners of a bounding extent, and the straight
+line between them cuts inside every curve of the shore. Measured over the 50
+beaches the traced coast reaches:
+
+|                                            |              |
+| ------------------------------------------ | ------------ |
+| worst distance off the line, ends-midpoint | **1,562 m**  |
+| beaches over 100 m off, ends-midpoint      | **17 of 50** |
+| worst distance off the line, run-midpoint  | **0 m**      |
+
+This is `beachStretch`'s rule one scope down — "a run of the polyline, never a
+chord" — and it failed the same way when broken: `la-jolla-community-beach`
+spans 5,082 m of a bay, and its mark floated in open land on the first draft of
+this picture. Found by looking at the rendered map, not by a test.
+
+**The one mark not on the line is `mission-bay-vacation-isle`**, which has no
+coast run because the committed mainland ring does not hold its island. It falls
+back to its own two ends — one point, that beach's extent being zero — and lands
+about 400 m off the traced shore, inside the frame its neighbours build. That is
+where the beach is, so it is drawn there rather than snapped onto the mainland
+or dropped. It is the only mark on any area map that is not on a coastline.
+
+**Positions cross the boundary, marks do not.** `shore.ts` returns one position
+per beach and `ShoreMap` decides length, direction and weight — the split the
+module already keeps, the assembler reading and the component drawing. The mark
+is perpendicular to the **local** coast, taken from the two drawn points either
+side of it, so a tick on a bay shore that turns through a right angle inside one
+frame still crosses the line. That is ADR-0041's reading applied to a second
+thing: take the direction from the walk, not from a normal computed once for the
+whole picture.
+
+**Four plot units long**, which is about 19px at the measured column width and
+is fixed on screen rather than in metres. An area is 1.7 km of coast at Ocean
+Beach and 8.9 km at San Diego Bay – Central; a mark in metres would be five
+times bigger on one than the other.
+
+## Consequences
+
+An area map says which beaches are in the area and roughly where, and the list
+above it says which is which. A beach map is unchanged: one subject, drawn as a
+heavy run, and no marks at all.
+
+**The crowding is accepted, not solved.** La Jolla's tightest pair sits 1.2
+units apart — about 6px — and reads as a cluster of crossing ticks rather than
+as four distinguishable marks. That is a true picture: those four beaches are
+inside 550 m of each other. What is refused is labelling them there or making
+them tappable, both of which the arithmetic above rules out.
+
+**Whether that cluster reads as a cluster rather than a smudge is a human check
+and no gate replaces it.** It was looked at on the rendered page at 1536×639
+before this landed.
+
+The part most likely to be re-litigated is whether this reopens ADR-0033. It
+does not: the test that decision implies is whether the thing drawn is an
+instrument the page reads. Every glyph it removed was; a beach is not.

--- a/docs/plans/areas-over-locations.md
+++ b/docs/plans/areas-over-locations.md
@@ -420,8 +420,12 @@ to make cheap.
 > area frame and `/conditions/<area>/<beach>` gets the beach's, with that
 > beach's run heavy. Two committed frames, swapped by the route.
 >
-> §6's other half — a tick per member, amending ADR-0033 — is unchanged and is
-> the next slice.
+> §6's other half — a tick per member, amending ADR-0033 — landed as
+> **ADR-0052**, with one correction: the mark goes at the middle of the beach's
+> _drawn run_, not at the middle of its two ends. §6 says "midpoint" without
+> saying of what, and the ends-midpoint lands up to 1,562 m off the traced coast
+> — `la-jolla-community-beach`'s mark floated in open land until it was looked
+> at. 17 of the 50 beaches with a run are over 100 m off by that reading.
 
 ## Test seams
 

--- a/docs/plans/areas-over-locations.md
+++ b/docs/plans/areas-over-locations.md
@@ -397,6 +397,32 @@ to make cheap.
 > will go. The readout goes with it rather than standing alone, because
 > `ShoreMap` owns the coupling ADR-0038 settled.
 
+> **Addendum, 2026-09-04. §6's frame decision is reversed: the area map is
+> square.**
+>
+> §6 says "The area frame is not square", rejecting `squareToward` because it
+> "would spend two thirds to four fifths of the width on slack". Measured at the
+> map column's real width — 472px at the review viewport — each area's own bbox
+> aspect makes Imperial Beach **1,908px tall** and Coronado a **199px
+> letterbox**, with seven of the twelve multi-beach areas over a thousand pixels
+> in a 639px window. What it buys is the tightest pair of marks going from 5.5px
+> to 11.4px, on the axis §6 had already conceded reads as a cluster either way.
+> The slack is drawn as sea by ADR-0041, and on Coronado the square frame is
+> what shows the whole peninsula rather than a strip of it. **ADR-0051** records
+> it.
+>
+> §6's own figures no longer reproduce: it gives Del Mar as 9,411 m by 1,773 m,
+> and the traced coast runs give 4,191 by 2,798. It predates ADR-0039, so it was
+> measuring a different geometry — the direction of its argument survived, the
+> numbers did not.
+>
+> **The zoom §6 describes needed no mechanism.** `/conditions/<area>` gets the
+> area frame and `/conditions/<area>/<beach>` gets the beach's, with that
+> beach's run heavy. Two committed frames, swapped by the route.
+>
+> §6's other half — a tick per member, amending ADR-0033 — is unchanged and is
+> the next slice.
+
 ## Test seams
 
 Agreed before starting, and chosen from what exists rather than invented.

--- a/src/components/conditions/ConditionsSection.test.tsx
+++ b/src/components/conditions/ConditionsSection.test.tsx
@@ -189,10 +189,11 @@ test("on an area page the measured block is given the area and a member", () => 
   render(<ConditionsSection areaSlug="la-jolla" beachSlug={null} />);
 
   const [props] = measuredPanel.mock.calls[0] as [Record<string, unknown>];
-  const area = props.area as { name: string; beaches: number };
+  const area = props.area as { name: string; beaches: readonly string[] };
 
   expect(area.name).toBe("La Jolla");
-  expect(area.beaches).toBe(10);
+  expect(area.beaches).toHaveLength(10);
+  expect(area.beaches[0]).toBe("la-jolla-shores-beach");
   expect(props.slug).toBe("la-jolla-shores-beach");
 });
 
@@ -494,9 +495,9 @@ test("the week is asked for a beach and the area it stands for", () => {
   const [props] = weekPanel.mock.calls[0] as [Record<string, unknown>];
   expect(Object.keys(props).sort()).toEqual(["area", "slug"]);
 
-  const area = props.area as { name: string; beaches: number };
+  const area = props.area as { name: string; beaches: readonly string[] };
   expect(area.name).toBe("La Jolla");
-  expect(area.beaches).toBe(10);
+  expect(area.beaches).toHaveLength(10);
   expect(props.slug).toBe("la-jolla-shores-beach");
 });
 
@@ -566,8 +567,9 @@ test("the day chart is asked for a beach and the area it stands for", () => {
   const [props] = dayPanel.mock.calls[0] as [Record<string, unknown>];
   expect(Object.keys(props).sort()).toEqual(["area", "slug"]);
 
-  const area = props.area as { name: string; beaches: number };
+  const area = props.area as { name: string; beaches: readonly string[] };
   expect(area.name).toBe("La Jolla");
+  expect(area.beaches).toHaveLength(10);
   expect(props.slug).toBe("la-jolla-shores-beach");
 });
 

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -1785,12 +1785,15 @@ test("the tab bar is the same four tabs at either scope", async () => {
 });
 
 /**
- * The map draws one beach's own stretch of coast. An area has no such run until
- * the area map lands, and drawing the first member's under the area's name is
- * the representative-beach lie ADR-0048 refuses -- so the column says what it
- * is missing rather than showing the wrong thing or nothing at all.
+ * An area page draws the area's own coast, which is the whole point of making
+ * the area the thing a reader picks: it had readings and a chooser and no
+ * picture of the place they were about.
+ *
+ * The spoken label says the count, because the picture cannot. Nothing on an
+ * area map is picked out, so a reader who cannot see it is owed the fact that
+ * this is several beaches' coast rather than one's.
  */
-test("an area page carries no map, and says what is there instead", async () => {
+test("an area page draws the whole area's coast", async () => {
   const { container } = render(
     await DayPanel({
       slug: "la-jolla-shores-beach",
@@ -1798,21 +1801,64 @@ test("an area page carries no map, and says what is there instead", async () => 
     }),
   );
 
-  expect(container.querySelector("svg[aria-label^='A map of']")).toBeNull();
-  expect(
-    screen.getByText(/The map draws one beach's own stretch of coast/),
-  ).toBeDefined();
-  expect(screen.getByText(/Choose a beach above for La Jolla's/)).toBeDefined();
+  const map = container.querySelector("svg[aria-label^='A map of']");
+  expect(map).not.toBeNull();
+  expect(map!.getAttribute("aria-label")).toBe(
+    "A map of La Jolla: the whole stretch of coast its 10 beaches sit on, " +
+      "with the open water shaded.",
+  );
+  // The placeholder it replaces is gone, and asserted gone: a sentence left
+  // beside a real map would read as the map having failed.
+  expect(screen.queryByText(/The map draws one beach's own/)).toBeNull();
 });
 
-/** And the beach page still draws it, which is what says the map was gated and not lost. */
-test("a beach page still draws its map", async () => {
+/**
+ * And nothing on it is drawn heavy, because no one beach is the subject.
+ *
+ * That is the zoom the plan describes rather than a missing feature: the beach
+ * page draws its own stretch heavy in a frame sized to it, and the two are two
+ * committed frames the route swaps between. Asserted against the beach page in
+ * the same test so it cannot pass by the marker having been renamed.
+ */
+test("an area map picks out no single beach, where a beach map does", async () => {
+  const onArea = render(
+    await DayPanel({
+      slug: "la-jolla-shores-beach",
+      area: await areaScope("la-jolla"),
+    }),
+  );
+  expect(onArea.container.querySelector("[data-segment]")).toBeNull();
+  onArea.unmount();
+
   const { container } = render(
     await DayPanel({ slug: "la-jolla-shores-beach" }),
   );
+  expect(container.querySelector("[data-segment]")).not.toBeNull();
+  expect(
+    container
+      .querySelector("svg[aria-label^='A map of']")!
+      .getAttribute("aria-label"),
+  ).toMatch(/^A map of La Jolla Shores Beach: its own stretch/);
+});
 
-  expect(container.querySelector("svg[aria-label^='A map of']")).not.toBeNull();
-  expect(screen.queryByText(/The map draws one beach's own/)).toBeNull();
+/**
+ * Every area gets a frame, which is what says this is not a feature only the
+ * area it was built against has. Measured over the twelve areas that draw one:
+ * the other six hold a single beach and show that beach's map instead.
+ */
+test("every multi-beach area has a coast to draw", async () => {
+  const { beachesByArea } = await import("@/lib/areas");
+  const { shoreViewForArea } = await import("./shore");
+
+  const drawn = beachesByArea().filter(({ area }) => area.beaches.length > 1);
+  expect(drawn).toHaveLength(12);
+
+  for (const { area } of drawn) {
+    const view = shoreViewForArea(area);
+    expect(view.bounds, area.slug).not.toBeNull();
+    expect(view.coast.length, area.slug).toBeGreaterThan(1);
+    expect(view.segment, area.slug).toBeNull();
+  }
 });
 
 /**
@@ -1919,4 +1965,70 @@ test("a beach page keeps the beach-scoped wording", async () => {
   expect(
     screen.getByText(/This forecast is not issued for this beach/),
   ).toBeDefined();
+});
+
+/**
+ * The readout arrives with the area map, and only where the area has a bearing
+ * to state.
+ *
+ * An area reports a wind bearing only where its beaches share a forecast cell
+ * and a swell bearing only where they share a model line. La Jolla shares
+ * neither, so no hour of any day has a needle — and `DayCompass` renders null
+ * in that state while `ShoreMap` would still draw its labelled box around it.
+ * That put an empty block under the coast, which reads as a fault. ADR-0051.
+ */
+test("an area with no shared cell or line carries the map and no readout", async () => {
+  const { container } = render(
+    await DayPanel({
+      slug: "la-jolla-shores-beach",
+      area: await areaScope("la-jolla"),
+    }),
+  );
+
+  expect(container.querySelector("svg[aria-label^='A map of']")).not.toBeNull();
+  expect(container.querySelector("[data-readout]")).toBeNull();
+});
+
+/** And an area that does share a cell keeps its wind, which is the promise. */
+test("an area that shares a forecast cell keeps its readout", async () => {
+  const { container } = render(
+    await DayPanel({
+      slug: "mission-bay-riviera-shores",
+      area: await areaScope("mission-bay-west"),
+    }),
+  );
+
+  const readout = container.querySelector("[data-readout]");
+  expect(readout).not.toBeNull();
+  expect(readout!.textContent).toContain("Wind");
+});
+
+/**
+ * A beach page never reaches the empty state, and this is what says the fix is
+ * about areas rather than a guard bolted onto both: every beach in the
+ * inventory binds a forecast cell, so there is always a wind arrow.
+ */
+test("a beach page always has a readout", async () => {
+  const { container } = render(
+    await DayPanel({ slug: "la-jolla-shores-beach" }),
+  );
+
+  expect(container.querySelector("[data-readout]")).not.toBeNull();
+});
+
+/**
+ * A slug the inventory does not hold draws no map, rather than inventing one.
+ *
+ * Unreachable from a URL — both routes resolve the slug before rendering — and
+ * asserted because this panel is handed a slug rather than a beach, so the
+ * question of what it does with a bad one has an answer either way. It was
+ * covered incidentally while an area page took this path; the area map moved
+ * area pages onto their own, so it is asserted deliberately now.
+ */
+test("a slug the inventory does not hold draws no map", async () => {
+  const { container } = render(await DayPanel({ slug: "not-a-beach" }));
+
+  expect(container.querySelector("svg[aria-label^='A map of']")).toBeNull();
+  // The rest of the region still renders: the map is one part of it.
+  expect(container.querySelector("[data-series-tab]")).not.toBeNull();
 });

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -1805,7 +1805,7 @@ test("an area page draws the whole area's coast", async () => {
   expect(map).not.toBeNull();
   expect(map!.getAttribute("aria-label")).toBe(
     "A map of La Jolla: the whole stretch of coast its 10 beaches sit on, " +
-      "with the open water shaded.",
+      "each marked, with the open water shaded.",
   );
   // The placeholder it replaces is gone, and asserted gone: a sentence left
   // beside a real map would read as the map having failed.
@@ -2031,4 +2031,37 @@ test("a slug the inventory does not hold draws no map", async () => {
   expect(container.querySelector("svg[aria-label^='A map of']")).toBeNull();
   // The rest of the region still renders: the map is one part of it.
   expect(container.querySelector("[data-series-tab]")).not.toBeNull();
+});
+
+/**
+ * The marks reach the page: ten beaches in La Jolla, ten marks on its coast.
+ *
+ * This is the half that makes the picture about an area rather than about a
+ * stretch of coast that happens to be wide, and it is asserted here as well as
+ * in `shore.test.ts` because a view model nothing renders is not a map.
+ */
+test("an area map marks every beach the area holds", async () => {
+  const { container } = render(
+    await DayPanel({
+      slug: "la-jolla-shores-beach",
+      area: await areaScope("la-jolla"),
+    }),
+  );
+
+  expect(container.querySelectorAll("[data-tick]")).toHaveLength(10);
+  expect(
+    container
+      .querySelector("svg[aria-label^='A map of']")!
+      .getAttribute("aria-label"),
+  ).toContain("its 10 beaches sit on, each marked");
+});
+
+/** And a beach map marks nothing, because it draws its one subject heavy. */
+test("a beach map marks nothing and draws its own stretch instead", async () => {
+  const { container } = render(
+    await DayPanel({ slug: "la-jolla-shores-beach" }),
+  );
+
+  expect(container.querySelectorAll("[data-tick]")).toHaveLength(0);
+  expect(container.querySelector("[data-segment]")).not.toBeNull();
 });

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -424,7 +424,7 @@ function mapDescription(beachName: string): string {
 function areaMapDescription(areaName: string, beaches: number): string {
   return (
     `A map of ${areaName}: the whole stretch of coast its ${beaches} beaches ` +
-    `sit on, with the open water shaded.`
+    `sit on, each marked, with the open water shaded.`
   );
 }
 

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -93,6 +93,7 @@ import {
   type WaveWeekView,
 } from "@/lib/conditions";
 import { beachBySlug } from "@/lib/beaches";
+import { areaBySlug } from "@/lib/areas";
 import {
   localMidnightOf,
   addLocalDays,
@@ -142,7 +143,7 @@ import {
 import type { ProvenanceFacts } from "./ProvenanceLine";
 import { ShoreMap } from "./ShoreMap";
 import { SurfZone } from "./SurfZone";
-import { shoreViewFor } from "./shore";
+import { shoreViewFor, shoreViewForArea } from "./shore";
 import { SkyWording } from "./SkyWording";
 import { gridPoints, swellPoints, tidePoints } from "./series";
 import {
@@ -405,6 +406,25 @@ function mapDescription(beachName: string): string {
   return (
     `A map of ${beachName}: its own stretch of coast drawn heavier than the ` +
     `shore either side of it, and the open water shaded.`
+  );
+}
+
+/**
+ * The same, for an area.
+ *
+ * **It says the count, because the picture cannot.** An area map draws the
+ * whole area's coast and nothing on it is picked out -- there is no heavier
+ * stretch, since no one beach is the subject -- so a reader who cannot see it
+ * is owed the fact that this is several beaches' coast rather than one's.
+ *
+ * It does not name them. The list of beaches is a heading and a set of links
+ * further up the page, which is where a reader goes to choose one; repeating
+ * ten names inside the map's label would make the label the list.
+ */
+function areaMapDescription(areaName: string, beaches: number): string {
+  return (
+    `A map of ${areaName}: the whole stretch of coast its ${beaches} beaches ` +
+    `sit on, with the open water shaded.`
   );
 }
 
@@ -768,32 +788,33 @@ export async function DayPanel({
     go quiet and does not belong behind a Suspense boundary.
   */
   /*
-    **No map on an area page, and a sentence in its place.**
+    **One map at either scope, and which coast it draws is the whole
+    difference.** An area page draws the area's whole coast in a square frame
+    with nothing picked out; a beach page draws that beach's own stretch heavy,
+    in a frame sized to it. That is the zoom the plan describes, and it needs no
+    mechanism beyond the route: the two views are two committed frames and the
+    URL says which.
 
-    The map draws one beach's own stretch of coast, heavier than the shore
-    either side of it. There is no such run for an area -- the area map, with a
-    tick per member and a frame taking the bbox's own aspect, is its own slice
-    and its own decision, because ADR-0033 says the map draws a place and not an
-    inventory and a mark per beach amends that. Drawing the first member's coast
-    here in the meantime is exactly the representative-beach lie ADR-0048
-    refuses: it would put one beach's shoreline under the area's name.
-
-    The readout goes with it, and that is the part worth stating. ADR-0034's
-    surviving clause has the readout rendered on every beach including the ones
-    with no coast, so a bearing dial without a shoreline is a shape this page
-    already permits -- but `ShoreMap` owns the coupling ADR-0038 settled, one
-    `hasReadout` gating the block and its sources together, and hoisting it out
-    would be a second change to a contract that decision has just finished
-    drawing. It arrives with the area map, over the area's own coast, which is
-    the frame that makes a wind bearing mean anything.
+    The area map is what stopped the area page having one at all. Drawing the
+    first member's coastline under the area's name would have been the
+    representative-beach lie ADR-0048 refuses, one layer down from a reading --
+    so until there was a frame built from every member, the column carried a
+    sentence saying so.
 
     A beach the inventory does not hold is not this component's error to invent
     a map for: the route already answered that question before rendering, and
     `beachBySlug` returning null here would mean the page is showing a beach it
-    does not have.
+    does not have. The same is true of the area, which `ConditionsSection`
+    resolved before it built the scope.
   */
   const beach = area ? null : beachBySlug(slug);
-  const shore = beach === null ? null : shoreViewFor(beach);
+  const areaOnMap = area ? areaBySlug(area.slug) : null;
+  const shore =
+    areaOnMap !== null
+      ? shoreViewForArea(areaOnMap)
+      : beach === null
+        ? null
+        : shoreViewFor(beach);
 
   /*
     Seven days of needles, built beside the seven days of series rather than
@@ -993,6 +1014,18 @@ export async function DayPanel({
   });
 
   /*
+    Whether the readout has anything to say at all.
+
+    An area reports a wind bearing only where its beaches share a forecast cell
+    and a swell bearing only where they share a model line, so an area that
+    shares neither has no needle on any hour of any day. `DayCompass` renders
+    null in that state and `ShoreMap` would still draw the box around it.
+  */
+  const hasNeedles = compassDays.some((day) =>
+    day.hours.some((hour) => hour.needles.length > 0),
+  );
+
+  /*
     Which hour it is now, as an index into any of the seven days.
 
     Computed here rather than in the client, because the page carries
@@ -1022,22 +1055,39 @@ export async function DayPanel({
         <ChosenDay
           days={days}
           map={
-            area ? (
-              <p className="leading-relaxed text-base text-fog">
-                The map draws one beach&apos;s own stretch of coast, with the
-                day&apos;s wind and swell laid under it. Choose a beach above
-                for {area.name}&apos;s.
-              </p>
-            ) : shore === null ? null : (
+            shore === null ? null : (
               <>
                 <ShoreMap
                   {...shore}
-                  description={mapDescription(beach!.name)}
+                  description={
+                    area === undefined
+                      ? mapDescription(beach!.name)
+                      : areaMapDescription(area.name, area.beaches.length)
+                  }
                   absence="We cannot place this beach on a map: the coordinates we hold for it are all one point."
                   noCoast="The coastline this site traces does not reach this beach."
                   coastCredit={`Shore traced from CDFW's ecoregion boundary, which follows this county's own coastline linework — close to the sand, but no tide level is published for it, so the edge is drawn where the land is mapped rather than where the water is today.`}
-                  readout={<DayCompass days={compassDays} />}
-                  readoutSources={<DayCompassSources days={compassDays} />}
+                  /*
+                    The readout arrives with the area map, which is what
+                    ADR-0049 said it would -- and only where the area has a
+                    bearing to state. `DayCompass` renders null when no hour has
+                    a needle, and passing it anyway put an empty labelled box
+                    under La Jolla's coast, where the forecast cell and the
+                    model line are both withheld and there is nothing to point.
+
+                    A beach page never reaches that: every beach in the
+                    inventory binds a forecast cell, so there is always a wind
+                    arrow. It is new with areas, so the emptiness is decided
+                    here rather than inside the readout -- `ShoreMap` gates the
+                    block and its sources on one `hasReadout`, and this is the
+                    caller answering that question honestly.
+                  */
+                  readout={
+                    hasNeedles ? <DayCompass days={compassDays} /> : null
+                  }
+                  readoutSources={
+                    hasNeedles ? <DayCompassSources days={compassDays} /> : null
+                  }
                 />
                 {/*
                 The sighting layer from #121, reserved *on* the map rather than

--- a/src/components/conditions/ShoreMap.test.tsx
+++ b/src/components/conditions/ShoreMap.test.tsx
@@ -298,3 +298,108 @@ test("the map's drawing space holds the picture and nothing else", () => {
   expect(svg.querySelector("[data-test-sources]")).toBeNull();
   expect(svg.textContent).not.toContain(PROPS.coastCredit);
 });
+
+/* =========================================================================
+ * Marks, one per beach an area holds
+ * ========================================================================= */
+
+/** Where a mark's two ends are, in plot units. */
+function markEnds(index = 0) {
+  const marks = [...document.querySelectorAll("[data-tick]")];
+  const line = marks[index];
+  return {
+    count: marks.length,
+    from: {
+      x: Number(line.getAttribute("x1")),
+      y: Number(line.getAttribute("y1")),
+    },
+    to: {
+      x: Number(line.getAttribute("x2")),
+      y: Number(line.getAttribute("y2")),
+    },
+  };
+}
+
+/** A beach map has one subject and draws it heavy, so it carries no marks. */
+test("no ticks given draws no marks, which is every beach map", () => {
+  render(<ShoreMap {...PROPS} />);
+
+  expect(document.querySelectorAll("[data-tick]")).toHaveLength(0);
+  // And the heavy run it draws instead is still there, so this is not just an
+  // empty picture passing both ways.
+  expect(document.querySelector("[data-segment]")).not.toBeNull();
+});
+
+test("a mark is drawn for every position given", () => {
+  render(<ShoreMap {...PROPS} segment={null} ticks={COAST.slice(0, 3)} />);
+
+  expect(document.querySelectorAll("[data-tick]")).toHaveLength(3);
+});
+
+/**
+ * A mark crosses the coast rather than lying along it, which is the whole of
+ * what makes it read as a mark.
+ *
+ * Asserted as a dot product against the local coast direction rather than
+ * against a fixed axis: the shore turns through more than a right angle inside
+ * one frame on the bays, so a mark that were perpendicular to the *frame* would
+ * lie flat along the line at half the beaches in Mission Bay.
+ */
+test("a mark crosses the coast, not along it", () => {
+  render(<ShoreMap {...PROPS} segment={null} ticks={[COAST[1]]} />);
+
+  const project = projectionFor(BOUNDS, { width: 100, height: 100 });
+  const before = project(COAST[0].lat, COAST[0].lon);
+  const after = project(COAST[2].lat, COAST[2].lon);
+  const { from, to } = markEnds();
+
+  const coastDir = { x: after.x - before.x, y: after.y - before.y };
+  const markDir = { x: to.x - from.x, y: to.y - from.y };
+  const dot =
+    (coastDir.x * markDir.x + coastDir.y * markDir.y) /
+    (Math.hypot(coastDir.x, coastDir.y) * Math.hypot(markDir.x, markDir.y));
+
+  // Perpendicular to within a rounding error of the two-decimal coordinates.
+  expect(Math.abs(dot)).toBeLessThan(0.01);
+});
+
+/**
+ * Every mark is the same size on screen whatever ground the frame covers. An
+ * area is 1.7 km of coast at Ocean Beach and 8.9 km at San Diego Bay – Central,
+ * and a mark measured in metres would be five times bigger on one than on the
+ * other.
+ */
+test("a mark is a fixed length in plot units, not in metres", () => {
+  const wide = render(
+    <ShoreMap {...PROPS} segment={null} ticks={[COAST[1]]} />,
+  );
+  const inWide = markEnds();
+  const wideLength = Math.hypot(
+    inWide.to.x - inWide.from.x,
+    inWide.to.y - inWide.from.y,
+  );
+  wide.unmount();
+
+  // The same coast in a box covering a tenth of the ground.
+  render(
+    <ShoreMap
+      {...PROPS}
+      segment={null}
+      ticks={[COAST[1]]}
+      bounds={{
+        south: 32.8555,
+        north: 32.8645,
+        west: -117.2645,
+        east: -117.2555,
+      }}
+    />,
+  );
+  const inTight = markEnds();
+  const tightLength = Math.hypot(
+    inTight.to.x - inTight.from.x,
+    inTight.to.y - inTight.from.y,
+  );
+
+  expect(wideLength).toBeCloseTo(tightLength, 1);
+  expect(wideLength).toBeCloseTo(4, 1);
+});

--- a/src/components/conditions/ShoreMap.tsx
+++ b/src/components/conditions/ShoreMap.tsx
@@ -63,6 +63,19 @@ export type ShoreMapProps = {
    * `shore.ts` makes that choice.
    */
   segment: readonly Position[] | null;
+  /**
+   * A mark per beach this map is about, drawn across the coast at each.
+   *
+   * Empty on a beach map, which has one subject and draws it as a heavy run
+   * instead. `shore.ts` decides where they go; the length, the direction and
+   * the weight are decided here, because they are answers in plot units.
+   *
+   * **Marks and never targets.** The plan measured what making them tappable
+   * would cost: four of La Jolla's midpoints fall within 549 m of one another,
+   * so four marks at ADR-0004's 44px floor would need the map 2,634px wide.
+   * The list of beaches above the map is the control; these are for orientation.
+   */
+  ticks?: readonly Position[];
   /** The spoken equivalent of the whole picture. */
   description: string;
   /** What to say instead of a map when there is no box at all. */
@@ -144,10 +157,24 @@ export type ShoreMapProps = {
 const WIDTH = 100;
 const HEIGHT = 100;
 
+/**
+ * How long a beach's mark is, in plot units, so it is the same size on screen
+ * whatever ground the frame covers.
+ *
+ * Four units of a hundred, which at the map column's measured 472px is about
+ * 19px -- long enough to read as a mark across the coast at the review
+ * viewport, short enough that La Jolla's tightest pair, 1.2 units apart, reads
+ * as a cluster rather than as a single thick smudge. That crowding is accepted
+ * rather than solved, and the plan measured why: those four beaches really do
+ * sit within 549 m of one another.
+ */
+const TICK_UNITS = 4;
+
 export function ShoreMap({
   coast,
   bounds,
   segment,
+  ticks = [],
   description,
   absence,
   noCoast,
@@ -209,6 +236,58 @@ export function ShoreMap({
     A readout with its sources missing is an unattributed figure, and sources
     printed under a map with no readout name a bearing nobody can see.
   */
+  /*
+    Each mark, as a short line across the coast rather than a dot on it.
+
+    **Perpendicular to the coast where it is, not to the frame.** The direction
+    comes from the two drawn points either side of the mark, so a tick on a bay
+    shore that turns through a right angle inside one frame still crosses the
+    line rather than lying along it. It is the same reading ADR-0041 gave the
+    wash: take the direction from the walk rather than from a normal computed
+    once for the whole picture.
+
+    **A fixed length in plot units, so every mark is the same size on screen**
+    whatever ground the frame covers. An area is 1.7 km of coast at Ocean Beach
+    and 8.9 km at San Diego Bay - Central, and a mark measured in metres would
+    be five times bigger on one than the other.
+
+    A mark whose beach has no drawn coast near it -- the island in Mission Bay -
+    West, about 400 m off the traced shore -- takes the direction of the nearest
+    drawn point anyway. It lies off the line, which is where that beach is.
+  */
+  const marks = ticks.map((at) => {
+    const point = project(at.lat, at.lon);
+    if (drawn.length < 2) return { from: point, to: point };
+
+    let nearest = 0;
+    for (let index = 1; index < drawn.length; index += 1) {
+      if (
+        Math.hypot(drawn[index].x - point.x, drawn[index].y - point.y) <
+        Math.hypot(drawn[nearest].x - point.x, drawn[nearest].y - point.y)
+      ) {
+        nearest = index;
+      }
+    }
+
+    const before = drawn[Math.max(0, nearest - 1)];
+    const after = drawn[Math.min(drawn.length - 1, nearest + 1)];
+    const dx = after.x - before.x;
+    const dy = after.y - before.y;
+    const length = Math.hypot(dx, dy) || 1;
+    const half = TICK_UNITS / 2;
+
+    return {
+      from: {
+        x: point.x - (-dy / length) * half,
+        y: point.y - (dx / length) * half,
+      },
+      to: {
+        x: point.x + (-dy / length) * half,
+        y: point.y + (dx / length) * half,
+      },
+    };
+  });
+
   const hasReadout = readout !== null && readout !== undefined;
 
   return (
@@ -257,6 +336,21 @@ export function ShoreMap({
             rather than only hue: the two are the same ocean, so a reader who
             sees no colour still sees which part of the shore they chose.
           */}
+        {marks.map((mark, index) => (
+          <line
+            key={index}
+            x1={mark.from.x.toFixed(2)}
+            y1={mark.from.y.toFixed(2)}
+            x2={mark.to.x.toFixed(2)}
+            y2={mark.to.y.toFixed(2)}
+            className="stroke-purple-deep"
+            strokeWidth={2}
+            strokeLinecap="round"
+            vectorEffect="non-scaling-stroke"
+            data-tick=""
+          />
+        ))}
+
         {drawnSegment.length > 0 && (
           <path
             d={drawnSegment

--- a/src/components/conditions/areaScope.ts
+++ b/src/components/conditions/areaScope.ts
@@ -50,6 +50,14 @@ import {
  * is not read at all, so no member's figure can leak into an area's answer.
  */
 export type AreaScope = {
+  /**
+   * Which area this is, for the one thing that needs to look it up again.
+   *
+   * The map is built from the area's own coast rather than from anything the
+   * scope carries pre-resolved, because a windowed coastline is a few hundred
+   * points and every panel would be handed it whether it drew a map or not.
+   */
+  slug: string;
   name: string;
   /**
    * The area's member beaches, north to south.
@@ -119,6 +127,7 @@ export type NotShared = {
  */
 export function scopeFor(area: Area): AreaScope {
   return {
+    slug: area.slug,
     name: area.name,
     beaches: area.beaches,
     sources: areaSources(area),

--- a/src/components/conditions/areaScope.ts
+++ b/src/components/conditions/areaScope.ts
@@ -51,7 +51,16 @@ import {
  */
 export type AreaScope = {
   name: string;
-  beaches: number;
+  /**
+   * The area's member beaches, north to south.
+   *
+   * **The slugs and not just how many**, because two things need them and one
+   * of them needs which: the withheld sentences count them, and the area map
+   * draws the coast of every one and a mark at each. It was a count until the
+   * map arrived, and keeping both a count and a list would be two fields for
+   * one fact.
+   */
+  beaches: readonly string[];
   sources: AreaSources;
   /**
    * The member the surf zone bulletin is read through, which is not the member
@@ -111,7 +120,7 @@ export type NotShared = {
 export function scopeFor(area: Area): AreaScope {
   return {
     name: area.name,
-    beaches: area.beaches.length,
+    beaches: area.beaches,
     sources: areaSources(area),
     bulletinBeach: surfZoneBeachOf(area),
   };
@@ -136,7 +145,7 @@ export function withheldBy(
   return {
     agreement: source.kind,
     areaName: scope.name,
-    beaches: scope.beaches,
+    beaches: scope.beaches.length,
     distinct: source.kind === "mixed" ? source.distinct : 0,
     without: source.kind === "mixed" ? source.without : 0,
   };

--- a/src/components/conditions/shore.test.ts
+++ b/src/components/conditions/shore.test.ts
@@ -9,7 +9,13 @@ import {
   SHORE_WINDOW_MARGIN,
   unbrokenAround,
 } from "@/lib/coastline";
-import { coastRunFor, seawardFrom, shoreViewFor } from "./shore";
+import {
+  coastRunFor,
+  seawardFrom,
+  shoreViewFor,
+  shoreViewForArea,
+} from "./shore";
+import { areaBySlug, beachesByArea } from "@/lib/areas";
 
 /** The beach the page opens on, and the one with all four sources bound. */
 const LA_JOLLA = beachBySlug("la-jolla-shores-beach")!;
@@ -396,4 +402,164 @@ test("a run stops at a gap rather than growing through it", () => {
 
   // And from the far fragment, the other way.
   expect(unbrokenAround(points, 3, 500)).toEqual({ from: 2, to: 3 });
+});
+
+/* =========================================================================
+ * The area's map
+ * ========================================================================= */
+
+/** Metres per degree of latitude, the same figure `coastline.ts` uses. */
+const M_PER_DEGREE = 111_320;
+
+function spanMetres(bounds: {
+  south: number;
+  north: number;
+  west: number;
+  east: number;
+}) {
+  const midLat = (bounds.south + bounds.north) / 2;
+  const lonScale = Math.cos((midLat * Math.PI) / 180);
+  return {
+    ns: (bounds.north - bounds.south) * M_PER_DEGREE,
+    ew: (bounds.east - bounds.west) * M_PER_DEGREE * lonScale,
+  };
+}
+
+/**
+ * The frame is square, and this is the assertion the decision to make it square
+ * rests on.
+ *
+ * The plan asked for each area's own bbox aspect. Measured at the map column's
+ * real width of 472px that makes Imperial Beach 1,908px tall and Coronado a
+ * 199px letterbox — a ten-fold swing between areas, seven of the twelve over a
+ * thousand pixels in a 639px window. `squareToward` is what this trades that
+ * for, and it is the frame the beach map beside it already uses. See ADR-0051.
+ *
+ * Asserted in metres rather than in degrees, because a degree of longitude is
+ * shorter than a degree of latitude at this latitude and a box that is square
+ * in degrees is not square on the ground.
+ */
+test("an area's frame is square on the ground, at every area", () => {
+  for (const { area } of beachesByArea()) {
+    const { bounds } = shoreViewForArea(area);
+    expect(bounds, area.slug).not.toBeNull();
+
+    const { ns, ew } = spanMetres(bounds!);
+    // Within a tenth of a percent: `squareToward` grows one axis to match the
+    // other, and the cosine is taken at the box's own mid-latitude.
+    expect(Math.abs(ns - ew) / ns, area.slug).toBeLessThan(0.001);
+  }
+});
+
+/**
+ * And it holds every member's coast, which is what makes it the *area's* frame
+ * rather than one member's with the others hanging off the edge.
+ *
+ * `mission-bay-vacation-isle` contributes no run — the committed mainland ring
+ * does not reach its island — so it is skipped here rather than asserted about.
+ * That it is still marked is the tick slice's claim, not this one's.
+ */
+test("an area's frame holds every member's own coast run", () => {
+  let skipped = 0;
+
+  for (const { area, beaches } of beachesByArea()) {
+    const { bounds } = shoreViewForArea(area);
+
+    for (const beach of beaches) {
+      const run = coastRunFor(beach);
+      if (run === null) {
+        skipped += 1;
+        continue;
+      }
+      for (const point of run.points) {
+        expect(point.lat, `${area.slug}/${beach.slug}`).toBeGreaterThanOrEqual(
+          bounds!.south,
+        );
+        expect(point.lat, `${area.slug}/${beach.slug}`).toBeLessThanOrEqual(
+          bounds!.north,
+        );
+        expect(point.lon, `${area.slug}/${beach.slug}`).toBeGreaterThanOrEqual(
+          bounds!.west,
+        );
+        expect(point.lon, `${area.slug}/${beach.slug}`).toBeLessThanOrEqual(
+          bounds!.east,
+        );
+      }
+    }
+  }
+
+  // The probe: one beach in the inventory has no traced coast, and a run where
+  // none were skipped would mean the loop above stopped exercising that path.
+  expect(skipped).toBe(1);
+});
+
+/**
+ * An area map is wider than any of its beaches' maps, which is the thing a
+ * reader is actually being shown: where this beach sits on a coast, rather than
+ * the beach alone.
+ */
+test("an area's frame is wider than its members' own", () => {
+  const area = areaBySlug("la-jolla")!;
+  const areaSpan = spanMetres(shoreViewForArea(area).bounds!);
+
+  for (const slug of area.beaches) {
+    const beach = beachBySlug(slug)!;
+    const own = shoreViewFor(beach).bounds;
+    if (own === null) continue;
+    expect(spanMetres(own).ns, slug).toBeLessThan(areaSpan.ns);
+  }
+});
+
+/**
+ * Nothing is drawn heavy on an area map, and that is the rule rather than a
+ * property of the area it was tried on: no one beach is the subject, so
+ * picking one out would be the representative-beach lie ADR-0048 refuses,
+ * drawn instead of stated.
+ */
+test("an area map marks no one beach as its subject", () => {
+  for (const { area } of beachesByArea()) {
+    expect(shoreViewForArea(area).segment, area.slug).toBeNull();
+  }
+});
+
+/**
+ * Two data files disagreeing should stop a build rather than quietly draw a
+ * coast with a beach missing from it — the guard `areaSources` and
+ * `beachesByArea` both carry, for the same reason.
+ */
+test("it refuses an area naming a beach the inventory does not have", () => {
+  expect(() =>
+    shoreViewForArea({
+      slug: "invented",
+      name: "Invented",
+      beaches: ["not-a-beach"],
+    }),
+  ).toThrow(/beaches.json has no such beach/);
+});
+
+/**
+ * An area the traced coast reaches nowhere has no frame, and says so rather
+ * than drawing an empty square — which on a page about the sea reads as open
+ * water.
+ *
+ * No committed area is in that state: `mission-bay-vacation-isle` is the one
+ * beach the mainland ring does not hold, and it sits in Mission Bay – West
+ * among seven that it does. The state is reachable by an authored table putting
+ * it alone, which is an edit somebody could make, so it returns an absence
+ * rather than a box built from nothing.
+ */
+test("an area with no traced coast anywhere in it has no frame", () => {
+  const view = shoreViewForArea({
+    slug: "island-only",
+    name: "Island Only",
+    beaches: ["mission-bay-vacation-isle"],
+  });
+
+  expect(view.bounds).toBeNull();
+  expect(view.coast).toEqual([]);
+  expect(view.segment).toBeNull();
+
+  // The probe: that beach really is the one with no run, so this test is about
+  // the state it names rather than about a slug that happens to be quiet.
+  expect(coastRunFor(beachBySlug("mission-bay-vacation-isle")!)).toBeNull();
 });

--- a/src/components/conditions/shore.test.ts
+++ b/src/components/conditions/shore.test.ts
@@ -563,3 +563,64 @@ test("an area with no traced coast anywhere in it has no frame", () => {
   // the state it names rather than about a slug that happens to be quiet.
   expect(coastRunFor(beachBySlug("mission-bay-vacation-isle")!)).toBeNull();
 });
+
+/**
+ * One mark per beach, and every one on the coast that beach occupies.
+ *
+ * **The middle of its drawn run, never the middle of its two ends.** Those ends
+ * are corners of a bounding extent and the line between them cuts inside every
+ * curve of the shore: measured over the 50 beaches the traced coast reaches,
+ * the ends-midpoint lands up to 1,562 m off the line and 17 of the 50 are over
+ * 100 m off. It is `beachStretch`'s rule one scope down, and it failed the same
+ * way — `la-jolla-community-beach`'s mark floated in open land.
+ */
+test("every beach in an area is marked, on its own coast", () => {
+  let offTheLine = 0;
+
+  for (const { area, beaches } of beachesByArea()) {
+    const { ticks } = shoreViewForArea(area);
+    expect(ticks, area.slug).toHaveLength(beaches.length);
+
+    for (const [index, tick] of ticks.entries()) {
+      const beach = beaches[index];
+      const metres = nearestOn(coastline(), tick)!.metres;
+
+      if (coastRunFor(beach) === null) {
+        // The island. Its mark is where that beach is, which is off the line.
+        offTheLine += 1;
+        expect(metres, beach.slug).toBeGreaterThan(100);
+        continue;
+      }
+      // On the line, because it is a point of it.
+      expect(metres, `${area.slug}/${beach.slug}`).toBeLessThan(1);
+    }
+  }
+
+  // The probe: exactly one beach in the inventory is off the traced coast, so a
+  // run finding none would mean the branch above stopped being exercised.
+  expect(offTheLine).toBe(1);
+});
+
+/**
+ * And every mark is inside the frame its neighbours build — including the
+ * island's, which contributes nothing to that frame.
+ */
+test("every mark falls inside its area's frame", () => {
+  for (const { area } of beachesByArea()) {
+    const { bounds, ticks } = shoreViewForArea(area);
+
+    for (const tick of ticks) {
+      expect(tick.lat, area.slug).toBeGreaterThanOrEqual(bounds!.south);
+      expect(tick.lat, area.slug).toBeLessThanOrEqual(bounds!.north);
+      expect(tick.lon, area.slug).toBeGreaterThanOrEqual(bounds!.west);
+      expect(tick.lon, area.slug).toBeLessThanOrEqual(bounds!.east);
+    }
+  }
+});
+
+/** A beach map has one subject and draws it heavy, so it marks nothing. */
+test("a beach map carries no marks", () => {
+  for (const beach of allBeaches()) {
+    expect(shoreViewFor(beach).ticks, beach.slug).toEqual([]);
+  }
+});

--- a/src/components/conditions/shore.ts
+++ b/src/components/conditions/shore.ts
@@ -16,7 +16,8 @@
  * for and always was.
  */
 
-import type { Beach } from "@/lib/beaches";
+import { allBeaches, type Beach } from "@/lib/beaches";
+import type { Area } from "@/lib/areas";
 import type { Bounds, Position, ShorePoint } from "@/lib/coastline";
 import {
   boundsAround,
@@ -317,4 +318,72 @@ export function shoreViewFor(beach: Beach): ShoreView {
     run === null || bounds === null ? [] : windowAround(coastline(), bounds);
 
   return { coast, bounds, segment: beachStretch(run, beach) };
+}
+
+/**
+ * The map an area is drawn on: its whole coast, in one square frame.
+ *
+ * The area counterpart of `shoreViewFor`, and deliberately the same shape --
+ * `ShoreMap` is handed a window, a box and nothing it has to look up, whichever
+ * scope it is drawing.
+ *
+ * **The frame is square, which reverses the plan that asked for the bbox's own
+ * aspect.** That plan rejected a square because it "would spend two thirds to
+ * four fifths of the width on slack"; measured at the map column's real width
+ * of 472px, taking each area's own aspect makes Imperial Beach 1,908px tall and
+ * Coronado a 199px letterbox -- a ten-fold swing, and seven of the twelve areas
+ * over a thousand pixels in a 639px window. What it buys is the tightest pair
+ * of marks going from 5.5px to 11.4px, on an axis the plan had already conceded
+ * reads as a cluster either way. The slack is not empty either: ADR-0041's wash
+ * closes on the frame, so it is drawn as sea. See ADR-0051.
+ *
+ * **No stretch drawn heavy, because no one beach is the subject.** `segment` is
+ * null here where a beach map carries its own run. That is the zoom the plan
+ * describes, and it needs no mechanism: `/conditions/<area>` gets this frame
+ * and `/conditions/<area>/<beach>` gets `shoreViewFor`'s, swapped by the route.
+ *
+ * **The seaward direction is read off the coastline's own walk**, not off the
+ * members' runs concatenated. Members are ordered north to south, so joining
+ * their runs end to end makes a walk that doubles back -- and `seawardFrom`
+ * takes a run's two ends, so it would answer about a chord across the doubling
+ * rather than about the coast. Windowing the county line to the draft box gives
+ * the walk in the order `coastline()` holds it, which is the order that
+ * property is true in.
+ *
+ * Throws for an area naming a beach the inventory does not have, like
+ * `areaSources` and for the same reason: two data files disagreeing should stop
+ * a build rather than quietly draw a coast with a beach missing from it.
+ */
+export function shoreViewForArea(area: Area): ShoreView {
+  const bySlug = new Map(allBeaches().map((beach) => [beach.slug, beach]));
+
+  const runs = area.beaches.flatMap((slug) => {
+    const beach = bySlug.get(slug);
+    if (!beach) {
+      throw new Error(
+        `areas.json puts ${slug} in ${area.slug}, but beaches.json has no such beach.`,
+      );
+    }
+    const run = coastRunFor(beach);
+    return run === null ? [] : [run];
+  });
+
+  /*
+    Built from the members' own runs rather than from their sand, which is the
+    rule `shoreViewFor` states one scope down: what the box is built from should
+    be what the box shows. A member the traced coast does not reach contributes
+    nothing here and is still marked -- `mission-bay-vacation-isle` is the one,
+    and its mark lands inside the frame its neighbours build.
+  */
+  const boxed = boundsAround(
+    runs.flatMap((run) => run.points),
+    SHORE_WINDOW_MARGIN,
+  );
+  if (boxed === null) return { coast: [], bounds: null, segment: null };
+
+  const draft = windowAround(coastline(), boxed);
+  const seaward = seawardFrom(draft);
+  const bounds = seaward === null ? boxed : squareToward(boxed, seaward);
+
+  return { coast: windowAround(coastline(), bounds), bounds, segment: null };
 }

--- a/src/components/conditions/shore.ts
+++ b/src/components/conditions/shore.ts
@@ -35,6 +35,20 @@ export type ShoreView = {
   coast: readonly ShorePoint[];
   bounds: Bounds | null;
   /**
+   * Where each beach this map is about sits, one position per beach.
+   *
+   * Empty on a beach map, which has one subject and draws it as a heavy run
+   * instead. On an area map it is every member's midpoint, and it is the whole
+   * of what makes the picture about an area rather than about a stretch of
+   * coast that happens to be wide.
+   *
+   * **Positions and not marks.** Where the tick is drawn, how long it is and
+   * which way it lies are `ShoreMap`'s, because they are answers in plot units
+   * and this file works in degrees -- the same split the rest of the module
+   * keeps: the assembler reads, the component draws.
+   */
+  ticks: readonly Position[];
+  /**
    * Where this beach is, drawn heavier than anything around it.
    *
    * The run of `coast` it occupies where there is a coast, and its own two ends
@@ -317,7 +331,7 @@ export function shoreViewFor(beach: Beach): ShoreView {
   const coast =
     run === null || bounds === null ? [] : windowAround(coastline(), bounds);
 
-  return { coast, bounds, segment: beachStretch(run, beach) };
+  return { coast, bounds, ticks: [], segment: beachStretch(run, beach) };
 }
 
 /**
@@ -379,11 +393,55 @@ export function shoreViewForArea(area: Area): ShoreView {
     runs.flatMap((run) => run.points),
     SHORE_WINDOW_MARGIN,
   );
-  if (boxed === null) return { coast: [], bounds: null, segment: null };
+  if (boxed === null)
+    return { coast: [], bounds: null, ticks: [], segment: null };
 
   const draft = windowAround(coastline(), boxed);
   const seaward = seawardFrom(draft);
   const bounds = seaward === null ? boxed : squareToward(boxed, seaward);
 
-  return { coast: windowAround(coastline(), bounds), bounds, segment: null };
+  /*
+    A mark per member, at the middle of the coast that member occupies.
+
+    **The middle of its drawn run, never the middle of its two ends**, which is
+    `beachStretch`'s rule one scope down and fails the same way when broken: the
+    two ends are corners of a bounding extent, and the straight line between
+    them cuts inside every curve of the shore. Measured over the 50 beaches the
+    traced coast reaches, the ends-midpoint lands up to **1,562 m** off the line
+    -- `la-jolla-community-beach`, whose mark floated in open land on the first
+    draft of this picture -- and 17 of the 50 are over 100 m off. The run's own
+    middle is on the line for all 50, because it is a point of it.
+
+    Midpoints and not extents, which is the plan's measurement rather than a
+    preference: drawn proportionally, `la-jolla-community-beach` spans 5,082 m
+    and contains eight of the other nine, so nesting redraws rather than stacks
+    and the small beaches would be underneath rather than small.
+
+    **Every member, including the one with no run.** The frame is built from the
+    runs, so `mission-bay-vacation-isle` contributes nothing to it -- but it is a
+    beach in the area and a reader choosing between them is owed where it is. It
+    falls back to its own two ends, which for that beach are one point, and its
+    mark lands inside the frame its neighbours build, about 400 m off the traced
+    shore. That is a true statement about an island the committed mainland ring
+    does not hold, and the only mark on any area map that is not on the line.
+  */
+  const ticks = area.beaches.map((slug) => {
+    const beach = bySlug.get(slug)!;
+    const run = coastRunFor(beach);
+    if (run === null) {
+      return {
+        lat: (beach.segment.upper.lat + beach.segment.lower.lat) / 2,
+        lon: (beach.segment.upper.lon + beach.segment.lower.lon) / 2,
+      };
+    }
+    const middle = run.stretch[Math.floor(run.stretch.length / 2)];
+    return { lat: middle.lat, lon: middle.lon };
+  });
+
+  return {
+    coast: windowAround(coastline(), bounds),
+    bounds,
+    ticks,
+    segment: null,
+  };
 }


### PR DESCRIPTION
An area page had readings, a chooser and a list of its beaches, and no picture of the place any of it was about, while a beach page had a map. This is plan §6.

Rebased onto `746653d` (post-#239) and re-gated there, so the raised coverage floor is the one this ran against.

## The slices

1. **Carry an area's beaches on its scope, not just how many** — `AreaScope.beaches` was a count because counting was all the withheld sentences needed. The map needs which. Pure refactor; the sentences are byte-identical and their existing tests are the proof.
2. **Draw an area's own coast on its page** — ADR-0051.
3. **Mark every beach an area holds on its map** — ADR-0052, amending ADR-0033.

## §6's frame decision did not survive measurement

The plan says "The area frame is not square", rejecting `squareToward` for spending "two thirds to four fifths of the width on slack". The map column is **472px** at the review viewport — measured in the browser at 1536×639, not derived from the breakpoints. Across the twelve areas that draw an area map (the other six hold one beach and show its map):

| | bbox aspect (§6) | square | capped 1.5:1 |
| -------------- | ---------------: | -----: | -----------: |
| tallest frame | **1,908px** | 472px | 708px |
| shortest frame | 199px | 472px | 199px |
| worst tick gap | 11.4px | 5.5px | 7.9px |

Seven of the twelve clear 1,000px under §6's rule. Imperial Beach is 1,908px — three screens for one picture in a 639px window — and Coronado a 199px letterbox, a ten-fold swing between areas.

**What that buys is an axis §6 had already conceded.** The tightest pair of marks goes 5.5px → 11.4px, and §6 itself says "The ticks still crowd, and that is accepted rather than solved… La Jolla's point genuinely _is_ a cluster of four beaches inside 550 m." Both are far below any separation that makes four readable as four.

**And the slack is water.** ADR-0041's wash closes on the frame, so it renders as sea. On Coronado — the widest area at 0.42:1 — the square frame is what shows the whole peninsula with the bay behind it; its own aspect would have cropped it to a strip.

**§6's own figures no longer reproduce.** It gives Del Mar as 9,411 m by 1,773 m; the traced coast runs give 4,191 by 2,798. It predates ADR-0039's traced shoreline, so it measured a different geometry. The direction survived; the numbers did not.

## Two things found by looking at the rendered page

Both would have passed every test I had written at the time.

**A mark floated in open land.** §6 says "a tick at each location's midpoint" without saying midpoint of what. The midpoint of a beach's two *ends* is a corner-to-corner chord that cuts inside every curve of the shore:

| | |
| ------------------------------------------ | ------------ |
| worst distance off the coast, ends-midpoint | **1,562 m** |
| beaches over 100 m off, ends-midpoint | **17 of 50** |
| worst distance off the coast, run-midpoint | **0 m** |

The 1,562 m is `la-jolla-community-beach`, which spans 5,082 m of a bay. Marks now sit at the middle of the beach's own drawn run — `beachStretch`'s existing rule, "a run of the polyline, never a chord", one scope down.

**An empty labelled box under La Jolla's coast.** The readout arrives with the area map, which ADR-0049 said it would — but an area reports a wind bearing only where its beaches share a forecast cell and a swell bearing only where they share a model line. La Jolla shares neither, so no hour has a needle, `DayCompass` renders null, and `ShoreMap` drew its box around nothing. The caller now answers `ShoreMap`'s one `hasReadout` question honestly. Mission Bay – West shares a cell and keeps its wind. A beach page never reached this state: every beach binds a forecast cell, so there is always a wind arrow.

## ADR-0033 says "No markers", and that is met rather than worked around

The distinction that decision was drawing is between an **instrument** and a **subject**. Every glyph it removed stood for a source the page *reads* — station, buoy, model line — and its objection was that drawing them "cost the picture its subject". A beach is not a source; on an area map the beaches *are* the subject. One mark type, not four glyphs of four shapes. The rest of ADR-0033 is untouched: no stations plotted, one flat wash, frame sized by coast.

Marks and never targets, which is arithmetic: four of La Jolla's midpoints fall within 549 m, so four tap targets at ADR-0004's 44px floor need the map 2,634px wide against 472px.

The one mark not on a coastline is `mission-bay-vacation-isle` — no coast run, because the committed mainland ring does not hold its island. It falls back to its own two ends and lands ~400 m out, inside the frame its neighbours build. That is where the beach is.

## Verified on the rendered page

`next build` renders none of these routes (`generateStaticParams` returns `[]`), so three area maps were fetched off a dev server at 1536×639 and looked at:

- **La Jolla** — 472×472, 324 coast points, ten marks all on the shore, the four-beach cluster reading as crossing ticks. No readout, correctly.
- **Coronado** — the whole peninsula with the bay behind it, three marks.
- **Mission Bay – West** — the bay's shoreline, eight marks, one of them out in open water where Vacation Isle is, and the wind readout present.

Whether that cluster reads as a cluster rather than a smudge is the human check §6 says no gate replaces. It looked like a cluster to me; it is your call.

## Gate

Clean `.next`, at `1641e38`, rebased onto `746653d`:

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  areas
  PASS  test
  PASS  build
  PASS  stylesheet
```

`1847 tests, 108 files`. Coverage **90.22 / 89.58 / 95.00 / 90.02** against the floor #239 just raised to 90.13 / 89.56 / 94.93 / 89.9 — above on all four, and branches only 0.02 clear, so the two compose but not by much.

## Not done

- **Hover or focus on a beach in the list highlighting its mark** — §6 mentions it; it is client state and its own slice.
- **The map as a picker** — measured impossible above.
- The zoom §6 describes needed no work: `/conditions/<area>` gets the area frame and `/conditions/<area>/<beach>` gets the beach's with its run heavy. Two committed frames, swapped by the route.

One process note: a screenshot script writing relative to the working directory dropped a PNG in the repo root and `git add -A` swept it into the first commit. Caught and amended out before pushing; nothing generated is in this branch's history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
