### PR TITLE
Pin, name and link every beach on its area's map

### DIFF
--- a/docs/adr/0052-a-beach-is-marked-on-its-areas-map.md
+++ b/docs/adr/0052-a-beach-is-marked-on-its-areas-map.md
@@ -1,6 +1,7 @@
 # 0052 — A beach is marked on its area's map
 
-Date: 2026-09-04. Status: accepted. **Amends ADR-0033**, which says the map
+Date: 2026-09-04. Status: superseded by ADR-0053, 2026-09-04. **Amends
+ADR-0033**, which says the map
 plots nothing but the place. Completes ADR-0051, which gave an area a frame and
 deliberately shipped it without marks. Nothing about a beach's own map changes.
 

--- a/docs/adr/0053-a-beach-is-pinned-named-and-clickable.md
+++ b/docs/adr/0053-a-beach-is-pinned-named-and-clickable.md
@@ -1,0 +1,185 @@
+# 0053 — A beach on its area's map is pinned, named and clickable
+
+Date: 2026-09-04. Status: accepted. **Supersedes ADR-0052**, which marked each
+beach with a tick and ruled that the marks could never be targets. Everything
+ADR-0052 established about _where_ a mark goes is kept and restated below;
+what changes is what is drawn there and what a reader can do with it.
+ADR-0051's square frame, ADR-0041's wash and ADR-0033's "no instruments" are
+untouched. A beach's own map is unchanged: one subject, drawn as a heavy run,
+no pins at all.
+
+## Context
+
+ADR-0052 shipped. It was reviewed on the rendered page and rejected: the ticks
+"look horrible". The request was pins with a beach emoji and a label, clickable,
+opening the beach.
+
+**The rejection was on looks and there is a mechanism under it.** A tick took
+its direction from the two drawn points either side of the mark, and ADR-0052
+recorded that as being perpendicular to the local coast. It is — to a two-vertex
+window. Measured against the shore at the scale a reader sees it, a fifteen-
+vertex window on the same 5,368-point traced line:
+
+| angle between the mark and the coast | La Jolla's ten marks |
+| ------------------------------------ | -------------------- |
+| under 45°, i.e. reading as along it  | **4**                |
+| the worst of them                    | **10.7°**            |
+| over 75°, i.e. reading as across it  | 3                    |
+
+On a shore traced at about 50 m a two-vertex window is noise, so the rule was
+answering a question about the wrong thing. Four of ten marks were strokes drawn
+along the coastline they were meant to cross, and in the cluster they crossed
+each other instead — which is what "scratches" describes.
+
+### What was measured before choosing a replacement
+
+Three variants were prototyped on the real route and shown. All three had a
+defect the prototype's own notes call fatal, and on measurement each defect was
+in the prototype rather than in the idea: labels everywhere with leader lines
+(complete but busiest), numbered pins with a key (**four of ten numbers hidden
+behind neighbours**, and `①` rendered as a fallback glyph), labels only where
+they fit (**five of ten beaches left anonymous**, and unlabelled pins collapsed
+to 1.9px by a negative margin).
+
+**What none of them questioned was ADR-0052's premise**, which reads one area's
+arithmetic onto all twelve. Measured on the rendered page, closest pair of marks
+per area:
+
+|                   | desktop, 472px map | phone, 342px map |
+| ----------------- | -----------------: | ---------------: |
+| la-jolla          |          **4.5px** |        **3.3px** |
+| mission-bay-north |             31.1px |           22.5px |
+| mission-bay-west  |             41.4px |           30.0px |
+| the other nine    |     70.7 – 245.4px |   51.2 – 177.5px |
+
+La Jolla is not the general case. It is the only pathological one, and eleven of
+the twelve areas have room ADR-0052 spent on none of them.
+
+**The labels are governed by a different measure, and it moves the count.** A
+label is a horizontal box on its pin's own row, so two labels collide when their
+marks share a row however far apart they are across the frame. By that measure
+three areas are crowded, not one — Mission Bay – North and – West have marks
+0.28 and 0.38 plot units apart vertically while being 31px and 41px apart on
+screen, because they are beaches on opposite shores of the same water at the
+same latitude.
+
+| tightest **vertical** gap            |             plot units |
+| ------------------------------------ | ---------------------: |
+| mission-bay-north / -west / la-jolla | 0.28 / 0.38 / **0.47** |
+| the next area after them (coronado)  |               **6.38** |
+| the remaining eight                  |            13.1 – 52.2 |
+
+## Decision
+
+**Each beach an area holds is an emoji pin and its name, and the pair is one
+link to that beach's own page.**
+
+**Two placements, chosen per area by the geometry.** Where every mark clears one
+label row, the name sits beside its pin. Where any two would share a row, every
+name in that picture moves out to a column at the frame's edge, joined to a dot
+on the coast by a leader line. Nine areas take the first, three the second.
+
+**Per area and never per beach.** A frame with some names beside their beaches
+and others carried out to the side is two conventions at once, and a reader has
+to work out which applies to the mark in front of them.
+
+**The threshold is one label row on the narrowest map, not on the review
+viewport.** A label is about 13px, and the map column is 472px at 1536×639 but
+**342px on a 390px phone** — 2.75 plot units of the first and 3.80 of the
+second. Taking the desktop figure would let labels overlap on a phone. Rounded
+up: **4 units**. The partition it produces has a 13-fold margin — the crowded
+areas top out at 0.47 and the next is 6.38 — so any threshold between about 0.5
+and 6.3 sorts the twelve the same way. The number earns its place by meaning
+something rather than by being tuned.
+
+**The column's row pitch is a second number, because it measures a second
+thing.** The threshold is the height of a _label_; the column stacks whole
+_anchors_, which are 24px because they hold the glyph. Deriving the pitch from
+the label put the rows 5.5 units apart, which is 26px at the review viewport and
+looked right there — and on a phone put a 24px anchor every 18.8px, so **every
+pair in every column overlapped by 5.2px**, and by 9px at 320px. So it is taken
+at the narrowest map the site supports: WCAG 1.4.10's 320px viewport gives a
+272px map, where 24px is 8.8 units. **9.5 units**, which leaves air there and
+still seats La Jolla's ten rows.
+
+**The mark's position is ADR-0052's and is unchanged**: the middle of the
+beach's own drawn run, never the middle of its two ends. That decision's
+measurements stand — the ends-midpoint lands up to 1,562 m off the line and 17
+of 50 are over 100 m off, against 0 m for the run's middle — and so does its
+consequence: `mission-bay-vacation-isle` has no run, falls back to its own two
+ends, and is the one mark on any area map that is not on a coastline. **It now
+carries its name**, which is a real improvement rather than a side effect: an
+unlabelled stroke in open water read as an error, and "Mission Bay, Vacation
+Isle" reads as what it is.
+
+**Identity crosses the boundary with the position, and the URL does not.**
+`shore.ts` answers with a slug and a name because it reads `beaches.json`;
+`DayPanel` turns the slug into a route because ADR-0047 makes that the page's
+question; `ShoreMap` projects and `BeachPins` places, because those are answers
+in plot units. That is the same split the module already kept, with one more
+thing travelling along it.
+
+**The pins sit outside the frame's own `role="img"`**, as siblings of the SVG
+rather than children. Inside, they would be part of one graphic with one label,
+and every pin would be a link no screen reader could reach — so the reader who
+most needs a beach to be named would be the one who could not get to it.
+
+### The tap-target question, settled rather than implied
+
+ADR-0052 said "marks, never targets, and that is arithmetic rather than taste",
+citing a 44px floor. Both halves need correcting.
+
+**ADR-0004's floor is not 44px here.** It is 44×44 _below_ `md` and **24×24 at
+`md` and above**. The review viewport is 1536px. Every pin is 24px tall at every
+breakpoint, so above `md` it meets that floor unaided.
+
+**Below `md` the floor is 44px and no pin reaches it**, and that is geometry
+rather than effort: the map is 342px on a phone, four of La Jolla's beaches sit
+within about 25px of one another, and four 44px targets in that cluster would
+need a map about 2,600px wide.
+
+**It conforms anyway, under the _Equivalent_ exception**, which both WCAG 2.5.5
+(Enhanced, AAA — the standard ADR-0004 adopts below `md`) and 2.5.8 (Minimum,
+AA) carry: a target may be undersized where the same function is available
+through another control on the same page that does meet the size. That control
+exists and was measured, not assumed — **the beach list above the map renders
+ten links, every one exactly 44px tall, at both breakpoints.**
+
+**So the list is load-bearing and this ADR says so.** It is not decoration above
+the picture; it is what makes the pins conformant. A change that shrinks those
+links, or drops one, or moves the list below the map, takes the exception away
+and has to answer this decision.
+
+**Where the pins are crowded they are not clickable at all**, and that is the
+one place this design refuses the obvious. In the three column areas the marks
+sit a few pixels apart — La Jolla's tightest pair about 4.5px — so overlapping
+targets there would not merely be small: a click would land on whichever beach
+happened to be painted last, silently and unpredictably. The dot on the coast is
+`aria-hidden` and inert, and the labelled anchor at the end of its leader line
+is the way in. **A mark that does nothing is better than a control that goes
+somewhere the reader did not choose**, which is this repo's "nothing fails
+silently" applied to a target instead of to a log line.
+
+## Consequences
+
+Every beach on every area map is named and reachable. Nine areas read as a coast
+with its beaches labelled on it; three read as a coast with a key beside it, and
+in those three the leader line is what ties a name to a place.
+
+**The emoji renders in the visitor's own font.** Any screenshot proves what one
+operating system does with `🏖️` and nothing more. That is why the name is beside
+it in both placements rather than the glyph carrying the identity — the same
+lesson the prototype learned from `①`, which is not an emoji and rendered as a
+placeholder box anyway.
+
+**One degradation is known and bounded.** At a 320px viewport — WCAG 1.4.10's
+reflow floor — the column's rows clear each other by 1.8px. Nothing overlaps,
+but there is no margin left, and an area gaining an eleventh beach would need
+this revisited before it renders there.
+
+**What is most likely to be re-litigated is the per-area switch.** Nine pictures
+labelled one way and three another is a real inconsistency, and the alternative
+— one convention everywhere — was rejected on measurement rather than taste:
+labels beside their beaches overlap on three areas, and a column on all twelve
+puts leader lines across nine pictures that have room to do without them. The
+switch is the price of both halves being right.

--- a/src/components/conditions/BeachPins.test.tsx
+++ b/src/components/conditions/BeachPins.test.tsx
@@ -1,0 +1,227 @@
+import { expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { projectionFor } from "@/lib/coastline";
+import { beachesByArea } from "@/lib/areas";
+import { shoreViewForArea } from "./shore";
+import { BeachPins, inlineFits, type PinnedBeach } from "./BeachPins";
+
+/** A beach at a given row of the plot, which is all either placement reads. */
+function at(y: number, name = `Beach at ${y}`): PinnedBeach {
+  return { name, href: `/conditions/here/${y}`, at: { x: 60, y } };
+}
+
+/* =========================================================================
+ * Which placement an area gets
+ * ========================================================================= */
+
+test("labels sit beside their beaches when every pair clears a label row", () => {
+  expect(inlineFits([at(10), at(30), at(60)])).toBe(true);
+});
+
+test("one pair sharing a row sends the whole area to the column", () => {
+  // Two of the three are 0.4 units apart -- far below the ~4 a label needs --
+  // and it is the picture that changes placement, not those two beaches. A
+  // frame drawn half one way and half the other is two conventions at once.
+  expect(inlineFits([at(10), at(30), at(30.4)])).toBe(false);
+});
+
+test("a lone beach and an empty area both fit trivially", () => {
+  expect(inlineFits([at(50)])).toBe(true);
+  expect(inlineFits([])).toBe(true);
+});
+
+/**
+ * The threshold is a label's own height on the narrowest map, so the boundary
+ * is worth pinning either side of: at 3.9 units two labels would touch on a
+ * phone, and at 4.1 they clear.
+ */
+test("the boundary sits at one label row, not at some rounder number", () => {
+  expect(inlineFits([at(10), at(13.9)])).toBe(false);
+  expect(inlineFits([at(10), at(14.1)])).toBe(true);
+});
+
+/* =========================================================================
+ * The committed areas, which are what the threshold was chosen against
+ * ========================================================================= */
+
+/** Every area's marks, projected into its own frame exactly as `ShoreMap` does. */
+function placedAreas() {
+  return beachesByArea()
+    .map(({ area }) => {
+      const view = shoreViewForArea(area);
+      if (view.bounds === null || view.marks.length < 2) return null;
+      const project = projectionFor(view.bounds, { width: 100, height: 100 });
+      const marks: PinnedBeach[] = view.marks.map((mark) => ({
+        name: mark.name,
+        href: `/conditions/${area.slug}/${mark.slug}`,
+        at: project(mark.at.lat, mark.at.lon),
+      }));
+      const rows = marks.map((mark) => mark.at.y).sort((a, b) => a - b);
+      const gaps = rows.slice(1).map((row, index) => row - rows[index]);
+      return { slug: area.slug, marks, tightest: Math.min(...gaps) };
+    })
+    .filter((area) => area !== null);
+}
+
+/**
+ * Which real areas need the column, asserted as an outcome rather than
+ * recomputed from the rule the code already applies.
+ *
+ * **Three, and they are the bays and La Jolla.** Mission Bay – North and – West
+ * are the surprise: their closest marks are 31px and 41px apart on screen and
+ * would pass any distance test. That separation is almost all horizontal —
+ * they are beaches on opposite shores of the same water at the same latitude —
+ * so their labels want the same row and collide however far apart the pins are.
+ */
+test("three of the twelve areas carry their names out to a column", () => {
+  const needColumn = placedAreas()
+    .filter((area) => !inlineFits(area.marks))
+    .map((area) => area.slug)
+    .sort();
+
+  expect(needColumn).toEqual([
+    "la-jolla",
+    "mission-bay-north",
+    "mission-bay-west",
+  ]);
+});
+
+/**
+ * And the partition is not balanced on the threshold, which is what makes the
+ * number defensible rather than tuned.
+ *
+ * The probe is that both classes are populated and the band between them is
+ * wide: nothing in the inventory sits near the boundary, so a beach shifting a
+ * few metres cannot flip a picture from one convention to the other.
+ */
+test("no area sits near the threshold, either side of it", () => {
+  const areas = placedAreas();
+  const crowded = areas.filter((area) => !inlineFits(area.marks));
+  const roomy = areas.filter((area) => inlineFits(area.marks));
+
+  expect(crowded.length).toBeGreaterThan(0);
+  expect(roomy.length).toBeGreaterThan(0);
+
+  // The worst crowded area is far below a label row; the tightest roomy one is
+  // comfortably above it. Measured today: 0.47 and 6.38.
+  expect(Math.max(...crowded.map((area) => area.tightest))).toBeLessThan(2);
+  expect(Math.min(...roomy.map((area) => area.tightest))).toBeGreaterThan(6);
+});
+
+/* =========================================================================
+ * What each placement draws
+ * ========================================================================= */
+
+test("a beach map hands no marks and gets no layer at all", () => {
+  const { container } = render(<BeachPins marks={[]} />);
+  expect(container.innerHTML).toBe("");
+});
+
+test("beside the beach, a pin is one link carrying the glyph and the name", () => {
+  const marks = [at(10, "North Beach"), at(40, "South Beach")];
+  const { container } = render(<BeachPins marks={marks} />);
+
+  for (const mark of marks) {
+    expect(
+      screen.getByRole("link", { name: mark.name }).getAttribute("href"),
+    ).toBe(mark.href);
+  }
+  // Nothing is carried anywhere, so there is nothing to lead the eye to.
+  expect(container.querySelectorAll("[data-leader]")).toHaveLength(0);
+  expect(container.querySelectorAll("[data-dot]")).toHaveLength(0);
+});
+
+test("in a column, every beach keeps a named link and gains a leader", () => {
+  const marks = [at(30, "Shell Beach"), at(30.5, "Cove"), at(31, "Pool")];
+  const { container } = render(<BeachPins marks={marks} />);
+
+  for (const mark of marks) {
+    expect(
+      screen.getByRole("link", { name: mark.name }).getAttribute("href"),
+    ).toBe(mark.href);
+  }
+  expect(container.querySelectorAll("[data-leader]")).toHaveLength(3);
+  expect(container.querySelectorAll("[data-dot]")).toHaveLength(3);
+});
+
+/**
+ * The dot on the coast is not a control, and that is deliberate.
+ *
+ * An area reaches the column only because its marks are within a few pixels of
+ * one another — La Jolla's tightest pair is about 4.5px apart at the review
+ * viewport. Overlapping targets there would not merely be small: a click would
+ * land on whichever beach happened to be painted last, silently. A mark that
+ * does nothing is better than a control that goes somewhere the reader did not
+ * choose, so the labelled anchor at the end of the leader is the only way in.
+ */
+test("the dot on the coast is inert, so no click lands on the wrong beach", () => {
+  const marks = [at(30, "Shell Beach"), at(30.5, "Cove")];
+  const { container } = render(<BeachPins marks={marks} />);
+
+  const dots = [...container.querySelectorAll("[data-dot]")];
+  expect(dots).toHaveLength(2);
+  for (const dot of dots) expect(dot.closest("a")).toBeNull();
+
+  // One link per beach and no more, so the column is not a second copy of a
+  // target that also exists on the coast.
+  expect(screen.getAllByRole("link")).toHaveLength(2);
+});
+
+/**
+ * A beach well clear of the cluster does not push the stack off the top.
+ *
+ * This is La Jolla's own shape and it was a real defect, found by rendering
+ * rather than by arithmetic: `la-jolla-shores-beach` sits about 20 units north
+ * of the other nine, so the rows spanned more of the frame than they had, and
+ * the correction that pulled the last row back inside carried the first one
+ * clean off the top edge. The lift is capped by the top now, and where that is
+ * not enough the rows are spaced evenly instead.
+ */
+test("an outlier above a cluster does not push the first name off the top", () => {
+  const marks = [
+    at(24, "La Jolla Shores"),
+    ...Array.from({ length: 9 }, (_, index) =>
+      at(43 + index * 0.4, `Cluster ${index}`),
+    ),
+  ];
+  const { container } = render(<BeachPins marks={marks} />);
+
+  const pins = [...container.querySelectorAll("[data-pin]")];
+  const tops = pins.map((pin) =>
+    Number((pin as HTMLElement).style.top.replace("%", "")),
+  );
+
+  expect(tops).toHaveLength(10);
+  // Half an anchor of headroom at each end, so nothing is cut off by the frame.
+  expect(Math.min(...tops)).toBeGreaterThanOrEqual(4.7);
+  expect(Math.max(...tops)).toBeLessThanOrEqual(95.3);
+  // Still in order, so the column still reads north to south.
+  expect([...tops].sort((a, b) => a - b)).toEqual(tops);
+});
+
+/**
+ * The stack stays inside the frame however many names it has to hold.
+ *
+ * Ten rows at the column's pitch span 85.5 units of 100, so La Jolla fits
+ * without compressing; a stack pushed past the bottom is lifted whole rather
+ * than squeezed, which is what keeps the order of the names readable against
+ * the order of the beaches.
+ */
+test("a full column is lifted rather than squeezed off the bottom", () => {
+  const marks = Array.from({ length: 10 }, (_, index) =>
+    at(80 + index * 0.3, `Beach ${index}`),
+  );
+  const { container } = render(<BeachPins marks={marks} />);
+
+  const tops = [...container.querySelectorAll("[data-pin]")].map((pin) =>
+    Number((pin as HTMLElement).style.top.replace("%", "")),
+  );
+
+  expect(tops).toHaveLength(10);
+  expect(Math.min(...tops)).toBeGreaterThanOrEqual(0);
+  expect(Math.max(...tops)).toBeLessThanOrEqual(100);
+  // Evenly pitched, which is the property lifting preserves and squeezing does
+  // not: consecutive rows are the same distance apart all the way down.
+  const pitches = tops.slice(1).map((top, index) => top - tops[index]);
+  for (const pitch of pitches) expect(pitch).toBeCloseTo(pitches[0], 5);
+});

--- a/src/components/conditions/BeachPins.tsx
+++ b/src/components/conditions/BeachPins.tsx
@@ -1,0 +1,368 @@
+/**
+ * The beaches an area holds, named and clickable, laid over its map.
+ *
+ * **HTML over the SVG, not text inside it**, and that is the finding the whole
+ * component rests on. `ShoreMap`'s viewBox is `0 0 100 100` and scales to
+ * whatever width its column has, so anything drawn inside it scales with the
+ * picture: a label would be a different size on every breakpoint and a tap
+ * target could not be expressed in CSS pixels at all. Positioned anchors give
+ * real pixels, real focus rings and real hit areas — and because the plot
+ * coordinates are already 0–100, they are percentages for free.
+ *
+ * **Two placements, one object.** A pin is an emoji and a name, and where that
+ * pair can sit beside the beach it does. Where an area's beaches are too close
+ * for their labels to share the frame, the pair moves out to a column at the
+ * edge and a leader line joins it to a dot on the coast. `inlineFits` decides
+ * which, per area, from the geometry rather than from a guess about the area.
+ *
+ * **The placement is per area and never per beach.** A picture with some names
+ * beside their beaches and others carried out to the side reads as two
+ * conventions at once, and a reader has to work out which applies to the mark
+ * they are looking at. One frame, one convention. Which *side* of its pin a
+ * name sits on is a different question, and is answered per pin — see
+ * `Inline`.
+ *
+ * See ADR-0053, which supersedes ADR-0052's ticks and carries the measurements.
+ */
+
+import type { CSSProperties } from "react";
+
+import type { PlotPoint } from "@/lib/coastline";
+
+/** One beach to draw, already projected into the map's own 0–100 plot units. */
+export type PinnedBeach = {
+  name: string;
+  href: string;
+  at: PlotPoint;
+};
+
+/**
+ * The glyph every pin carries.
+ *
+ * **It renders in the visitor's own font, not in one this repo ships**, so a
+ * screenshot only ever proves what one operating system does with it. That is
+ * a property of every emoji on this site and is why the pin is never the only
+ * thing saying which beach this is: the name is beside it in both placements.
+ */
+const PIN = "🏖️";
+
+/**
+ * The room one label needs, in plot units, and therefore the gap two marks need
+ * before both can be labelled where they stand.
+ *
+ * **Derived from the narrowest map rather than from the review viewport.** A
+ * label is `text-2xs` on `leading-tight`, about 13px tall, and the map column
+ * measures 472px at 1536×639 but **342px on a 390px phone**. The same label is
+ * 2.75 plot units of the first and 3.80 of the second, so a threshold chosen on
+ * a desktop would let labels overlap on a phone. This is the phone's figure,
+ * rounded up.
+ *
+ * **The partition it produces has a wide margin either side of it.** Measured
+ * over the twelve areas holding more than one beach, the tightest vertical gap
+ * between two marks is 0.28, 0.38 and 0.47 units on Mission Bay – North,
+ * Mission Bay – West and La Jolla, and 6.38 units on the next area after them.
+ * Any threshold between about 0.5 and 6.3 sorts them the same way, so this
+ * number is not balanced on a knife edge — it earns its place by meaning
+ * something rather than by being tuned.
+ */
+const LABEL_ROW_UNITS = 4;
+
+/**
+ * How far apart the column's rows sit, in plot units.
+ *
+ * A second number rather than a reuse of `LABEL_ROW_UNITS`, because it measures
+ * a second thing. That one is the height of a *label*, which is what decides
+ * whether two names can share a picture. This is the height of a whole
+ * **anchor** — 24px, because it holds the glyph — and the column stacks
+ * anchors, not labels. Deriving it from the label was the first attempt and it
+ * put the rows 5.5 units apart, which is 26px on the review viewport and looked
+ * right there: measured on a phone the same rows were 18.8px apart around a
+ * 24px anchor, so every pair in the column **overlapped by 5.2px**, and at 320px
+ * by 9px. Overlapping anchors are the one failure this whole placement exists
+ * to prevent.
+ *
+ * So it is taken at the narrowest map the site supports rather than at the
+ * widest. WCAG 1.4.10 puts that at a 320px viewport, where the map column is
+ * 272px and a 24px anchor is 8.8 units. 9.5 leaves air at that width and still
+ * seats the largest area's ten rows: the last sits at 90.5 and ends at 95.
+ */
+const COLUMN_PITCH_UNITS = 9.5;
+
+/** How far the column's anchors sit from the frame's side, in plot units. */
+const COLUMN_INSET_UNITS = 2;
+
+/**
+ * Whether every label can sit beside its own beach.
+ *
+ * **The test is vertical separation, not distance.** A label is a horizontal
+ * box on its pin's own row, so two labels collide when their marks share a row
+ * however far apart they are across the frame — which is exactly the case the
+ * bays produce. Mission Bay – North's closest pair is 31px apart on screen and
+ * would pass any distance test; its marks sit 0.28 units apart vertically,
+ * because they are on opposite shores of the same water at the same latitude.
+ *
+ * Exported for its test, which runs it over the committed areas.
+ */
+export function inlineFits(marks: readonly PinnedBeach[]): boolean {
+  const rows = marks.map((mark) => mark.at.y).sort((a, b) => a - b);
+
+  for (let index = 1; index < rows.length; index += 1) {
+    if (rows[index] - rows[index - 1] < LABEL_ROW_UNITS) return false;
+  }
+  return true;
+}
+
+/**
+ * Which side of the frame has the room, from where the marks already are.
+ *
+ * Taken from the marks and not from `seawardFrom`. The frame is squared toward
+ * the sea, so the slack is on the water's side and that direction is the right
+ * answer — but `seawardFrom` reads a run's two ends, and on a bay, which is
+ * where the column is needed, those two ends are a chord across the water and
+ * the direction they give is about nothing. Where the marks are not is a fact
+ * about the picture being drawn, and it is true on an open coast and in a bay
+ * alike.
+ */
+function columnSide(marks: readonly PinnedBeach[]): "left" | "right" {
+  const meanX =
+    marks.reduce((total, mark) => total + mark.at.x, 0) / marks.length;
+  return meanX > 50 ? "left" : "right";
+}
+
+/**
+ * Where each anchor sits in the column, in plot units, top to bottom.
+ *
+ * **Three steps, and each earns its place by a case the one before it fails.**
+ *
+ * A row would rather sit at its own beach's height, so a reader can match the
+ * column against the coast without following a line. So the first pass takes
+ * each beach's own row and pushes it down only as far as clearing the one above
+ * it requires.
+ *
+ * That can walk off the bottom, because a stack that starts low ends lower. So
+ * the second lifts the whole block back up -- and lifts it, rather than
+ * squeezing it, because even rows are what let the order be read at a glance.
+ *
+ * The lift is capped at what the top edge allows, which is the step the first
+ * draft was missing: La Jolla's northernmost beach sits 20 units above the
+ * cluster, so the stack spanned 95 units of an available 90 and the correction
+ * carried `la-jolla-shores-beach` clean off the top of the frame. Where the
+ * capped lift still leaves the last row low, the rows cannot all keep their own
+ * heights, and the third step spaces them evenly across the frame instead --
+ * which always fits, because an even pitch over the available height is at
+ * least `COLUMN_PITCH_UNITS` for every area in the inventory.
+ */
+function columnRows(sorted: readonly PinnedBeach[]): number[] {
+  // Rows are centred on their own y, so the first and last need half an anchor
+  // of headroom or the stack is clipped by the frame it sits in.
+  const half = COLUMN_PITCH_UNITS / 2;
+  const top = half;
+  const bottom = 100 - half;
+
+  const rows: number[] = [];
+  for (const [index, mark] of sorted.entries()) {
+    const floor = index === 0 ? top : rows[index - 1] + COLUMN_PITCH_UNITS;
+    rows.push(Math.max(mark.at.y, floor));
+  }
+
+  const last = rows[rows.length - 1];
+  if (last <= bottom) return rows;
+
+  const lift = Math.min(last - bottom, rows[0] - top);
+  const lifted = rows.map((row) => row - lift);
+  if (lifted[lifted.length - 1] <= bottom) return lifted;
+
+  const pitch = (bottom - top) / Math.max(1, sorted.length - 1);
+  return sorted.map((_, index) => top + index * pitch);
+}
+
+/**
+ * The anchor itself: the glyph and the name, one control, in both placements.
+ *
+ * **`pill` decides how much of it is opaque, and that is a placement question
+ * rather than a decorative one.** Beside its beach, only the name needs a
+ * ground to be read against, and the glyph sits directly on the coastline it is
+ * pointing at — a white box there would hide the one spot the pin exists to
+ * indicate. Out in the column there is a leader line running in from the coast,
+ * and the whole anchor is opaque so the line stops cleanly at its edge instead
+ * of showing through the gaps in a glyph.
+ */
+function PinLink({
+  beach,
+  pill,
+  className,
+  style,
+}: {
+  beach: PinnedBeach;
+  pill: boolean;
+  className: string;
+  style: CSSProperties;
+}) {
+  return (
+    <a
+      href={beach.href}
+      data-pin=""
+      className={`text-dark focus-visible:outline-ocean group absolute flex items-center gap-1 rounded focus-visible:outline-2 focus-visible:outline-offset-2 ${pill ? "bg-white/90 pr-1" : ""} ${className}`}
+      style={style}
+    >
+      <span
+        aria-hidden="true"
+        className="flex size-6 shrink-0 items-center justify-center text-[15px] leading-none"
+      >
+        {PIN}
+      </span>
+      <span
+        className={`text-2xs leading-tight font-semibold whitespace-nowrap underline-offset-2 group-hover:underline ${pill ? "" : "rounded bg-white/90 px-1"}`}
+      >
+        {beach.name}
+      </span>
+    </a>
+  );
+}
+
+/**
+ * Every beach labelled where it stands, which is nine of the twelve areas.
+ *
+ * The anchor is the pin and the name together, so the whole object is the
+ * target rather than the glyph alone, and it is centred on the beach so the
+ * glyph sits where the beach is rather than beside it.
+ *
+ * **Each name takes whichever side of its own pin has more frame**, which is
+ * the one thing here decided per beach rather than per picture. It is not a
+ * second convention — the name is beside its pin either way — and the
+ * alternative was measured rather than argued: one side for the whole picture
+ * ran `coronado-north-beach` off the left edge, its name being about 200px of
+ * a 472px frame with its pin a quarter of the way across. Growing into the
+ * larger half cannot overflow while a name is shorter than half the frame,
+ * which every name on an inline area is.
+ */
+function Inline({ marks }: { marks: readonly PinnedBeach[] }) {
+  return (
+    <>
+      {marks.map((beach) => {
+        const toLeft = beach.at.x > 50;
+        return (
+          <PinLink
+            key={beach.href}
+            beach={beach}
+            pill={false}
+            className={`-translate-y-1/2 ${toLeft ? "flex-row-reverse" : "flex-row"}`}
+            style={{
+              top: `${beach.at.y}%`,
+              maxWidth: "50%",
+              ...(toLeft
+                ? { right: `${100 - beach.at.x}%`, marginRight: "-12px" }
+                : { left: `${beach.at.x}%`, marginLeft: "-12px" }),
+            }}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+/**
+ * The names carried out to a column, which is the three crowded areas.
+ *
+ * **A dot on the coast rather than an emoji.** Ten glyphs at fifteen pixels
+ * inside a cluster 15px tall is a smear that says less than one small mark
+ * does, and the emoji is not lost — it travels with the name to the column,
+ * where the pair is the same object it is on the other nine areas.
+ *
+ * **The dot is not a link, and that is the one place this design refuses the
+ * obvious.** La Jolla's marks sit about 4.5px apart at the review viewport, so
+ * overlapping targets there would not merely be small — a click would land on
+ * whichever of two beaches happened to be painted on top, silently and
+ * unpredictably. A control that navigates somewhere a reader did not choose is
+ * worse than a mark that does not navigate at all, so the dot is drawn
+ * `aria-hidden` and inert and the labelled anchor at the end of its leader line
+ * is the control.
+ */
+function Column({ marks }: { marks: readonly PinnedBeach[] }) {
+  const side = columnSide(marks);
+  const sorted = [...marks].sort((a, b) => a.at.y - b.at.y);
+  const rows = columnRows(sorted);
+  const anchorX =
+    side === "left" ? COLUMN_INSET_UNITS : 100 - COLUMN_INSET_UNITS;
+
+  return (
+    <>
+      {/*
+        The leaders and the dots, under the anchors rather than over them.
+
+        Each line runs from its beach's dot to the column's own inset, which is
+        exactly where that beach's anchor begins — and the anchor is opaque
+        there, so the line arrives at its edge and stops. Ending it any later
+        would mean knowing how wide the name is, and the names running from 76
+        to 199px makes that a question only the browser can answer.
+      */}
+      <svg
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 h-full w-full"
+      >
+        {sorted.map((beach, index) => (
+          <line
+            key={beach.href}
+            x1={beach.at.x}
+            y1={beach.at.y}
+            x2={anchorX}
+            y2={rows[index]}
+            className="stroke-purple-deep/40"
+            strokeWidth={1}
+            vectorEffect="non-scaling-stroke"
+            data-leader=""
+          />
+        ))}
+        {sorted.map((beach) => (
+          <circle
+            key={beach.href}
+            cx={beach.at.x}
+            cy={beach.at.y}
+            r={1}
+            className="fill-purple-deep"
+            data-dot=""
+          />
+        ))}
+      </svg>
+
+      {sorted.map((beach, index) => (
+        <PinLink
+          key={beach.href}
+          beach={beach}
+          pill
+          className={
+            side === "left"
+              ? "-translate-y-1/2 flex-row"
+              : "-translate-y-1/2 flex-row-reverse"
+          }
+          style={{
+            top: `${rows[index]}%`,
+            maxWidth: "46%",
+            ...(side === "left"
+              ? { left: `${COLUMN_INSET_UNITS}%` }
+              : { right: `${COLUMN_INSET_UNITS}%` }),
+          }}
+        />
+      ))}
+    </>
+  );
+}
+
+/**
+ * The layer itself, which renders nothing at all on a beach map.
+ *
+ * A beach page has one subject and draws it as a heavy run, so it hands this no
+ * marks and gets no pins — the same condition `ShoreMap` has always applied to
+ * the marks it used to draw itself.
+ */
+export function BeachPins({ marks }: { marks: readonly PinnedBeach[] }) {
+  if (marks.length === 0) return null;
+
+  return inlineFits(marks) ? (
+    <Inline marks={marks} />
+  ) : (
+    <Column marks={marks} />
+  );
+}

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -1805,7 +1805,8 @@ test("an area page draws the whole area's coast", async () => {
   expect(map).not.toBeNull();
   expect(map!.getAttribute("aria-label")).toBe(
     "A map of La Jolla: the whole stretch of coast its 10 beaches sit on, " +
-      "each marked, with the open water shaded.",
+      "with the open water shaded. Each beach is pinned on it, and the pins " +
+      "follow as links.",
   );
   // The placeholder it replaces is gone, and asserted gone: a sentence left
   // beside a real map would read as the map having failed.
@@ -2034,13 +2035,16 @@ test("a slug the inventory does not hold draws no map", async () => {
 });
 
 /**
- * The marks reach the page: ten beaches in La Jolla, ten marks on its coast.
+ * The pins reach the page: ten beaches in La Jolla, ten named links on its map.
  *
  * This is the half that makes the picture about an area rather than about a
  * stretch of coast that happens to be wide, and it is asserted here as well as
  * in `shore.test.ts` because a view model nothing renders is not a map.
+ *
+ * The href is this component's contribution -- `shore.ts` answers with a slug
+ * and knows nothing about routes -- so it is checked here rather than there.
  */
-test("an area map marks every beach the area holds", async () => {
+test("an area map pins every beach the area holds, each linked", async () => {
   const { container } = render(
     await DayPanel({
       slug: "la-jolla-shores-beach",
@@ -2048,20 +2052,28 @@ test("an area map marks every beach the area holds", async () => {
     }),
   );
 
-  expect(container.querySelectorAll("[data-tick]")).toHaveLength(10);
+  const pins = [...container.querySelectorAll("[data-pin]")];
+  expect(pins).toHaveLength(10);
+  expect(pins.map((pin) => pin.getAttribute("href"))).toContain(
+    "/conditions/la-jolla/la-jolla-cove",
+  );
+  // Every pin names its beach, so none is an anonymous glyph.
+  for (const pin of pins)
+    expect(pin.textContent!.trim().length).toBeGreaterThan(0);
+
   expect(
     container
       .querySelector("svg[aria-label^='A map of']")!
       .getAttribute("aria-label"),
-  ).toContain("its 10 beaches sit on, each marked");
+  ).toContain("its 10 beaches sit on");
 });
 
-/** And a beach map marks nothing, because it draws its one subject heavy. */
-test("a beach map marks nothing and draws its own stretch instead", async () => {
+/** And a beach map pins nothing, because it draws its one subject heavy. */
+test("a beach map pins nothing and draws its own stretch instead", async () => {
   const { container } = render(
     await DayPanel({ slug: "la-jolla-shores-beach" }),
   );
 
-  expect(container.querySelectorAll("[data-tick]")).toHaveLength(0);
+  expect(container.querySelectorAll("[data-pin]")).toHaveLength(0);
   expect(container.querySelector("[data-segment]")).not.toBeNull();
 });

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -417,14 +417,20 @@ function mapDescription(beachName: string): string {
  * stretch, since no one beach is the subject -- so a reader who cannot see it
  * is owed the fact that this is several beaches' coast rather than one's.
  *
- * It does not name them. The list of beaches is a heading and a set of links
- * further up the page, which is where a reader goes to choose one; repeating
- * ten names inside the map's label would make the label the list.
+ * It does not name them, and now it does not have to. The pins themselves are
+ * links, sitting outside the frame's own graphic precisely so that a reader
+ * using assistive technology reaches them -- so the names arrive immediately
+ * after this sentence, in the order the beaches run down the coast. Listing
+ * them here as well would say everything twice.
+ *
+ * **It says they are coming, though**, because a graphic followed by ten
+ * unheralded links is a reader wondering what they belong to. ADR-0053.
  */
 function areaMapDescription(areaName: string, beaches: number): string {
   return (
     `A map of ${areaName}: the whole stretch of coast its ${beaches} beaches ` +
-    `sit on, each marked, with the open water shaded.`
+    `sit on, with the open water shaded. Each beach is pinned on it, and the ` +
+    `pins follow as links.`
   );
 }
 
@@ -817,6 +823,27 @@ export async function DayPanel({
         : shoreViewFor(beach);
 
   /*
+    The pins' destinations, resolved here because this is the layer that knows
+    where a beach is published.
+
+    `shore.ts` answers with a slug: it reads `beaches.json` and knows what a
+    beach is. `ShoreMap` draws and resolves nothing, which is the rule that has
+    kept every word on that picture the caller's. The route in between is this
+    component's, and it is the one part of the three that ADR-0047 has already
+    changed once.
+
+    Empty on a beach page, whose map has one subject and no pins at all.
+  */
+  const pins =
+    shore === null || areaOnMap === null
+      ? []
+      : shore.marks.map((mark) => ({
+          name: mark.name,
+          href: `/conditions/${areaOnMap.slug}/${mark.slug}`,
+          at: mark.at,
+        }));
+
+  /*
     Seven days of needles, built beside the seven days of series rather than
     inside them.
 
@@ -1059,6 +1086,7 @@ export async function DayPanel({
               <>
                 <ShoreMap
                   {...shore}
+                  marks={pins}
                   description={
                     area === undefined
                       ? mapDescription(beach!.name)

--- a/src/components/conditions/ShoreMap.test.tsx
+++ b/src/components/conditions/ShoreMap.test.tsx
@@ -300,106 +300,63 @@ test("the map's drawing space holds the picture and nothing else", () => {
 });
 
 /* =========================================================================
- * Marks, one per beach an area holds
+ * Pins, one per beach an area holds
  * ========================================================================= */
 
-/** Where a mark's two ends are, in plot units. */
-function markEnds(index = 0) {
-  const marks = [...document.querySelectorAll("[data-tick]")];
-  const line = marks[index];
-  return {
-    count: marks.length,
-    from: {
-      x: Number(line.getAttribute("x1")),
-      y: Number(line.getAttribute("y1")),
-    },
-    to: {
-      x: Number(line.getAttribute("x2")),
-      y: Number(line.getAttribute("y2")),
-    },
-  };
-}
+/** Two marks far enough apart in y that both labels sit beside their beaches. */
+const APART = [
+  { name: "North Beach", href: "/conditions/here/north", at: COAST[0] },
+  { name: "South Beach", href: "/conditions/here/south", at: COAST[3] },
+];
 
-/** A beach map has one subject and draws it heavy, so it carries no marks. */
-test("no ticks given draws no marks, which is every beach map", () => {
-  render(<ShoreMap {...PROPS} />);
+/** A beach map has one subject and draws it heavy, so it carries no pins. */
+test("no marks given draws no pins, which is every beach map", () => {
+  const { container } = render(<ShoreMap {...PROPS} />);
 
-  expect(document.querySelectorAll("[data-tick]")).toHaveLength(0);
+  expect(container.querySelectorAll("[data-pin]")).toHaveLength(0);
   // And the heavy run it draws instead is still there, so this is not just an
   // empty picture passing both ways.
-  expect(document.querySelector("[data-segment]")).not.toBeNull();
+  expect(container.querySelector("[data-segment]")).not.toBeNull();
 });
 
-test("a mark is drawn for every position given", () => {
-  render(<ShoreMap {...PROPS} segment={null} ticks={COAST.slice(0, 3)} />);
+test("a pin is drawn for every beach given, named and pointing somewhere", () => {
+  render(<ShoreMap {...PROPS} segment={null} marks={APART} />);
 
-  expect(document.querySelectorAll("[data-tick]")).toHaveLength(3);
+  for (const beach of APART) {
+    const link = screen.getByRole("link", { name: beach.name });
+    expect(link.getAttribute("href")).toBe(beach.href);
+  }
+  expect(document.querySelectorAll("[data-pin]")).toHaveLength(APART.length);
 });
 
 /**
- * A mark crosses the coast rather than lying along it, which is the whole of
- * what makes it read as a mark.
+ * The ticks are gone rather than restyled, which is the half of ADR-0053 a
+ * test can hold. Their direction came from a two-vertex window on a
+ * 5,368-point shore, and measured against the coast at the scale a reader sees
+ * it four of La Jolla's ten sat at under 45 degrees to the line.
+ */
+test("nothing on the map is a tick any more", () => {
+  const { container } = render(
+    <ShoreMap {...PROPS} segment={null} marks={APART} />,
+  );
+
+  expect(container.querySelectorAll("[data-tick]")).toHaveLength(0);
+});
+
+/**
+ * The pins are siblings of the picture, not children of it.
  *
- * Asserted as a dot product against the local coast direction rather than
- * against a fixed axis: the shore turns through more than a right angle inside
- * one frame on the bays, so a mark that were perpendicular to the *frame* would
- * lie flat along the line at half the beaches in Mission Bay.
+ * The frame carries `role="img"` with one label for the whole drawing, which
+ * makes everything inside it opaque to assistive technology. A link in there
+ * would be a link no screen reader could reach — so the one reader who most
+ * needs a beach to be named would be the one who could not get to it.
  */
-test("a mark crosses the coast, not along it", () => {
-  render(<ShoreMap {...PROPS} segment={null} ticks={[COAST[1]]} />);
-
-  const project = projectionFor(BOUNDS, { width: 100, height: 100 });
-  const before = project(COAST[0].lat, COAST[0].lon);
-  const after = project(COAST[2].lat, COAST[2].lon);
-  const { from, to } = markEnds();
-
-  const coastDir = { x: after.x - before.x, y: after.y - before.y };
-  const markDir = { x: to.x - from.x, y: to.y - from.y };
-  const dot =
-    (coastDir.x * markDir.x + coastDir.y * markDir.y) /
-    (Math.hypot(coastDir.x, coastDir.y) * Math.hypot(markDir.x, markDir.y));
-
-  // Perpendicular to within a rounding error of the two-decimal coordinates.
-  expect(Math.abs(dot)).toBeLessThan(0.01);
-});
-
-/**
- * Every mark is the same size on screen whatever ground the frame covers. An
- * area is 1.7 km of coast at Ocean Beach and 8.9 km at San Diego Bay – Central,
- * and a mark measured in metres would be five times bigger on one than on the
- * other.
- */
-test("a mark is a fixed length in plot units, not in metres", () => {
-  const wide = render(
-    <ShoreMap {...PROPS} segment={null} ticks={[COAST[1]]} />,
-  );
-  const inWide = markEnds();
-  const wideLength = Math.hypot(
-    inWide.to.x - inWide.from.x,
-    inWide.to.y - inWide.from.y,
-  );
-  wide.unmount();
-
-  // The same coast in a box covering a tenth of the ground.
-  render(
-    <ShoreMap
-      {...PROPS}
-      segment={null}
-      ticks={[COAST[1]]}
-      bounds={{
-        south: 32.8555,
-        north: 32.8645,
-        west: -117.2645,
-        east: -117.2555,
-      }}
-    />,
-  );
-  const inTight = markEnds();
-  const tightLength = Math.hypot(
-    inTight.to.x - inTight.from.x,
-    inTight.to.y - inTight.from.y,
+test("the pins are outside the frame's own graphic, so they stay reachable", () => {
+  const { container } = render(
+    <ShoreMap {...PROPS} segment={null} marks={APART} />,
   );
 
-  expect(wideLength).toBeCloseTo(tightLength, 1);
-  expect(wideLength).toBeCloseTo(4, 1);
+  const svg = container.querySelector("svg[role='img']")!;
+  expect(svg.querySelectorAll("[data-pin]")).toHaveLength(0);
+  expect(container.querySelectorAll("[data-pin]")).toHaveLength(APART.length);
 });

--- a/src/components/conditions/ShoreMap.tsx
+++ b/src/components/conditions/ShoreMap.tsx
@@ -45,7 +45,22 @@
 import type { ReactNode } from "react";
 import type { Bounds, Position, ShorePoint } from "@/lib/coastline";
 import { projectionFor } from "@/lib/coastline";
+import { BeachPins } from "./BeachPins";
 import { seaWash } from "./wash";
+
+/**
+ * One beach to pin, as this component needs it: a place, a name and a
+ * destination.
+ *
+ * `shore.ts` answers with a slug because it knows what a beach is; the caller
+ * turns that into a URL because it knows where beaches are published. Neither
+ * job belongs to the thing that draws.
+ */
+export type ShoreMapMark = {
+  name: string;
+  href: string;
+  at: Position;
+};
 
 export type ShoreMapProps = {
   /** The windowed coast in walk order. Empty draws no shoreline and says so. */
@@ -64,18 +79,26 @@ export type ShoreMapProps = {
    */
   segment: readonly Position[] | null;
   /**
-   * A mark per beach this map is about, drawn across the coast at each.
+   * A pin per beach this map is about: where it is, what it is called and where
+   * it goes when a reader clicks it.
    *
    * Empty on a beach map, which has one subject and draws it as a heavy run
-   * instead. `shore.ts` decides where they go; the length, the direction and
-   * the weight are decided here, because they are answers in plot units.
+   * instead. `shore.ts` decides where they go and what they are called; this
+   * component projects them and hands them to `BeachPins`, which decides the
+   * placement — those are answers in plot units.
    *
-   * **Marks and never targets.** The plan measured what making them tappable
-   * would cost: four of La Jolla's midpoints fall within 549 m of one another,
-   * so four marks at ADR-0004's 44px floor would need the map 2,634px wide.
-   * The list of beaches above the map is the control; these are for orientation.
+   * **The href is the caller's**, because which route a beach is published on
+   * is the page's business and this component resolves nothing. It was true of
+   * the copy already and it is true of a URL for the same reason.
+   *
+   * **Named and clickable, which reverses ADR-0052's "marks, never targets".**
+   * That rule read one area's arithmetic onto all twelve: La Jolla's marks
+   * really do sit 4.5px apart, but nine of the twelve areas carry their labels
+   * beside their beaches with room to spare. See ADR-0053, which also settles
+   * why undersized pins conform — the 44px beach list above the map is the
+   * equivalent control WCAG's exception asks for.
    */
-  ticks?: readonly Position[];
+  marks?: readonly ShoreMapMark[];
   /** The spoken equivalent of the whole picture. */
   description: string;
   /** What to say instead of a map when there is no box at all. */
@@ -157,24 +180,11 @@ export type ShoreMapProps = {
 const WIDTH = 100;
 const HEIGHT = 100;
 
-/**
- * How long a beach's mark is, in plot units, so it is the same size on screen
- * whatever ground the frame covers.
- *
- * Four units of a hundred, which at the map column's measured 472px is about
- * 19px -- long enough to read as a mark across the coast at the review
- * viewport, short enough that La Jolla's tightest pair, 1.2 units apart, reads
- * as a cluster rather than as a single thick smudge. That crowding is accepted
- * rather than solved, and the plan measured why: those four beaches really do
- * sit within 549 m of one another.
- */
-const TICK_UNITS = 4;
-
 export function ShoreMap({
   coast,
   bounds,
   segment,
-  ticks = [],
+  marks = [],
   description,
   absence,
   noCoast,
@@ -237,138 +247,113 @@ export function ShoreMap({
     printed under a map with no readout name a bearing nobody can see.
   */
   /*
-    Each mark, as a short line across the coast rather than a dot on it.
+    Each pin, projected and handed on, and that is the whole of this
+    component's part in it.
 
-    **Perpendicular to the coast where it is, not to the frame.** The direction
-    comes from the two drawn points either side of the mark, so a tick on a bay
-    shore that turns through a right angle inside one frame still crosses the
-    line rather than lying along it. It is the same reading ADR-0041 gave the
-    wash: take the direction from the walk rather than from a normal computed
-    once for the whole picture.
+    **The geometry that used to live here is gone rather than restyled.** A
+    mark was a short line taking its direction from the two drawn points either
+    side of it -- perpendicular to the coast, ADR-0052 said, and it was, to a
+    two-vertex window. Measured against the shore at the scale a reader sees it,
+    over a fifteen-vertex window, four of La Jolla's ten sat at less than 45
+    degrees to the line and one at 11, which is a stroke drawn *along* the coast
+    it was meant to cross. On a 5,368-point traced shore that window is noise,
+    so the rule was answering a question about the wrong thing.
 
-    **A fixed length in plot units, so every mark is the same size on screen**
-    whatever ground the frame covers. An area is 1.7 km of coast at Ocean Beach
-    and 8.9 km at San Diego Bay - Central, and a mark measured in metres would
-    be five times bigger on one than the other.
-
-    A mark whose beach has no drawn coast near it -- the island in Mission Bay -
-    West, about 400 m off the traced shore -- takes the direction of the nearest
-    drawn point anyway. It lies off the line, which is where that beach is.
+    A pin needs no direction, which is why nothing replaces it.
   */
-  const marks = ticks.map((at) => {
-    const point = project(at.lat, at.lon);
-    if (drawn.length < 2) return { from: point, to: point };
-
-    let nearest = 0;
-    for (let index = 1; index < drawn.length; index += 1) {
-      if (
-        Math.hypot(drawn[index].x - point.x, drawn[index].y - point.y) <
-        Math.hypot(drawn[nearest].x - point.x, drawn[nearest].y - point.y)
-      ) {
-        nearest = index;
-      }
-    }
-
-    const before = drawn[Math.max(0, nearest - 1)];
-    const after = drawn[Math.min(drawn.length - 1, nearest + 1)];
-    const dx = after.x - before.x;
-    const dy = after.y - before.y;
-    const length = Math.hypot(dx, dy) || 1;
-    const half = TICK_UNITS / 2;
-
-    return {
-      from: {
-        x: point.x - (-dy / length) * half,
-        y: point.y - (dx / length) * half,
-      },
-      to: {
-        x: point.x + (-dy / length) * half,
-        y: point.y + (dx / length) * half,
-      },
-    };
-  });
+  const pins = marks.map((mark) => ({
+    name: mark.name,
+    href: mark.href,
+    at: project(mark.at.lat, mark.at.lon),
+  }));
 
   const hasReadout = readout !== null && readout !== undefined;
 
   return (
     <div>
-      <svg
-        role="img"
-        aria-label={description}
-        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
-        className="rounded-tile border-[1.5px] border-ocean block h-auto w-full bg-white/60"
-      >
-        {/*
+      {/*
+        The picture and the pins over it, in a box that is theirs alone.
+
+        The wrapper is as tight as it can be, around the frame and nothing
+        else: the pins are placed as percentages of it, so anything else inside
+        would move them. The readout and the credits stay outside for that
+        reason and not only for ADR-0038's.
+      */}
+      <div className="relative">
+        <svg
+          role="img"
+          aria-label={description}
+          viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+          className="rounded-tile border-[1.5px] border-ocean block h-auto w-full bg-white/60"
+        >
+          {/*
             One wash, no gradient and no depth. The sea is the only filled
             region on this map, so a reader can tell water from land at a glance
             without a legend -- and it is a flat tint rather than a shaded one,
             because shading implies depth and depth here would be invented.
           */}
-        {sea !== null && (
-          <path
-            d={`${sea
-              .map(
-                (at, index) =>
-                  `${index === 0 ? "M" : "L"}${at.x.toFixed(2)} ${at.y.toFixed(2)}`,
-              )
-              .join(" ")} Z`}
-            className="fill-ocean"
-            fillOpacity={0.16}
-            data-sea=""
-          />
-        )}
+          {sea !== null && (
+            <path
+              d={`${sea
+                .map(
+                  (at, index) =>
+                    `${index === 0 ? "M" : "L"}${at.x.toFixed(2)} ${at.y.toFixed(2)}`,
+                )
+                .join(" ")} Z`}
+              className="fill-ocean"
+              fillOpacity={0.16}
+              data-sea=""
+            />
+          )}
 
-        {hasCoast && (
-          <path
-            d={path}
-            fill="none"
-            className="stroke-ocean"
-            strokeWidth={1.2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            vectorEffect="non-scaling-stroke"
-            data-coast=""
-          />
-        )}
+          {hasCoast && (
+            <path
+              d={path}
+              fill="none"
+              className="stroke-ocean"
+              strokeWidth={1.2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              vectorEffect="non-scaling-stroke"
+              data-coast=""
+            />
+          )}
 
-        {marks.map((mark, index) => (
-          <line
-            key={index}
-            x1={mark.from.x.toFixed(2)}
-            y1={mark.from.y.toFixed(2)}
-            x2={mark.to.x.toFixed(2)}
-            y2={mark.to.y.toFixed(2)}
-            className="stroke-purple-deep"
-            strokeWidth={2}
-            strokeLinecap="round"
-            vectorEffect="non-scaling-stroke"
-            data-tick=""
-          />
-        ))}
-
-        {/*
+          {/*
             This beach's own stretch, heavier than the coast it sits on. Weight
             rather than only hue: the two are the same ocean, so a reader who
             sees no colour still sees which part of the shore they chose.
           */}
-        {drawnSegment.length > 0 && (
-          <path
-            d={drawnSegment
-              .map(
-                (at, index) =>
-                  `${index === 0 ? "M" : "L"}${at.x.toFixed(2)} ${at.y.toFixed(2)}`,
-              )
-              .join(" ")}
-            fill="none"
-            className="stroke-purple-deep"
-            strokeWidth={3.5}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            vectorEffect="non-scaling-stroke"
-            data-segment=""
-          />
-        )}
-      </svg>
+          {drawnSegment.length > 0 && (
+            <path
+              d={drawnSegment
+                .map(
+                  (at, index) =>
+                    `${index === 0 ? "M" : "L"}${at.x.toFixed(2)} ${at.y.toFixed(2)}`,
+                )
+                .join(" ")}
+              fill="none"
+              className="stroke-purple-deep"
+              strokeWidth={3.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              vectorEffect="non-scaling-stroke"
+              data-segment=""
+            />
+          )}
+        </svg>
+
+        {/*
+          The pins, over the picture rather than inside it.
+
+          Inside would put them under the SVG's own `role="img"`, which
+          declares the whole frame one graphic and hides everything within it
+          from assistive technology -- so the links a reader most needs a name
+          for would be the ones they could not reach. Outside, they are
+          ordinary anchors in the document.
+        */}
+        <BeachPins marks={pins} />
+      </div>
 
       {/*
         Under the picture rather than over it, which is ADR-0038 reversing

--- a/src/components/conditions/ShoreMap.tsx
+++ b/src/components/conditions/ShoreMap.tsx
@@ -331,11 +331,6 @@ export function ShoreMap({
           />
         )}
 
-        {/*
-            This beach's own stretch, heavier than the coast it sits on. Weight
-            rather than only hue: the two are the same ocean, so a reader who
-            sees no colour still sees which part of the shore they chose.
-          */}
         {marks.map((mark, index) => (
           <line
             key={index}
@@ -351,6 +346,11 @@ export function ShoreMap({
           />
         ))}
 
+        {/*
+            This beach's own stretch, heavier than the coast it sits on. Weight
+            rather than only hue: the two are the same ocean, so a reader who
+            sees no colour still sees which part of the shore they chose.
+          */}
         {drawnSegment.length > 0 && (
           <path
             d={drawnSegment

--- a/src/components/conditions/shore.test.ts
+++ b/src/components/conditions/shore.test.ts
@@ -578,12 +578,17 @@ test("every beach in an area is marked, on its own coast", () => {
   let offTheLine = 0;
 
   for (const { area, beaches } of beachesByArea()) {
-    const { ticks } = shoreViewForArea(area);
-    expect(ticks, area.slug).toHaveLength(beaches.length);
+    const { marks } = shoreViewForArea(area);
+    expect(marks, area.slug).toHaveLength(beaches.length);
 
-    for (const [index, tick] of ticks.entries()) {
+    for (const [index, mark] of marks.entries()) {
       const beach = beaches[index];
-      const metres = nearestOn(coastline(), tick)!.metres;
+      const metres = nearestOn(coastline(), mark.at)!.metres;
+
+      // The pin is named and goes somewhere, so identity travels with the
+      // position. It is the same beach the frame was built from, in order.
+      expect(mark.slug, area.slug).toBe(beach.slug);
+      expect(mark.name, beach.slug).toBe(beach.name);
 
       if (coastRunFor(beach) === null) {
         // The island. Its mark is where that beach is, which is off the line.
@@ -607,13 +612,13 @@ test("every beach in an area is marked, on its own coast", () => {
  */
 test("every mark falls inside its area's frame", () => {
   for (const { area } of beachesByArea()) {
-    const { bounds, ticks } = shoreViewForArea(area);
+    const { bounds, marks } = shoreViewForArea(area);
 
-    for (const tick of ticks) {
-      expect(tick.lat, area.slug).toBeGreaterThanOrEqual(bounds!.south);
-      expect(tick.lat, area.slug).toBeLessThanOrEqual(bounds!.north);
-      expect(tick.lon, area.slug).toBeGreaterThanOrEqual(bounds!.west);
-      expect(tick.lon, area.slug).toBeLessThanOrEqual(bounds!.east);
+    for (const { at } of marks) {
+      expect(at.lat, area.slug).toBeGreaterThanOrEqual(bounds!.south);
+      expect(at.lat, area.slug).toBeLessThanOrEqual(bounds!.north);
+      expect(at.lon, area.slug).toBeGreaterThanOrEqual(bounds!.west);
+      expect(at.lon, area.slug).toBeLessThanOrEqual(bounds!.east);
     }
   }
 });
@@ -621,6 +626,6 @@ test("every mark falls inside its area's frame", () => {
 /** A beach map has one subject and draws it heavy, so it marks nothing. */
 test("a beach map carries no marks", () => {
   for (const beach of allBeaches()) {
-    expect(shoreViewFor(beach).ticks, beach.slug).toEqual([]);
+    expect(shoreViewFor(beach).marks, beach.slug).toEqual([]);
   }
 });

--- a/src/components/conditions/shore.ts
+++ b/src/components/conditions/shore.ts
@@ -366,7 +366,10 @@ export function shoreViewFor(beach: Beach): ShoreView {
  *
  * Throws for an area naming a beach the inventory does not have, like
  * `areaSources` and for the same reason: two data files disagreeing should stop
- * a build rather than quietly draw a coast with a beach missing from it.
+ * a build rather than quietly draw a coast with a beach missing from it. It
+ * throws a second time, on the same reasoning, where the windowed coast gives
+ * no seaward direction and the frame therefore cannot be squared -- see the
+ * comment on that guard for why it is unreachable and what would make it live.
  */
 export function shoreViewForArea(area: Area): ShoreView {
   const bySlug = new Map(allBeaches().map((beach) => [beach.slug, beach]));
@@ -396,9 +399,38 @@ export function shoreViewForArea(area: Area): ShoreView {
   if (boxed === null)
     return { coast: [], bounds: null, ticks: [], segment: null };
 
+  /*
+    The draft window always has a direction, so failing to find one stops the
+    build rather than quietly returning a frame that is not square.
+
+    It is the same call the missing-beach throw above makes, for the same
+    reason: this function has two data files under it, and a picture drawn from
+    a disagreement between them is worse than no picture. What ADR-0051 promises
+    is a *square* frame -- `boxed` is the un-squared box, so falling back to it
+    would ship the one thing that decision rules out, invisibly, on whichever
+    area happened to trip it.
+
+    Unreachable as the data stands, and the argument is short enough to check.
+    `boxed` is non-null, so at least two coastline points with different
+    coordinates lie inside it; `windowAround` therefore returns a slice of two
+    or more whose first and last sit at different indices; and no coordinate
+    appears at two indices of the committed shore, which `coastline.test.ts`
+    pins. Different coordinates give a direction, so `seawardFrom` answers.
+
+    That last step is the load-bearing one and it is the weakest: it is a
+    property of the traced file rather than of the code. `withoutRepeats` does
+    not give it -- it drops a point equal to its neighbour, and these two are
+    never neighbours -- so a regenerated shore could take it away. The test
+    fails first if that happens, which is the point of stating it there.
+  */
   const draft = windowAround(coastline(), boxed);
   const seaward = seawardFrom(draft);
-  const bounds = seaward === null ? boxed : squareToward(boxed, seaward);
+  if (seaward === null) {
+    throw new Error(
+      `The coast under ${area.slug} gives no seaward direction, so its frame cannot be squared. The traced shoreline has likely gained a repeated coordinate; see coastline.test.ts.`,
+    );
+  }
+  const bounds = squareToward(boxed, seaward);
 
   /*
     A mark per member, at the middle of the coast that member occupies.

--- a/src/components/conditions/shore.ts
+++ b/src/components/conditions/shore.ts
@@ -30,24 +30,47 @@ import {
   windowAround,
 } from "@/lib/coastline";
 
+/**
+ * One beach an area holds, as much of it as a map needs to draw a pin.
+ *
+ * **Identity travels with the position, because the mark is now named.** It was
+ * a bare `Position` while the mark was a tick: a stroke across the coast says
+ * "a beach is here" and needs nothing else. A pin carries the beach's name and
+ * goes somewhere when it is clicked, and both of those are facts about the
+ * beach rather than about the picture -- so they come from the file that reads
+ * `beaches.json` rather than being looked up a second time by the one that
+ * draws. See ADR-0053.
+ *
+ * The slug and not a URL. Which route a beach sits on is the page's business
+ * and changed once already under ADR-0047; this module knows what a beach is,
+ * not where it is published.
+ */
+export type BeachMark = {
+  slug: string;
+  name: string;
+  at: Position;
+};
+
 /** Everything `ShoreMap` needs, and nothing it has to look up for itself. */
 export type ShoreView = {
   coast: readonly ShorePoint[];
   bounds: Bounds | null;
   /**
-   * Where each beach this map is about sits, one position per beach.
+   * Each beach this map is about, one entry per beach.
    *
    * Empty on a beach map, which has one subject and draws it as a heavy run
-   * instead. On an area map it is every member's midpoint, and it is the whole
-   * of what makes the picture about an area rather than about a stretch of
-   * coast that happens to be wide.
+   * instead. On an area map it is every member at its own midpoint, and it is
+   * the whole of what makes the picture about an area rather than about a
+   * stretch of coast that happens to be wide.
    *
-   * **Positions and not marks.** Where the tick is drawn, how long it is and
-   * which way it lies are `ShoreMap`'s, because they are answers in plot units
-   * and this file works in degrees -- the same split the rest of the module
-   * keeps: the assembler reads, the component draws.
+   * **Positions and names, never placement.** Where a pin sits on the screen,
+   * whether its label fits beside it or has to be carried out to a column, and
+   * which side of the frame that column stands on are all `ShoreMap`'s, because
+   * they are answers in plot units and this file works in degrees -- the same
+   * split the rest of the module keeps: the assembler reads, the component
+   * draws.
    */
-  ticks: readonly Position[];
+  marks: readonly BeachMark[];
   /**
    * Where this beach is, drawn heavier than anything around it.
    *
@@ -331,7 +354,7 @@ export function shoreViewFor(beach: Beach): ShoreView {
   const coast =
     run === null || bounds === null ? [] : windowAround(coastline(), bounds);
 
-  return { coast, bounds, ticks: [], segment: beachStretch(run, beach) };
+  return { coast, bounds, marks: [], segment: beachStretch(run, beach) };
 }
 
 /**
@@ -397,7 +420,7 @@ export function shoreViewForArea(area: Area): ShoreView {
     SHORE_WINDOW_MARGIN,
   );
   if (boxed === null)
-    return { coast: [], bounds: null, ticks: [], segment: null };
+    return { coast: [], bounds: null, marks: [], segment: null };
 
   /*
     The draft window always has a direction, so failing to find one stops the
@@ -457,23 +480,24 @@ export function shoreViewForArea(area: Area): ShoreView {
     shore. That is a true statement about an island the committed mainland ring
     does not hold, and the only mark on any area map that is not on the line.
   */
-  const ticks = area.beaches.map((slug) => {
+  const marks = area.beaches.map((slug) => {
     const beach = bySlug.get(slug)!;
     const run = coastRunFor(beach);
-    if (run === null) {
-      return {
-        lat: (beach.segment.upper.lat + beach.segment.lower.lat) / 2,
-        lon: (beach.segment.upper.lon + beach.segment.lower.lon) / 2,
-      };
-    }
-    const middle = run.stretch[Math.floor(run.stretch.length / 2)];
-    return { lat: middle.lat, lon: middle.lon };
+    const at =
+      run === null
+        ? {
+            lat: (beach.segment.upper.lat + beach.segment.lower.lat) / 2,
+            lon: (beach.segment.upper.lon + beach.segment.lower.lon) / 2,
+          }
+        : run.stretch[Math.floor(run.stretch.length / 2)];
+
+    return { slug, name: beach.name, at: { lat: at.lat, lon: at.lon } };
   });
 
   return {
     coast: windowAround(coastline(), bounds),
     bounds,
-    ticks,
+    marks,
     segment: null,
   };
 }

--- a/src/lib/coastline.test.ts
+++ b/src/lib/coastline.test.ts
@@ -99,6 +99,41 @@ test("a repeated coordinate is dropped rather than kept as a zero-length step", 
   ]);
 });
 
+/**
+ * The stronger property `withoutRepeats` does not give, and the one
+ * `shoreViewForArea`'s square frame rests on.
+ *
+ * `withoutRepeats` drops a point equal to the one before it, so it rules out
+ * *adjacent* repeats only. A coordinate appearing twice with other points
+ * between them survives it, and that is the case that matters: `windowAround`
+ * hands `seawardFrom` a slice, `seawardFrom` reads the slice's first and last
+ * points, and those two are never adjacent. Equal there means a window with no
+ * direction, and `shoreViewForArea` would have no way to square its box.
+ *
+ * So this is not a fact about tidiness. It is the premise under an error that
+ * is unreachable today: if this ever fails, that throw becomes live, and this
+ * test is where the reason is written down.
+ */
+test("no coordinate appears at two indices, which is what makes a window's ends distinct", () => {
+  const points = coastline();
+  const seen = new Map<string, number>();
+
+  for (const [index, point] of points.entries()) {
+    const key = `${point.lat},${point.lon}`;
+    const first = seen.get(key);
+    expect(
+      first,
+      `${key} is at index ${first} and again at ${index}`,
+    ).toBeUndefined();
+    seen.set(key, index);
+  }
+
+  // The probe: the map really was built, so a run finding an empty coastline
+  // would not pass this by having nothing to compare.
+  expect(seen.size).toBe(points.length);
+  expect(points.length).toBeGreaterThan(1);
+});
+
 test("the window keeps one point past each end so the coast reaches the frame", () => {
   // Clipping to exactly what falls inside would draw a coastline that stops
   // short of the edge with white on both sides of it, which reads as the land


### PR DESCRIPTION
Replaces the tick marks on `/conditions/<area>` with named, clickable pins,
after they were reviewed and rejected on looks. Supersedes ADR-0052.

No issue: this came out of an audit rather than the tracker.

## The slices

**1. `17db576` — Put the segment comment back on the segment.** A comment
describing the heavy stroke sat above `marks.map`, orphaned when the marks block
landed above the segment block. No behaviour.

**2. `d74f1b7` — Stop an area's frame from silently coming out unsquared.**
`shoreViewForArea` fell back to the un-squared box where the windowed coast gave
no seaward direction — shipping the one shape ADR-0051 rules out, invisibly. It
throws now, as it already does when `areas.json` names a beach `beaches.json`
lacks. Unreachable today, and the argument runs through a test rather than a
comment: a non-null box means two coastline points with distinct coordinates are
inside it, so the window's two ends sit at different indices, and those differ
only because no coordinate appears twice in the committed shore.

`withoutRepeats` does not give that property — it drops a point equal to its
*neighbour*, and a window's ends are never neighbours — so it is pinned in
`coastline.test.ts`. Verified falsifiable: injecting a duplicate of index 10 at
index 500 fails the test and names both indices.

**3. `2390602` — Pin, name and link every beach on its area's map.** Below.

## Why the ticks looked wrong, measured

A tick took its direction from the two drawn points either side of it. ADR-0052
called that perpendicular to the local coast, and it is — to a two-vertex window
on a 5,368-point traced shore, which is noise. Against a fifteen-vertex window,
the scale a reader sees:

| angle between the mark and the coast | La Jolla's ten marks |
| ------------------------------------ | -------------------- |
| under 45°, reading as *along* it      | **4** |
| the worst of them                     | **10.7°** |
| over 75°, reading as *across* it      | 3 |

So the geometry is deleted rather than restyled.

## What replaces it

Each beach is an emoji pin and its name, together one link to that beach's page.
Two placements, chosen **per area** by the geometry:

- **nine areas** — the name sits beside its pin;
- **three** — every name moves to a column at the frame's edge, joined to a dot
  on the coast by a leader line.

**Three areas, not one.** ADR-0052 read La Jolla's arithmetic onto all twelve,
and by distance La Jolla really is the only bad case (4.5px against the next
area's 31px). But labels collide on *vertical* separation, and Mission Bay –
North and – West have marks 31px and 41px apart on screen while sitting 0.28 and
0.38 plot units apart in y — beaches on opposite shores of one bay at one
latitude.

The threshold is one label row on the **narrowest** map: 13px of a 342px phone
column, not of the 472px review viewport. The partition has a thirteen-fold
margin — crowded areas top out at 0.47 units, the next is 6.38 — so any value
between about 0.5 and 6.3 sorts the twelve identically.

## Tap targets, settled explicitly

ADR-0052's "44px floor" was wrong twice, and ADR-0053 says so:

- **ADR-0004 asks 44px only *below* `md`, and 24px at `md` and above.** Every
  pin is 24px at every breakpoint, so above `md` it meets that floor unaided.
- **Below `md` no pin reaches 44px, and it conforms anyway** under the
  *Equivalent* exception in both WCAG 2.5.5 (AAA) and 2.5.8 (AA) — discharged by
  the beach list above the map, measured at exactly 44px across ten links at
  both breakpoints. The ADR names that list load-bearing so a later change
  cannot quietly remove the exception.
- **Where pins are crowded they are not clickable at all.** At 4.5px apart a
  click would land on whichever beach was painted last. A mark that does nothing
  beats a control that goes somewhere the reader did not choose.

## Found by rendering, not by arithmetic

The gate never renders these routes, so all three of these came from the dev
server; two carry a test that fails without the fix.

- One label side per picture ran **Coronado North Beach off the left edge**. Each
  name now takes whichever side of its own pin has more frame.
- The column's pitch was derived from the *label*'s height when the column
  stacks whole **24px anchors** — every pair overlapped by **5.2px on a phone**
  and 9px at 320px. Re-derived at the narrowest supported map. Verified: gaps
  are now +20.8px / +8.5px / +1.8px at 1536 / 390 / 320.
- Lifting an overlong stack back inside the frame carried its **first row off the
  top** — La Jolla Shores sits 20 units above the cluster. Regression test fails
  at 0.25 without the fix.

Measured across all twelve areas after the fixes: **0 clipped, 0 unreachable,
every pin 24px.**

## Audit findings not addressed here

Reported rather than filed, per the standing rule:

- `compassDays` builds 7×24 hours including ~168 `hourLabelAt` calls on area
  pages, then `hasNeedles` discards it. Both products withheld guarantees no
  needles, so an early gate would be sound.
- `AreaScope` is `Area` plus two fields, and `DayPanel` calls `areaBySlug(area.slug)`
  to recover the `Area` it was built from. Carrying the `Area` removes the round trip.
- ADR-0052 states the tightest pair as "1.2 units — about 6px"; measured 4.5px.

**Resolved incidentally:** `ShoreMap.tsx`'s reintroduced `Math.hypot(...) || 1` —
the guard a previous PR had deliberately removed from `seaPath` — went with the
tick geometry.

**No plan file.** CLAUDE.md wants one for work that will not finish in a sitting
or that turns on a contested choice. This was three slices in one sitting, and
the contested parts — the threshold and the accessibility argument — are in
ADR-0053, which is the record that is kept current.

## Gates

Run on `2390602` after `rm -rf .next`, so the `stylesheet` row reads a fresh
build.

```
> wild-coast-kids@0.1.0 gate
> node scripts/run-gates.mjs

… format
… lint
… typecheck
… adr-numbers
… sea-side
… areas
… test
… build
… stylesheet

  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  areas
  PASS  test
  PASS  build
  PASS  stylesheet
```

Coverage moved up, which relieves the 0.02 branch headroom the audit flagged:

```
                     %stmt   %branch   %func   %lines
before (main)        90.22    89.58     95.00   90.02
after                90.31    89.77     95.09   90.06
floor                90.13    89.56     94.93   89.90
```

`ShoreMap.tsx` and `BeachPins.tsx` are both at 100% and leave the uncovered
table. `shore.ts` gains one uncovered line, the new throw, which no test in this
suite can provoke by design.

Floors not raised — the repo's pattern is to catch several PRs up at once, and
that was last done today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
