### PR TITLE
Word a wave absence where the model that replaces it is drawn

### DIFF
--- a/docs/adr/0055-wave-absences-are-worded-where-the-model-is-drawn.md
+++ b/docs/adr/0055-wave-absences-are-worded-where-the-model-is-drawn.md
@@ -1,0 +1,94 @@
+# 0055 — A wave absence is worded where the model that replaces it is drawn
+
+Date: 2026-09-04. Status: accepted. Discharges a condition of ADR-0019 by
+moving it; applies ADR-0049's rule to a panel that is about to lose its slot.
+Plan: `docs/plans/the-measured-band.md`.
+
+## Context
+
+**Thirty-six of the fifty-one beaches have no wave buoy.** All fifty-one have an
+air station. Ten of the thirty-six are the beaches ADR-0019 admits, where a CDIP
+MOP line answers for the waves and no instrument does; the rest are bays,
+lagoons and inlets where swell does not reach at all.
+
+Applying ADR-0048's intersection rule over the eighteen areas gives the same
+shape one level up: waves are `shared` in 3 areas, `mixed` in 2 and `absent` in 13. So a measured wave height exists on 15 of 51 beach pages and 3 of 18 area
+pages — **18 of 69 routes**.
+
+Today every one of the other 51 routes says so inside the measured block, in a
+card: a paragraph, plus a `<details>` carrying the join's own reason. That was
+the right shape while the block was two cards, and ADR-0049 says so in as many
+words — "that block is two cards, one per product, so a withheld product is a
+card". `docs/plans/the-measured-band.md` takes the block to one line, and a line
+has no room for a paragraph.
+
+**The question is not where the sentence fits. It is who the sentence is for.**
+ADR-0019 names the reader it protects: "a parent reading '1.5 ft' before taking
+children into the water is not weighing model against instrument", and it
+records the model and the buoy disagreeing 2.0 ft against 0.8 ft at La Jolla
+Shores on 2026-08-26. That reader is looking at a **modelled height**. The
+modelled heights are drawn in two places, and neither of them is the measured
+block: the day chart's swell tab, and the week grid's wave row.
+
+So the disclosure has been sitting one region away from the figure it is about.
+
+## Decision
+
+**A sentence explaining a missing wave measurement is worded where the model
+standing in for it is drawn.** Two homes, because there are two drawings:
+
+- **The week grid**, as a note under it. That array already carries every "why
+  is this row not what you expected" sentence, conditional, one per cause.
+- **The day chart's swell tab**, on the provenance line, as its note. That line
+  already carries `MOP_MODEL_NOTE` — "a model of the swell at 10 m depth, not a
+  measurement" — which is the same claim about the same figure, one clause
+  short of this one.
+
+**Not in the `absence` slot**, and this is the part most likely to be got
+wrong. `HourSeries.absence` is "what to say instead of a plot when `points` is
+empty", and on the ten ADR-0019 beaches the plot is **not** empty: MOP answers,
+the curve draws, and a sentence in the absence slot would never render. The
+whole risk this discloses is a reader trusting a curve that is there.
+
+**The measured block keeps the absence and hands over the substitution.** Its
+card said two things — that no buoy reaches this coast, and that every wave
+height on the page is therefore modelled. The first is a fact about this beach
+and stays where the reader asks "what was measured here". The second is a fact
+about the other two panels and belongs beside them.
+
+## Consequences
+
+**ADR-0019's condition is discharged, not weakened, and the wording is
+stronger.** That decision requires the page to say "the height shown is
+modelled" and warns that if the disclosure "is ever removed or weakened, this
+decision goes with it". It now sits on the attribution of the modelled height
+itself, on both panels that draw one, rather than one region above them in a
+block about a different thing. A reader who scrolls past the measured block —
+which is most of them, since it is the part with no figure on these beaches —
+used to miss it entirely.
+
+**ADR-0049's rule survives its own example.** That decision's rule is that a
+withheld product is worded "in the slot its own panel already uses for a product
+it cannot draw". Its worked example was the measured block's card, because that
+was the panel in question. Here the panel that cannot draw is the wave row and
+the swell tab, and both already have such a slot. The rule generalises; the
+example was never the rule.
+
+**A note fires on inventory, not on a fetch.** Whether a beach has a buoy is
+`beach.wave_buoy`, known without a request, so the week's note does not wait on
+CDIP and does not vanish when CDIP is quiet. That is deliberate: ADR-0019
+already records that `modelAnswersInstead` is "carried as a fact from the join
+rather than inferred from whether a forecast happened to arrive, because CDIP
+having a bad day must not make the card claim swell does not reach an open
+coast."
+
+**One existing sentence pointed at the card and is repaired.** The week's
+`no-line` note reads "for the same reason as the reading above", which is the
+wave card. With a second wave note landing in the same array the pointer becomes
+ambiguous, and the card is scheduled for deletion regardless. It states the
+reason instead of pointing at it.
+
+**A bay is not an ADR-0019 beach and gets no such note.** Where there is no buoy
+_and_ no line, nothing is drawn to be disclosed about, and the week's existing
+`no-line` note already says why. Telling a lagoon's reader that its wave heights
+are modelled would name a figure the page does not show.

--- a/docs/adr/0055-wave-absences-are-worded-where-the-model-is-drawn.md
+++ b/docs/adr/0055-wave-absences-are-worded-where-the-model-is-drawn.md
@@ -28,21 +28,33 @@ children into the water is not weighing model against instrument", and it
 records the model and the buoy disagreeing 2.0 ft against 0.8 ft at La Jolla
 Shores on 2026-08-26. That reader is looking at a **modelled height**. The
 modelled heights are drawn in two places, and neither of them is the measured
-block: the day chart's swell tab, and the week grid's wave row.
+block: the week grid's wave row, the day chart's swell tab, and the shore map's
+readout.
 
 So the disclosure has been sitting one region away from the figure it is about.
 
 ## Decision
 
-**A sentence explaining a missing wave measurement is worded where the model
-standing in for it is drawn.** Two homes, because there are two drawings:
+**A sentence explaining a missing wave measurement is worded on the attribution
+of the modelled height that replaces it, everywhere one is drawn.** Three
+places, and the rule rather than the list is what is being decided — a fourth
+drawing would take it too.
 
-- **The week grid**, as a note under it. That array already carries every "why
-  is this row not what you expected" sentence, conditional, one per cause.
-- **The day chart's swell tab**, on the provenance line, as its note. That line
-  already carries `MOP_MODEL_NOTE` — "a model of the swell at 10 m depth, not a
-  measurement" — which is the same claim about the same figure, one clause
-  short of this one.
+- **The week grid's wave row**, on its provenance line.
+- **The day chart's swell tab**, on its provenance line.
+- **The shore map's readout**, on the swell row's provenance line.
+
+All three already carry `MOP_MODEL_NOTE` — "a model of the swell at 10 m depth,
+not a measurement" — which is the same claim about the same figure, one clause
+short of this one. The clause is appended to it, semicolon-joined, the way the
+cloud row composes `GRID_MODEL_NOTE` with its cell caveat.
+
+**On the attribution and not in the week's notes array**, which was the first
+answer and is the wrong one. That array says why a row a reader expected is
+_not there_; this says what a row that _is_ there is made of. Putting it in the
+notes would also have left the claim in two shapes — a free sentence in one
+region, a provenance clause in the other two — for one fact, which is the drift
+`mopLine.ts` exists to prevent.
 
 **Not in the `absence` slot**, and this is the part most likely to be got
 wrong. `HourSeries.absence` is "what to say instead of a plot when `points` is
@@ -81,6 +93,15 @@ already records that `modelAnswersInstead` is "carried as a fact from the join
 rather than inferred from whether a forecast happened to arrive, because CDIP
 having a bad day must not make the card claim swell does not reach an open
 coast."
+
+**The third drawing was found while building the second, and the decision is
+what changed rather than the code.** This ADR first named two homes and put the
+week's in the notes array. The shore map's readout composes its own MOP
+attribution through `swellStepNote`, so it draws a modelled swell height with a
+provenance line of its own — and would have been the one place on the page
+where a modelled height stood unqualified, which is precisely the state
+ADR-0019 forbids. Naming the rule rather than the list is the repair: any
+attribution built from `MOP_MODEL_NOTE` carries the clause.
 
 **One existing sentence pointed at the card and is repaired.** The week's
 `no-line` note reads "for the same reason as the reading above", which is the

--- a/src/components/conditions/DayPanel.test.tsx
+++ b/src/components/conditions/DayPanel.test.tsx
@@ -519,6 +519,53 @@ test("a read that names no day today selects no hour, rather than midnight", asy
   );
 });
 
+/**
+ * ADR-0019's condition at the second of the two places a modelled height is
+ * drawn (ADR-0055), and the one where getting the slot wrong is invisible.
+ *
+ * NOT in `absence`: at these ten beaches MOP answers and the curve draws, so a
+ * sentence in that slot would never render — and a drawn curve a reader trusts
+ * as a measurement is the entire risk. It goes on the attribution, beside
+ * `MOP_MODEL_NOTE`, which the plot renders whether or not there are points.
+ */
+test("a beach whose only wave source is a model says so on the swell attribution", async () => {
+  const { container } = render(await DayPanel({ slug: "sunset-cliffs-park" }));
+
+  fireEvent.click(container.querySelector('[data-series-tab="swell"]')!);
+
+  // EVERY MOP attribution on the page, not one of them. The rule ADR-0055
+  // decides is that any attribution built from MOP_MODEL_NOTE carries the
+  // clause -- this region draws two, the chart's swell tab and the shore map's
+  // readout, and the second was nearly missed.
+  const lines = screen.getAllByText(/MOP line D0481/);
+  expect(lines.length).toBeGreaterThan(1);
+  for (const line of lines) {
+    // Both clauses, because they say different things: this figure is a model,
+    // and there is no measured figure anywhere on the page to weigh it against.
+    expect(line.textContent).toContain("not a measurement");
+    expect(line.textContent).toContain(
+      "no buoy reaches this beach, so nothing on this page measures its waves",
+    );
+  }
+});
+
+test("a beach with a buoy carries the model clause alone", async () => {
+  // La Jolla Shores has a buoy, so a measured height stands in the block above
+  // and the second clause would be false rather than merely redundant.
+  const { container } = render(
+    await DayPanel({ slug: "la-jolla-shores-beach" }),
+  );
+
+  fireEvent.click(container.querySelector('[data-series-tab="swell"]')!);
+
+  const lines = screen.getAllByText(/MOP line D0481/);
+  expect(lines.length).toBeGreaterThan(1);
+  for (const line of lines) {
+    expect(line.textContent).toContain("not a measurement");
+    expect(line.textContent).not.toContain("no buoy reaches this beach");
+  }
+});
+
 test("a beach with no MOP line says that, not that the feed failed", async () => {
   // Two absences that look alike and are not: 26 of 51 beaches have no line at
   // all, which is permanent, where an outage is this quarter of an hour.

--- a/src/components/conditions/DayPanel.tsx
+++ b/src/components/conditions/DayPanel.tsx
@@ -126,6 +126,7 @@ import {
   MOP_MODEL_NOTE,
   MOP_NETWORK,
   mopLineDistanceKm,
+  mopNote,
   mopLineSource,
   swellFigure,
   swellStepNote,
@@ -513,6 +514,45 @@ export async function DayPanel({
           note: tideStationNote(station.distanceM, station.water),
         };
 
+  /*
+    The beach itself, on a beach page, and null on an area's.
+
+    Hoisted to its first caller: the swell attribution below asks whether a buoy
+    reaches this beach, and the shore map further down asks for its coastline.
+    Two lookups of one slug is the drift `mopLine.ts` and `ProvenanceLine` both
+    exist to stop, one layer down.
+
+    A beach the inventory does not hold is not this component's error to invent
+    an answer for: the route resolved that before rendering, and `beachBySlug`
+    returning null here would mean the page is showing a beach it does not have.
+    The same is true of the area, which `ConditionsSection` resolved before it
+    built the scope.
+  */
+  const beach = area ? null : beachBySlug(slug);
+
+  /*
+    The second of the two places a modelled height is drawn, and so the second
+    place ADR-0019's disclosure has to reach (ADR-0055).
+
+    **On the provenance note and not in `absence`.** That slot is what to say
+    instead of a plot when `points` is empty, and at these ten beaches the plot
+    is not empty: MOP answers, the curve draws, and a sentence there would never
+    render. A drawn curve is the whole risk being disclosed.
+
+    Semicolon-joined onto `MOP_MODEL_NOTE` rather than replacing it, the way the
+    cloud row composes `GRID_MODEL_NOTE` with its cell caveat. The two clauses
+    say different things: one that this figure is a model, the other that there
+    is no measured figure anywhere on the page to weigh it against.
+
+    Beach scope only, and read off the join rather than off `waves.view`: which
+    beach has a buoy is inventory, so a quiet NDBC cannot take this sentence
+    down. `beach` is already null on an area page, where the swell row's own
+    withheld wording answers and naming one member's buoy as the area's is what
+    ADR-0048 forbids.
+  */
+  const unmeasuredWaves =
+    beach !== null && beach.wave_buoy === null && beach.mop_line !== null;
+
   const swellProvenance: ProvenanceFacts | null =
     waves.view === null || waves.view.line === null
       ? null
@@ -521,7 +561,7 @@ export async function DayPanel({
           source: mopLineSource(waves.view.line.id),
           network: MOP_NETWORK,
           distanceKm: mopLineDistanceKm(waves.view.line.distanceM),
-          note: MOP_MODEL_NOTE,
+          note: mopNote(MOP_MODEL_NOTE, unmeasuredWaves),
         };
 
   /*
@@ -807,13 +847,8 @@ export async function DayPanel({
     so until there was a frame built from every member, the column carried a
     sentence saying so.
 
-    A beach the inventory does not hold is not this component's error to invent
-    a map for: the route already answered that question before rendering, and
-    `beachBySlug` returning null here would mean the page is showing a beach it
-    does not have. The same is true of the area, which `ConditionsSection`
-    resolved before it built the scope.
+    `beach` is resolved further up, where the swell attribution first needs it.
   */
-  const beach = area ? null : beachBySlug(slug);
   const areaOnMap = area ? areaBySlug(area.slug) : null;
   const shore =
     areaOnMap !== null
@@ -970,7 +1005,17 @@ export async function DayPanel({
               source: mopLineSource(line.id),
               network: MOP_NETWORK,
               distanceKm: mopLineDistanceKm(line.distanceM),
-              note: swellStepNote({ timeLabel: localTimeOf(step.atMs) }),
+              /*
+                The third drawing of a modelled height, and the one that made
+                ADR-0055 a rule rather than a list of two. This row is a CDIP
+                estimate with a provenance line of its own, so leaving the
+                clause off it would put an unqualified modelled height on the
+                page at exactly the ten beaches ADR-0019 admits.
+              */
+              note: mopNote(
+                swellStepNote({ timeLabel: localTimeOf(step.atMs) }),
+                unmeasuredWaves,
+              ),
             },
           };
           rows.set(step, row);

--- a/src/components/conditions/MeasuredToday.test.tsx
+++ b/src/components/conditions/MeasuredToday.test.tsx
@@ -282,16 +282,13 @@ test("a bay beach is told this is expected, not a fault", () => {
 });
 
 /**
- * The disclosure ADR-0019 was accepted on, which that decision says goes with
- * it if it is "ever removed or weakened". Ten beaches now carry a wave figure
- * that was never measured anywhere, and this is the only place a reader meets
- * that fact before the number.
+ * A beach ADR-0019 admits: no buoy, and a MOP line answering in its place.
  *
- * It got stronger in the move rather than weaker. On the card the sentence
- * pointed at a forecast block eighty pixels below it and had a second form for
- * when CDIP had not answered; there is no block below it now, so it names the
- * chart and the week where those modelled heights actually are, and it says so
- * whatever CDIP is doing.
+ * What this card owes such a reader is the absence — that nothing here was
+ * measured. What ADR-0019 additionally requires, that the heights they *can*
+ * see are modelled, is asserted where those heights are drawn: `WeekPanel`'s
+ * and `DayPanel`'s own tests, on the attribution `mopNote` builds. See
+ * ADR-0055.
  */
 const NO_BUOY_MODELLED = {
   kind: "no-buoy",
@@ -306,25 +303,29 @@ const MODELLED_BEACH = {
   state: NO_BUOY_MODELLED,
 };
 
-test("a beach no buoy reaches is told its wave heights are modelled", () => {
+test("a beach no buoy reaches is told nothing here was measured", () => {
   render(<MeasuredToday readings={readings({ waves: MODELLED_BEACH })} />);
 
-  expect(screen.getByText(/nothing here is measured/)).toBeDefined();
   const sentence =
     screen.getByText(/nothing here is measured/).textContent ?? "";
-  expect(sentence).toContain("comes from a model of the swell");
-  expect(sentence).toContain("not from an instrument in the water");
+  expect(sentence).toContain("No wave buoy reaches this stretch of coast");
 });
 
-test("the disclosure points at where the modelled heights actually are", () => {
-  // It used to say "the wave heights below", which was true when a forecast
-  // block sat beneath it on the card. Below this sentence now is the air card.
+/**
+ * ADR-0055. The half of this sentence saying every wave height on the page is
+ * modelled now hangs off the attribution of each modelled height, in all three
+ * places one is drawn -- the week grid's wave row, the day chart's swell tab
+ * and the shore map's readout. Leaving a copy here would be one claim in two
+ * shapes, and it pointed at panels ("the chart above and in the week above
+ * that") that this card is about to stop sitting above at all.
+ */
+test("the card no longer says what stands in for the missing measurement", () => {
   render(<MeasuredToday readings={readings({ waves: MODELLED_BEACH })} />);
 
   const sentence =
     screen.getByText(/nothing here is measured/).textContent ?? "";
-  expect(sentence).toContain("on the chart above and in the week above that");
-  expect(sentence).not.toContain("below");
+  expect(sentence).not.toContain("comes from a model of the swell");
+  expect(sentence).not.toContain("the chart above");
 });
 
 test("it does not tell an open-coast beach that swell does not reach it", () => {

--- a/src/components/conditions/MeasuredToday.tsx
+++ b/src/components/conditions/MeasuredToday.tsx
@@ -114,15 +114,18 @@ function heightWords(feet: number): string {
  * under each reading. What stays here is what differs per beach: which buoy, and
  * how far away it is when that is far enough to matter.
  *
- * **The `no-buoy` disclosure is a condition of ADR-0019 and it got stronger
- * here rather than weaker.** That decision admits ten beaches whose only wave
- * source is a model, and it says in its own text that if the disclosure "is
- * ever removed or weakened, this decision goes with it". On the card this
- * sentence pointed at the forecast block beneath it and had a second form for
- * when CDIP had not answered. There is no block beneath it now — the model is
- * the chart above and the week above that — so the sentence names where the
- * modelled heights are instead, unconditionally. It can no longer be wrong
- * about whether a forecast arrived, because it no longer asks.
+ * **The `no-buoy` card states an absence, and no longer states what fills
+ * it.** ADR-0019 admits ten beaches whose only wave source is a model on
+ * condition the page says the height is modelled, and warns that if the
+ * disclosure "is ever removed or weakened, this decision goes with it". That
+ * half of the sentence has moved to the attribution of each modelled height,
+ * in all three places one is drawn — the week grid's wave row, the day chart's
+ * swell tab and the shore map's readout. See ADR-0055 and `mopNote`.
+ *
+ * It is stronger there, not weaker: a reader with no measured figure on this
+ * card has no reason to stop at it, and the figure they are at risk of
+ * misreading is a curve one region down. What is left here is this card's own
+ * answer to what was measured, which is nothing, and why.
  *
  * **`Measured` stays on the provenance line, and lost the word `now`.**
  * ADR-0016 put that label there to separate the buoy from the MOP block below
@@ -189,18 +192,23 @@ function SeaCard({ beachName, buoy, state }: WavesView) {
             that reader "every wave buoy sits out on the open coast" would state
             the reason their beach is fine as the reason it is not.
 
-            The second sentence is the disclosure ADR-0019 was accepted on. It
-            leads rather than sitting in the attribution below, because the card
-            has no measured figure at all here and a reader who stops at the
-            plain-words line must still learn that nothing on it was measured.
+            **It says what is absent and no longer what stands in.** A second
+            sentence here carried ADR-0019's disclosure -- that every wave
+            height on the page for this beach is modelled -- and it now hangs
+            off the attribution of each modelled height itself, in all three
+            places one is drawn (ADR-0055). That is where the reader it protects
+            is: looking at a curve, not at a card with no figure on it.
+
+            What is left is this card's own answer to "what was measured here",
+            which is nothing, and why. The disclosure is not weakened by the
+            move; it went from one region above the modelled heights to beside
+            them, three times over.
           */}
           <p className={`leading-relaxed mb-4 text-base ${CARD_PROSE}`}>
             {state.modelAnswersInstead ? (
               <>
                 No wave buoy reaches this stretch of coast, so nothing here is
-                measured. Every wave height this page shows for this beach — on
-                the chart above and in the week above that — comes from a model
-                of the swell, not from an instrument in the water.
+                measured.
               </>
             ) : (
               <>

--- a/src/components/conditions/WeekPanel.test.tsx
+++ b/src/components/conditions/WeekPanel.test.tsx
@@ -615,6 +615,89 @@ test("a beach with no MOP line says so, and keeps the rest of the grid", async (
   expect(daylightWindows()).toHaveLength(2);
 });
 
+/**
+ * ADR-0019's condition, at the first of the two places a modelled height is
+ * drawn (ADR-0055). Ten beaches are admitted to the inventory on the strength
+ * of this sentence, and that decision says in its own text that if the
+ * disclosure "is ever removed or weakened, this decision goes with it".
+ *
+ * `sunset-cliffs-park` is one of the ten: no buoy, a MOP line, and — since it
+ * is the only beach in its area — served at the area's own URL with no scope,
+ * which is the path this note is reachable on.
+ */
+test("a beach whose only wave source is a model says every height here is modelled", async () => {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
+  });
+  readWaveWeek.mockResolvedValue({
+    beachName: "Sunset Cliffs Park",
+    line: { id: "D0045", distanceM: 310 },
+    state: { kind: "week", days: [] },
+  });
+
+  render(await WeekPanel({ slug: "sunset-cliffs-park" }));
+
+  // On the row's own attribution, beside the clause saying the figure is a
+  // model -- not in the notes array, which says why a row a reader expected is
+  // *not* there. This row is there; what is disclosed is what it is made of.
+  const line = screen.getByText(/MOP line/).textContent ?? "";
+  expect(line).toContain("not a measurement");
+  expect(line).toContain(
+    "no buoy reaches this beach, so nothing on this page measures its waves",
+  );
+});
+
+/**
+ * The other half of the same rule. A beach with a buoy has a measured height in
+ * the block above to weigh the model against, so the sentence would be false
+ * there -- and it is the falseness that matters, not the redundancy.
+ */
+test("a beach with a buoy is not told its wave heights are unmeasured", async () => {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
+  });
+  readWaveWeek.mockResolvedValue({
+    beachName: "La Jolla Shores Beach",
+    line: { id: "D0498", distanceM: 240 },
+    state: { kind: "week", days: [] },
+  });
+
+  render(await WeekPanel({ slug: "la-jolla-shores-beach" }));
+
+  const line = screen.getByText(/MOP line/).textContent ?? "";
+  expect(line).toContain("not a measurement");
+  expect(line).not.toContain("no buoy reaches this beach");
+});
+
+/**
+ * A bay has no buoy and no line, so nothing is drawn for the sentence to be
+ * about. Telling a lagoon's reader that its wave heights are modelled would
+ * name a figure the page does not show.
+ */
+test("a bay is told there is no forecast, not that its heights are modelled", async () => {
+  readWeekOfLowestLows.mockResolvedValue({
+    ...BINDING,
+    state: { kind: "week", days: [tideDay(0, "6:41 PM", 0.9)] },
+  });
+  readWaveWeek.mockResolvedValue({
+    beachName: "Children's Pool",
+    line: null,
+    state: { kind: "no-line", reason: "inside a bay" },
+  });
+
+  render(await WeekPanel({ slug: "childrens-pool" }));
+
+  expect(screen.queryByText(/no buoy reaches this beach/)).toBeNull();
+  expect(
+    screen.getByText(/no wave forecast for this beach either/i),
+  ).toBeDefined();
+  // The pointer at the wave card is gone: this note now states the reason
+  // rather than saying "for the same reason as the reading above".
+  expect(screen.queryByText(/the reading above/)).toBeNull();
+});
+
 test("a CDIP outage costs the wave row and nothing else", async () => {
   readWeekOfLowestLows.mockResolvedValue({
     ...BINDING,

--- a/src/components/conditions/WeekPanel.tsx
+++ b/src/components/conditions/WeekPanel.tsx
@@ -65,6 +65,7 @@ import {
   readWeekOfLowestLows,
   type TideHourlyDay,
 } from "@/lib/conditions";
+import { beachBySlug } from "@/lib/beaches";
 import { type AreaScope, withheldBy, withheldWords } from "./areaScope";
 import { DaylightWeek } from "./DaylightWeek";
 import { DaySpark } from "./DaySpark";
@@ -74,6 +75,7 @@ import {
   MOP_NETWORK,
   mopLineDistanceKm,
   mopLineSource,
+  mopNote,
 } from "./mopLine";
 import {
   GRID_MODEL_NOTE,
@@ -162,6 +164,27 @@ export async function WeekPanel({
   const withheldTide = withheldBy(area, "tide");
   const withheldSwell = withheldBy(area, "swell");
   const withheldSky = withheldBy(area, "sky");
+
+  /*
+    Whether this row's heights are the only wave figures the page has -- the
+    disclosure ADR-0019 was accepted on, at the first of the three places a
+    modelled height is drawn (ADR-0055).
+
+    It reads the inventory rather than the fetch: `wave_buoy` and `mop_line` are
+    joins, known without a request, so a quiet CDIP cannot take the clause down
+    with the row it qualifies. Same reason `modelAnswersInstead` is a fact from
+    the join rather than an inference from whether a forecast arrived.
+
+    Beach scope only. On an area page "no buoy reaches this beach" would be a
+    claim about one member printed as the area's, and the swell row's own
+    withheld wording answers instead. `areas.test.ts` asserts that no
+    multi-beach area can draw a shared swell row with no buoy anywhere behind
+    it, so this scoping leaves no beach undisclosed rather than merely none
+    today.
+  */
+  const beach = area === undefined ? beachBySlug(slug) : null;
+  const unmeasuredWaves =
+    beach != null && beach.wave_buoy === null && beach.mop_line !== null;
 
   // Concurrently, and failing apart: NOAA and CDIP share no publisher and no
   // outage, so neither may hold up or take down the other's row.
@@ -336,7 +359,7 @@ export async function WeekPanel({
         source: mopLineSource(line.id),
         network: MOP_NETWORK,
         distanceKm: mopLineDistanceKm(line.distanceM),
-        note: MOP_MODEL_NOTE,
+        note: mopNote(MOP_MODEL_NOTE, unmeasuredWaves),
       },
     });
   }
@@ -475,10 +498,16 @@ export async function WeekPanel({
   */
   withheldNote(withheldSwell, "a swell forecast");
   if (waves !== null && waves.state.kind === "no-line") {
+    /*
+      This said "for the same reason as the reading above", pointing at the wave
+      card. A second wave note now lands in this array above it, and the card is
+      scheduled for deletion regardless, so it states the reason rather than
+      pointing at where the reason used to be.
+    */
     notes.push(
-      "There is no wave forecast for this beach either, and for the same reason " +
-        "as the reading above: every point the model publishes sits at 10 m " +
-        "depth out on the open coast.",
+      "There is no wave forecast for this beach either: every point the model " +
+        "publishes sits at 10 m depth out on the open coast, which is also why " +
+        "no buoy reaches it.",
     );
   }
   /*

--- a/src/components/conditions/mopLine.ts
+++ b/src/components/conditions/mopLine.ts
@@ -1,8 +1,12 @@
 /**
  * How a MOP line is named, credited and measured for a reader.
  *
- * Four facts, in one place, because two components are about to state them: the
- * week grid's wave row and the wave card's forecast block. `ProvenanceLine`'s
+ * Five facts, in one place, because three components state them: the week
+ * grid's wave row, the day chart's swell tab and the shore map's readout. It
+ * was two when this was written, and one of them was the wave card's forecast
+ * block -- that block went one region up and became a curve, the readout
+ * arrived with ADR-0034, and the fifth fact arrived with ADR-0055 because every
+ * drawing of a modelled height needs it. `ProvenanceLine`'s
  * own docstring records what happens otherwise — on `fiesta-island`, where two
  * bindings resolved to one station, the page printed "San Diego Airport · 4.7 km
  * from this beach" and "San Diego Airport · 4.7 km away" eighty pixels apart.
@@ -34,6 +38,51 @@ export const MOP_NETWORK = "CDIP, Scripps Institution of Oceanography";
  */
 export const MOP_MODEL_NOTE =
   "a model of the swell at 10 m depth, not a measurement";
+
+/**
+ * The clause for a beach where the model is not standing beside a measurement,
+ * but standing in for one that does not exist.
+ *
+ * **`MOP_MODEL_NOTE` is not enough on its own at these ten beaches, and the
+ * difference is what ADR-0019 was accepted on.** That clause tells a reader
+ * this figure is modelled. It does not tell them there is no measured figure
+ * anywhere on the page to weigh it against — which at the other fifteen beaches
+ * there is, sitting in the measured block. ADR-0019 admits a beach whose only
+ * wave source is a model *on condition* the page says so, and warns that if the
+ * disclosure "is ever removed or weakened, this decision goes with it".
+ *
+ * **Three callers, one sentence, which is the whole reason this file exists.**
+ * The week grid's wave row, the day chart's swell tab and the shore map's
+ * readout all draw modelled heights, so a reader meets this claim three times
+ * and must meet the same words (ADR-0055). It is not exported: `mopNote` below
+ * is the only way to reach it, so a fourth drawing cannot compose its own
+ * variant -- which is the drift `ProvenanceLine`'s docstring records.
+ *
+ * Not for a bay. Where there is no buoy *and* no line nothing is drawn, and
+ * telling a lagoon's reader that its wave heights are modelled would name a
+ * figure the page does not show.
+ */
+const MOP_UNMEASURED_NOTE =
+  "no buoy reaches this beach, so nothing on this page measures its waves";
+
+/**
+ * A MOP attribution's note, with the unmeasured clause where it applies.
+ *
+ * **Every attribution built from `MOP_MODEL_NOTE` goes through here**, which is
+ * the rule ADR-0055 decides rather than the list of places it currently
+ * applies. Three drawings of a modelled height exist today — the week grid's
+ * wave row, the day chart's swell tab and the shore map's readout — and the
+ * third was nearly missed, which is the argument for a helper over three
+ * conditionals.
+ *
+ * Semicolon-joined rather than replacing the base, and `gridCellCaveat` is
+ * composed onto `GRID_MODEL_NOTE` the same way. The two clauses are not
+ * alternatives: one says this figure is a model, the other says there is no
+ * measured figure anywhere on the page to weigh it against.
+ */
+export function mopNote(base: string, unmeasured: boolean): string {
+  return unmeasured ? `${base}; ${MOP_UNMEASURED_NOTE}` : base;
+}
 
 /**
  * What the page calls a line.

--- a/src/lib/areas.test.ts
+++ b/src/lib/areas.test.ts
@@ -254,6 +254,38 @@ describe("what an area's beaches agree on", () => {
   });
 
   /**
+   * ADR-0019's disclosure is scoped to a beach page, and this is what makes
+   * that scoping total rather than merely true today.
+   *
+   * The week grid and the day chart say "no buoy reaches this beach, so nothing
+   * on this page measures its waves" only where `area` is absent — because at
+   * area scope the claim would be about one member printed as the area's. That
+   * leaves a beach undisclosed if an area could ever draw a shared swell row
+   * with no buoy anywhere behind it.
+   *
+   * Two areas satisfy the antecedent today, Sunset Cliffs and Silver Strand,
+   * and both hold one beach — so `soleBeachOf` serves them at their own URL
+   * with no scope, and the note fires. What must not appear is a *multi-beach*
+   * area in that state, which no wording currently exists for.
+   *
+   * This is the half no gate could assert for ADR-0019 itself. It can assert
+   * this half. See ADR-0055.
+   */
+  test("no multi-beach area draws a shared swell row with no buoy behind it", () => {
+    const bySlug = new Map(allBeaches().map((beach) => [beach.slug, beach]));
+
+    for (const { area, beaches } of beachesByArea()) {
+      if (beaches.length === 1) continue;
+      if (areaSources(area).swell.kind !== "shared") continue;
+
+      const withABuoy = beaches.filter(
+        (beach) => bySlug.get(beach.slug)!.wave_buoy !== null,
+      );
+      expect(withABuoy.length, area.name).toBeGreaterThan(0);
+    }
+  });
+
+  /**
    * The claim that makes "shared" usable: where an area shares a product, any
    * of its beaches resolves to the same source, so the page may read the
    * product through any member without choosing a representative. Asserted


### PR DESCRIPTION
**Stacked on #242** — its base is `measured-band-observation-times`, not `main`.
#242 must merge first. I stacked rather than branching from `main` because
CLAUDE.md forbids starting work on an unmerged blocker's ground, and building
directly on its commits avoids the rebase-onto-a-moved-blocker failure that rule
names. The diff below is this PR's four commits only.

The second of three PRs for `docs/plans/the-measured-band.md`.

## Why

**Thirty-six of the fifty-one beaches have no wave buoy.** At ten of them a CDIP
MOP line answers instead, and ADR-0019 admits those ten *on condition* the page
says the height is modelled — a condition it calls "the half no gate can
assert", warning that if the disclosure "is ever removed or weakened, this
decision goes with it".

That sentence has been in the measured block, one region above the modelled
heights it is about. ADR-0019 names the reader it protects: "a parent reading
'1.5 ft' before taking children into the water is not weighing model against
instrument". That reader is looking at a **curve** — and on these ten beaches
the measured block has no figure in it at all, so it is the part of the page
they have least reason to stop at.

## What changed

`docs/adr/0055-wave-absences-are-worded-where-the-model-is-drawn.md`, and then
the code, and then the ADR again — see below.

The clause hangs off the MOP attribution itself, beside the existing "a model of
the swell at 10 m depth, not a measurement":

```
MOP line D0045 · CDIP, Scripps Institution of Oceanography · about 0.8 km from
this beach — a model of the swell at 10 m depth, not a measurement; no buoy
reaches this beach, so nothing on this page measures its waves
```

Every such attribution goes through one `mopNote` helper, and
`MOP_UNMEASURED_NOTE` is **not** exported, so a fourth drawing cannot compose
its own variant.

The measured block's card keeps the absence — "No wave buoy reaches this stretch
of coast, so nothing here is measured" — and drops the half that said what
stands in, which pointed at "the chart above and in the week above that".

## Two corrections the build forced on the ADR

I amended the decision rather than bending the code to the decision:

**The page draws a modelled height in three places, not two.** I wrote the ADR
naming the week grid's wave row and the day chart's swell tab. The shore map's
readout composes its own MOP attribution through `swellStepNote` and would have
been the one place on the page where a modelled height stood unqualified —
exactly the state ADR-0019 forbids. So the decision now names the **rule** —
any attribution built from `MOP_MODEL_NOTE` — rather than a list of sites.

**The week's belongs on its row's provenance, not in the notes array.** That
array says why a row a reader expected is *not there*. This says what a row that
*is* there is made of. Putting it there would also have left one fact in two
shapes: a free sentence in one region, a provenance clause in the other two.

And the slot I deliberately did **not** use: `HourSeries.absence`. It is the
obvious one and it never renders here — at these ten beaches MOP answers and the
curve draws. A drawn curve is the entire risk being disclosed.

## Scoping, and the assertion behind it

The clause fires on a **beach page** only: at area scope "no buoy reaches this
beach" would be a claim about one member printed as the area's, which ADR-0048
forbids. It reads the **inventory** (`wave_buoy`, `mop_line`), not the fetch, so
a quiet CDIP cannot take the clause down with the row it qualifies.

That scoping is only total if no *multi-beach* area can draw a shared swell row
with no buoy anywhere behind it. Two areas satisfy the antecedent today —
Sunset Cliffs and Silver Strand — and both hold one beach, so `soleBeachOf`
serves them at their own URL with no scope and the clause fires. `areas.test.ts`
now asserts that, so a later edit to `areas.json` cannot silently leave a beach
undisclosed.

## Verified

Mutation, because a passing test proves nothing until it can fail. Dropping the
clause from the readout alone — the site the ADR first missed:

```
× a beach whose only wave source is a model says so on the swell attribution
```

That test asserts **every** MOP attribution on the page, not one of them.

Live, by curl, since `generateStaticParams` returns `[]` and the gate renders
none of these routes:

| route | | occurrences |
| --- | --- | --- |
| `/conditions/sunset-cliffs` | no buoy, has a line | **present** |
| `/conditions/la-jolla/shell-beach` | has a buoy | 0 |
| `/conditions/la-jolla/childrens-pool` | bay, no line | 0 |
| `/conditions/la-jolla` | area, mixed | 0 |

## Gate

```
  PASS  format
  PASS  lint
  PASS  typecheck
  PASS  adr-numbers
  PASS  sea-side
  PASS  areas
  PASS  test
  PASS  build
  PASS  stylesheet
```

## Noticed, not fixed

**The per-step provenance objects repeat their note in the RSC payload.** The
shore map's readout builds one `CompassNeedle` per published estimate — about 56
across the week — each carrying its own note string, so `not a measurement`
appears 61 times in the payload on *every* beach with a MOP line, before this
branch. This PR adds ~70 characters to each of those on the ten ADR-0019
beaches, roughly 4 KB. It is a pre-existing shape rather than one this change
introduces, and the rendered markup carries the clause twice, so I have left it
alone and am recording it here rather than opening a tracker row.

## What this does not do

- **No layout moves and nothing is deleted.** The band and the ~2,100 lines of
  deletions are PR 3.
- **ADR-0019 and ADR-0049 are not edited.** ADR-0055 says in its header that it
  discharges a condition of the first and generalises the second; both are dated
  records and stay as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
