### PR TITLE
Say when a reading was taken, instead of saying it was taken now

### DIFF
--- a/docs/adr/0054-a-reading-states-when-it-was-taken.md
+++ b/docs/adr/0054-a-reading-states-when-it-was-taken.md
@@ -1,0 +1,98 @@
+# 0054 — A reading states when it was taken, and "now" comes from the client
+
+Date: 2026-09-04. Status: accepted. Narrows ADR-0016's `Measured now` label.
+Plan: `docs/plans/the-measured-band.md`.
+
+## Context
+
+`MAX_WAVE_AGE_MINUTES` and `MAX_OBSERVATION_AGE_MINUTES` are both 180. A buoy
+publishing every thirty minutes can miss five cycles and still be inside the
+window; an hourly station can miss two. The observation's own timestamp is read
+in `lib/upstream.ts`, used to enforce that limit, and then dropped — nothing
+downstream of `lib/conditions.ts` knows when anything was measured.
+
+So the page prints a figure that may be nearly three hours old under a
+provenance line reading **`Measured now`**. ADR-0016 put that label there for a
+real reason — to separate the buoy's height from the modelled forecast beside
+it — and the separation it draws is still the right one. The word that has
+stopped being true is `now`.
+
+`CONTEXT.md`'s **Conditions** entry has said since it was written that this tool
+shows readings "attributed and timestamped". The attribution shipped. The
+timestamp never did.
+
+**A reading is not one row.** Probed on 2026-09-04 at 21:26 UTC for Shell Beach:
+buoy `46254` published wave height at 21:26, station `LJAC1` published wind at
+21:00 and air temperature at 20:48 — its `ATMP` column was `MM` on the four
+newest rows. `fetchLatestNdbcAir` ages each field independently on purpose, so
+that "a station reporting wind every six minutes and temperature every hour
+yields a current wind rather than nothing". The consequence is that the air half
+of the panel is two rows as often as one.
+
+**And "now" cannot come from the server.** The route sets `revalidate = 900`.
+A server-rendered clock is the render time and can be a quarter of an hour
+behind the reader — a confidently wrong number on a page whose entire discipline
+is refusing to print one.
+
+## Decision
+
+**Every reading carries `observedAtMs`, and it is the oldest row that
+contributed to it.** Not the newest, and not the row the lead figure came from.
+A view model that carried the newest would let one fresh field vouch for a stale
+one standing beside it.
+
+**A single-row source states its time; a multi-row source states a bound.**
+The wave read is one row of `realtime2`, so the card says `Measured 2:26 PM`.
+The air read is up to two rows and the panel cannot see which network answered —
+`StationBinding` carries a name and a distance and no network, deliberately
+(ADR-0010) — so it says `nothing older than 1:48 PM`.
+
+The bound wording is load-bearing twice. It is **true**, where `readings from
+1:48 PM` would be false of the wind. And a bound over a set is not a provenance
+claim about any figure, so it does not put two rows behind one attribution.
+
+**`Measured now` becomes `Measured`.** ADR-0016's contrast is between a
+measurement and a model, and that contrast survives the word `now` leaving. The
+time now says what `now` was asserting, and says it correctly.
+
+**"Now" is rendered on the client, ticking, in Pacific time.** Behind
+`useHydrated()`, which is already this site's answer for a value allowed to
+differ between the server render and the client one (ADR-0027). Pacific rather
+than the browser's locale: a reader in New York would otherwise see 5:26 PM
+beside a reading taken at 2:26 PM at a San Diego beach, and the gap between
+those two numbers is the only reason to show both.
+
+Without JavaScript the reader gets the observation time and no "now". Nothing
+false is shown, which is the same trade `hydrated.ts` records.
+
+## Consequences
+
+**A reading can now look stale, and that is the point.** A card that said
+`Measured now` at 11:40 for an observation taken at 08:55 said the wrong thing
+confidently. It now says `Measured 8:55 AM` and the reader decides. Some beaches
+will look worse than they did, at moments when they were already worse than they
+looked.
+
+**The oldest-row rule understates freshness, knowingly.** On the probe above,
+the air line reads `nothing older than 1:48 PM` while the wind it describes is
+26 minutes newer. Understating is the safe direction here: the failure it
+prevents is a reader trusting a figure staler than they think, and the failure
+it causes is a reader distrusting one fresher than they think.
+
+**`ProvenanceLine` acquires a fifth fact.** It already carries what, who, how
+far and why-not-a-nearer-one; `observed` is when. It renders as the last
+interpunct segment, so the wave line reads `Measured · Buoy Scripps Nearshore ·
+NDBC · 2:26 PM` and the air line ends with its bound. One placement for both,
+because the alternative is the four-wordings-of-one-fact drift that component's
+docstring exists to record.
+
+**The 180-minute windows are not touched.** Making the bound honest by
+construction would mean tightening them, which changes what the page shows
+rather than how it labels it, on every beach. If the windows look wrong once the
+times are visible, that is its own decision with its own evidence — and it will
+have evidence, which it does not today.
+
+**A client island enters the measured block.** It is small, it renders nothing
+before hydration, and it is the second one on this page after `AreaSelector`.
+The cost is that the only figure on this block a no-script reader cannot see is
+the one that was never on it before.

--- a/docs/plans/the-measured-band.md
+++ b/docs/plans/the-measured-band.md
@@ -1,0 +1,276 @@
+# The measured band
+
+> Planned 2026-09-04. In flight.
+
+The two dark cards at the top of `/conditions` become one line. It says what was
+measured, when it was measured, and what time it is now — and it says nothing
+else, because everything a card said about an absence moves to the panel that
+draws the model standing in for it.
+
+## The problem, from the reader's point of view
+
+A parent opens `/conditions` on a phone or a laptop to decide whether to drive
+to the beach. The first 340px of the page is a headline, a liability notice and
+a list of beach links. Under that sit two dark cards, roughly 180px tall, and
+under those the week and the day — the two regions that actually answer "which
+day should we go".
+
+At the review viewport (1536×639 CSS pixels; see `docs/plans/section-snapping.md`
+and issue #37 for why that is the number) the cards straddle the fold. Nothing
+below them is visible without scrolling. The cards hold eight figures, and the
+reader who came to compare Saturday against Sunday has to scroll past all eight
+to reach anything that mentions Saturday.
+
+The second half of the problem is worse and is not about layout at all.
+
+**The page says "Measured now" over readings up to three hours old.**
+`MAX_WAVE_AGE_MINUTES` and `MAX_OBSERVATION_AGE_MINUTES` are both 180. A buoy
+publishing every thirty minutes can miss five cycles and the card still prints
+its height under a provenance line reading `Measured now`, with nothing to say
+otherwise. The observation's own timestamp is computed in `lib/upstream.ts`,
+used to enforce the limit, and then thrown away before the view model is built.
+Nothing downstream of `lib/conditions.ts` knows when anything was measured.
+
+`CONTEXT.md`'s **Conditions** entry has always said the tool shows readings
+"attributed and timestamped". Half of that has never been true.
+
+## What the reader gets instead
+
+One band, full width, directly under the page header, in every state:
+
+```
+🏄 3.0 ft · 72°F water — about waist high.
+💨 70°F · 7 mph from the west — Mild, with a light breeze.
+   2:26 PM, Thu Sep 4 · nothing older than 1:48 PM
+   Waves from Buoy Scripps Nearshore (NDBC) · air from Scripps Pier, 2.5 km
+```
+
+At 13px that is about 148 characters for the three segments — roughly 1005px,
+so one line at 1536 with the attribution on a second. At the 342px phone width
+it wraps to about five lines, against roughly 360px for the two stacked cards
+it replaces.
+
+## Measurements only, and why that decides the shape
+
+**Only 15 of the 51 beaches have a wave buoy at all.** All 51 have an air
+station. Applying ADR-0048's intersection rule over the eighteen areas, waves
+are `shared` in 3, `mixed` in 2 and `absent` in 13 — so the wave half of this
+block is a figure on:
+
+- 15 of 51 beach pages,
+- 3 of 18 area pages.
+
+**18 of 69 routes, about 26%.** On the other 74% the wave half of the card today
+is a paragraph explaining an absence, plus a `<details>` carrying the join's own
+reason. Designing a compact band around two figures would be designing for the
+minority case.
+
+So the band carries **what was measured and nothing else**, and every sentence
+explaining a missing wave measurement moves to the day chart's wave tab and the
+week's wave row — beside the modelled heights that stand in for it. That is
+already where ADR-0019's disclosure most belongs: the risk that decision names
+is a reader trusting a modelled height as an instrument reading, and the
+modelled heights are drawn in those two places, not here.
+
+## The two clocks, and why they come from different places
+
+The route sets `revalidate = 900`. A "now" rendered on the server is the render
+time and can be a quarter of an hour behind the reader. On a page whose whole
+discipline is refusing to print a confident wrong number, a clock that is
+quietly fourteen minutes slow is the worst figure available to add.
+
+The asymmetry that resolves it: **an observation time is a fact about the past
+and survives caching intact; "now" does not.** So:
+
+- the observation bound is rendered on the server as an absolute local time,
+- "now" is a client component behind `useHydrated()`, ticking each minute.
+
+It renders **Pacific time**, not the browser's locale. A reader in New York
+would otherwise see 5:26 PM beside a reading taken at 2:26 PM at a San Diego
+beach, and the gap between the two numbers is the whole point of showing both.
+
+Without JavaScript the reader gets the observation bound and no "now", which is
+honest: nothing false is shown, and `hydrated.ts` records that this is the
+site's established answer (ADR-0027).
+
+### One bound, worded as a bound
+
+There are up to **three** observation times behind five figures. Probed live on
+2026-09-04 at 21:26 UTC, for Shell Beach — buoy `46254` and station `LJAC1`:
+
+| value           | newest row | local   |
+| --------------- | ---------- | ------- |
+| wave height     | 21:26 UTC  | 2:26 PM |
+| wind            | 21:00 UTC  | 2:00 PM |
+| air temperature | 20:48 UTC  | 1:48 PM |
+
+The buoy publishes every thirty minutes. `LJAC1` publishes every six, but its
+`ATMP` column was already `MM` on the newest row, so temperature sat four rows
+behind wind. Three times spanning 38 minutes, in the ordinary case, on the beach
+the design was drawn against.
+
+The band prints **one** value: the oldest contributing row, worded as a bound —
+`nothing older than 1:48 PM`, never `readings from 1:48 PM`. The distinction is
+load-bearing twice over. It is true, where the second form is false. And a bound
+over a set is not a provenance claim about any figure, so it does not put two
+networks behind one attribution — which is what ADR-0010 refuses.
+
+The cost is accepted knowingly: a five-minute-old wave height reads as
+38 minutes old. Understating freshness is the safe direction for this site, and
+one line is worth it.
+
+## Decisions
+
+**Two provenances stay behind one panel, and behind two sentences.**
+`ReadingCard`'s `gloss` docstring anticipates this exact change — "the
+temptation once the cards are being compressed is to merge them; that decision
+refuses two provenances behind one sentence, and this is that sentence." The
+band keeps two glyph-anchored groups with their own plain-words lines. `about
+waist high, mild with a light breeze` is the merge ADR-0010 forbids and is not
+built.
+
+**Period and gust are dropped.** They need the words "period" and "gusting" to
+mean anything to a parent, which costs about 25 characters, and they are the two
+most surfer-specific figures on the block. Both values leave the site: nothing
+else on the page carries a measured period or gust. This is the one deliberate
+loss of published data in the plan.
+
+**The attribution stays visible, one line, under the band.** Moving it into
+`ConditionsNotes` was considered and rejected — see below.
+
+**No third glyph.** ADR-0015 makes the emoji vocabulary closed. 🏄 and 💨 come
+across; the clock segment carries no glyph.
+
+**One `role="region"` with an `aria-label`, no visible heading.** The two card
+`<h2>`s leave the outline, which becomes `h1` → region `h2` → day `h3` with no
+card level between. The label goes on `aria-label` rather than a hidden heading:
+`ReadingCard` records the accessible-name algorithm joining adjacent inline text
+nodes with no separator, and this repo does not use `sr-only` anywhere.
+
+**The band is called a band.** `badge` is taken by the program-card pill,
+`readout` by the map corner block, and `strip` by the marquee — all three in
+`CONTEXT.md`. `band` is unclaimed and is already the informal word for this
+block in `ConditionsSection` and `MeasuredToday`.
+
+## Slices
+
+Three pull requests. Each is vertical, leaves the page working, and is
+revertible on its own.
+
+### PR 1 — A reading states when it was taken
+
+`observedAtMs` plumbed from `lib/upstream.ts` through `lib/conditions.ts` into
+`WavesView` and `AirView`, as the oldest contributing row per source. Printed on
+the **existing cards**, replacing `Measured now`.
+
+This ships alone because it fixes a defect alone: a three-hour-old reading stops
+being labelled as current. No layout moves.
+
+ADR: _A reading states when it was taken, and "now" comes from the client._
+
+### PR 2 — Wave absences are worded where the model is drawn
+
+The ADR-0019 modelled-source disclosure, the bay sentence, the `unavailable`
+sentence and ADR-0049's withheld-product wording move out of the wave card and
+into the day chart's wave tab and the week's wave row. The card keeps a short
+marker in its slot.
+
+Nothing is deleted here and nothing is hidden; the sentences change position.
+After this PR the explanation of a missing wave height sits beside the modelled
+height that answers in its place, which is where a reader who might be misled by
+that height actually is.
+
+ADR: _Wave absences are worded where the model is drawn_ — extends ADR-0019 and
+ADR-0049.
+
+### PR 3 — The measured band
+
+The band replaces both cards. `MeasuredToday`, `ReadingCard` and `StatGroup` are
+deleted with their tests — about 2,100 lines, and `ReadingCard` and `StatGroup`
+have exactly one caller each. `MeasuredPanel` survives as the fetch seam.
+`CONTEXT.md` gains a **Measured band** entry.
+
+ADR: _The measured block is one band, not two cards._
+
+## Test seams
+
+Agreed before any code, because they decide whether this is verifiable at all.
+
+- **`observedAtMs` in `lib/upstream.ts`.** Fixture-fed, asserting the oldest
+  contributing row — including the NDBC per-field case, where temperature and
+  wind come off different rows and the older one has to win.
+- **A pure `measuredBand.ts`.** Takes the view models and returns the band's
+  text segments. Every state is assertable with no network and no DOM: both
+  readings, waves absent, waves withheld, air unavailable, air drifted, a
+  partial air reading with a null temperature or a null wind.
+- **The clock as a client component behind `useHydrated()`.** Fake timers,
+  asserting nothing renders before hydration and Pacific time after — not the
+  test runner's locale.
+- **The existing wording functions are not touched.** `heightWords`,
+  `warmthWord`, `windWords`, `plainWords` and `compassWords` keep their current
+  tests and move into the band unchanged.
+
+Two things the gate cannot do, stated so they are not assumed:
+
+- **`generateStaticParams` returns `[]`,** so `npm run gate` compiles these
+  routes and renders none of them. The band is checked by curling the dev
+  server, not by `build`.
+- **The height saving is an estimate from tokens.** It is measured with
+  Playwright at 1536×639, 390×844 and 320×640 before the layout is accepted.
+  Every layout figure in this file above was derived from the narrowest width
+  the site supports and then checked at the widest, not the other way round.
+
+## Considered and rejected
+
+**A summary badge with the cards left in place** — the `RipLevel` pattern, which
+this repo already runs: a compact readout beside the chooser summarising a fuller
+block further down. Nothing would be lost and no ADR would move. Rejected
+because it _adds_ height at the top of the page instead of removing it, which is
+the opposite of the ask, and duplicates every figure six inches apart.
+
+**The band inside the chooser column, beside the dropdown.** Literally what was
+asked for. The column is `md:w-72` — 288px — and the content is six stacked
+lines there, about 130px, so the header row grows from ~100px to ~246px and the
+net saving falls to about 70px. A 288px column cannot hold a badge, only a
+narrow card: it is the cards, rotated. A third column beside the chooser does
+not fit until `xl`, because at `md` the title is already compressed below its
+`max-w-130`.
+
+**One timestamp per source, two lines.** More honest per figure — the printed
+time would never understate by more than the gap inside a single source. Costs a
+line, and the gap inside `LJAC1` alone was 12 minutes on the day this was
+measured, so the second line does not buy as much as it looks like it does.
+
+**Moving the attribution into `ConditionsNotes`.** That component is `<details>`,
+closed by default, at the page bottom, and its API is `{ entries, reach }` —
+inventory-wide constants with no per-beach data. The move would need a new
+per-beach parameter on a component built for the opposite, and would put "which
+buoy is this?" one click and one page-scroll away. ADR-0010's guarantee is that
+no figure is shown without the reader being able to see where it came from; one
+visible line under the band costs about 20px and keeps it intact.
+
+**Showing the modelled height in the band on the 36 beaches with no buoy.**
+Every route would get two figures. Rejected outright: the band's entire claim is
+that this is what was measured, and ADR-0019 records the model and the buoy
+disagreeing 2.0 ft against 0.8 ft at La Jolla Shores on 2026-08-26.
+
+**Dropping `revalidate` to 60s so the server can print "now".** No client island
+and no hydration question, at fifteen times the origin renders — and the clock
+would still be up to a minute stale, with a CDN free to serve a
+stale-while-revalidate copy older than that. A real bill for a smaller lie.
+
+## Out of scope
+
+- The rip current line. It stays where it is, under the chooser, outside the
+  band. ADR-0009 forbids a relayed judgement _inside_ a block claiming to be
+  measurements; adjacency is already the shipped layout and is not the problem.
+- `MAX_WAVE_AGE_MINUTES` and `MAX_OBSERVATION_AGE_MINUTES`. Tightening the
+  acceptance window would make one bound honest by construction, but it changes
+  what the page shows rather than how it labels it, on every beach. If the
+  timestamps make the 180-minute window look wrong once they are visible, that
+  is its own decision with its own evidence.
+- The week grid and the day chart, except for the sentences PR 2 moves into
+  them. Their own figures, tabs and rows are untouched.
+- Issues. This plan is three strictly sequential pull requests on one branch
+  each; two people could not pick up two of them without colliding, which is the
+  test `CLAUDE.md` sets for whether splitting earns its keep.

--- a/src/components/conditions/ConditionsSection.test.tsx
+++ b/src/components/conditions/ConditionsSection.test.tsx
@@ -216,6 +216,7 @@ const MEASURED = {
       periodS: 5,
       directionDegT: 278,
       waterTempF: 69.98,
+      observedAtMs: Date.UTC(2026, 7, 17, 18, 13),
     },
   },
   air: {

--- a/src/components/conditions/ConditionsSection.test.tsx
+++ b/src/components/conditions/ConditionsSection.test.tsx
@@ -228,6 +228,7 @@ const MEASURED = {
       windMph: 8.05,
       gustMph: null,
       windDirDegT: 320,
+      observedAtMs: Date.UTC(2026, 7, 17, 17, 48),
     },
   },
 };

--- a/src/components/conditions/MeasuredPanel.test.tsx
+++ b/src/components/conditions/MeasuredPanel.test.tsx
@@ -29,6 +29,7 @@ const AIR = {
     windMph: 8.05,
     gustMph: null,
     windDirDegT: 320,
+    observedAtMs: Date.UTC(2026, 7, 17, 17, 48),
   },
 };
 

--- a/src/components/conditions/MeasuredPanel.test.tsx
+++ b/src/components/conditions/MeasuredPanel.test.tsx
@@ -16,6 +16,7 @@ const WAVES = {
     periodS: 5,
     directionDegT: 278,
     waterTempF: 69.98,
+    observedAtMs: Date.UTC(2026, 7, 17, 18, 13),
   },
 };
 

--- a/src/components/conditions/MeasuredToday.test.tsx
+++ b/src/components/conditions/MeasuredToday.test.tsx
@@ -9,12 +9,16 @@ const FAR_BUOY = { name: "Point Loma South", distanceM: 34_159 };
 /** Scripps Pier: the one station the air card names, and the only one it reads. */
 const PIER = { name: "Scripps Pier", distanceM: 1_381 };
 
+/** 2026-08-17, 11:13 AM Pacific: a time, not a round hour, so a formatter that dropped the minutes would show. */
+const WAVE_TAKEN_AT_MS = Date.UTC(2026, 7, 17, 18, 13);
+
 const WAVE_READING = {
   kind: "reading",
   heightFt: 2.62,
   periodS: 5,
   directionDegT: 278,
   waterTempF: 69.98,
+  observedAtMs: WAVE_TAKEN_AT_MS,
 } as const;
 
 const AIR_READING = {
@@ -183,6 +187,43 @@ test("every wave height band has its own words", () => {
     expect(screen.getByText(`${words}.`)).toBeDefined();
     unmount();
   }
+});
+
+test("the buoy's line states when it read, and no longer claims it was now", () => {
+  render(<MeasuredToday readings={readings()} />);
+
+  const line = screen.getByText(/NDBC/).textContent ?? "";
+  // Pacific, because the reading is: the buoy is off San Diego and the row is
+  // 18:13 UTC. A line printing 6:13 PM would be the test runner's clock.
+  expect(line).toContain("11:13 AM");
+  // ADR-0054. MAX_WAVE_AGE_MINUTES is 180, so this label stood over readings
+  // up to three hours old and asserted the one thing it could not know.
+  expect(line).toContain("Measured");
+  expect(line).not.toContain("Measured now");
+});
+
+test("a quiet buoy is still credited, with no time to state", () => {
+  render(
+    <MeasuredToday
+      readings={readings({
+        waves: {
+          state: {
+            kind: "unavailable",
+            detail: "NDBC timed out.",
+            drift: false,
+          },
+        },
+      })}
+    />,
+  );
+
+  // By the buoy's name rather than by /NDBC/: the disclosure this state opens
+  // quotes the feed's own message, which names NDBC too.
+  const line = screen.getByText(new RegExp(NEAR_BUOY.name)).textContent ?? "";
+  // Which buoy was asked is a fact about the beach and survives the outage.
+  // The time is not: there is no row, so the line must not invent one.
+  expect(line).toContain(NEAR_BUOY.name);
+  expect(line).not.toMatch(/\d{1,2}:\d{2}\s?(AM|PM)/);
 });
 
 test("a nearby buoy is credited without a distance", () => {

--- a/src/components/conditions/MeasuredToday.test.tsx
+++ b/src/components/conditions/MeasuredToday.test.tsx
@@ -21,12 +21,20 @@ const WAVE_READING = {
   observedAtMs: WAVE_TAKEN_AT_MS,
 } as const;
 
+/**
+ * 2026-08-17, 10:48 AM Pacific: 25 minutes behind the buoy's row, the way the
+ * two feeds actually run. Different from `WAVE_TAKEN_AT_MS` so a card printing
+ * its neighbour's time would be visible rather than coincidentally right.
+ */
+const AIR_TAKEN_AT_MS = Date.UTC(2026, 7, 17, 17, 48);
+
 const AIR_READING = {
   kind: "reading",
   airTempF: 71.42,
   windMph: 8.05,
   gustMph: null,
   windDirDegT: 320,
+  observedAtMs: AIR_TAKEN_AT_MS,
 } as const;
 
 /**
@@ -468,6 +476,42 @@ test("the air station is named, with its distance", () => {
   const air = screen.getByText(/Scripps Pier/).textContent ?? "";
   expect(air).toContain("Temperature and wind");
   expect(air).toContain("about 1.4 km from this beach");
+});
+
+test("the air line states a bound where the wave line states a time", () => {
+  render(<MeasuredToday readings={readings()} />);
+
+  const air = screen.getByText(/Scripps Pier/).textContent ?? "";
+  // "Nothing older than" and not "measured at". An NDBC station ages
+  // temperature and wind on their own rows, so these two figures can be an hour
+  // apart, and this card cannot see which network answered. ADR-0054.
+  expect(air).toContain("nothing older than 10:48 AM");
+
+  // The two cards read two feeds and must not print one instant between them.
+  // The wave row here is 25 minutes newer, which is the shape the feeds
+  // actually have.
+  const sea = screen.getByText(/NDBC/).textContent ?? "";
+  expect(sea).toContain("11:13 AM");
+  expect(sea).not.toContain("10:48 AM");
+});
+
+test("a station that could not be reached is credited with no time", () => {
+  render(
+    <MeasuredToday
+      readings={readings({
+        air: {
+          air: {
+            kind: "unavailable",
+            detail: "The station did not answer.",
+            drift: false,
+          },
+        },
+      })}
+    />,
+  );
+
+  const air = screen.getByText(/Scripps Pier/).textContent ?? "";
+  expect(air).not.toMatch(/\d{1,2}:\d{2}\s?(AM|PM)/);
 });
 
 test("a gust is shown when the station published one", () => {

--- a/src/components/conditions/MeasuredToday.tsx
+++ b/src/components/conditions/MeasuredToday.tsx
@@ -45,6 +45,7 @@
  */
 
 import type { AirView, WavesView } from "@/lib/conditions";
+import { localTimeOf } from "@/lib/pacific-time";
 import { type NotShared, withheldWords } from "./areaScope";
 import { compassWords } from "./bearing";
 import { CARD_PROSE } from "./cardText";
@@ -123,12 +124,14 @@ function heightWords(feet: number): string {
  * modelled heights are instead, unconditionally. It can no longer be wrong
  * about whether a forecast arrived, because it no longer asks.
  *
- * **`Measured now` stays on the provenance line, against a different second
- * thing.** ADR-0016 put that label there to separate the buoy from the MOP
- * block below it. The block has gone one region up and become a curve, so the
- * label now separates this figure from the chart rather than from a sibling
- * group — which is the same distinction, drawn between the same two kinds of
- * claim, at the distance the page now puts them.
+ * **`Measured` stays on the provenance line, and lost the word `now`.**
+ * ADR-0016 put that label there to separate the buoy from the MOP block below
+ * it. The block has gone one region up and become a curve, so the label now
+ * separates this figure from the chart rather than from a sibling group — the
+ * same distinction, between the same two kinds of claim, at the distance the
+ * page now puts them. What `now` was asserting is asserted properly by the time
+ * beside it: `MAX_WAVE_AGE_MINUTES` is 180, so this label stood over readings
+ * up to three hours old and said they were current. See ADR-0054.
  */
 function SeaCard({ beachName, buoy, state }: WavesView) {
   const distanceM = buoy?.distanceM ?? null;
@@ -234,10 +237,23 @@ function SeaCard({ beachName, buoy, state }: WavesView) {
 
       {buoy !== null && (
         <ProvenanceLine
-          label="Measured now"
+          label="Measured"
           source={`Buoy ${buoy.name}`}
           network="NDBC"
           distanceKm={distantKm}
+          /*
+            The row's own time, stated rather than bounded: every figure on this
+            card came off one line of `realtime2`, so there is nothing here for
+            a bound to be a bound over. The air card next door says it the other
+            way for the opposite reason. See ADR-0054.
+
+            `null` outside a reading, where there is no row and so no time. The
+            line still renders: which buoy was asked is a fact about a beach and
+            stays true when the buoy is quiet.
+          */
+          observed={
+            state.kind === "reading" ? localTimeOf(state.observedAtMs) : null
+          }
         />
       )}
     </ReadingCard>

--- a/src/components/conditions/MeasuredToday.tsx
+++ b/src/components/conditions/MeasuredToday.tsx
@@ -454,6 +454,19 @@ function AirCard({ beachName, airStation, air }: AirView) {
               ? roundedKm(airStation.distanceM)
               : null
           }
+          /*
+            A bound, not a time, and the wave card next door states its time
+            instead. The difference is the feed: an NDBC station ages
+            temperature and wind independently, so these two figures can be an
+            hour apart, and this card cannot see which network answered.
+            "Nothing older than" is true of either; "measured at" is false of
+            the wind whenever the temperature is the older row. See ADR-0054.
+          */
+          observed={
+            air.kind === "reading"
+              ? `nothing older than ${localTimeOf(air.observedAtMs)}`
+              : null
+          }
         />
       )}
 

--- a/src/components/conditions/ProvenanceLine.test.tsx
+++ b/src/components/conditions/ProvenanceLine.test.tsx
@@ -139,3 +139,34 @@ test("on a card it keeps the colour measured against that card", () => {
     "text-white/55",
   );
 });
+
+/**
+ * The fifth fact, and the one the caller words rather than this component.
+ *
+ * A source read off one row states its time and a source read off several
+ * states a bound, and which of those is true depends on how the read was
+ * composed -- something this component cannot see. So it renders the string it
+ * is handed, in one position, and does not decide what the claim is. ADR-0054.
+ */
+test("an observation time is rendered as the caller worded it", () => {
+  render(
+    <ProvenanceLine
+      source={SOURCE}
+      network="NDBC"
+      observed="nothing older than 1:48 PM"
+    />,
+  );
+
+  const line = screen.getByText(/NDBC/).textContent ?? "";
+  expect(line).toContain("nothing older than 1:48 PM");
+  // The claim survives verbatim. A component that reworded this could turn a
+  // bound into a point, which is the one thing the wording is protecting.
+  expect(line).not.toContain("Measured now");
+});
+
+test("no time is shown when the caller has none to give", () => {
+  render(<ProvenanceLine source={SOURCE} network="NDBC" />);
+
+  const line = screen.getByText(/NDBC/).textContent ?? "";
+  expect(line).toBe(`${SOURCE} · NDBC`);
+});

--- a/src/components/conditions/ProvenanceLine.tsx
+++ b/src/components/conditions/ProvenanceLine.tsx
@@ -1,5 +1,6 @@
 /**
- * Which instrument answered, who publishes it, and how far away it stands.
+ * Which instrument answered, who publishes it, how far away it stands and when
+ * it read.
  *
  * **This is the half of the old attribution paragraph that stayed.** The other
  * half — what the figure means — went to `ConditionsNotes`, because it was the
@@ -60,6 +61,20 @@ type ProvenanceLineProps = {
    * the unit and the reference point -- belongs to this component.
    */
   distanceKm?: string | null;
+  /**
+   * When the reading was taken, already worded by the caller.
+   *
+   * **The wording is the caller's because the claim is.** A source read off one
+   * row states its time — `2:26 PM` — and a source read off several states a
+   * bound — `nothing older than 1:48 PM`. Which of those is true depends on how
+   * the read was composed, which this component cannot see. It renders the
+   * fifth fact and does not decide what the fact is. See ADR-0054.
+   *
+   * Last of the interpunct segments, one placement for every caller, for the
+   * reason the distance wording moved in here: four wordings of one fact across
+   * three components is what this component exists to prevent.
+   */
+  observed?: string | null;
   /** Why this source and not a nearer one, when there is something to say. */
   note?: string | null;
   /** What these figures are, when a card carries more than one source. */
@@ -101,6 +116,7 @@ export function ProvenanceLine({
   source,
   network = null,
   distanceKm = null,
+  observed = null,
   note = null,
   label = null,
   surface = "card",
@@ -113,6 +129,7 @@ export function ProvenanceLine({
       {source}
       {network !== null ? ` · ${network}` : ""}
       {distanceKm !== null ? ` · about ${distanceKm} km from this beach` : ""}
+      {observed !== null ? ` · ${observed}` : ""}
       {note !== null ? ` — ${note}` : ""}
     </p>
   );

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -529,6 +529,9 @@ const ndbcAirOk = (overrides = {}) => ({
   windMph: 8.05,
   gustMph: null,
   windDirDegT: 320,
+  // Already the older of the station's two rows when it reaches this layer:
+  // fetchLatestNdbcAir takes that minimum, because only it can see the rows.
+  observedAtMs: Date.UTC(2026, 7, 18, 4, 40),
   url: "https://example.invalid",
   ...overrides,
 });
@@ -565,6 +568,26 @@ test("temperature and wind come from the pier, and nothing else does", async () 
     expect(view.air.airTempF).toBeCloseTo(71.42, 2);
     expect(view.air.windMph).toBeCloseTo(8.05, 2);
   }
+});
+
+test("both networks put an observation time in the view, from their own shapes", async () => {
+  // One field for two feeds that carry the instant differently. NDBC ages
+  // temperature and wind apart and hands over a minimum already taken; the
+  // weather service answers with one observation and one atMs. A view model
+  // that read only one of those would leave half the inventory with a card that
+  // could not say when it read. ADR-0054.
+  fetchLatestNdbcAir.mockResolvedValue(ndbcAirOk());
+  const ndbc = await readLatestAir(BEACH, NOON_PACIFIC_20260817);
+
+  if (ndbc.air.kind !== "reading") throw new Error("expected a reading");
+  expect(ndbc.air.observedAtMs).toBe(Date.UTC(2026, 7, 18, 4, 40));
+
+  fetchLatestObservation.mockResolvedValue(nwsObservationOk());
+  // The bay: no buoy, and an air station on the weather service's network.
+  const nws = await readLatestAir(BAY_BEACH, NOON_PACIFIC_20260817);
+
+  if (nws.air.kind !== "reading") throw new Error("expected a reading");
+  expect(nws.air.observedAtMs).toBe(KNKX_OBSERVATION.atMs);
 });
 
 test("the airport is not asked at all any more", async () => {

--- a/src/lib/conditions.test.ts
+++ b/src/lib/conditions.test.ts
@@ -411,6 +411,36 @@ test("a wave reading carries the buoy, its distance and the water temperature", 
   });
 });
 
+test("a wave reading carries the row's own time, not the time it was read", async () => {
+  // Forty-seven minutes behind `nowMs`, which is the whole point of the
+  // assertion: MAX_WAVE_AGE_MINUTES is 180, so a buoy this stale is admitted
+  // and used to print under a label saying "Measured now". A view model that
+  // reported the read's clock rather than the row's would pass every other
+  // test in this file and lie on the page. See ADR-0054.
+  const takenAtMs = NOON_PACIFIC_20260817 - 47 * 60_000;
+  fetchLatestWave.mockResolvedValue({
+    kind: "ok",
+    observation: {
+      atMs: takenAtMs,
+      heightFt: 2.62,
+      periodS: 5,
+      directionDegT: 278,
+      waterTempF: 69.98,
+    },
+    ageMinutes: 47,
+    url: "https://example.invalid",
+  });
+
+  const view = await readLatestWaves(
+    "la-jolla-shores-beach",
+    NOON_PACIFIC_20260817,
+  );
+
+  if (view.state.kind !== "reading") throw new Error("expected a reading");
+  expect(view.state.observedAtMs).toBe(takenAtMs);
+  expect(view.state.observedAtMs).not.toBe(NOON_PACIFIC_20260817);
+});
+
 test("a bay beach is never asked about, because there is nothing to ask", async () => {
   const view = await readLatestWaves(BAY_BEACH, NOON_PACIFIC_20260817);
 

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -656,6 +656,19 @@ export type WavesState =
       periodS: number | null;
       directionDegT: number | null;
       waterTempF: number | null;
+      /**
+       * When the buoy took this reading, epoch milliseconds UTC.
+       *
+       * **One row, so this is exact rather than a bound.** Height, period,
+       * direction and water temperature all come off the same line of
+       * `realtime2`; the air half of this block is up to two rows and says so
+       * differently. See ADR-0054.
+       *
+       * Raw rather than worded, unlike `WaveReading.timeLabel` next door. Two
+       * labels cannot be compared, and the measured band composes one bound
+       * across both sources by taking the older of them.
+       */
+      observedAtMs: number;
     }
   | {
       kind: "no-buoy";
@@ -744,6 +757,12 @@ export async function readLatestWaves(
       periodS: result.observation.periodS,
       directionDegT: result.observation.directionDegT,
       waterTempF: result.observation.waterTempF,
+      // The row's own time, which `fetchLatestWave` has already held against
+      // MAX_WAVE_AGE_MINUTES. Carried rather than recomputed: the limit that
+      // let this row through and the time the page prints must be the same
+      // instant, or the page can say a reading is older than the check that
+      // admitted it.
+      observedAtMs: result.observation.atMs,
     },
   };
 }

--- a/src/lib/conditions.ts
+++ b/src/lib/conditions.ts
@@ -783,6 +783,21 @@ export type AirState =
       windMph: number | null;
       gustMph: number | null;
       windDirDegT: number | null;
+      /**
+       * The oldest row that contributed a figure, epoch milliseconds UTC.
+       *
+       * **A bound, where the wave read's is exact**, and the difference is the
+       * feed rather than a choice about wording. An NDBC station ages
+       * temperature and wind independently, on purpose, so this half of the
+       * block is two rows as often as one. An NWS station answers with a single
+       * observation and this is that instant.
+       *
+       * The card cannot tell those apart and must not try: `StationBinding`
+       * carries no network, deliberately (ADR-0010). So it words this as a
+       * bound in both cases — conservative on the NWS path, correct on the NDBC
+       * one, and never false on either. See ADR-0054.
+       */
+      observedAtMs: number;
     }
   | { kind: "no-station"; reason: string }
   | { kind: "unavailable"; detail: string; drift: boolean };
@@ -888,6 +903,10 @@ async function readAirHalf(
       windMph: result.windMph,
       gustMph: result.gustMph,
       windDirDegT: result.windDirDegT,
+      // Already the oldest of the rows still standing: this feed publishes
+      // temperature and wind on their own cadences and `fetchLatestNdbcAir`
+      // ages them apart.
+      observedAtMs: result.observedAtMs,
     };
   }
 
@@ -902,6 +921,10 @@ async function readAirHalf(
     windMph: observation.windMph,
     gustMph: observation.gustMph,
     windDirDegT: observation.windDirDegT,
+    // One observation, so one instant, and no minimum to take. The card still
+    // words it as a bound: it cannot see which network answered, and a bound
+    // over a set of one is true.
+    observedAtMs: observation.atMs,
   };
 }
 

--- a/src/lib/upstream.test.ts
+++ b/src/lib/upstream.test.ts
@@ -532,6 +532,49 @@ describe("fetchLatestNdbcAir", () => {
     expect(result.airTempF).toBeNull();
   });
 
+  test("the observation time is the older of the two rows, not the newer", async () => {
+    // What the card prints one time over both figures from. The newer row would
+    // let a fresh wind vouch for a temperature 45 minutes behind it, which on
+    // this feed is the ordinary case: probed 2026-09-04, LJAC1 published wind
+    // at 21:00 and temperature at 20:48. ADR-0054.
+    const text = [
+      HEADER,
+      row("2026 08 19 02 30", { wdir: "320", wspd: "3.6", gst: "4.6" }),
+      row("2026 08 19 01 45", { atmp: "23.4" }),
+      "",
+    ].join("\n");
+    fetchMock.mockResolvedValue(textResponse(text));
+
+    const result = await fetchLatestNdbcAir("LJAC1", AT_PIER);
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.observedAtMs).toBe(Date.UTC(2026, 7, 19, 1, 45));
+    expect(result.observedAtMs).not.toBe(Date.UTC(2026, 7, 19, 2, 30));
+  });
+
+  test("a row aged out of the reading does not bound it", async () => {
+    // The temperature is four hours stale, so it is not on the card -- and a
+    // time bounding a figure the reader cannot see would report the whole
+    // reading as four hours old when the only figure shown is current. The
+    // minimum is taken over the rows that survived `fresh`, not over the rows
+    // the parser found.
+    const text = [
+      HEADER,
+      row("2026 08 19 02 30", { wdir: "320", wspd: "3.6", gst: "4.6" }),
+      row("2026 08 18 22 00", { atmp: "23.4" }),
+      "",
+    ].join("\n");
+    fetchMock.mockResolvedValue(textResponse(text));
+
+    const result = await fetchLatestNdbcAir("LJAC1", AT_PIER);
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") return;
+    expect(result.airTempF).toBeNull();
+    expect(result.observedAtMs).toBe(Date.UTC(2026, 7, 19, 2, 30));
+  });
+
   test("keeps a temperature exactly at the limit", async () => {
     // A boundary that decides whether a reading shows at all, so it is asserted
     // rather than left to the comparison operator.

--- a/src/lib/upstream.ts
+++ b/src/lib/upstream.ts
@@ -460,6 +460,20 @@ export type AirReadingResult =
       windMph: number | null;
       gustMph: number | null;
       windDirDegT: number | null;
+      /**
+       * The oldest row that contributed a value, epoch milliseconds UTC.
+       *
+       * **Oldest and not newest**, because the caller prints one time over both
+       * figures. The newest would let a fresh wind vouch for a temperature an
+       * hour behind it, which on this feed is the ordinary case rather than the
+       * edge one: probed 2026-09-04, LJAC1 published wind at 21:00 and
+       * temperature at 20:48, its `ATMP` column blank on the four newest rows.
+       *
+       * Only rows whose value survived `fresh` count. A temperature aged out of
+       * the window is not on the card, so the time it was taken is not a bound
+       * on anything the reader can see. See ADR-0054.
+       */
+      observedAtMs: number;
       url: string;
     }
   | { kind: "unavailable"; reason: string; drift: boolean; url: string };
@@ -550,10 +564,28 @@ export async function fetchLatestNdbcAir(
     );
   }
 
+  /*
+    The rows still standing on the card, and the oldest of them.
+
+    A field nulled by `fresh` is not on the card, so its row bounds nothing a
+    reader can see -- which is why this reads `airTempF`/`windMph` rather than
+    `observation.airTemp`/`observation.wind`. Gust and direction add no third
+    candidate: they came off the wind's own row.
+
+    Never empty. The branch above returns `unavailable` when both fields are
+    null, so at least one instant reaches this line, and the non-null assertion
+    is that guarantee rather than an assumption about the feed.
+  */
+  const contributing = [
+    airTempF === null ? null : observation.airTemp!.atMs,
+    windMph === null ? null : observation.wind!.atMs,
+  ].filter((atMs): atMs is number => atMs !== null);
+
   return {
     kind: "ok",
     airTempF,
     windMph,
+    observedAtMs: Math.min(...contributing),
     // Gust and direction ride on the wind's own freshness: they came off that
     // row, and without a current speed they describe nothing.
     gustMph: fresh(


### PR DESCRIPTION
The first of three PRs for `docs/plans/the-measured-band.md`. It fixes a defect
on its own and moves no layout: the two dark cards are untouched apart from what
their provenance lines say.

## The defect

`MAX_WAVE_AGE_MINUTES` and `MAX_OBSERVATION_AGE_MINUTES` are both 180. A buoy
publishing every thirty minutes can miss five cycles and still be inside the
window. The observation's own timestamp was read in `lib/upstream.ts`, used to
enforce that limit, and then dropped — so nothing below `lib/conditions.ts`
could contradict a provenance line reading **`Measured now`**.

`CONTEXT.md`'s **Conditions** entry has always said this tool shows readings
"attributed and timestamped". The attribution shipped; the timestamp never did.

## What changed

**`docs/adr/0054-a-reading-states-when-it-was-taken.md`** — the decision, which
is narrower than "show a timestamp". A reading is not one row, so `observedAtMs`
is the **oldest** row that contributed to it; a single-row source states its
time and a multi-row source states a bound; and "now" cannot come from the
server at `revalidate = 900`.

**The buoy** — `WavesState.reading` carries `observedAtMs`, taken from the
observation rather than recomputed, so the instant the page prints and the
instant the freshness check admitted cannot diverge. The label becomes
`Measured` and the time follows it. Stated rather than bounded, because a wave
read is one line of `realtime2`.

**The air station** — `AirState.reading` carries `observedAtMs`. On the NDBC
path it is the minimum over the rows that *survived* the freshness check, not
over the rows the parser found: a temperature aged out of the window is not on
the card, and a time bounding a figure the reader cannot see would report a
current wind as four hours old. On the NWS path there is one observation and one
instant. The card words it as a bound either way — `StationBinding` carries no
network by ADR-0010, so it cannot tell the two apart, and a bound is true of
both.

**`ProvenanceLine`** gains a fifth fact, `observed`, worded by the caller
because the *claim* is the caller's. One placement for every call site, which is
what that component exists to enforce.

## Verified against the live feeds, not only fixtures

Probed NDBC on 2026-09-04 at 21:26 UTC for Shell Beach — buoy `46254`, station
`LJAC1`:

| value | newest row | local |
| --- | --- | --- |
| wave height | 21:26 UTC | 2:26 PM |
| wind | 21:00 UTC | 2:00 PM |
| air temperature | 20:48 UTC | 1:48 PM |

`LJAC1`'s `ATMP` column was blank on its four newest rows, which is why the
oldest-row rule is the ordinary case here rather than an edge one.

`generateStaticParams` returns `[]`, so `build` compiles these routes and
renders none — the page was checked by curling the dev server. At 00:43 UTC:

```
Measured · Buoy Scripps Nearshore · NDBC · 4:56 PM
Temperature and wind · Scripps Pier · nothing older than 5:00 PM
```

That wave reading is 47 minutes old and said `Measured now` before this branch.
The two times differ, which is the property showing the cards do not share one
value.

## The new assertions were checked by mutation

A test that passes proves nothing until it can fail:

- `observedAtMs: Math.min(...)` → `Math.max(...)`
  → `✗ the observation time is the older of the two rows, not the newer`
- the air card's `nothing older than` → `measured at`
  → `✗ the air line states a bound where the wave line states a time`

The existing wave-reading fixture set `observation.atMs` equal to `nowMs`, so it
could not have distinguished a view model reporting the read's clock from one
reporting the row's. The regression test uses a row 47 minutes behind.

## Gate

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  areas
  PASS  test
  PASS  build
  PASS  stylesheet
```

## What this does not do

- **The 180-minute windows are not touched.** Tightening them would make the
  bound honest by construction, but it changes what the page shows rather than
  how it labels it, on every beach. If they look wrong now the times are
  visible, that is its own decision — and it will have evidence, which it did
  not before.
- **No client clock yet.** ADR-0054 settles where "now" comes from; the
  component arrives with the band in PR 3, since there is nowhere useful to put
  it on a card.
- **No layout moves and nothing is deleted.** The band, the deletions and the
  relocation of the wave-absence prose are PRs 2 and 3.
- ADR-0016 and ADR-0029 both quote `Measured now` in their own text. They are
  dated records and are left as written; ADR-0054 says in its header that it
  narrows the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
